### PR TITLE
cmake: make __FILE__ macro value relative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,6 +528,11 @@ if (MSVC AND CMAKE_GENERATOR STREQUAL "Ninja")
     )
 endif()
 
+# Set __FILE__ macro value to a relative path for reproducible builds
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    add_compile_options("-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=.")
+endif()
+
 enable_testing()
 add_subdirectory(externals)
 add_subdirectory(src)


### PR DESCRIPTION
By default the `__FILE__` macro used in `src/common/atomic_helpers.h` and `src/common/logging/log.h` contains the full path of the build directory. Use the `-fmacro-prefix-map` flag (supported by Clang and GCC) to make this path relative and allow reproducible builds.