### PR TITLE
core/arm: skip watchpoint checks when reading instructions

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -52,7 +52,7 @@ public:
         if (!memory.IsValidVirtualAddressRange(vaddr, sizeof(u32))) {
             return std::nullopt;
         }
-        return MemoryRead32(vaddr);
+        return memory.Read32(vaddr);
     }
 
     void MemoryWrite8(u32 vaddr, u8 value) override {
@@ -97,7 +97,7 @@ public:
         parent.LogBacktrace();
         LOG_ERROR(Core_ARM,
                   "Unimplemented instruction @ 0x{:X} for {} instructions (instr = {:08X})", pc,
-                  num_instructions, MemoryRead32(pc));
+                  num_instructions, memory.Read32(pc));
     }
 
     void ExceptionRaised(u32 pc, Dynarmic::A32::Exception exception) override {
@@ -115,7 +115,7 @@ public:
             parent.LogBacktrace();
             LOG_CRITICAL(Core_ARM,
                          "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X}, thumb = {})",
-                         exception, pc, MemoryRead32(pc), parent.IsInThumbMode());
+                         exception, pc, memory.Read32(pc), parent.IsInThumbMode());
         }
     }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -56,7 +56,7 @@ public:
         if (!memory.IsValidVirtualAddressRange(vaddr, sizeof(u32))) {
             return std::nullopt;
         }
-        return MemoryRead32(vaddr);
+        return memory.Read32(vaddr);
     }
 
     void MemoryWrite8(u64 vaddr, u8 value) override {
@@ -111,7 +111,7 @@ public:
         parent.LogBacktrace();
         LOG_ERROR(Core_ARM,
                   "Unimplemented instruction @ 0x{:X} for {} instructions (instr = {:08X})", pc,
-                  num_instructions, MemoryRead32(pc));
+                  num_instructions, memory.Read32(pc));
     }
 
     void InstructionCacheOperationRaised(Dynarmic::A64::InstructionCacheOperation op,
@@ -156,7 +156,7 @@ public:
 
             parent.LogBacktrace();
             LOG_CRITICAL(Core_ARM, "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X})",
-                         static_cast<std::size_t>(exception), pc, MemoryRead32(pc));
+                         static_cast<std::size_t>(exception), pc, memory.Read32(pc));
         }
     }
 


### PR DESCRIPTION
Watchpoints should only be checked for data, not instructions.