### PR TITLE
hid: core: Properly emulate controller color and battery level

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -84,17 +84,18 @@ void EmulatedController::ReloadFromSettings() {
         motion_params[index] = Common::ParamPackage(player.motions[index]);
     }
 
+    controller.colors_state.fullkey = {
+        .body = GetNpadColor(player.body_color_left),
+        .button = GetNpadColor(player.button_color_left),
+    };
     controller.colors_state.left = {
-        .body = player.body_color_left,
-        .button = player.button_color_left,
+        .body = GetNpadColor(player.body_color_left),
+        .button = GetNpadColor(player.button_color_left),
     };
-
-    controller.colors_state.right = {
-        .body = player.body_color_right,
-        .button = player.button_color_right,
+    controller.colors_state.left = {
+        .body = GetNpadColor(player.body_color_right),
+        .button = GetNpadColor(player.button_color_right),
     };
-
-    controller.colors_state.fullkey = controller.colors_state.left;
 
     // Other or debug controller should always be a pro controller
     if (npad_id_type != NpadIdType::Other) {
@@ -1308,6 +1309,15 @@ BatteryLevelState EmulatedController::GetBattery() const {
 const CameraState& EmulatedController::GetCamera() const {
     std::scoped_lock lock{mutex};
     return controller.camera_state;
+}
+
+NpadColor EmulatedController::GetNpadColor(u32 color) {
+    return {
+        .r = static_cast<u8>((color >> 16) & 0xFF),
+        .g = static_cast<u8>((color >> 8) & 0xFF),
+        .b = static_cast<u8>(color & 0xFF),
+        .a = 0xff,
+    };
 }
 
 void EmulatedController::TriggerOnChange(ControllerTriggerType type, bool is_npad_service_update) {

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -425,6 +425,13 @@ private:
     void SetCamera(const Common::Input::CallbackStatus& callback);
 
     /**
+     * Converts a color format from bgra to rgba
+     * @param color in bgra format
+     * @return NpadColor in rgba format
+     */
+    NpadColor GetNpadColor(u32 color);
+
+    /**
      * Triggers a callback that something has changed on the controller status
      * @param type Input type of the event to trigger
      * @param is_service_update indicates if this event should only be sent to HID services

--- a/src/core/hid/hid_types.h
+++ b/src/core/hid/hid_types.h
@@ -327,10 +327,18 @@ struct TouchState {
 };
 static_assert(sizeof(TouchState) == 0x28, "Touchstate is an invalid size");
 
+struct NpadColor {
+    u8 r{};
+    u8 g{};
+    u8 b{};
+    u8 a{};
+};
+static_assert(sizeof(NpadColor) == 4, "NpadColor is an invalid size");
+
 // This is nn::hid::NpadControllerColor
 struct NpadControllerColor {
-    u32 body{};
-    u32 button{};
+    NpadColor body{};
+    NpadColor button{};
 };
 static_assert(sizeof(NpadControllerColor) == 8, "NpadControllerColor is an invalid size");
 


### PR DESCRIPTION
~~The invested time to figure out this issue can't be correlated to the line changed. Qt provided alpha values for the controller color. The switch doesn't have alpha values for the controllers.~~

Properly reports battery and controller colors depending on the controller type.

Fixes Mario Party Superstars displaying the wrong controller icon.
![image](https://user-images.githubusercontent.com/5944268/183232105-83a1cd31-dff4-4a43-92e7-d507d5552590.png)
