### PR TITLE
video_core: stop waiting for shader compilation on user cancel

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -299,7 +299,7 @@ void ShaderCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading,
     state.has_loaded = true;
     lock.unlock();
 
-    workers->WaitForRequests();
+    workers->WaitForRequests(stop_loading);
     if (!use_asynchronous_shaders) {
         workers.reset();
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -452,7 +452,7 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
     state.has_loaded = true;
     lock.unlock();
 
-    workers.WaitForRequests();
+    workers.WaitForRequests(stop_loading);
 
     if (state.statistics) {
         state.statistics->Report();


### PR DESCRIPTION
This is very annoying while testing fixes for XC3, which compiles thousands of shaders on boot.