### PR TITLE
externals: Use yuzu-emu/discord-rpc to provide Discord integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/libusb/libusb.git
 [submodule "discord-rpc"]
     path = externals/discord-rpc
-    url = https://github.com/discord/discord-rpc.git
+    url = https://github.com/yuzu-emu/discord-rpc.git
 [submodule "Vulkan-Headers"]
     path = externals/Vulkan-Headers
     url = https://github.com/KhronosGroup/Vulkan-Headers.git


### PR DESCRIPTION
Our fork includes a commit to disable clang-format, preventing the dirty flag from being set when building yuzu on CI.