### PR TITLE
ci,transifex: enable vcpkg on transifex step

### DIFF
--- a/.ci/scripts/transifex/docker.sh
+++ b/.ci/scripts/transifex/docker.sh
@@ -16,8 +16,11 @@ cmake --version
 gcc -v
 tx --version
 
+# vcpkg needs these: curl zip unzip tar, have tar
+apt-get install -y curl zip unzip
+
 mkdir build && cd build
-cmake .. -DENABLE_QT_TRANSLATION=ON -DGENERATE_QT_TRANSLATION=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_SDL2=OFF
+cmake .. -DENABLE_QT_TRANSLATION=ON -DGENERATE_QT_TRANSLATION=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_SDL2=OFF -DYUZU_TESTS=OFF -DYUZU_USE_BUNDLED_VCPKG=ON
 make translation
 cd ..
 


### PR DESCRIPTION
The slim docker container that runs transifex needs a few packages added
in, curl zip unzip

I've tested everything except actually pushing to transifex, but it's
not November 2022 yet so we're fine for now. Or we're actually using the
newer client and all is well.

-------

I just noticed that I didn't mention that vcpkg wants tar, but we have tar, I'm not editing the commit message for that 😛 