### PR TITLE
Controller bugfixes in profile select applet

### DIFF
--- a/src/yuzu/applets/qt_profile_select.cpp
+++ b/src/yuzu/applets/qt_profile_select.cpp
@@ -100,6 +100,7 @@ QtProfileSelectionDialog::QtProfileSelectionDialog(Core::HID::HIDCore& hid_core,
                 }
                 QKeyEvent* event = new QKeyEvent(QEvent::KeyPress, key, Qt::NoModifier);
                 QCoreApplication::postEvent(tree_view, event);
+                SelectUser(tree_view->currentIndex());
             });
 
     const auto& profiles = profile_manager->GetAllUsers();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1588,17 +1588,18 @@ bool GMainWindow::LoadROM(const QString& filename, u64 program_id, std::size_t p
     return true;
 }
 
-void GMainWindow::SelectAndSetCurrentUser() {
+bool GMainWindow::SelectAndSetCurrentUser() {
     QtProfileSelectionDialog dialog(system->HIDCore(), this);
     dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
                           Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
     dialog.setWindowModality(Qt::WindowModal);
 
     if (dialog.exec() == QDialog::Rejected) {
-        return;
+        return false;
     }
 
     Settings::values.current_user = dialog.GetIndex();
+    return true;
 }
 
 void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t program_index,
@@ -1632,7 +1633,8 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
     Settings::LogSettings();
 
     if (UISettings::values.select_user_on_boot) {
-        SelectAndSetCurrentUser();
+        if (SelectAndSetCurrentUser() == false)
+            return;
     }
 
     if (!LoadROM(filename, program_id, program_index))

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -218,7 +218,7 @@ private:
     void SetDiscordEnabled(bool state);
     void LoadAmiibo(const QString& filename);
 
-    void SelectAndSetCurrentUser();
+    bool SelectAndSetCurrentUser();
 
     /**
      * Stores the filename in the recently loaded files list.


### PR DESCRIPTION
2 fixes for using a controller in profile select dialog.
1) Pressing 'B' cancels the launch of the game
2) Using controller to select a profile now correctly sets the index to use for the launch