### PR TITLE
Qt5 work around for suzhou numerals

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -4067,6 +4067,15 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
     QApplication app(argc, argv);
 
+    // Workaround for QTBUG-85409, for Suzhou numerals the number 1 is actually \u3021
+    // so we can see if we get \u3008 instead
+    // TL;DR all other number formats are consecutive in unicode code points
+    // This bug is fixed in Qt6, specifically 6.0.0-alpha1
+    const QLocale locale = QLocale::system();
+    if (QStringLiteral("\u3008") == locale.toString(1)) {
+        QLocale::setDefault(QLocale::system().name());
+    }
+
     // Qt changes the locale and causes issues in float conversion using std::to_string() when
     // generating shaders
     setlocale(LC_ALL, "C");


### PR DESCRIPTION
When windows is told to display Standard digits as suzhou, it is showing
incorrect information in yuzu, file sizes and the CPU speed limiter are
effected by this. See #8698 for some screenshots.

Setting number format to Chinese (Simplified, Hong Kong SAR) is one
way to see this issue in action.

Fixes #8698

--------
![image](https://user-images.githubusercontent.com/190571/182765902-a2022c97-fbb6-4982-985d-c65d6ffed03a.png)
