### PR TITLE
ci: Graft source when archiving

### DIFF
--- a/.ci/scripts/common/post-upload.sh
+++ b/.ci/scripts/common/post-upload.sh
@@ -8,7 +8,8 @@ cp LICENSE.txt "$DIR_NAME"
 cp README.md "$DIR_NAME"
 
 if [[ -z "${NO_SOURCE_PACK}" ]]; then
-  tar -cJvf "${REV_NAME}-source.tar.xz" src externals CMakeLists.txt README.md LICENSE.txt
+  git clone --depth 1 file://$(readlink -e .) ${REV_NAME}-source
+  tar -cJvf "${REV_NAME}-source.tar.xz" ${REV_NAME}-source
   cp -v "${REV_NAME}-source.tar.xz" "$DIR_NAME"
 fi
 

--- a/.ci/scripts/common/post-upload.sh
+++ b/.ci/scripts/common/post-upload.sh
@@ -11,6 +11,7 @@ if [[ -z "${NO_SOURCE_PACK}" ]]; then
   git clone --depth 1 file://$(readlink -e .) ${REV_NAME}-source
   tar -cJvf "${REV_NAME}-source.tar.xz" ${REV_NAME}-source
   cp -v "${REV_NAME}-source.tar.xz" "$DIR_NAME"
+  cp -v "${REV_NAME}-source.tar.xz" "${ARTIFACTS_DIR}/"
 fi
 
 tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$DIR_NAME"

--- a/.ci/scripts/windows/upload.ps1
+++ b/.ci/scripts/windows/upload.ps1
@@ -42,14 +42,10 @@ mkdir $RELEASE_DIST
 mkdir $MSVC_SOURCE
 mkdir "artifacts"
 
+$CURRENT_DIR = Convert-Path .
+
 # Build a tar.xz for the source of the release
-Copy-Item .\LICENSE.txt -Destination $MSVC_SOURCE
-Copy-Item .\README.md -Destination $MSVC_SOURCE
-Copy-Item .\CMakeLists.txt -Destination $MSVC_SOURCE
-Copy-Item .\src -Recurse -Destination $MSVC_SOURCE
-Copy-Item .\externals -Recurse -Destination $MSVC_SOURCE
-Copy-Item .\dist -Recurse -Destination $MSVC_SOURCE
-Copy-Item .\CMakeModules -Recurse -Destination $MSVC_SOURCE
+git clone --depth 1 file://$CURRENT_DIR $MSVC_SOURCE
 7z a -r -ttar $MSVC_SOURCE_TAR $MSVC_SOURCE
 7z a -r -txz $MSVC_SOURCE_TARXZ $MSVC_SOURCE_TAR
 


### PR DESCRIPTION
Instead of including yuzu and all the sources it uses directly, include only what specifically belongs to yuzu. Submodules can be downloaded separately later using git since a shallow clone includes minimally all the repository information needed for it.

Shrinks the source archive down from about 32 MB at time of writing to about 8 MB, both numbers after XZ compression.