### PR TITLE
externals: Use GitHub for FFmpeg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = https://github.com/yhirose/cpp-httplib.git
 [submodule "ffmpeg"]
 	path = externals/ffmpeg/ffmpeg
-	url = https://git.ffmpeg.org/ffmpeg.git
+	url = https://github.com/FFmpeg/FFmpeg.git
 [submodule "vcpkg"]
 	path = externals/vcpkg
 	url = https://github.com/Microsoft/vcpkg.git


### PR DESCRIPTION
FFmpeg's own git repo seems to be down, so switch to GitHub like we use for most externals.

The FFmpeg external should still be set to n4.3.1.