### PR TITLE
arm_dynarmic: Fix nullptr fastmem arenas

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -195,14 +195,16 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
     if (page_table) {
         config.page_table = reinterpret_cast<std::array<std::uint8_t*, NUM_PAGE_TABLE_ENTRIES>*>(
             page_table->pointers.data());
+        config.absolute_offset_page_table = true;
+        config.page_table_pointer_mask_bits = Common::PageTable::ATTRIBUTE_BITS;
+        config.detect_misaligned_access_via_page_table = 16 | 32 | 64 | 128;
+        config.only_detect_misalignment_via_page_table_on_page_boundary = true;
+
         config.fastmem_pointer = page_table->fastmem_arena;
+
+        config.fastmem_exclusive_access = config.fastmem_pointer != nullptr;
+        config.recompile_on_exclusive_fastmem_failure = true;
     }
-    config.absolute_offset_page_table = true;
-    config.page_table_pointer_mask_bits = Common::PageTable::ATTRIBUTE_BITS;
-    config.detect_misaligned_access_via_page_table = 16 | 32 | 64 | 128;
-    config.only_detect_misalignment_via_page_table_on_page_boundary = true;
-    config.fastmem_exclusive_access = true;
-    config.recompile_on_exclusive_fastmem_failure = true;
 
     // Multi-process state
     config.processor_id = core_index;
@@ -254,6 +256,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
         }
         if (!Settings::values.cpuopt_fastmem) {
             config.fastmem_pointer = nullptr;
+            config.fastmem_exclusive_access = false;
         }
         if (!Settings::values.cpuopt_fastmem_exclusives) {
             config.fastmem_exclusive_access = false;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -250,7 +250,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
         config.fastmem_address_space_bits = address_space_bits;
         config.silently_mirror_fastmem = false;
 
-        config.fastmem_exclusive_access = true;
+        config.fastmem_exclusive_access = config.fastmem_pointer != nullptr;
         config.recompile_on_exclusive_fastmem_failure = true;
     }
 
@@ -314,6 +314,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
         }
         if (!Settings::values.cpuopt_fastmem) {
             config.fastmem_pointer = nullptr;
+            config.fastmem_exclusive_access = false;
         }
         if (!Settings::values.cpuopt_fastmem_exclusives) {
             config.fastmem_exclusive_access = false;


### PR DESCRIPTION
Many thanks to @vladkosi for investigating the underlying issue regarding non-functioning on earlier versions of Windows. See: merryhime/dynarmic#701.

On earlier versions of Windows, because they do not support modern memory allocation APIs, the fastmem pointer would be nullptr. Yuzu attempts to enable fastmem of exclusive accesses without a valid fastmem arena, which is not a valid state to be in. Dynarmic thus asserts internally when this happens.

Verification would be helpful as I am unable to test this.