### PR TITLE
ci/windows: Cleanup unused data in submodules before packaging

### DIFF
--- a/.ci/scripts/windows/upload.ps1
+++ b/.ci/scripts/windows/upload.ps1
@@ -25,6 +25,9 @@ $env:BUILD_UPDATE = $MSVC_SEVENZIP
 
 $BUILD_DIR = ".\build\bin\Release"
 
+# Cleanup unneeded data in submodules
+git submodule foreach git clean -fxd
+
 # Upload debugging symbols
 mkdir pdb
 Get-ChildItem "$BUILD_DIR\" -Recurse -Filter "*.pdb" | Copy-Item -destination .\pdb


### PR DESCRIPTION
vcpkg data takes up a lot of space, and currently the scripts will package all that data with the source archive which is unnecessary.