### PR TITLE
common/setting: Make ranged a property of the type

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -143,8 +143,8 @@ void Config::ReadBasicSetting(Settings::Setting<std::string>& setting) {
     }
 }
 
-template <typename Type>
-void Config::ReadBasicSetting(Settings::Setting<Type>& setting) {
+template <typename Type, bool ranged>
+void Config::ReadBasicSetting(Settings::Setting<Type, ranged>& setting) {
     const QString name = QString::fromStdString(setting.GetLabel());
     const Type default_value = setting.GetDefault();
     if (qt_config->value(name + QStringLiteral("/default"), false).toBool()) {
@@ -164,16 +164,16 @@ void Config::WriteBasicSetting(const Settings::Setting<std::string>& setting) {
     qt_config->setValue(name, QString::fromStdString(value));
 }
 
-template <typename Type>
-void Config::WriteBasicSetting(const Settings::Setting<Type>& setting) {
+template <typename Type, bool ranged>
+void Config::WriteBasicSetting(const Settings::Setting<Type, ranged>& setting) {
     const QString name = QString::fromStdString(setting.GetLabel());
     const Type value = setting.GetValue();
     qt_config->setValue(name + QStringLiteral("/default"), value == setting.GetDefault());
     qt_config->setValue(name, value);
 }
 
-template <typename Type>
-void Config::WriteGlobalSetting(const Settings::SwitchableSetting<Type>& setting) {
+template <typename Type, bool ranged>
+void Config::WriteGlobalSetting(const Settings::SwitchableSetting<Type, ranged>& setting) {
     const QString name = QString::fromStdString(setting.GetLabel());
     const Type& value = setting.GetValue(global);
     if (!global) {
@@ -1421,8 +1421,8 @@ QVariant Config::ReadSetting(const QString& name, const QVariant& default_value)
     return result;
 }
 
-template <typename Type>
-void Config::ReadGlobalSetting(Settings::SwitchableSetting<Type>& setting) {
+template <typename Type, bool ranged>
+void Config::ReadGlobalSetting(Settings::SwitchableSetting<Type, ranged>& setting) {
     QString name = QString::fromStdString(setting.GetLabel());
     const bool use_global = qt_config->value(name + QStringLiteral("/use_global"), true).toBool();
     setting.SetGlobal(use_global);

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -159,8 +159,8 @@ private:
      *
      * @param The setting
      */
-    template <typename Type>
-    void ReadGlobalSetting(Settings::SwitchableSetting<Type>& setting);
+    template <typename Type, bool ranged>
+    void ReadGlobalSetting(Settings::SwitchableSetting<Type, ranged>& setting);
 
     /**
      * Sets a value to the qt_config using the setting's label and default value. If the config is a
@@ -168,8 +168,8 @@ private:
      *
      * @param The setting
      */
-    template <typename Type>
-    void WriteGlobalSetting(const Settings::SwitchableSetting<Type>& setting);
+    template <typename Type, bool ranged>
+    void WriteGlobalSetting(const Settings::SwitchableSetting<Type, ranged>& setting);
 
     /**
      * Reads a value from the qt_config using the setting's label and default value and applies the
@@ -177,15 +177,15 @@ private:
      *
      * @param The setting
      */
-    template <typename Type>
-    void ReadBasicSetting(Settings::Setting<Type>& setting);
+    template <typename Type, bool ranged>
+    void ReadBasicSetting(Settings::Setting<Type, ranged>& setting);
 
     /** Sets a value from the setting in the qt_config using the setting's label and default value.
      *
      * @param The setting
      */
-    template <typename Type>
-    void WriteBasicSetting(const Settings::Setting<Type>& setting);
+    template <typename Type, bool ranged>
+    void WriteBasicSetting(const Settings::Setting<Type, ranged>& setting);
 
     ConfigType type;
     std::unique_ptr<QSettings> qt_config;

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -27,8 +27,9 @@ enum class CheckState {
 // ApplyPerGameSetting, given a Settings::Setting and a Qt UI element, properly applies a Setting
 void ApplyPerGameSetting(Settings::SwitchableSetting<bool>* setting, const QCheckBox* checkbox,
                          const CheckState& tracker);
-template <typename Type>
-void ApplyPerGameSetting(Settings::SwitchableSetting<Type>* setting, const QComboBox* combobox) {
+template <typename Type, bool ranged>
+void ApplyPerGameSetting(Settings::SwitchableSetting<Type, ranged>* setting,
+                         const QComboBox* combobox) {
     if (Settings::IsConfiguringGlobal() && setting->UsingGlobal()) {
         setting->SetValue(static_cast<Type>(combobox->currentIndex()));
     } else if (!Settings::IsConfiguringGlobal()) {
@@ -45,8 +46,9 @@ void ApplyPerGameSetting(Settings::SwitchableSetting<Type>* setting, const QComb
 // Sets a Qt UI element given a Settings::Setting
 void SetPerGameSetting(QCheckBox* checkbox, const Settings::SwitchableSetting<bool>* setting);
 
-template <typename Type>
-void SetPerGameSetting(QComboBox* combobox, const Settings::SwitchableSetting<Type>* setting) {
+template <typename Type, bool ranged>
+void SetPerGameSetting(QComboBox* combobox,
+                       const Settings::SwitchableSetting<Type, ranged>* setting) {
     combobox->setCurrentIndex(setting->UsingGlobal() ? ConfigurationShared::USE_GLOBAL_INDEX
                                                      : static_cast<int>(setting->GetValue()) +
                                                            ConfigurationShared::USE_GLOBAL_OFFSET);

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -99,8 +99,8 @@ void Config::ReadSetting(const std::string& group, Settings::Setting<bool>& sett
     setting = sdl2_config->GetBoolean(group, setting.GetLabel(), setting.GetDefault());
 }
 
-template <typename Type>
-void Config::ReadSetting(const std::string& group, Settings::Setting<Type>& setting) {
+template <typename Type, bool ranged>
+void Config::ReadSetting(const std::string& group, Settings::Setting<Type, ranged>& setting) {
     setting = static_cast<Type>(sdl2_config->GetInteger(group, setting.GetLabel(),
                                                         static_cast<long>(setting.GetDefault())));
 }

--- a/src/yuzu_cmd/config.h
+++ b/src/yuzu_cmd/config.h
@@ -33,6 +33,6 @@ private:
      * @param group The name of the INI group
      * @param setting The yuzu setting to modify
      */
-    template <typename Type>
-    void ReadSetting(const std::string& group, Settings::Setting<Type>& setting);
+    template <typename Type, bool ranged>
+    void ReadSetting(const std::string& group, Settings::Setting<Type, ranged>& setting);
 };


### PR DESCRIPTION
- Avoids new GCC 12 warnings when Type is of form std::optional<T>.
- Makes more sense this way, because ranged is not a property which would change over time.