### PR TITLE
renderer_opengl: delete shader source after linking

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -17,6 +17,7 @@ static OGLProgram LinkSeparableProgram(GLuint shader) {
     glProgramParameteri(program.handle, GL_PROGRAM_SEPARABLE, GL_TRUE);
     glAttachShader(program.handle, shader);
     glLinkProgram(program.handle);
+    glDetachShader(program.handle, shader);
     if (!Settings::values.renderer_debug) {
         return program;
     }


### PR DESCRIPTION
Improves memory usage a little bit in XC3 when using OpenGL.
before
![Screenshot from 2022-07-30 12-34-10](https://user-images.githubusercontent.com/9658600/181932863-cb257ecc-5f4a-4a01-a0be-798e2de21635.png)
after
![Screenshot from 2022-07-30 12-38-29](https://user-images.githubusercontent.com/9658600/181932970-a89ad3d8-b952-466c-853c-fc7aab058998.png)
