### PR TITLE
nvflinger: Polymorphic destructor requried for abstract class IBinder

### DIFF
--- a/src/core/hle/service/nvflinger/binder.h
+++ b/src/core/hle/service/nvflinger/binder.h
@@ -34,6 +34,7 @@ enum class TransactionId {
 
 class IBinder {
 public:
+    virtual ~IBinder() = default;
     virtual void Transact(Kernel::HLERequestContext& ctx, android::TransactionId code,
                           u32 flags) = 0;
     virtual Kernel::KReadableEvent& GetNativeHandle() = 0;


### PR DESCRIPTION
Corrects behaviour: Correctly call the appropriate child destructor on deletion of `IBinder`, when `delete` is performed on pointer to `IBinder`.