### PR TITLE
core/file_sys: fix BuildId padding in patch loading

### DIFF
--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -217,9 +217,7 @@ void IPSwitchCompiler::Parse() {
             break;
         } else if (StartsWith(line, "@nsobid-")) {
             // NSO Build ID Specifier
-            auto raw_build_id = line.substr(8);
-            if (raw_build_id.size() != 0x40)
-                raw_build_id.resize(0x40, '0');
+            const auto raw_build_id = fmt::format("{:0>64}", line.substr(8));
             nso_build_id = Common::HexStringToArray<0x20>(raw_build_id);
         } else if (StartsWith(line, "#")) {
             // Mandatory Comment

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -191,6 +191,7 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
 std::vector<VirtualFile> PatchManager::CollectPatches(const std::vector<VirtualDir>& patch_dirs,
                                                       const std::string& build_id) const {
     const auto& disabled = Settings::values.disabled_addons[title_id];
+    const auto nso_build_id = fmt::format("{:0>64}", build_id);
 
     std::vector<VirtualFile> out;
     out.reserve(patch_dirs.size());
@@ -203,21 +204,18 @@ std::vector<VirtualFile> PatchManager::CollectPatches(const std::vector<VirtualD
             for (const auto& file : exefs_dir->GetFiles()) {
                 if (file->GetExtension() == "ips") {
                     auto name = file->GetName();
-                    const auto p1 = name.substr(0, name.find('.'));
-                    const auto this_build_id = p1.substr(0, p1.find_last_not_of('0') + 1);
 
-                    if (build_id == this_build_id)
+                    const auto this_build_id =
+                        fmt::format("{:0>64}", name.substr(0, name.find('.')));
+                    if (nso_build_id == this_build_id)
                         out.push_back(file);
                 } else if (file->GetExtension() == "pchtxt") {
                     IPSwitchCompiler compiler{file};
                     if (!compiler.IsValid())
                         continue;
 
-                    auto this_build_id = Common::HexToString(compiler.GetBuildID());
-                    this_build_id =
-                        this_build_id.substr(0, this_build_id.find_last_not_of('0') + 1);
-
-                    if (build_id == this_build_id)
+                    const auto this_build_id = Common::HexToString(compiler.GetBuildID());
+                    if (nso_build_id == this_build_id)
                         out.push_back(file);
                 }
             }


### PR DESCRIPTION
Fixes spurious inability to load patches for NSOs with BuildIds less than 32 bytes long