### PR TITLE
Allow audio volume up to 200%

### DIFF
--- a/src/audio_core/sink/cubeb_sink.cpp
+++ b/src/audio_core/sink/cubeb_sink.cpp
@@ -185,6 +185,9 @@ public:
             constexpr s32 max{std::numeric_limits<s16>::max()};
 
             auto yuzu_volume{Settings::Volume()};
+            if (yuzu_volume > 1.0f) {
+                yuzu_volume = 0.6f + 20 * std::log10(yuzu_volume);
+            }
             auto volume{system_volume * device_volume * yuzu_volume};
 
             if (system_channels == 6 && device_channels == 2) {

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -105,7 +105,7 @@ float Volume() {
     if (values.audio_muted) {
         return 0.0f;
     }
-    return values.volume.GetValue() / 100.0f;
+    return values.volume.GetValue() / static_cast<f32>(values.volume.GetDefault());
 }
 
 void UpdateRescalingInfo() {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -374,7 +374,7 @@ struct Values {
     Setting<std::string> audio_output_device_id{"auto", "output_device"};
     Setting<std::string> audio_input_device_id{"auto", "input_device"};
     Setting<bool> audio_muted{false, "audio_muted"};
-    SwitchableSetting<u8, true> volume{100, 0, 100, "volume"};
+    SwitchableSetting<u8, true> volume{100, 0, 200, "volume"};
     Setting<bool> dump_audio_commands{false, "dump_audio_commands"};
 
     // Core

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -73,7 +73,7 @@ const std::array<int, 2> Config::default_ringcon_analogs{{
 const std::array<UISettings::Shortcut, 22> Config::default_hotkeys{{
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Audio Mute/Unmute")),        QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("Ctrl+M"),  QStringLiteral("Home+Dpad_Right"), Qt::WindowShortcut}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Audio Volume Down")),        QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("-"),       QStringLiteral("Home+Dpad_Down"), Qt::ApplicationShortcut}},
-    {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Audio Volume Up")),          QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("+"),       QStringLiteral("Home+Dpad_Up"), Qt::ApplicationShortcut}},
+    {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Audio Volume Up")),          QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("="),       QStringLiteral("Home+Dpad_Up"), Qt::ApplicationShortcut}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Capture Screenshot")),       QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("Ctrl+P"),  QStringLiteral("Screenshot"), Qt::WidgetWithChildrenShortcut}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Change Adapting Filter")),   QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("F8"),      QStringLiteral("Home+L"), Qt::ApplicationShortcut}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Change Docked Mode")),       QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("F10"),     QStringLiteral("Home+X"), Qt::ApplicationShortcut}},

--- a/src/yuzu/configuration/configure_audio.ui
+++ b/src/yuzu/configuration/configure_audio.ui
@@ -120,10 +120,10 @@
             </sizepolicy>
            </property>
            <property name="maximum">
-            <number>100</number>
+            <number>200</number>
            </property>
            <property name="pageStep">
-            <number>10</number>
+            <number>5</number>
            </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1094,7 +1094,7 @@ void GMainWindow::InitializeHotkeys() {
     connect_shortcut(QStringLiteral("Audio Mute/Unmute"),
                      [] { Settings::values.audio_muted = !Settings::values.audio_muted; });
     connect_shortcut(QStringLiteral("Audio Volume Down"), [] {
-        const auto current_volume = static_cast<int>(Settings::values.volume.GetValue());
+        const auto current_volume = static_cast<s32>(Settings::values.volume.GetValue());
         int step = 5;
         if (current_volume <= 30) {
             step = 2;
@@ -1102,11 +1102,10 @@ void GMainWindow::InitializeHotkeys() {
         if (current_volume <= 6) {
             step = 1;
         }
-        const auto new_volume = std::max(current_volume - step, 0);
-        Settings::values.volume.SetValue(static_cast<u8>(new_volume));
+        Settings::values.volume.SetValue(std::max(current_volume - step, 0));
     });
     connect_shortcut(QStringLiteral("Audio Volume Up"), [] {
-        const auto current_volume = static_cast<int>(Settings::values.volume.GetValue());
+        const auto current_volume = static_cast<s32>(Settings::values.volume.GetValue());
         int step = 5;
         if (current_volume < 30) {
             step = 2;
@@ -1114,8 +1113,7 @@ void GMainWindow::InitializeHotkeys() {
         if (current_volume < 6) {
             step = 1;
         }
-        const auto new_volume = std::min(current_volume + step, 100);
-        Settings::values.volume.SetValue(static_cast<u8>(new_volume));
+        Settings::values.volume.SetValue(current_volume + step);
     });
     connect_shortcut(QStringLiteral("Toggle Framerate Limit"), [] {
         Settings::values.use_speed_limit.SetValue(!Settings::values.use_speed_limit.GetValue());


### PR DESCRIPTION
Requested by a couple people, allows the volume slider to go up to 200%. Also changes the default volume up key from + to =. It was weird that for volume down you just press -, but volume up required shift+=. Changing the key from + to = lets you skip the shift, as was originally intended I think.