### PR TITLE
common: move forwarded value into SPSCQueue

### DIFF
--- a/src/common/threadsafe_queue.h
+++ b/src/common/threadsafe_queue.h
@@ -39,7 +39,7 @@ public:
     template <typename Arg>
     void Push(Arg&& t) {
         // create the element, add it to the queue
-        write_ptr->current = std::forward<Arg>(t);
+        write_ptr->current = std::move(t);
         // set the next pointer to a new element ptr
         // then advance the write pointer
         ElementPtr* new_ptr = new ElementPtr();


### PR DESCRIPTION
Fixes a -Wmaybe-uninitialized on gcc 12.1. I don't have the energy to file another upstream bug report at this point given that none of the previously filed issues have been fixed.