### PR TITLE
Rename Undocked to Handheld in input settings

### DIFF
--- a/src/yuzu/configuration/configure_input.ui
+++ b/src/yuzu/configuration/configure_input.ui
@@ -166,7 +166,7 @@
          <item>
           <widget class="QRadioButton" name="radioUndocked">
            <property name="text">
-            <string>Undocked</string>
+            <string>Handheld</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
For consistency, as it was previously renamed from the status bar.