### PR TITLE
Qt: work around Qt5's font choice for Chinese (in Windows)

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -261,6 +261,18 @@ static QString PrettyProductName() {
     return QSysInfo::prettyProductName();
 }
 
+#ifdef _WIN32
+static void OverrideWindowsFont() {
+    // Qt5 chooses these fonts on Windows and they have fairly ugly alphanumeric/cyrllic characters
+    // Asking to use "MS Shell Dlg 2" gives better other chars while leaving the Chinese Characters.
+    const QString startup_font = QApplication::font().family();
+    const QStringList ugly_fonts = {QStringLiteral("SimSun"), QStringLiteral("PMingLiU")};
+    if (ugly_fonts.contains(startup_font)) {
+        QApplication::setFont(QFont(QStringLiteral("MS Shell Dlg 2"), 9, QFont::Normal));
+    }
+}
+#endif
+
 bool GMainWindow::CheckDarkMode() {
 #ifdef __linux__
     const QPalette test_palette(qApp->palette());
@@ -4133,6 +4145,10 @@ int main(int argc, char* argv[]) {
     // Enables the core to make the qt created contexts current on std::threads
     QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
     QApplication app(argc, argv);
+
+#ifdef _WIN32
+    OverrideWindowsFont();
+#endif
 
     // Workaround for QTBUG-85409, for Suzhou numerals the number 1 is actually \u3021
     // so we can see if we get \u3008 instead


### PR DESCRIPTION
On Windows there are currently two fonts used.

The first, does the Menu, QTreeView and Tooltips
Second is Everything else which is a default font.

From inspecting QApplication::font() at runtime
Windows 10 English: QFont(MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0)
Windows 11 Japanese:        MS UI Gothic,9   ,-1,5,50,0,0,0,0,0
Windows 11 Traditional Chinese: PMingLiU,9   ,-1,5,50,0,0,0,0,0
Windows 11 Simplified Chinese:    SimSun,9   ,-1,5,50,0,0,0,0,0
Windows 11 Korean:                 Gulim,9   ,-1,5,50,0,0,0,0,0

I initially investigated dynamically changing the font when
the UI language is English, but this was getting quite messy

Qt6 makes changes to default font in some situations, so this
PR is being narrowed in scope to only effect Chinese font choices.
This change only effects rendering of Latin/Cyrillic characters.

----

Comparison of the font choices is in this comment: https://github.com/yuzu-emu/yuzu/pull/8807#issuecomment-1229195994

I was originally going to submit this PR using Comic Sans MS,
but at size 9 it was starting to not be noticeable.

This fixes an issue where between Windows and Qt, a font is being
chosen that looks worse than the rest of the OS.

--------------

IBM Plex Mono is most likely the wrong font

TODO
Right click menus
Tooltips
The about box

IBM Plex Mono, English
![image](https://user-images.githubusercontent.com/190571/186204387-d700f0bb-7a0e-4e0b-84ee-6367ff487a85.png)

`\` Character is Japanese yen symbol in that default font.
![image](https://user-images.githubusercontent.com/190571/186206783-b16ed8e3-129d-441f-bd85-77670ddc55b6.png)

Most replacements we would provide would fix this.
![image](https://user-images.githubusercontent.com/190571/186207006-ee268399-f982-4ecc-a177-52ccec1ad756.png)

----
Extra notes
RFN has been removed in Fira fonts, https://github.com/mozilla/Fira/pull/219 in/around May 2019

TTF fonts seem to be able to hold variants in the same TTF, but this is different from a TTC according to `file`

https://github.com/bluescan/proggyfonts <--- MIT
