### PR TITLE
video_core: Fix gpu thread deadlock

### DIFF
--- a/src/video_core/dma_pusher.cpp
+++ b/src/video_core/dma_pusher.cpp
@@ -34,7 +34,6 @@ void DmaPusher::DispatchCalls() {
     }
     gpu.FlushCommands();
     gpu.SyncGuestHost();
-    gpu.OnCommandListEnd();
 }
 
 bool DmaPusher::Step() {

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -107,14 +107,6 @@ struct GPU::Impl {
         rasterizer->SyncGuestHost();
     }
 
-    /// Signal the ending of command list.
-    void OnCommandListEnd() {
-        if (is_async) {
-            // This command only applies to asynchronous GPU mode
-            gpu_thread.OnCommandListEnd();
-        }
-    }
-
     /// Request a host GPU memory flush from the CPU.
     [[nodiscard]] u64 RequestFlush(VAddr addr, std::size_t size) {
         std::unique_lock lck{flush_request_mutex};
@@ -763,10 +755,6 @@ void GPU::FlushCommands() {
 
 void GPU::SyncGuestHost() {
     impl->SyncGuestHost();
-}
-
-void GPU::OnCommandListEnd() {
-    impl->OnCommandListEnd();
 }
 
 u64 GPU::RequestFlush(VAddr addr, std::size_t size) {

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -77,6 +77,9 @@ void ThreadManager::StartThread(VideoCore::RendererBase& renderer,
 
 void ThreadManager::SubmitList(Tegra::CommandList&& entries) {
     PushCommand(SubmitListCommand(std::move(entries)));
+    if (is_async) {
+        PushCommand(OnCommandListEndCommand());
+    }
 }
 
 void ThreadManager::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
@@ -105,10 +108,6 @@ void ThreadManager::InvalidateRegion(VAddr addr, u64 size) {
 void ThreadManager::FlushAndInvalidateRegion(VAddr addr, u64 size) {
     // Skip flush on asynch mode, as FlushAndInvalidateRegion is not used for anything too important
     rasterizer->OnCPUWrite(addr, size);
-}
-
-void ThreadManager::OnCommandListEnd() {
-    PushCommand(OnCommandListEndCommand());
 }
 
 u64 ThreadManager::PushCommand(CommandData&& command_data, bool block) {

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -129,8 +129,6 @@ public:
     /// Notify rasterizer that any caches of the specified region should be flushed and invalidated
     void FlushAndInvalidateRegion(VAddr addr, u64 size);
 
-    void OnCommandListEnd();
-
 private:
     /// Pushes a command to be executed by the GPU thread
     u64 PushCommand(CommandData&& command_data, bool block = false);


### PR DESCRIPTION
Supersedes PR #8542

Issue caused by bounded queue introduced by PR #8413.

Because the bounded queue is capped by the capacity. The queue has multiple threads push command at the same time, and only the gpu thread is consuming. The problem is that the gpu thread is also adding data to it. When the queue is full, this will cause the gpu thread to be blocked, and the gpu thread will directly deadlock, that is, we will see that the screen will not be refreshed.

This fixes the DRAGON QUEST BUILDERS startup deadlock. Other more tests are welcome.


