### PR TITLE
ci: pass environment variables to linux docker (AppImage)

### DIFF
--- a/.ci/scripts/linux/exec.sh
+++ b/.ci/scripts/linux/exec.sh
@@ -4,5 +4,10 @@ mkdir -p "ccache"  || true
 chmod a+x ./.ci/scripts/linux/docker.sh
 # the UID for the container yuzu user is 1027
 sudo chown -R 1027 ./
-docker run -e ENABLE_COMPATIBILITY_REPORTING -e CCACHE_DIR=/yuzu/ccache -v "$(pwd):/yuzu" -w /yuzu yuzuemu/build-environments:linux-fresh /bin/bash /yuzu/.ci/scripts/linux/docker.sh "$1"
+
+# The environment variables listed below:
+# AZURECIREPO TITLEBARFORMATIDLE TITLEBARFORMATRUNNING DISPLAYVERSION 
+#  are requested in src/common/CMakeLists.txt and appear to be provided somewhere in Azure DevOps
+
+docker run -e AZURECIREPO -e TITLEBARFORMATIDLE -e TITLEBARFORMATRUNNING -e DISPLAYVERSION -e ENABLE_COMPATIBILITY_REPORTING -e CCACHE_DIR=/yuzu/ccache -v "$(pwd):/yuzu" -w /yuzu yuzuemu/build-environments:linux-fresh /bin/bash /yuzu/.ci/scripts/linux/docker.sh "$1"
 sudo chown -R $UID ./


### PR DESCRIPTION

Windows: yuzu 1100
Linux AppImage: yuzu | HEAD-mainline-636-9115-ge567e755d-dirty

This PR just takes a stab at sharing more environment variables into the docker, I don't have Azure Dev Ops to test with, From what I can tell, some of the configuration of environment variables isn't in the repository

Long term I think the AppImage should have a title bar like: yuzu 1100 | mainline-20220720-e567e755d

------------

Variables in question:
AZURECIREPO TITLEBARFORMATIDLE TITLEBARFORMATRUNNING DISPLAYVERSION

CMakeModules/GenerateSCMRev.cmake has some logic that looks at BUILD_REPOSITORY variable inside CMake

src/common/CMakeLists.txt has some logic that takes some items from environment variables and
 sets variables inside CMake

This is the whole section at the moment.

    if (DEFINED ENV{AZURECIREPO})
      set(BUILD_REPOSITORY $ENV{AZURECIREPO})
    endif()
    if (DEFINED ENV{TITLEBARFORMATIDLE})
      set(TITLE_BAR_FORMAT_IDLE $ENV{TITLEBARFORMATIDLE})
    endif ()
    if (DEFINED ENV{TITLEBARFORMATRUNNING})
      set(TITLE_BAR_FORMAT_RUNNING $ENV{TITLEBARFORMATRUNNING})
    endif ()
    if (DEFINED ENV{DISPLAYVERSION})
      set(DISPLAY_VERSION $ENV{DISPLAYVERSION})
    endif ()

------

