### PR TITLE
video_core: implement R16G16B16X16 texture format

### DIFF
--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -172,7 +172,7 @@ struct FormatTuple {
     {VK_FORMAT_R8G8_SINT, Attachable | Storage},               // R8G8_SINT
     {VK_FORMAT_R8G8_UINT, Attachable | Storage},               // R8G8_UINT
     {VK_FORMAT_R32G32_UINT, Attachable | Storage},             // R32G32_UINT
-    {VK_FORMAT_UNDEFINED},                                     // R16G16B16X16_FLOAT
+    {VK_FORMAT_R16G16B16A16_SFLOAT, Attachable | Storage},     // R16G16B16X16_FLOAT
     {VK_FORMAT_R32_UINT, Attachable | Storage},                // R32_UINT
     {VK_FORMAT_R32_SINT, Attachable | Storage},                // R32_SINT
     {VK_FORMAT_ASTC_8x8_UNORM_BLOCK},                          // ASTC_2D_8X8_UNORM


### PR DESCRIPTION
Used by Rocket League
|Before|After|
|---------|------|
|![01005ee0036ec000_2022-08-19_14-52-40-454](https://user-images.githubusercontent.com/9658600/185708627-6bf89e1b-3511-49b0-9741-c51841709072.png)|![01005ee0036ec000_2022-08-19_17-07-36-647](https://user-images.githubusercontent.com/9658600/185708663-64f46cbd-c9ed-49b2-a3ca-07b249af9565.png)|
