### PR TITLE
[SPIRV] Add missed shader defines

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1306,7 +1306,7 @@ void EmitContext::DefineInputs(const IR::Program& program) {
         subgroup_mask_gt = DefineInput(*this, U32[4], false, spv::BuiltIn::SubgroupGtMaskKHR);
         subgroup_mask_ge = DefineInput(*this, U32[4], false, spv::BuiltIn::SubgroupGeMaskKHR);
     }
-    if (info.uses_subgroup_invocation_id || info.uses_subgroup_shuffles ||
+    if (info.uses_fswzadd || info.uses_subgroup_invocation_id || info.uses_subgroup_shuffles ||
         (profile.warp_size_potentially_larger_than_guest &&
          (info.uses_subgroup_vote || info.uses_subgroup_mask))) {
         subgroup_local_invocation_id =
@@ -1411,7 +1411,8 @@ void EmitContext::DefineInputs(const IR::Program& program) {
 void EmitContext::DefineOutputs(const IR::Program& program) {
     const Info& info{program.info};
     const std::optional<u32> invocations{program.invocations};
-    if (info.stores.AnyComponent(IR::Attribute::PositionX) || stage == Stage::VertexB) {
+    if (runtime_info.convert_depth_mode || info.stores.AnyComponent(IR::Attribute::PositionX) ||
+        stage == Stage::VertexB) {
         output_position = DefineOutput(*this, F32[4], invocations, spv::BuiltIn::Position);
     }
     if (info.stores[IR::Attribute::PointSize] || runtime_info.fixed_state_point_size) {


### PR DESCRIPTION
FSwizzleAdd uses subgroup_local_invocation_id, and ConvertDepthMode uses output_position, but they weren't being set, resulting in some invalid shader opcodes which crashed Vulkan. 

This allows Xenoblade Chronicles 3 to boot with Vulkan. All credits to @liamwhite for this, I was just a guinea pig.