### PR TITLE
[Coretiming/NVNFlinger] Improve multi-core vsync timing, and core timing accuracy

### DIFF
--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -54,6 +54,10 @@ public:
         is_set = false;
     }
 
+    [[nodiscard]] bool IsSet() {
+        return is_set;
+    }
+
 private:
     std::condition_variable condvar;
     std::mutex mutex;

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -143,13 +143,17 @@ void CoreTiming::ScheduleLoopingEvent(std::chrono::nanoseconds start_time,
                                       std::chrono::nanoseconds resched_time,
                                       const std::shared_ptr<EventType>& event_type,
                                       std::uintptr_t user_data, bool absolute_time) {
-    std::scoped_lock scope{basic_lock};
-    const auto next_time{absolute_time ? start_time : GetGlobalTimeNs() + start_time};
+    {
+        std::scoped_lock scope{basic_lock};
+        const auto next_time{absolute_time ? start_time : GetGlobalTimeNs() + start_time};
 
-    event_queue.emplace_back(
-        Event{next_time.count(), event_fifo_id++, user_data, event_type, resched_time.count()});
+        event_queue.emplace_back(
+            Event{next_time.count(), event_fifo_id++, user_data, event_type, resched_time.count()});
 
-    std::push_heap(event_queue.begin(), event_queue.end(), std::greater<>());
+        std::push_heap(event_queue.begin(), event_queue.end(), std::greater<>());
+    }
+
+    event.Set();
 }
 
 void CoreTiming::UnscheduleEvent(const std::shared_ptr<EventType>& event_type,

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -126,11 +126,14 @@ private:
     u32 swap_interval = 1;
 
     /// Event that handles screen composition.
-    std::shared_ptr<Core::Timing::EventType> composition_event;
+    std::shared_ptr<Core::Timing::EventType> multi_composition_event;
+    std::shared_ptr<Core::Timing::EventType> single_composition_event;
 
     std::shared_ptr<std::mutex> guard;
 
     Core::System& system;
+
+    std::atomic<bool> vsync_signal;
 
     std::jthread vsync_thread;
 


### PR DESCRIPTION
This re-works the vsync timing a bit for multi-core. After the core timing changes to make it more accurate, we can now use it for vsync flipping as well, which is an improvement over the current sleep method. 

Games in multicore should now be smoother, some quite noticeably (XC2), and can also boost FPS as well (again noticeably XC2), and also eliminates the time drift in Smash. 

Also fixes games that get locked to 58 FPS rather than 60, such as Three Hopes. Images courtesy of Dunastique (the frametime bar at the bottom):
Before: 
![unknown2](https://user-images.githubusercontent.com/34639600/181386735-ad9b1dc3-db69-4fe9-b9c0-11764107054d.png)

After:
 ![unknown](https://user-images.githubusercontent.com/34639600/181386739-dafa91fd-526a-4fa0-8467-dcd8ede03bf5.png)
