### PR TITLE
Make vsync setting work for Vulkan

### DIFF
--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -33,9 +33,10 @@ VkSurfaceFormatKHR ChooseSwapSurfaceFormat(vk::Span<VkSurfaceFormatKHR> formats)
 }
 
 VkPresentModeKHR ChooseSwapPresentMode(vk::Span<VkPresentModeKHR> modes) {
-    // Mailbox doesn't lock the application like fifo (vsync), prefer it
+    // Mailbox (triple buffering) doesn't lock the application like fifo (vsync),
+    // prefer it if vsync option is not selected
     const auto found_mailbox = std::find(modes.begin(), modes.end(), VK_PRESENT_MODE_MAILBOX_KHR);
-    if (found_mailbox != modes.end()) {
+    if (found_mailbox != modes.end() && !Settings::values.use_vsync.GetValue()) {
         return VK_PRESENT_MODE_MAILBOX_KHR;
     }
     if (!Settings::values.use_speed_limit.GetValue()) {

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -75,7 +75,7 @@
            <string>VSync prevents the screen from tearing, but some graphics cards have lower performance with VSync enabled. Keep it enabled if you don't notice a performance difference.</string>
           </property>
           <property name="text">
-           <string>Use VSync (OpenGL only)</string>
+           <string>Use VSync</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The Vulkan renderer does not support setting vsync.   It currently prefers mailbox (Triple buffering) mode if found. 

Mailbox mode avoids tearing, but it has a downside: it does not keep the emulation in sync with the real display.   If the emulation and display are very close to precise sync, there can be fits of juddering when the newly generated frames don't decisively fall as next in the display's sequence.  

Related to issue #7310.   I experienced the same behavior as [DelghLay](https://github.com/DelghLay).   Yuzu shows a rock solid 60fps, but on my setup, the display judders for ~30 seconds or so every few minutes.   After switching the code to use FIFO mode, the issue goes away completely and scrolling games like Metroid Dread and Link's Awakening become butter smooth.   I'm using the existing vsync checkbox so I can still disable it for less performant titles. 

A better fix would be to give access to more vulkan swap mode options.  
