### PR TITLE
Rework CoreTiming events

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <limits>
+#include <optional>
 #include <vector>
 
 #include "audio_core/audio_out.h"
@@ -88,9 +89,12 @@ AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing_, Core::Memor
     stream = audio_out->OpenStream(
         core_timing, params.sample_rate, AudioCommon::STREAM_NUM_CHANNELS,
         fmt::format("AudioRenderer-Instance{}", instance_number), std::move(release_callback));
-    process_event = Core::Timing::CreateEvent(
-        fmt::format("AudioRenderer-Instance{}-Process", instance_number),
-        [this](std::uintptr_t, std::chrono::nanoseconds) { ReleaseAndQueueBuffers(); });
+    process_event =
+        Core::Timing::CreateEvent(fmt::format("AudioRenderer-Instance{}-Process", instance_number),
+                                  [this](std::uintptr_t, s64, std::chrono::nanoseconds) {
+                                      ReleaseAndQueueBuffers();
+                                      return std::nullopt;
+                                  });
     for (s32 i = 0; i < NUM_BUFFERS; ++i) {
         QueueMixedBuffer(i);
     }

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -34,9 +34,10 @@ Stream::Stream(Core::Timing::CoreTiming& core_timing_, u32 sample_rate_, Format 
                ReleaseCallback&& release_callback_, SinkStream& sink_stream_, std::string&& name_)
     : sample_rate{sample_rate_}, format{format_}, release_callback{std::move(release_callback_)},
       sink_stream{sink_stream_}, core_timing{core_timing_}, name{std::move(name_)} {
-    release_event =
-        Core::Timing::CreateEvent(name, [this](std::uintptr_t, std::chrono::nanoseconds ns_late) {
+    release_event = Core::Timing::CreateEvent(
+        name, [this](std::uintptr_t, s64 time, std::chrono::nanoseconds ns_late) {
             ReleaseActiveBuffer(ns_late);
+            return std::nullopt;
         });
 }
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -20,8 +20,9 @@
 namespace Core::Timing {
 
 /// A callback that may be scheduled for a particular core timing event.
-using TimedCallback =
-    std::function<void(std::uintptr_t user_data, std::chrono::nanoseconds ns_late)>;
+using TimedCallback = std::function<std::optional<std::chrono::nanoseconds>(
+    std::uintptr_t user_data, s64 time, std::chrono::nanoseconds ns_late)>;
+using PauseCallback = std::function<void(bool paused)>;
 
 /// Contains the characteristics of a particular event.
 struct EventType {
@@ -93,7 +94,15 @@ public:
 
     /// Schedules an event in core timing
     void ScheduleEvent(std::chrono::nanoseconds ns_into_future,
-                       const std::shared_ptr<EventType>& event_type, std::uintptr_t user_data = 0);
+                       const std::shared_ptr<EventType>& event_type, std::uintptr_t user_data = 0,
+                       bool absolute_time = false);
+
+    /// Schedules an event which will automatically re-schedule itself with the given time, until
+    /// unscheduled
+    void ScheduleLoopingEvent(std::chrono::nanoseconds start_time,
+                              std::chrono::nanoseconds resched_time,
+                              const std::shared_ptr<EventType>& event_type,
+                              std::uintptr_t user_data = 0, bool absolute_time = false);
 
     void UnscheduleEvent(const std::shared_ptr<EventType>& event_type, std::uintptr_t user_data);
 
@@ -125,6 +134,9 @@ public:
     /// Checks for events manually and returns time in nanoseconds for next event, threadsafe.
     std::optional<s64> Advance();
 
+    /// Register a callback function to be called when coretiming pauses.
+    void RegisterPauseCallback(PauseCallback&& callback);
+
 private:
     struct Event;
 
@@ -136,7 +148,7 @@ private:
 
     std::unique_ptr<Common::WallClock> clock;
 
-    u64 global_timer = 0;
+    s64 global_timer = 0;
 
     // The queue is a min-heap using std::make_heap/push_heap/pop_heap.
     // We don't use std::priority_queue because we need to be able to serialize, unserialize and
@@ -162,10 +174,13 @@ private:
     bool shutting_down{};
     bool is_multicore{};
     size_t pause_count{};
+    s64 pause_end_time{};
 
     /// Cycle timing
     u64 ticks{};
     s64 downcount{};
+
+    std::vector<PauseCallback> pause_callbacks{};
 };
 
 /// Creates a core timing event with the given name and callback.

--- a/src/core/hardware_interrupt_manager.cpp
+++ b/src/core/hardware_interrupt_manager.cpp
@@ -11,11 +11,14 @@ namespace Core::Hardware {
 
 InterruptManager::InterruptManager(Core::System& system_in) : system(system_in) {
     gpu_interrupt_event = Core::Timing::CreateEvent(
-        "GPUInterrupt", [this](std::uintptr_t message, std::chrono::nanoseconds) {
+        "GPUInterrupt",
+        [this](std::uintptr_t message, u64 time,
+               std::chrono::nanoseconds) -> std::optional<std::chrono::nanoseconds> {
             auto nvdrv = system.ServiceManager().GetService<Service::Nvidia::NVDRV>("nvdrv");
             const u32 syncpt = static_cast<u32>(message >> 32);
             const u32 value = static_cast<u32>(message);
             nvdrv->SignalGPUInterruptSyncpt(syncpt, value);
+            return std::nullopt;
         });
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -245,8 +245,7 @@ struct KernelCore::Impl {
             });
 
         const auto time_interval = std::chrono::nanoseconds{std::chrono::milliseconds(10)};
-        system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), time_interval,
-                                                 preemption_event);
+        system.CoreTiming().ScheduleLoopingEvent(time_interval, time_interval, preemption_event);
     }
 
     void InitializeShutdownThreads() {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -234,17 +234,19 @@ struct KernelCore::Impl {
 
     void InitializePreemption(KernelCore& kernel) {
         preemption_event = Core::Timing::CreateEvent(
-            "PreemptionCallback", [this, &kernel](std::uintptr_t, std::chrono::nanoseconds) {
+            "PreemptionCallback",
+            [this, &kernel](std::uintptr_t, s64 time,
+                            std::chrono::nanoseconds) -> std::optional<std::chrono::nanoseconds> {
                 {
                     KScopedSchedulerLock lock(kernel);
                     global_scheduler_context->PreemptThreads();
                 }
-                const auto time_interval = std::chrono::nanoseconds{std::chrono::milliseconds(10)};
-                system.CoreTiming().ScheduleEvent(time_interval, preemption_event);
+                return std::nullopt;
             });
 
         const auto time_interval = std::chrono::nanoseconds{std::chrono::milliseconds(10)};
-        system.CoreTiming().ScheduleEvent(time_interval, preemption_event);
+        system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), time_interval,
+                                                 preemption_event);
     }
 
     void InitializeShutdownThreads() {

--- a/src/core/hle/kernel/time_manager.cpp
+++ b/src/core/hle/kernel/time_manager.cpp
@@ -11,15 +11,17 @@
 namespace Kernel {
 
 TimeManager::TimeManager(Core::System& system_) : system{system_} {
-    time_manager_event_type =
-        Core::Timing::CreateEvent("Kernel::TimeManagerCallback",
-                                  [this](std::uintptr_t thread_handle, std::chrono::nanoseconds) {
-                                      KThread* thread = reinterpret_cast<KThread*>(thread_handle);
-                                      {
-                                          KScopedSchedulerLock sl(system.Kernel());
-                                          thread->OnTimer();
-                                      }
-                                  });
+    time_manager_event_type = Core::Timing::CreateEvent(
+        "Kernel::TimeManagerCallback",
+        [this](std::uintptr_t thread_handle, s64 time,
+               std::chrono::nanoseconds) -> std::optional<std::chrono::nanoseconds> {
+            KThread* thread = reinterpret_cast<KThread*>(thread_handle);
+            {
+                KScopedSchedulerLock sl(system.Kernel());
+                thread->OnTimer();
+            }
+            return std::nullopt;
+        });
 }
 
 void TimeManager::ScheduleTimeEvent(KThread* thread, s64 nanoseconds) {

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -97,11 +97,10 @@ IAppletResource::IAppletResource(Core::System& system_,
             return std::nullopt;
         });
 
-    system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), pad_update_ns,
-                                             pad_update_event);
-    system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), mouse_keyboard_update_ns,
+    system.CoreTiming().ScheduleLoopingEvent(pad_update_ns, pad_update_ns, pad_update_event);
+    system.CoreTiming().ScheduleLoopingEvent(mouse_keyboard_update_ns, mouse_keyboard_update_ns,
                                              mouse_keyboard_update_event);
-    system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), motion_update_ns,
+    system.CoreTiming().ScheduleLoopingEvent(motion_update_ns, motion_update_ns,
                                              motion_update_event);
 
     system.HIDCore().ReloadInputDevices();

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -74,26 +74,35 @@ IAppletResource::IAppletResource(Core::System& system_,
     // Register update callbacks
     pad_update_event = Core::Timing::CreateEvent(
         "HID::UpdatePadCallback",
-        [this](std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+        [this](std::uintptr_t user_data, s64 time,
+               std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
             UpdateControllers(user_data, ns_late);
+            return std::nullopt;
         });
     mouse_keyboard_update_event = Core::Timing::CreateEvent(
         "HID::UpdateMouseKeyboardCallback",
-        [this](std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+        [this](std::uintptr_t user_data, s64 time,
+               std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
             UpdateMouseKeyboard(user_data, ns_late);
+            return std::nullopt;
         });
     motion_update_event = Core::Timing::CreateEvent(
         "HID::UpdateMotionCallback",
-        [this](std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+        [this](std::uintptr_t user_data, s64 time,
+               std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
             UpdateMotion(user_data, ns_late);
+            return std::nullopt;
         });
 
-    system.CoreTiming().ScheduleEvent(pad_update_ns, pad_update_event);
-    system.CoreTiming().ScheduleEvent(mouse_keyboard_update_ns, mouse_keyboard_update_event);
-    system.CoreTiming().ScheduleEvent(motion_update_ns, motion_update_event);
+    system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), pad_update_ns,
+                                             pad_update_event);
+    system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), mouse_keyboard_update_ns,
+                                             mouse_keyboard_update_event);
+    system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), motion_update_ns,
+                                             motion_update_event);
 
     system.HIDCore().ReloadInputDevices();
 }
@@ -135,13 +144,6 @@ void IAppletResource::UpdateControllers(std::uintptr_t user_data,
         }
         controller->OnUpdate(core_timing);
     }
-
-    // If ns_late is higher than the update rate ignore the delay
-    if (ns_late > pad_update_ns) {
-        ns_late = {};
-    }
-
-    core_timing.ScheduleEvent(pad_update_ns - ns_late, pad_update_event);
 }
 
 void IAppletResource::UpdateMouseKeyboard(std::uintptr_t user_data,
@@ -150,26 +152,12 @@ void IAppletResource::UpdateMouseKeyboard(std::uintptr_t user_data,
 
     controllers[static_cast<size_t>(HidController::Mouse)]->OnUpdate(core_timing);
     controllers[static_cast<size_t>(HidController::Keyboard)]->OnUpdate(core_timing);
-
-    // If ns_late is higher than the update rate ignore the delay
-    if (ns_late > mouse_keyboard_update_ns) {
-        ns_late = {};
-    }
-
-    core_timing.ScheduleEvent(mouse_keyboard_update_ns - ns_late, mouse_keyboard_update_event);
 }
 
 void IAppletResource::UpdateMotion(std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
     auto& core_timing = system.CoreTiming();
 
     controllers[static_cast<size_t>(HidController::NPad)]->OnMotionUpdate(core_timing);
-
-    // If ns_late is higher than the update rate ignore the delay
-    if (ns_late > motion_update_ns) {
-        ns_late = {};
-    }
-
-    core_timing.ScheduleEvent(motion_update_ns - ns_late, motion_update_event);
 }
 
 class IActiveVibrationDeviceList final : public ServiceFramework<IActiveVibrationDeviceList> {

--- a/src/core/hle/service/hid/hidbus.cpp
+++ b/src/core/hle/service/hid/hidbus.cpp
@@ -50,12 +50,15 @@ HidBus::HidBus(Core::System& system_)
     // Register update callbacks
     hidbus_update_event = Core::Timing::CreateEvent(
         "Hidbus::UpdateCallback",
-        [this](std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+        [this](std::uintptr_t user_data, s64 time,
+               std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
             UpdateHidbus(user_data, ns_late);
+            return std::nullopt;
         });
 
-    system_.CoreTiming().ScheduleEvent(hidbus_update_ns, hidbus_update_event);
+    system_.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), hidbus_update_ns,
+                                              hidbus_update_event);
 }
 
 HidBus::~HidBus() {
@@ -63,8 +66,6 @@ HidBus::~HidBus() {
 }
 
 void HidBus::UpdateHidbus(std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
-    auto& core_timing = system.CoreTiming();
-
     if (is_hidbus_enabled) {
         for (std::size_t i = 0; i < devices.size(); ++i) {
             if (!devices[i].is_device_initializated) {
@@ -82,13 +83,6 @@ void HidBus::UpdateHidbus(std::uintptr_t user_data, std::chrono::nanoseconds ns_
                         sizeof(HidbusStatusManagerEntry));
         }
     }
-
-    // If ns_late is higher than the update rate ignore the delay
-    if (ns_late > hidbus_update_ns) {
-        ns_late = {};
-    }
-
-    core_timing.ScheduleEvent(hidbus_update_ns - ns_late, hidbus_update_event);
 }
 
 std::optional<std::size_t> HidBus::GetDeviceIndexFromHandle(BusHandle handle) const {

--- a/src/core/hle/service/hid/hidbus.cpp
+++ b/src/core/hle/service/hid/hidbus.cpp
@@ -57,7 +57,7 @@ HidBus::HidBus(Core::System& system_)
             return std::nullopt;
         });
 
-    system_.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), hidbus_update_ns,
+    system_.CoreTiming().ScheduleLoopingEvent(hidbus_update_ns, hidbus_update_ns,
                                               hidbus_update_event);
 }
 

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -73,14 +73,14 @@ NVFlinger::NVFlinger(Core::System& system_, HosBinderDriverServer& hos_binder_dr
             const auto lock_guard = Lock();
             Compose();
 
-            return std::chrono::nanoseconds(GetNextTicks()) - ns_late;
+            return std::max(std::chrono::nanoseconds::zero(),
+                            std::chrono::nanoseconds(GetNextTicks()) - ns_late);
         });
 
     if (system.IsMulticore()) {
         vsync_thread = std::jthread([this](std::stop_token token) { SplitVSync(token); });
     } else {
-        system.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), frame_ns,
-                                                 composition_event);
+        system.CoreTiming().ScheduleLoopingEvent(frame_ns, frame_ns, composition_event);
     }
 }
 

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -189,7 +189,7 @@ void CheatEngine::Initialize() {
             FrameCallback(user_data, ns_late);
             return std::nullopt;
         });
-    core_timing.ScheduleLoopingEvent(std::chrono::nanoseconds(0), CHEAT_ENGINE_NS, event);
+    core_timing.ScheduleLoopingEvent(CHEAT_ENGINE_NS, CHEAT_ENGINE_NS, event);
 
     metadata.process_id = system.CurrentProcess()->GetProcessID();
     metadata.title_id = system.GetCurrentProcessProgramID();

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -184,10 +184,12 @@ CheatEngine::~CheatEngine() {
 void CheatEngine::Initialize() {
     event = Core::Timing::CreateEvent(
         "CheatEngine::FrameCallback::" + Common::HexToString(metadata.main_nso_build_id),
-        [this](std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+        [this](std::uintptr_t user_data, s64 time,
+               std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             FrameCallback(user_data, ns_late);
+            return std::nullopt;
         });
-    core_timing.ScheduleEvent(CHEAT_ENGINE_NS, event);
+    core_timing.ScheduleLoopingEvent(std::chrono::nanoseconds(0), CHEAT_ENGINE_NS, event);
 
     metadata.process_id = system.CurrentProcess()->GetProcessID();
     metadata.title_id = system.GetCurrentProcessProgramID();
@@ -237,8 +239,6 @@ void CheatEngine::FrameCallback(std::uintptr_t, std::chrono::nanoseconds ns_late
     MICROPROFILE_SCOPE(Cheat_Engine);
 
     vm.Execute(metadata);
-
-    core_timing.ScheduleEvent(CHEAT_ENGINE_NS - ns_late, event);
 }
 
 } // namespace Core::Memory

--- a/src/core/tools/freezer.cpp
+++ b/src/core/tools/freezer.cpp
@@ -53,8 +53,10 @@ Freezer::Freezer(Core::Timing::CoreTiming& core_timing_, Core::Memory::Memory& m
     : core_timing{core_timing_}, memory{memory_} {
     event = Core::Timing::CreateEvent(
         "MemoryFreezer::FrameCallback",
-        [this](std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+        [this](std::uintptr_t user_data, s64 time,
+               std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             FrameCallback(user_data, ns_late);
+            return std::nullopt;
         });
     core_timing.ScheduleEvent(memory_freezer_ns, event);
 }

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 
 #include "core/core.h"
@@ -25,13 +26,15 @@ u64 expected_callback = 0;
 std::mutex control_mutex;
 
 template <unsigned int IDX>
-void HostCallbackTemplate(std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+std::optional<std::chrono::nanoseconds> HostCallbackTemplate(std::uintptr_t user_data, s64 time,
+                                                             std::chrono::nanoseconds ns_late) {
     std::unique_lock<std::mutex> lk(control_mutex);
     static_assert(IDX < CB_IDS.size(), "IDX out of range");
     callbacks_ran_flags.set(IDX);
     REQUIRE(CB_IDS[IDX] == user_data);
     delays[IDX] = ns_late.count();
     ++expected_callback;
+    return std::nullopt;
 }
 
 struct ScopeInit final {


### PR DESCRIPTION
The main idea here is to make coretiming much more accurate in its callback timing, and add an automatically looping type of event, so that functions don't need to keep re-registering themselves, as almost all events are auto, and not one-shot.

The current problem with coretiming callbacks is the reliance on the callback to re-schedule itself, which necessarily means that some time is lost, between the coretiming timestamp to calculate `ns_late`, and the schedule function doing the same thing some point later. 

If some event was scheduled at time 100, maybe the callback delay is calculated at time 102, passing a ns_late of 2 into the callback. The callback runs and at the end wants to reschedule itself 10 units later. It calls reschedule with 10 - 2, the scheduling function then gets the current time, which may now be 103 or 104, and adds 8. A inherant drift happens due to continued calling to get a timestamp and some "lost time".

This PR changes the callback such that you can register an event which will loop itself, and will automatically use the event time + reschedule time. So if you event scheduled at time 100, with a reschedule of 10, it will *always* reschedule it for time 100 + 10, and then 110 + 10, and then 120 + 10, etc. The *only* time a timestamp is taken, is on the very first schedule to start the event, so it'll reschedule with the appropriate time.

Here's some timestamp logging from hidbus for example, which aims for 15,000,000:
old https://pastebin.com/iPq2rFK6
new https://pastebin.com/JxTAj9ZB

The current frame timings are larger, and in particular the log timestamp itself is all over the place as the time drifts forward. In the new, it's able to fix quite firmly on 3758 -> 8758 -> 3758 -> 8758.

This is spun out of Project Andio, which needs a much more accurate callback than coretiming was giving, due to the real-time deadline of audio output. PR'ing separately due to merge conflicts.