### PR TITLE
ci/linux: Exclude libwayland-client from AppImage

### DIFF
--- a/.ci/scripts/linux/docker.sh
+++ b/.ci/scripts/linux/docker.sh
@@ -51,6 +51,9 @@ mkdir -p AppDir/usr/optional/libgcc_s
 # Deploy yuzu's needed dependencies
 ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin qt
 
+# Workaround for libQt5MultimediaGstTools indirectly requiring libwayland-client and breaking Vulkan usage on end-user systems
+find AppDir -type f -regex '.*libwayland-client\.so.*' -delete -print
+
 # Workaround for building yuzu with GCC 10 but also trying to distribute it to Ubuntu 18.04 et al.
 # See https://github.com/darealshinji/AppImageKit-checkrt
 cp exec-x86_64.so AppDir/usr/optional/exec.so


### PR DESCRIPTION
This library causes issues in Vulkan driver detection. libQt5Multimedia's dependencies seem to be the issue.

If excluding this library causes larger issues (i.e. the AppImage doesn't work on end-user systems), removing Qt5Multimedia altogether may be necessary.

Please wait for me to verify CI output.