### PR TITLE
core: hid: Add fallback for dualjoycon and pro controllers

### DIFF
--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -401,6 +401,7 @@ private:
 
     const NpadIdType npad_id_type;
     NpadStyleIndex npad_type{NpadStyleIndex::None};
+    NpadStyleIndex original_npad_type{NpadStyleIndex::None};
     NpadStyleTag supported_style_tag{NpadStyleSet::All};
     bool is_connected{false};
     bool is_configuring{false};


### PR DESCRIPTION
Super Mario Galaxy soft locked when dual joycon was selected. This was due the game only enabling pro controller and handheld support at boot. Then later on enabling dual joycon support. 

Original behavior will disconnect the controller since it's not supported at boot.  But after a few HW test with homebrew I found that the controller never stops working it just fallback itself to pro controller then restore the original type once it's supported.

This PR fixes Mario Galaxy with dual joycons.