### PR TITLE
package MSVC CI Builds differently, and include yuzu.exe

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,8 @@ name: 'yuzu verify'
 on:
   pull_request:
     branches: [ master ]
+env:
+  PR_NUMBER: pr${{ github.event.number }}
 
 jobs:
   format:
@@ -99,7 +101,7 @@ jobs:
         run: |
           glslangValidator --version
           mkdir build
-          cmake . -B build -GNinja -DCMAKE_TOOLCHAIN_FILE="CMakeModules/MSVCCache.cmake" -DUSE_CCACHE=ON -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_BUNDLED_SDL2=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DYUZU_ENABLE_COMPATIBILITY_REPORTING=ON -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON -DCMAKE_BUILD_TYPE=Release -DYUZU_TESTS=OFF -DYUZU_USE_BUNDLED_VCPKG=ON
+          cmake . -B build -GNinja -DCMAKE_TOOLCHAIN_FILE="CMakeModules/MSVCCache.cmake" -DUSE_CCACHE=ON -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_BUNDLED_SDL2=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DYUZU_ENABLE_COMPATIBILITY_REPORTING=ON -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON -DCMAKE_BUILD_TYPE=Release -DGIT_BRANCH=pr-verify -DCLANG_FORMAT_SUFFIX=discordplzdontclang -DYUZU_TESTS=OFF -DYUZU_USE_BUNDLED_VCPKG=ON
       - name: Build
         run: cmake --build build
       - name: Cache Summary
@@ -112,3 +114,8 @@ jobs:
         with:
           name: msvc
           path: artifacts/
+      - name: Upload EXE
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.INDIVIDUAL_EXE }}
+          path: ${{ env.INDIVIDUAL_EXE }}


### PR DESCRIPTION
This is related to #8486

    Ninja places the exe files into .\build\bin while MSBuild may place them
    into .\build\bin\Release

    upload.ps1 was originally written for use with Azure Dev Ops to cough up about
    5 files and the script appears to be used for both CI and mainline builds

    GHA (GitHub Actions) makes available a single zip of the items uploaded by
    each Upload action (artifacts directory), so we want to work with that.

    I'm doing changes to upload.ps1 to accomplish this.

    The changes to the verify.yml are as follows

    -DGIT_BRANCH=pr-verify changes the header in yuzu, instead of saying
    HEAD-<hash>-dirty it'll say pr-verify-<hash>

    -DCLANG_FORMAT_SUFFIX=discordplzdontclang tricks the CMake stuff for
    discord-rpc to NOT run clang-format, as this was marking CI builds as
    dirty

    I'm also making it upload just the exe by itself, as the msvc builds are
    quite chunky. but maybe this is unnecessary.

    Currently the MSVC artifact option is a 274MB zip that contains 3 copies
    of the DLLs, and 4 copies of the source tarball, and zero copies of yuzu.exe

    This PR should have msvc artifacts of about 190MB that downloads as 81 MB zip



---

This will fix the missing yuzu.exe as ninja puts the .exe into build\bin\ instead of build\bin\Release

Fixes #8595