### PR TITLE
ips_layer: Delimit parsed hex value string

### DIFF
--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -287,7 +287,8 @@ void IPSwitchCompiler::Parse() {
                     std::copy(value.begin(), value.end(), std::back_inserter(replace));
                 } else {
                     // hex replacement
-                    const auto value = patch_line.substr(9);
+                    const auto value =
+                        patch_line.substr(9, patch_line.find_first_of(" /\r\n", 9) - 9);
                     replace = Common::HexStringToVector(value, is_little_endian);
                 }
 


### PR DESCRIPTION
Delimits the hex value string on spaces, slashes, carriage returns or newlines, allowing for comments to be added in-line.

Thanks to @theboy181 pestering me to fix this :smile: