### PR TITLE
core/file_sys: fix alignment of BuildId

### DIFF
--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -217,7 +217,7 @@ void IPSwitchCompiler::Parse() {
             break;
         } else if (StartsWith(line, "@nsobid-")) {
             // NSO Build ID Specifier
-            const auto raw_build_id = fmt::format("{:0>64}", line.substr(8));
+            const auto raw_build_id = fmt::format("{:0<64}", line.substr(8));
             nso_build_id = Common::HexStringToArray<0x20>(raw_build_id);
         } else if (StartsWith(line, "#")) {
             // Mandatory Comment

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -191,7 +191,7 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
 std::vector<VirtualFile> PatchManager::CollectPatches(const std::vector<VirtualDir>& patch_dirs,
                                                       const std::string& build_id) const {
     const auto& disabled = Settings::values.disabled_addons[title_id];
-    const auto nso_build_id = fmt::format("{:0>64}", build_id);
+    const auto nso_build_id = fmt::format("{:0<64}", build_id);
 
     std::vector<VirtualFile> out;
     out.reserve(patch_dirs.size());
@@ -206,7 +206,7 @@ std::vector<VirtualFile> PatchManager::CollectPatches(const std::vector<VirtualD
                     auto name = file->GetName();
 
                     const auto this_build_id =
-                        fmt::format("{:0>64}", name.substr(0, name.find('.')));
+                        fmt::format("{:0<64}", name.substr(0, name.find('.')));
                     if (nso_build_id == this_build_id)
                         out.push_back(file);
                 } else if (file->GetExtension() == "pchtxt") {


### PR DESCRIPTION
It's aligned to the left, not the right. Oops.