### PR TITLE
ci: use dep5 for GitHub issue template files

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -104,3 +104,11 @@ License: GPL-2.0-or-later
 Files: vcpkg.json
 Copyright: 2022 yuzu Emulator Project
 License: GPL-3.0-or-later
+
+Files: .github/ISSUE_TEMPLATE/config.yml
+Copyright: 2020 tgsm <doodrabbit@hotmail.com>
+License: GPL-2.0-or-later
+
+Files: .github/ISSUE_TEMPLATE/bug-report-feature-request.md
+Copyright: 2016 MerryMage
+License: GPL-2.0-or-later


### PR DESCRIPTION
Adding comments to these files completely removes the ability to file issues.