### PR TITLE
Qt: tweak ui files

### DIFF
--- a/src/yuzu/aboutdialog.ui
+++ b/src/yuzu/aboutdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>616</width>
-    <height>261</height>
+    <height>294</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -165,6 +165,7 @@ p, li { white-space: pre-wrap; }
  </widget>
  <resources>
   <include location="../../dist/qt_themes_default/default/default.qrc"/>
+  <include location="../../dist/qt_themes/default/default.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/yuzu/multiplayer/direct_connect.ui
+++ b/src/yuzu/multiplayer/direct_connect.ui
@@ -83,7 +83,7 @@
                <number>5</number>
               </property>
               <property name="placeholderText">
-               <string>24872</string>
+               <string notr="true" extracomment="placeholder string that tells user default port">24872</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
make about dialog a bit taller for full message on more systems

for direct_connect.ui hedging bets here, there is a text field for port
number that possibly shouldn't be translated, marking as such, but also
adding a translation note for the event that it makes sense to translate
the placeholder text to something other than the default multiplayer
direct connect port.

------

It might make sense to look into a unified font between Windows/Linux to reduce the need to tweak the GUI beyond what is done on Windows, but sometimes its fun to embrace chaos

![image](https://user-images.githubusercontent.com/190571/183642791-0ad377e0-f7f7-4b18-8a68-bd95638b5ac5.png)

![image](https://user-images.githubusercontent.com/190571/183642878-2bde9a6e-9ef6-44aa-ab7e-37de52b4847a.png)

direct_connect.ui in Qt Creator, it's that 24872 that GillianMC and I think shouldn't be translated.
![image](https://user-images.githubusercontent.com/190571/183644729-22802a45-8905-4a5a-b126-b1352e45e923.png)




