### PR TITLE
vcpkg,yuzu: Update to fmt 9.0.0

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -1089,8 +1089,8 @@ QStringList GRenderWindow::GetUnsupportedGLExtensions() const {
     }
 
     if (!unsupported_ext.empty()) {
-        LOG_ERROR(Frontend, "GPU does not support all required extensions: {}",
-                  glGetString(GL_RENDERER));
+        const std::string gl_renderer{reinterpret_cast<const char*>(glGetString(GL_RENDERER))};
+        LOG_ERROR(Frontend, "GPU does not support all required extensions: {}", gl_renderer);
     }
     for (const QString& ext : unsupported_ext) {
         LOG_ERROR(Frontend, "Unsupported GL extension: {}", ext.toStdString());

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3338,7 +3338,8 @@ void GMainWindow::MigrateConfigFiles() {
         }
         const auto origin = config_dir_fs_path / filename;
         const auto destination = config_dir_fs_path / "custom" / filename;
-        LOG_INFO(Frontend, "Migrating config file from {} to {}", origin, destination);
+        LOG_INFO(Frontend, "Migrating config file from {} to {}", origin.string(),
+                 destination.string());
         if (!Common::FS::RenameFile(origin, destination)) {
             // Delete the old config file if one already exists in the new location.
             Common::FS::RemoveFile(origin);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
     "name": "yuzu",
-    "builtin-baseline": "cef0b3ec767df6e83806899fe9525f6cf8d7bc91",
+    "builtin-baseline": "9b22b40c6c61bf0da2d46346dd44a11e90972cc9",
     "version": "1.0",
     "dependencies": [
         "boost-algorithm",
@@ -37,6 +37,10 @@
         {
             "name": "catch2",
             "version": "2.13.9"
+        },
+        {
+            "name": "fmt",
+            "version": "9.0.0"
         }
     ]
 }


### PR DESCRIPTION
Soft-requires #8675 to fix build issues
Also of note is yuzu-emu/build-environments#58

The build environments completed their routine update last night, and vcpkg updated their fmt to 9.0.0. Since we probably want to move to fmt 9.0.0 anyway, this fixes the couple of compile issues we had with that version.

This also specifies the fmt version that we want to use in the vcpkg.json. At the moment there is no later version of fmt, but this helps keep things in our control should we update vcpkg and builtin-baseline later.