### PR TITLE
common: remove unneeded x86-specific header

### DIFF
--- a/src/common/uint128.h
+++ b/src/common/uint128.h
@@ -12,7 +12,6 @@
 #pragma intrinsic(_udiv128)
 #else
 #include <cstring>
-#include <x86intrin.h>
 #endif
 
 #include "common/common_types.h"


### PR DESCRIPTION
This header does not seem to be needed, and also removing it may allow some parts of yuzu to compile on non-x86 devices.