### PR TITLE
video_core: vulkan: rasterizer: Workaround on viewport swizzle on AMD

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -69,10 +69,17 @@ VkViewport GetViewportState(const Device& device, const Maxwell& regs, size_t in
     const float width = conv(src.scale_x * 2.0f);
     float y = conv(src.translate_y - src.scale_y);
     float height = conv(src.scale_y * 2.0f);
-    if (regs.screen_y_control.y_negate) {
+    bool y_negate = regs.screen_y_control.y_negate;
+
+    if (!device.IsNvViewportSwizzleSupported()) {
+        y_negate = y_negate != (src.swizzle.y == Maxwell::ViewportSwizzle::NegativeY);
+    }
+
+    if (y_negate) {
         y += height;
         height = -height;
     }
+
     const float reduce_z = regs.depth_mode == Maxwell::DepthMode::MinusOneToOne ? 1.0f : 0.0f;
     VkViewport viewport{
         .x = x,


### PR DESCRIPTION
Thanks to bylaws to make this possible. Viewport swizzle is not supported on AMD. Some games where upside down. This PR should fix those errors.
![image](https://user-images.githubusercontent.com/5944268/186285070-4de66368-938a-46ea-822a-fce5efcce1ea.png)

Should fix the following games. Please confirm:
Fixes #7627
Fixes #8056