### PR TITLE
Qt: Retranslate GameList header and Filter line

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -126,10 +126,8 @@ GameListSearchField::GameListSearchField(GameList* parent) : QWidget{parent} {
     layout_filter = new QHBoxLayout;
     layout_filter->setContentsMargins(8, 8, 8, 8);
     label_filter = new QLabel;
-    label_filter->setText(tr("Filter:"));
     edit_filter = new QLineEdit;
     edit_filter->clear();
-    edit_filter->setPlaceholderText(tr("Enter pattern to filter"));
     edit_filter->installEventFilter(key_release_eater);
     edit_filter->setClearButtonEnabled(true);
     connect(edit_filter, &QLineEdit::textChanged, parent, &GameList::OnTextChanged);
@@ -149,6 +147,7 @@ GameListSearchField::GameListSearchField(GameList* parent) : QWidget{parent} {
     layout_filter->addWidget(label_filter_result);
     layout_filter->addWidget(button_filter_close);
     setLayout(layout_filter);
+    RetranslateUI();
 }
 
 /**
@@ -333,13 +332,9 @@ GameList::GameList(FileSys::VirtualFilesystem vfs_, FileSys::ManualContentProvid
     tree_view->setStyleSheet(QStringLiteral("QTreeView{ border: none; }"));
 
     item_model->insertColumns(0, COLUMN_COUNT);
-    item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, tr("Name"));
-    item_model->setHeaderData(COLUMN_COMPATIBILITY, Qt::Horizontal, tr("Compatibility"));
+    RetranslateUI();
 
-    item_model->setHeaderData(COLUMN_ADD_ONS, Qt::Horizontal, tr("Add-ons"));
     tree_view->setColumnHidden(COLUMN_ADD_ONS, !UISettings::values.show_add_ons);
-    item_model->setHeaderData(COLUMN_FILE_TYPE, Qt::Horizontal, tr("File type"));
-    item_model->setHeaderData(COLUMN_SIZE, Qt::Horizontal, tr("Size"));
     item_model->setSortRole(GameListItemPath::SortRole);
 
     connect(main_window, &GMainWindow::UpdateThemedIcons, this, &GameList::OnUpdateThemedIcons);
@@ -751,6 +746,35 @@ void GameList::LoadCompatibilityList() {
                                        std::make_pair(QString::number(compatibility), directory));
         }
     }
+}
+
+void GameList::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void GameList::RetranslateUI() {
+    item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, tr("Name"));
+    item_model->setHeaderData(COLUMN_COMPATIBILITY, Qt::Horizontal, tr("Compatibility"));
+    item_model->setHeaderData(COLUMN_ADD_ONS, Qt::Horizontal, tr("Add-ons"));
+    item_model->setHeaderData(COLUMN_FILE_TYPE, Qt::Horizontal, tr("File type"));
+    item_model->setHeaderData(COLUMN_SIZE, Qt::Horizontal, tr("Size"));
+}
+
+void GameListSearchField::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void GameListSearchField::RetranslateUI() {
+    label_filter->setText(tr("Filter:"));
+    edit_filter->setPlaceholderText(tr("Enter pattern to filter"));
 }
 
 QStandardItemModel* GameList::GetModel() const {

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -140,6 +140,9 @@ private:
     void AddPermDirPopup(QMenu& context_menu, QModelIndex selected);
     void AddFavoritesPopup(QMenu& context_menu);
 
+    void changeEvent(QEvent*) override;
+    void RetranslateUI();
+
     std::shared_ptr<FileSys::VfsFilesystem> vfs;
     FileSys::ManualContentProvider* provider;
     GameListSearchField* search_field;

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -353,6 +353,9 @@ public:
     void setFocus();
 
 private:
+    void changeEvent(QEvent*) override;
+    void RetranslateUI();
+
     class KeyReleaseEater : public QObject {
     public:
         explicit KeyReleaseEater(GameList* gamelist_, QObject* parent = nullptr);


### PR DESCRIPTION
Didn't notice this until I was trying to change the default font
to Comic Sans MS when language is set to English in yuzu.

--------------

yuzu started in chinese, switched to english, ignore the size column, that has been fixed. 
Otherwise Illustrates bug being fixed, also shows PMIngLiU font because this is VM set to chinese
![image](https://user-images.githubusercontent.com/190571/185752567-c6666c65-1b16-4bdb-91eb-63343114c1a0.png)

Not much to look at when fixed. 
![image](https://user-images.githubusercontent.com/190571/185753214-62673915-39ed-40b2-8a46-1efd1b8e42a6.png)
