### PR TITLE
[Audio] Avoid an out-of-bounds span write in depop prepare

### DIFF
--- a/src/audio_core/renderer/command/command_buffer.cpp
+++ b/src/audio_core/renderer/command/command_buffer.cpp
@@ -339,7 +339,7 @@ void CommandBuffer::GenerateDepopPrepareCommand(const s32 node_id, const VoiceSt
     cmd.previous_samples = memory_pool->Translate(CpuAddr(voice_state.previous_samples.data()),
                                                   MaxMixBuffers * sizeof(s32));
     cmd.buffer_count = buffer_count;
-    cmd.depop_buffer = memory_pool->Translate(CpuAddr(buffer.data()), buffer_count * sizeof(s32));
+    cmd.depop_buffer = memory_pool->Translate(CpuAddr(buffer.data()), buffer.size_bytes());
 
     GenerateEnd<DepopPrepareCommand>(cmd);
 }

--- a/src/audio_core/renderer/command/mix/depop_prepare.cpp
+++ b/src/audio_core/renderer/command/mix/depop_prepare.cpp
@@ -19,7 +19,7 @@ void DepopPrepareCommand::Dump([[maybe_unused]] const ADSP::CommandListProcessor
 
 void DepopPrepareCommand::Process(const ADSP::CommandListProcessor& processor) {
     auto samples{reinterpret_cast<s32*>(previous_samples)};
-    auto buffer{std::span(reinterpret_cast<s32*>(depop_buffer), buffer_count)};
+    auto buffer{reinterpret_cast<s32*>(depop_buffer)};
 
     for (u32 i = 0; i < buffer_count; i++) {
         if (samples[i]) {


### PR DESCRIPTION
The buffer count isn't all of the available mix buffers, and the indexes don't start at 0, so you can have say, 40 mix buffers, but a buffer count of 6, and the inputs of those 6 buffers could be 12/13/14/15/16/17, which is out of bounds for a 6 buffer span that only considered buffers 0-5.

There wasn't any *actual* out of bounds writing here, the underlying buffer is big enough, just the reinterpreted span being too small, so just make it a pointer instead.

Fixes https://github.com/flathub/org.yuzu_emu.yuzu/issues/582#issuecomment-1197358199