### PR TITLE
qt: reset progress bar after shader compilation

### DIFF
--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -147,6 +147,10 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
         ui->progress_bar->setMaximum(static_cast<int>(total));
         previous_total = total;
     }
+    // Reset the progress bar ranges if compilation is done
+    if (stage == VideoCore::LoadCallbackStage::Complete) {
+        ui->progress_bar->setRange(0, 0);
+    }
 
     QString estimate;
     // If theres a drastic slowdown in the rate, then display an estimate


### PR DESCRIPTION
This prevents yuzu from appearing stalled when booting a program. This would occur if there were no shaders cached for the program, which generally means for the first boot for games, and always for most homebrew.