### PR TITLE
core: nfp: Implement amiibo encryption

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -525,6 +525,9 @@ add_library(core STATIC
     hle/service/ncm/ncm.h
     hle/service/nfc/nfc.cpp
     hle/service/nfc/nfc.h
+    hle/service/nfp/amiibo_crypto.cpp
+    hle/service/nfp/amiibo_crypto.h
+    hle/service/nfp/amiibo_types.h
     hle/service/nfp/nfp.cpp
     hle/service/nfp/nfp.h
     hle/service/nfp/nfp_user.cpp

--- a/src/core/hle/service/am/applets/applet_mii_edit_types.h
+++ b/src/core/hle/service/am/applets/applet_mii_edit_types.h
@@ -32,7 +32,7 @@ enum class MiiEditResult : u32 {
 };
 
 struct MiiEditCharInfo {
-    Service::Mii::MiiInfo mii_info{};
+    Service::Mii::CharInfo mii_info{};
 };
 static_assert(sizeof(MiiEditCharInfo) == 0x58, "MiiEditCharInfo has incorrect size.");
 

--- a/src/core/hle/service/mii/mii.cpp
+++ b/src/core/hle/service/mii/mii.cpp
@@ -43,7 +43,7 @@ public:
             {20, nullptr, "IsBrokenDatabaseWithClearFlag"},
             {21, &IDatabaseService::GetIndex, "GetIndex"},
             {22, &IDatabaseService::SetInterfaceVersion, "SetInterfaceVersion"},
-            {23, nullptr, "Convert"},
+            {23, &IDatabaseService::Convert, "Convert"},
             {24, nullptr, "ConvertCoreDataToCharInfo"},
             {25, nullptr, "ConvertCharInfoToCoreData"},
             {26, nullptr, "Append"},
@@ -130,7 +130,7 @@ private:
             return;
         }
 
-        std::vector<MiiInfo> values;
+        std::vector<CharInfo> values;
         for (const auto& element : *result) {
             values.emplace_back(element.info);
         }
@@ -144,7 +144,7 @@ private:
 
     void UpdateLatest(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
-        const auto info{rp.PopRaw<MiiInfo>()};
+        const auto info{rp.PopRaw<CharInfo>()};
         const auto source_flag{rp.PopRaw<SourceFlag>()};
 
         LOG_DEBUG(Service_Mii, "called with source_flag={}", source_flag);
@@ -156,9 +156,9 @@ private:
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(MiiInfo) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
         rb.Push(ResultSuccess);
-        rb.PushRaw<MiiInfo>(*result);
+        rb.PushRaw<CharInfo>(*result);
     }
 
     void BuildRandom(Kernel::HLERequestContext& ctx) {
@@ -191,9 +191,9 @@ private:
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(MiiInfo) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
         rb.Push(ResultSuccess);
-        rb.PushRaw<MiiInfo>(manager.BuildRandom(age, gender, race));
+        rb.PushRaw<CharInfo>(manager.BuildRandom(age, gender, race));
     }
 
     void BuildDefault(Kernel::HLERequestContext& ctx) {
@@ -210,14 +210,14 @@ private:
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(MiiInfo) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
         rb.Push(ResultSuccess);
-        rb.PushRaw<MiiInfo>(manager.BuildDefault(index));
+        rb.PushRaw<CharInfo>(manager.BuildDefault(index));
     }
 
     void GetIndex(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
-        const auto info{rp.PopRaw<MiiInfo>()};
+        const auto info{rp.PopRaw<CharInfo>()};
 
         LOG_DEBUG(Service_Mii, "called");
 
@@ -237,6 +237,18 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultSuccess);
+    }
+
+    void Convert(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+
+        const auto mii_v3{rp.PopRaw<Ver3StoreData>()};
+
+        LOG_INFO(Service_Mii, "called");
+
+        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
+        rb.Push(ResultSuccess);
+        rb.PushRaw<CharInfo>(manager.ConvertV3ToCharInfo(mii_v3));
     }
 
     constexpr bool IsInterfaceVersionSupported(u32 interface_version) const {

--- a/src/core/hle/service/mii/mii_manager.cpp
+++ b/src/core/hle/service/mii/mii_manager.cpp
@@ -443,8 +443,9 @@ CharInfo MiiManager::ConvertV3ToCharInfo(Ver3StoreData mii_v3) const {
     mii.height = mii_v3.height;
     mii.build = mii_v3.build;
 
+    memset(mii.name.data(), 0, sizeof(mii.name));
+    memcpy(mii.name.data(), mii_v3.mii_name.data(), sizeof(mii_v3.mii_name));
     mii.font_region = mii_v3.region_information.character_set;
-    memcpy(mii.name.data(), mii_v3.mii_name.data(), 10);
 
     mii.faceline_type = mii_v3.appearance_bits1.face_shape;
     mii.faceline_color = mii_v3.appearance_bits1.skin_color;

--- a/src/core/hle/service/mii/mii_manager.cpp
+++ b/src/core/hle/service/mii/mii_manager.cpp
@@ -42,7 +42,7 @@ std::array<T, DestArraySize> ResizeArray(const std::array<T, SourceArraySize>& i
     return out;
 }
 
-MiiInfo ConvertStoreDataToInfo(const MiiStoreData& data) {
+CharInfo ConvertStoreDataToInfo(const MiiStoreData& data) {
     MiiStoreBitFields bf;
     std::memcpy(&bf, data.data.data.data(), sizeof(MiiStoreBitFields));
 
@@ -409,8 +409,8 @@ u32 MiiManager::GetCount(SourceFlag source_flag) const {
     return static_cast<u32>(count);
 }
 
-ResultVal<MiiInfo> MiiManager::UpdateLatest([[maybe_unused]] const MiiInfo& info,
-                                            SourceFlag source_flag) {
+ResultVal<CharInfo> MiiManager::UpdateLatest([[maybe_unused]] const CharInfo& info,
+                                             SourceFlag source_flag) {
     if ((source_flag & SourceFlag::Database) == SourceFlag::None) {
         return ERROR_CANNOT_FIND_ENTRY;
     }
@@ -419,12 +419,88 @@ ResultVal<MiiInfo> MiiManager::UpdateLatest([[maybe_unused]] const MiiInfo& info
     return ERROR_CANNOT_FIND_ENTRY;
 }
 
-MiiInfo MiiManager::BuildRandom(Age age, Gender gender, Race race) {
+CharInfo MiiManager::BuildRandom(Age age, Gender gender, Race race) {
     return ConvertStoreDataToInfo(BuildRandomStoreData(age, gender, race, user_id));
 }
 
-MiiInfo MiiManager::BuildDefault(std::size_t index) {
+CharInfo MiiManager::BuildDefault(std::size_t index) {
     return ConvertStoreDataToInfo(BuildDefaultStoreData(RawData::DefaultMii.at(index), user_id));
+}
+
+CharInfo MiiManager::ConvertV3ToCharInfo(Ver3StoreData mii_v3) const {
+    Service::Mii::MiiManager manager;
+    auto mii = manager.BuildDefault(0);
+
+    // Check if mii data exist
+    if (mii_v3.mii_name[0] == 0) {
+        return mii;
+    }
+
+    // TODO: We are ignoring a bunch of data from the mii_v3
+
+    mii.gender = static_cast<u8>(mii_v3.mii_information.gender);
+    mii.favorite_color = static_cast<u8>(mii_v3.mii_information.favorite_color);
+    mii.height = mii_v3.height;
+    mii.build = mii_v3.build;
+
+    mii.font_region = mii_v3.region_information.character_set;
+    memcpy(mii.name.data(), mii_v3.mii_name.data(), 10);
+
+    mii.faceline_type = mii_v3.appearance_bits1.face_shape;
+    mii.faceline_color = mii_v3.appearance_bits1.skin_color;
+    mii.faceline_wrinkle = mii_v3.appearance_bits2.wrinkles;
+    mii.faceline_make = mii_v3.appearance_bits2.makeup;
+
+    mii.hair_type = mii_v3.hair_style;
+    mii.hair_color = mii_v3.appearance_bits3.hair_color;
+    mii.hair_flip = mii_v3.appearance_bits3.flip_hair;
+
+    mii.eye_type = static_cast<u8>(mii_v3.appearance_bits4.eye_type);
+    mii.eye_color = static_cast<u8>(mii_v3.appearance_bits4.eye_color);
+    mii.eye_scale = static_cast<u8>(mii_v3.appearance_bits4.eye_scale);
+    mii.eye_aspect = static_cast<u8>(mii_v3.appearance_bits4.eye_vertical_stretch);
+    mii.eye_rotate = static_cast<u8>(mii_v3.appearance_bits4.eye_rotation);
+    mii.eye_x = static_cast<u8>(mii_v3.appearance_bits4.eye_spacing);
+    mii.eye_y = static_cast<u8>(mii_v3.appearance_bits4.eye_y_position);
+
+    mii.eyebrow_type = static_cast<u8>(mii_v3.appearance_bits5.eyebrow_style);
+    mii.eyebrow_color = static_cast<u8>(mii_v3.appearance_bits5.eyebrow_color);
+    mii.eyebrow_scale = static_cast<u8>(mii_v3.appearance_bits5.eyebrow_scale);
+    mii.eyebrow_aspect = static_cast<u8>(mii_v3.appearance_bits5.eyebrow_yscale);
+    mii.eyebrow_rotate = static_cast<u8>(mii_v3.appearance_bits5.eyebrow_rotation);
+    mii.eyebrow_x = static_cast<u8>(mii_v3.appearance_bits5.eyebrow_spacing);
+    mii.eyebrow_y = static_cast<u8>(mii_v3.appearance_bits5.eyebrow_y_position);
+
+    mii.nose_type = static_cast<u8>(mii_v3.appearance_bits6.nose_type);
+    mii.nose_scale = static_cast<u8>(mii_v3.appearance_bits6.nose_scale);
+    mii.nose_y = static_cast<u8>(mii_v3.appearance_bits6.nose_y_position);
+
+    mii.mouth_type = static_cast<u8>(mii_v3.appearance_bits7.mouth_type);
+    mii.mouth_color = static_cast<u8>(mii_v3.appearance_bits7.mouth_color);
+    mii.mouth_scale = static_cast<u8>(mii_v3.appearance_bits7.mouth_scale);
+    mii.mouth_aspect = static_cast<u8>(mii_v3.appearance_bits7.mouth_horizontal_stretch);
+    mii.mouth_y = static_cast<u8>(mii_v3.appearance_bits8.mouth_y_position);
+
+    mii.mustache_type = static_cast<u8>(mii_v3.appearance_bits8.mustache_type);
+    mii.mustache_scale = static_cast<u8>(mii_v3.appearance_bits9.mustache_scale);
+    mii.mustache_y = static_cast<u8>(mii_v3.appearance_bits9.mustache_y_position);
+
+    mii.beard_type = static_cast<u8>(mii_v3.appearance_bits9.bear_type);
+    mii.beard_color = static_cast<u8>(mii_v3.appearance_bits9.facial_hair_color);
+
+    mii.glasses_type = static_cast<u8>(mii_v3.appearance_bits10.glasses_type);
+    mii.glasses_color = static_cast<u8>(mii_v3.appearance_bits10.glasses_color);
+    mii.glasses_scale = static_cast<u8>(mii_v3.appearance_bits10.glasses_scale);
+    mii.glasses_y = static_cast<u8>(mii_v3.appearance_bits10.glasses_y_position);
+
+    mii.mole_type = static_cast<u8>(mii_v3.appearance_bits11.mole_enabled);
+    mii.mole_scale = static_cast<u8>(mii_v3.appearance_bits11.mole_scale);
+    mii.mole_x = static_cast<u8>(mii_v3.appearance_bits11.mole_x_position);
+    mii.mole_y = static_cast<u8>(mii_v3.appearance_bits11.mole_y_position);
+
+    // TODO: Validate mii data
+
+    return mii;
 }
 
 ResultVal<std::vector<MiiInfoElement>> MiiManager::GetDefault(SourceFlag source_flag) {
@@ -441,7 +517,7 @@ ResultVal<std::vector<MiiInfoElement>> MiiManager::GetDefault(SourceFlag source_
     return result;
 }
 
-Result MiiManager::GetIndex([[maybe_unused]] const MiiInfo& info, u32& index) {
+Result MiiManager::GetIndex([[maybe_unused]] const CharInfo& info, u32& index) {
     constexpr u32 INVALID_INDEX{0xFFFFFFFF};
 
     index = INVALID_INDEX;

--- a/src/core/hle/service/mii/mii_manager.h
+++ b/src/core/hle/service/mii/mii_manager.h
@@ -19,11 +19,12 @@ public:
     bool CheckAndResetUpdateCounter(SourceFlag source_flag, u64& current_update_counter);
     bool IsFullDatabase() const;
     u32 GetCount(SourceFlag source_flag) const;
-    ResultVal<MiiInfo> UpdateLatest(const MiiInfo& info, SourceFlag source_flag);
-    MiiInfo BuildRandom(Age age, Gender gender, Race race);
-    MiiInfo BuildDefault(std::size_t index);
+    ResultVal<CharInfo> UpdateLatest(const CharInfo& info, SourceFlag source_flag);
+    CharInfo BuildRandom(Age age, Gender gender, Race race);
+    CharInfo BuildDefault(std::size_t index);
+    CharInfo ConvertV3ToCharInfo(Ver3StoreData mii_v3) const;
     ResultVal<std::vector<MiiInfoElement>> GetDefault(SourceFlag source_flag);
-    Result GetIndex(const MiiInfo& info, u32& index);
+    Result GetIndex(const CharInfo& info, u32& index);
 
 private:
     const Common::UUID user_id{};

--- a/src/core/hle/service/mii/types.h
+++ b/src/core/hle/service/mii/types.h
@@ -86,7 +86,8 @@ enum class SourceFlag : u32 {
 };
 DECLARE_ENUM_FLAG_OPERATORS(SourceFlag);
 
-struct MiiInfo {
+// nn::mii::CharInfo
+struct CharInfo {
     Common::UUID uuid;
     std::array<char16_t, 11> name;
     u8 font_region;
@@ -140,16 +141,16 @@ struct MiiInfo {
     u8 mole_y;
     u8 padding;
 };
-static_assert(sizeof(MiiInfo) == 0x58, "MiiInfo has incorrect size.");
-static_assert(std::has_unique_object_representations_v<MiiInfo>,
-              "All bits of MiiInfo must contribute to its value.");
+static_assert(sizeof(CharInfo) == 0x58, "CharInfo has incorrect size.");
+static_assert(std::has_unique_object_representations_v<CharInfo>,
+              "All bits of CharInfo must contribute to its value.");
 
 #pragma pack(push, 4)
 
 struct MiiInfoElement {
-    MiiInfoElement(const MiiInfo& info_, Source source_) : info{info_}, source{source_} {}
+    MiiInfoElement(const CharInfo& info_, Source source_) : info{info_}, source{source_} {}
 
-    MiiInfo info{};
+    CharInfo info{};
     Source source{};
 };
 static_assert(sizeof(MiiInfoElement) == 0x5c, "MiiInfoElement has incorrect size.");
@@ -242,6 +243,131 @@ struct MiiStoreBitFields {
 static_assert(sizeof(MiiStoreBitFields) == 0x1c, "MiiStoreBitFields has incorrect size.");
 static_assert(std::is_trivially_copyable_v<MiiStoreBitFields>,
               "MiiStoreBitFields is not trivially copyable.");
+
+// This is nn::mii::Ver3StoreData
+// Based on citra HLE::Applets::MiiData and PretendoNetwork.
+// https://github.com/citra-emu/citra/blob/master/src/core/hle/applets/mii_selector.h#L48
+// https://github.com/PretendoNetwork/mii-js/blob/master/mii.js#L299
+struct Ver3StoreData {
+    u8 version;
+    union {
+        u8 raw;
+
+        BitField<0, 1, u8> allow_copying;
+        BitField<1, 1, u8> profanity_flag;
+        BitField<2, 2, u8> region_lock;
+        BitField<4, 2, u8> character_set;
+    } region_information;
+    u16_be mii_id;
+    u64_be system_id;
+    u32_be specialness_and_creation_date;
+    std::array<u8, 0x6> creator_mac;
+    u16_be padding;
+    union {
+        u16 raw;
+
+        BitField<0, 1, u16> gender;
+        BitField<1, 4, u16> birth_month;
+        BitField<5, 5, u16> birth_day;
+        BitField<10, 4, u16> favorite_color;
+        BitField<14, 1, u16> favorite;
+    } mii_information;
+    std::array<char16_t, 0xA> mii_name;
+    u8 height;
+    u8 build;
+    union {
+        u8 raw;
+
+        BitField<0, 1, u8> disable_sharing;
+        BitField<1, 4, u8> face_shape;
+        BitField<5, 3, u8> skin_color;
+    } appearance_bits1;
+    union {
+        u8 raw;
+
+        BitField<0, 4, u8> wrinkles;
+        BitField<4, 4, u8> makeup;
+    } appearance_bits2;
+    u8 hair_style;
+    union {
+        u8 raw;
+
+        BitField<0, 3, u8> hair_color;
+        BitField<3, 1, u8> flip_hair;
+    } appearance_bits3;
+    union {
+        u32 raw;
+
+        BitField<0, 6, u32> eye_type;
+        BitField<6, 3, u32> eye_color;
+        BitField<9, 4, u32> eye_scale;
+        BitField<13, 3, u32> eye_vertical_stretch;
+        BitField<16, 5, u32> eye_rotation;
+        BitField<21, 4, u32> eye_spacing;
+        BitField<25, 5, u32> eye_y_position;
+    } appearance_bits4;
+    union {
+        u32 raw;
+
+        BitField<0, 5, u32> eyebrow_style;
+        BitField<5, 3, u32> eyebrow_color;
+        BitField<8, 4, u32> eyebrow_scale;
+        BitField<12, 3, u32> eyebrow_yscale;
+        BitField<16, 4, u32> eyebrow_rotation;
+        BitField<21, 4, u32> eyebrow_spacing;
+        BitField<25, 5, u32> eyebrow_y_position;
+    } appearance_bits5;
+    union {
+        u16 raw;
+
+        BitField<0, 5, u16> nose_type;
+        BitField<5, 4, u16> nose_scale;
+        BitField<9, 5, u16> nose_y_position;
+    } appearance_bits6;
+    union {
+        u16 raw;
+
+        BitField<0, 6, u16> mouth_type;
+        BitField<6, 3, u16> mouth_color;
+        BitField<9, 4, u16> mouth_scale;
+        BitField<13, 3, u16> mouth_horizontal_stretch;
+    } appearance_bits7;
+    union {
+        u8 raw;
+
+        BitField<0, 5, u8> mouth_y_position;
+        BitField<5, 3, u8> mustache_type;
+    } appearance_bits8;
+    u8 allow_copying;
+    union {
+        u16 raw;
+
+        BitField<0, 3, u16> bear_type;
+        BitField<3, 3, u16> facial_hair_color;
+        BitField<6, 4, u16> mustache_scale;
+        BitField<10, 5, u16> mustache_y_position;
+    } appearance_bits9;
+    union {
+        u16 raw;
+
+        BitField<0, 4, u16> glasses_type;
+        BitField<4, 3, u16> glasses_color;
+        BitField<7, 4, u16> glasses_scale;
+        BitField<11, 5, u16> glasses_y_position;
+    } appearance_bits10;
+    union {
+        u16 raw;
+
+        BitField<0, 1, u16> mole_enabled;
+        BitField<1, 4, u16> mole_scale;
+        BitField<5, 5, u16> mole_x_position;
+        BitField<10, 5, u16> mole_y_position;
+    } appearance_bits11;
+
+    std::array<u16_le, 0xA> author_name;
+    INSERT_PADDING_BYTES(0x4);
+};
+static_assert(sizeof(Ver3StoreData) == 0x60, "Ver3StoreData is an invalid size");
 
 struct MiiStoreData {
     using Name = std::array<char16_t, 10>;

--- a/src/core/hle/service/nfp/amiibo_crypto.cpp
+++ b/src/core/hle/service/nfp/amiibo_crypto.cpp
@@ -1,0 +1,455 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// SPDX-FileCopyrightText: Copyright 2017 socram8888/amiitool
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <mbedtls/aes.h>
+#include <mbedtls/hmac_drbg.h>
+
+#include "common/fs/file.h"
+#include "common/fs/path_util.h"
+#include "common/logging/log.h"
+#include "core/hle/service/mii/mii_manager.h"
+#include "core/hle/service/nfp/amiibo_crypto.h"
+
+namespace Service::NFP::AmiiboCrypto {
+
+Service::Mii::MiiInfo AmiiboRegisterInfoToMii(const AmiiboRegisterInfo& mii_info) {
+
+    Service::Mii::MiiManager manager;
+    auto mii = manager.BuildDefault(0);
+
+    // TODO: We are ignoring a bunch of data from the amiibo mii
+
+    mii.gender = static_cast<u8>(mii_info.mii_information.gender);
+    mii.favorite_color = static_cast<u8>(mii_info.mii_information.favorite_color);
+    memcpy(mii.name.data(), mii_info.mii_name.data(), 10);
+    mii.height = mii_info.height;
+    mii.build = mii_info.build;
+
+    mii.faceline_type = mii_info.appearance_bits1.face_shape;
+    mii.faceline_color = mii_info.appearance_bits1.skin_color;
+    mii.faceline_wrinkle = mii_info.appearance_bits2.wrinkles;
+    mii.faceline_make = mii_info.appearance_bits2.makeup;
+
+    mii.hair_type = mii_info.hair_style;
+    mii.hair_color = mii_info.appearance_bits3.hair_color;
+    mii.hair_flip = mii_info.appearance_bits3.flip_hair;
+
+    mii.eye_type = static_cast<u8>(mii_info.appearance_bits4.eye_type);
+    mii.eye_color = static_cast<u8>(mii_info.appearance_bits4.eye_color);
+    mii.eye_scale = static_cast<u8>(mii_info.appearance_bits4.eye_scale);
+    mii.eye_aspect = static_cast<u8>(mii_info.appearance_bits4.eye_vertical_stretch);
+    mii.eye_rotate = static_cast<u8>(mii_info.appearance_bits4.eye_rotation);
+    mii.eye_x = static_cast<u8>(mii_info.appearance_bits4.eye_spacing);
+    mii.eye_y = static_cast<u8>(mii_info.appearance_bits4.eye_y_position);
+
+    mii.eyebrow_type = static_cast<u8>(mii_info.appearance_bits5.eyebrow_style);
+    mii.eyebrow_color = static_cast<u8>(mii_info.appearance_bits5.eyebrow_color);
+    mii.eyebrow_scale = static_cast<u8>(mii_info.appearance_bits5.eyebrow_scale);
+    mii.eyebrow_aspect = static_cast<u8>(mii_info.appearance_bits5.eyebrow_yscale);
+    mii.eyebrow_rotate = static_cast<u8>(mii_info.appearance_bits5.eyebrow_rotation);
+    mii.eyebrow_x = static_cast<u8>(mii_info.appearance_bits5.eyebrow_spacing);
+    mii.eyebrow_y = static_cast<u8>(mii_info.appearance_bits5.eyebrow_y_position);
+
+    mii.nose_type = static_cast<u8>(mii_info.appearance_bits6.nose_type);
+    mii.nose_scale = static_cast<u8>(mii_info.appearance_bits6.nose_scale);
+    mii.nose_y = static_cast<u8>(mii_info.appearance_bits6.nose_y_position);
+
+    mii.mouth_type = static_cast<u8>(mii_info.appearance_bits7.mouth_type);
+    mii.mouth_color = static_cast<u8>(mii_info.appearance_bits7.mouth_color);
+    mii.mouth_scale = static_cast<u8>(mii_info.appearance_bits7.mouth_scale);
+    mii.mouth_aspect = static_cast<u8>(mii_info.appearance_bits7.mouth_horizontal_stretch);
+    mii.mouth_y = static_cast<u8>(mii_info.appearance_bits8.mouth_y_position);
+
+    mii.mustache_type = static_cast<u8>(mii_info.appearance_bits8.mustache_type);
+    mii.mustache_scale = static_cast<u8>(mii_info.appearance_bits9.mustache_scale);
+    mii.mustache_y = static_cast<u8>(mii_info.appearance_bits9.mustache_y_position);
+
+    mii.beard_type = static_cast<u8>(mii_info.appearance_bits9.bear_type);
+    mii.beard_color = static_cast<u8>(mii_info.appearance_bits9.facial_hair_color);
+
+    mii.glasses_type = static_cast<u8>(mii_info.appearance_bits10.glasses_type);
+    mii.glasses_color = static_cast<u8>(mii_info.appearance_bits10.glasses_color);
+    mii.glasses_scale = static_cast<u8>(mii_info.appearance_bits10.glasses_scale);
+    mii.glasses_y = static_cast<u8>(mii_info.appearance_bits10.glasses_y_position);
+
+    mii.mole_type = static_cast<u8>(mii_info.appearance_bits11.mole_enabled);
+    mii.mole_scale = static_cast<u8>(mii_info.appearance_bits11.mole_scale);
+    mii.mole_x = static_cast<u8>(mii_info.appearance_bits11.mole_x_position);
+    mii.mole_y = static_cast<u8>(mii_info.appearance_bits11.mole_y_position);
+
+    // TODO: Validate mii data
+
+    return mii;
+}
+
+bool IsAmiiboValid(const EncryptedNTAG215File& ntag_file) {
+    const auto& amiibo_data = ntag_file.user_memory;
+    LOG_DEBUG(Service_NFP, "uuid_lock=0x{0:x}", ntag_file.static_lock);
+    LOG_DEBUG(Service_NFP, "compability_container=0x{0:x}", ntag_file.compability_container);
+    LOG_INFO(Service_NFP, "write_count={}", amiibo_data.write_counter);
+
+    LOG_INFO(Service_NFP, "character_id=0x{0:x}", amiibo_data.model_info.character_id);
+    LOG_INFO(Service_NFP, "character_variant={}", amiibo_data.model_info.character_variant);
+    LOG_INFO(Service_NFP, "amiibo_type={}", amiibo_data.model_info.amiibo_type);
+    LOG_INFO(Service_NFP, "model_number=0x{0:x}", amiibo_data.model_info.model_number);
+    LOG_INFO(Service_NFP, "series={}", amiibo_data.model_info.series);
+    LOG_DEBUG(Service_NFP, "fixed_value=0x{0:x}", amiibo_data.model_info.constant_value);
+
+    LOG_DEBUG(Service_NFP, "tag_dynamic_lock=0x{0:x}", ntag_file.dynamic_lock);
+    LOG_DEBUG(Service_NFP, "tag_CFG0=0x{0:x}", ntag_file.CFG0);
+    LOG_DEBUG(Service_NFP, "tag_CFG1=0x{0:x}", ntag_file.CFG1);
+
+    // Validate UUID
+    constexpr u8 CT = 0x88; // As defined in `ISO / IEC 14443 - 3`
+    if ((CT ^ ntag_file.uuid[0] ^ ntag_file.uuid[1] ^ ntag_file.uuid[2]) != ntag_file.uuid[3]) {
+        return false;
+    }
+    if ((ntag_file.uuid[4] ^ ntag_file.uuid[5] ^ ntag_file.uuid[6] ^ ntag_file.uuid[7]) !=
+        ntag_file.uuid[8]) {
+        return false;
+    }
+
+    // Check against all know constants on an amiibo binary
+    if (ntag_file.static_lock != 0xE00F) {
+        return false;
+    }
+    if (ntag_file.compability_container != 0xEEFF10F1U) {
+        return false;
+    }
+    if (amiibo_data.constant_value != 0xA5) {
+        return false;
+    }
+    if (amiibo_data.model_info.constant_value != 0x02) {
+        return false;
+    }
+    if ((ntag_file.dynamic_lock & 0xFFFFFF) != 0x0F0001) {
+        return false;
+    }
+    if (ntag_file.CFG0 != 0x04000000U) {
+        return false;
+    }
+    if (ntag_file.CFG1 != 0x5F) {
+        return false;
+    }
+    return true;
+}
+
+NTAG215File NfcDataToEncodedData(const EncryptedNTAG215File& nfc_data) {
+    NTAG215File encoded_data{};
+
+    memcpy(encoded_data.uuid2.data(), nfc_data.uuid.data() + 0x8, 2);
+    encoded_data.static_lock = nfc_data.static_lock;
+    encoded_data.compability_container = nfc_data.compability_container;
+    encoded_data.unfixed_hash = nfc_data.user_memory.unfixed_hash;
+    encoded_data.constant_value = nfc_data.user_memory.constant_value;
+    encoded_data.write_counter = nfc_data.user_memory.write_counter;
+    encoded_data.settings = nfc_data.user_memory.settings;
+    encoded_data.owner_mii = nfc_data.user_memory.owner_mii;
+    encoded_data.title_id = nfc_data.user_memory.title_id;
+    encoded_data.applicaton_write_counter = nfc_data.user_memory.applicaton_write_counter;
+    encoded_data.application_area_id = nfc_data.user_memory.application_area_id;
+    encoded_data.unknown = nfc_data.user_memory.unknown;
+    encoded_data.hash = nfc_data.user_memory.hash;
+    encoded_data.application_area = nfc_data.user_memory.application_area;
+    encoded_data.locked_hash = nfc_data.user_memory.locked_hash;
+    memcpy(encoded_data.uuid.data(), nfc_data.uuid.data(), 8);
+    encoded_data.model_info = nfc_data.user_memory.model_info;
+    encoded_data.keygen_salt = nfc_data.user_memory.keygen_salt;
+    encoded_data.dynamic_lock = nfc_data.dynamic_lock;
+    encoded_data.CFG0 = nfc_data.CFG0;
+    encoded_data.CFG1 = nfc_data.CFG1;
+    encoded_data.password = nfc_data.password;
+
+    return encoded_data;
+}
+
+EncryptedNTAG215File EncodedDataToNfcData(const NTAG215File& encoded_data) {
+    EncryptedNTAG215File nfc_data{};
+
+    memcpy(nfc_data.uuid.data() + 0x8, encoded_data.uuid2.data(), 2);
+    memcpy(nfc_data.uuid.data(), encoded_data.uuid.data(), 8);
+    nfc_data.static_lock = encoded_data.static_lock;
+    nfc_data.compability_container = encoded_data.compability_container;
+    nfc_data.user_memory.unfixed_hash = encoded_data.unfixed_hash;
+    nfc_data.user_memory.constant_value = encoded_data.constant_value;
+    nfc_data.user_memory.write_counter = encoded_data.write_counter;
+    nfc_data.user_memory.settings = encoded_data.settings;
+    nfc_data.user_memory.owner_mii = encoded_data.owner_mii;
+    nfc_data.user_memory.title_id = encoded_data.title_id;
+    nfc_data.user_memory.applicaton_write_counter = encoded_data.applicaton_write_counter;
+    nfc_data.user_memory.application_area_id = encoded_data.application_area_id;
+    nfc_data.user_memory.unknown = encoded_data.unknown;
+    nfc_data.user_memory.hash = encoded_data.hash;
+    nfc_data.user_memory.application_area = encoded_data.application_area;
+    nfc_data.user_memory.locked_hash = encoded_data.locked_hash;
+    nfc_data.user_memory.model_info = encoded_data.model_info;
+    nfc_data.user_memory.keygen_salt = encoded_data.keygen_salt;
+    nfc_data.dynamic_lock = encoded_data.dynamic_lock;
+    nfc_data.CFG0 = encoded_data.CFG0;
+    nfc_data.CFG1 = encoded_data.CFG1;
+    nfc_data.password = encoded_data.password;
+
+    return nfc_data;
+}
+
+u32 GetTagPassword(const TagUuid& uuid) {
+    // Verifiy that the generated password is correct
+    u32 password = 0xAA ^ (uuid[1] ^ uuid[3]);
+    password &= (0x55 ^ (uuid[2] ^ uuid[4])) << 8;
+    password &= (0xAA ^ (uuid[3] ^ uuid[5])) << 16;
+    password &= (0x55 ^ (uuid[4] ^ uuid[6])) << 24;
+    return password;
+}
+
+HashSeed GetSeed(const NTAG215File& data) {
+    HashSeed seed{
+        .data =
+            {
+                .magic = data.write_counter,
+                .padding = {},
+                .uuid1 = {},
+                .uuid2 = {},
+                .keygen_salt = data.keygen_salt,
+            },
+    };
+
+    // Copy the first 8 bytes of uuid
+    memcpy(seed.data.uuid1.data(), data.uuid.data(), sizeof(seed.data.uuid1));
+    memcpy(seed.data.uuid2.data(), data.uuid.data(), sizeof(seed.data.uuid2));
+
+    return seed;
+}
+
+void PreGenerateKey(const InternalKey& key, const HashSeed& seed, u8* output,
+                    std::size_t& outputLen) {
+    std::size_t index = 0;
+
+    // Copy whole type string
+    memccpy(output + index, key.type_string.data(), '\0', key.type_string.size());
+    index += key.type_string.size();
+
+    // Append (16 - magic_length) from the input seed
+    std::size_t seedPart1Len = 16 - key.magic_length;
+    memcpy(output + index, &seed, seedPart1Len);
+    index += seedPart1Len;
+
+    // Append all bytes from magicBytes
+    memcpy(output + index, &key.magic_bytes, key.magic_length);
+    index += key.magic_length;
+
+    // Seed 16 bytes at +0x10
+    memcpy(output + index, &seed.raw[0x10], 16);
+    index += 16;
+
+    // 32 bytes at +0x20 from input seed xored with xor pad
+    for (std::size_t i = 0; i < 32; i++)
+        output[index + i] = seed.raw[i + 32] ^ key.xor_pad[i];
+    index += 32;
+
+    outputLen = index;
+}
+
+void CryptoInit(CryptoCtx& ctx, mbedtls_md_context_t& hmac_ctx, const HmacKey& hmac_key,
+                const u8* seed, std::size_t seed_size) {
+
+    // Initialize context
+    ctx.used = false;
+    ctx.counter = 0;
+    ctx.buffer_size = sizeof(ctx.counter) + seed_size;
+    memcpy(ctx.buffer.data() + sizeof(u16), seed, seed_size);
+
+    // Initialize HMAC context
+    mbedtls_md_init(&hmac_ctx);
+    mbedtls_md_setup(&hmac_ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1);
+    mbedtls_md_hmac_starts(&hmac_ctx, hmac_key.data(), hmac_key.size());
+}
+
+void CryptoStep(CryptoCtx& ctx, mbedtls_md_context_t& hmac_ctx, DrgbOutput& output) {
+    // If used at least once, reinitialize the HMAC
+    if (ctx.used) {
+        mbedtls_md_hmac_reset(&hmac_ctx);
+    }
+
+    ctx.used = true;
+
+    // Store counter in big endian, and increment it
+    ctx.buffer[0] = static_cast<u8>(ctx.counter >> 8);
+    ctx.buffer[1] = static_cast<u8>(ctx.counter >> 0);
+    ctx.counter++;
+
+    // Do HMAC magic
+    mbedtls_md_hmac_update(&hmac_ctx, reinterpret_cast<const unsigned char*>(ctx.buffer.data()),
+                           ctx.buffer_size);
+    mbedtls_md_hmac_finish(&hmac_ctx, output.data());
+}
+
+DerivedKeys GenerateKey(const InternalKey& key, const NTAG215File& data) {
+    constexpr std::size_t OUTPUT_SIZE = 512;
+    const auto seed = GetSeed(data);
+
+    // Generate internal seed
+    u8 internal_key[OUTPUT_SIZE];
+    std::size_t internal_key_lenght = 0;
+    PreGenerateKey(key, seed, internal_key, internal_key_lenght);
+
+    // Initialize context
+    CryptoCtx ctx{};
+    mbedtls_md_context_t hmac_ctx;
+    CryptoInit(ctx, hmac_ctx, key.hmac_key, internal_key, internal_key_lenght);
+
+    // Generate derived keys
+    DerivedKeys derived_keys{};
+    std::array<DrgbOutput, 2> temp{};
+    CryptoStep(ctx, hmac_ctx, temp[0]);
+    CryptoStep(ctx, hmac_ctx, temp[1]);
+    memcpy(&derived_keys, temp.data(), sizeof(DerivedKeys));
+
+    // Cleanup context
+    mbedtls_md_free(&hmac_ctx);
+
+    return derived_keys;
+}
+
+void Cipher(const DerivedKeys& keys, const NTAG215File& in_data, NTAG215File& out_data) {
+    mbedtls_aes_context aes;
+    std::size_t nc_off = 0;
+    std::array<u8, 0x10> nonce_counter{};
+    std::array<u8, 0x10> stream_block{};
+
+    mbedtls_aes_setkey_enc(&aes, keys.aes_key.data(), 128);
+    memcpy(nonce_counter.data(), keys.aes_iv.data(), sizeof(nonce_counter));
+
+    std::array<u8, sizeof(NTAG215File)> in_data_byes{};
+    std::array<u8, sizeof(NTAG215File)> out_data_bytes{};
+    memcpy(in_data_byes.data(), &in_data, sizeof(NTAG215File));
+    memcpy(out_data_bytes.data(), &out_data, sizeof(NTAG215File));
+
+    mbedtls_aes_crypt_ctr(&aes, 0x188, &nc_off, nonce_counter.data(), stream_block.data(),
+                          in_data_byes.data() + 0x2c, out_data_bytes.data() + 0x2c);
+
+    memcpy(out_data_bytes.data(), in_data_byes.data(), 0x008);
+    // Data signature NOT copied
+    memcpy(out_data_bytes.data() + 0x028, in_data_byes.data() + 0x028, 0x004);
+    // Tag signature NOT copied
+    memcpy(out_data_bytes.data() + 0x1D4, in_data_byes.data() + 0x1D4, 0x048);
+
+    memcpy(&out_data, out_data_bytes.data(), sizeof(NTAG215File));
+}
+
+bool LoadKeys(InternalKey& locked_secret, InternalKey& unfixed_info) {
+    const auto yuzu_keys_dir = Common::FS::GetYuzuPath(Common::FS::YuzuPath::KeysDir);
+
+    const Common::FS::IOFile keys_file{yuzu_keys_dir / "key_retail.bin",
+                                       Common::FS::FileAccessMode::Read,
+                                       Common::FS::FileType::BinaryFile};
+
+    if (!keys_file.IsOpen()) {
+        LOG_ERROR(Core, "No keys detected");
+        return false;
+    }
+
+    if (keys_file.Read(unfixed_info) != 1) {
+        LOG_ERROR(Core, "Failed to read unfixed_info");
+        return false;
+    }
+    if (keys_file.Read(locked_secret) != 1) {
+        LOG_ERROR(Core, "Failed to read locked-secret");
+        return false;
+    }
+
+    return true;
+}
+
+bool DecodeAmiibo(const EncryptedNTAG215File& encrypted_tag_data, NTAG215File& tag_data) {
+    InternalKey locked_secret{};
+    InternalKey unfixed_info{};
+
+    if (!LoadKeys(locked_secret, unfixed_info)) {
+        return false;
+    }
+
+    // Generate keys
+    NTAG215File encoded_data = NfcDataToEncodedData(encrypted_tag_data);
+    const auto data_keys = GenerateKey(unfixed_info, encoded_data);
+    const auto tag_keys = GenerateKey(locked_secret, encoded_data);
+
+    // Decrypt
+    Cipher(data_keys, encoded_data, tag_data);
+
+    std::array<u8, sizeof(NTAG215File)> out{};
+    memcpy(out.data(), &tag_data, sizeof(NTAG215File));
+
+    // Regenerate tag HMAC. Note: order matters, data HMAC depends on tag HMAC!
+    mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), tag_keys.hmac_key.data(),
+                    sizeof(HmacKey), out.data() + 0x1D4, 0x34, out.data() + HMAC_POS_TAG);
+
+    // Regenerate data HMAC
+    mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), data_keys.hmac_key.data(),
+                    sizeof(HmacKey), out.data() + 0x29, 0x1DF, out.data() + HMAC_POS_DATA);
+
+    memcpy(&tag_data, out.data(), sizeof(NTAG215File));
+
+    if (memcmp(tag_data.unfixed_hash.data(), encrypted_tag_data.user_memory.unfixed_hash.data(),
+               32) != 0) {
+        return false;
+    }
+
+    if (memcmp(tag_data.locked_hash.data(), encrypted_tag_data.user_memory.locked_hash.data(),
+               32) != 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bool EncodeAmiibo(const NTAG215File& tag_data, EncryptedNTAG215File& encrypted_tag_data) {
+    InternalKey locked_secret{};
+    InternalKey unfixed_info{};
+
+    if (!LoadKeys(locked_secret, unfixed_info)) {
+        return false;
+    }
+
+    // Generate keys
+    const auto data_keys = GenerateKey(unfixed_info, tag_data);
+    const auto tag_keys = GenerateKey(locked_secret, tag_data);
+
+    std::array<u8, sizeof(NTAG215File)> plain{};
+    std::array<u8, sizeof(NTAG215File)> cipher{};
+    memcpy(plain.data(), &tag_data, sizeof(NTAG215File));
+
+    // Generate tag HMAC
+    mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), tag_keys.hmac_key.data(),
+                    sizeof(HmacKey), plain.data() + 0x1D4, 0x34, cipher.data() + HMAC_POS_TAG);
+
+    // Init mbedtls HMAC context
+    mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
+    mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1);
+
+    // Generate data HMAC
+    mbedtls_md_hmac_starts(&ctx, data_keys.hmac_key.data(), sizeof(HmacKey));
+    mbedtls_md_hmac_update(&ctx, plain.data() + 0x029, 0x18B);        // Data
+    mbedtls_md_hmac_update(&ctx, cipher.data() + HMAC_POS_TAG, 0x20); // Tag HMAC
+    mbedtls_md_hmac_update(&ctx, plain.data() + 0x1D4, 0x34);
+    mbedtls_md_hmac_finish(&ctx, cipher.data() + HMAC_POS_DATA);
+
+    // HMAC cleanup
+    mbedtls_md_free(&ctx);
+
+    // Encrypt
+    NTAG215File encoded_tag_data{};
+    memcpy(&encoded_tag_data, cipher.data(), sizeof(NTAG215File));
+    Cipher(data_keys, tag_data, encoded_tag_data);
+
+    // Convert back to hardware
+    encrypted_tag_data = EncodedDataToNfcData(encoded_tag_data);
+
+    return true;
+}
+
+} // namespace Service::NFP::AmiiboCrypto

--- a/src/core/hle/service/nfp/amiibo_crypto.h
+++ b/src/core/hle/service/nfp/amiibo_crypto.h
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <array>
+
+#include "core/hle/service/nfp/amiibo_types.h"
+
+struct mbedtls_md_context_t;
+
+namespace Service::NFP::AmiiboCrypto {
+constexpr std::size_t HMAC_POS_DATA = 0x8;
+constexpr std::size_t HMAC_POS_TAG = 0x1B4;
+
+using HmacKey = std::array<u8, 0x10>;
+using DrgbOutput = std::array<u8, 0x20>;
+
+struct HashSeed {
+    union {
+        std::array<u8, 0x40> raw;
+        struct {
+            u16 magic;
+            std::array<u8, 0xE> padding;
+            std::array<u8, 0x8> uuid1;
+            std::array<u8, 0x8> uuid2;
+            std::array<u8, 0x20> keygen_salt;
+        } data;
+    };
+};
+static_assert(sizeof(HashSeed) == 0x40, "HashSeed is an invalid size");
+
+struct InternalKey {
+    HmacKey hmac_key;
+    std::array<char, 0xE> type_string;
+    u8 reserved;
+    u8 magic_length;
+    std::array<u8, 0x10> magic_bytes;
+    std::array<u8, 0x20> xor_pad;
+};
+static_assert(sizeof(InternalKey) == 0x50, "InternalKey is an invalid size");
+static_assert(std::is_trivially_copyable_v<InternalKey>, "InternalKey must be trivially copyable.");
+
+struct CryptoCtx {
+    std::array<char, 480> buffer;
+    bool used;
+    std::size_t buffer_size;
+    s16 counter;
+};
+
+struct DerivedKeys {
+    std::array<u8, 0x10> aes_key;
+    std::array<u8, 0x10> aes_iv;
+    std::array<u8, 0x10> hmac_key;
+};
+static_assert(sizeof(DerivedKeys) == 0x30, "DerivedKeys is an invalid size");
+
+/// Converts mii data from nintendo 3ds format to nintendo switch format
+Service::Mii::MiiInfo AmiiboRegisterInfoToMii(const AmiiboRegisterInfo& register_info);
+
+/// Validates that the amiibo file is not corrupted
+bool IsAmiiboValid(const EncryptedNTAG215File& ntag_file);
+
+/// Converts from encrypted file format to encoded file format
+NTAG215File NfcDataToEncodedData(const EncryptedNTAG215File& nfc_data);
+
+/// Converts from encoded file format to encrypted file format
+EncryptedNTAG215File EncodedDataToNfcData(const NTAG215File& encoded_data);
+
+/// Returns password needed to allow write access to protected memory
+u32 GetTagPassword(const TagUuid& uuid);
+
+// Generates Seed needed for key derivation
+HashSeed GetSeed(const NTAG215File& data);
+
+// Middle step on the generation of derived keys
+void PreGenerateKey(const InternalKey& key, const HashSeed& seed, u8* output,
+                    std::size_t& outputLen);
+
+// Initializes mbedtls context
+void CryptoInit(CryptoCtx& ctx, mbedtls_md_context_t& hmac_ctx, const HmacKey& hmac_key,
+                const u8* seed, std::size_t seed_size);
+
+// Feeds data to mbedtls context to generate the derived key
+void CryptoStep(CryptoCtx& ctx, mbedtls_md_context_t& hmac_ctx, DrgbOutput& output);
+
+// Generates the derived key from amiibo data
+DerivedKeys GenerateKey(const InternalKey& key, const NTAG215File& data);
+
+// Encodes or decodes amiibo data
+void Cipher(const DerivedKeys& keys, const NTAG215File& in_data, NTAG215File& out_data);
+
+/// Loads both amiibo keys from key_retail.bin
+bool LoadKeys(InternalKey& locked_secret, InternalKey& unfixed_info);
+
+/// Decodes encripted amiibo data returns true if output is valid
+bool DecodeAmiibo(const EncryptedNTAG215File& encrypted_tag_data, NTAG215File& tag_data);
+
+/// Encodes plain amiibo data returns true if output is valid
+bool EncodeAmiibo(const NTAG215File& tag_data, EncryptedNTAG215File& encrypted_tag_data);
+
+} // namespace Service::NFP::AmiiboCrypto

--- a/src/core/hle/service/nfp/amiibo_crypto.h
+++ b/src/core/hle/service/nfp/amiibo_crypto.h
@@ -10,23 +10,23 @@
 struct mbedtls_md_context_t;
 
 namespace Service::NFP::AmiiboCrypto {
-constexpr std::size_t HMAC_POS_DATA = 0x8;
-constexpr std::size_t HMAC_POS_TAG = 0x1B4;
+// Byte locations in Service::NFP::NTAG215File
+constexpr std::size_t HMAC_DATA_START = 0x8;
+constexpr std::size_t SETTINGS_START = 0x2c;
+constexpr std::size_t WRITE_COUNTER_START = 0x29;
+constexpr std::size_t HMAC_TAG_START = 0x1B4;
+constexpr std::size_t UUID_START = 0x1D4;
+constexpr std::size_t DYNAMIC_LOCK_START = 0x208;
 
 using HmacKey = std::array<u8, 0x10>;
 using DrgbOutput = std::array<u8, 0x20>;
 
 struct HashSeed {
-    union {
-        std::array<u8, 0x40> raw;
-        struct {
-            u16 magic;
-            std::array<u8, 0xE> padding;
-            std::array<u8, 0x8> uuid1;
-            std::array<u8, 0x8> uuid2;
-            std::array<u8, 0x20> keygen_salt;
-        } data;
-    };
+    u16 magic;
+    std::array<u8, 0xE> padding;
+    std::array<u8, 0x8> uuid1;
+    std::array<u8, 0x8> uuid2;
+    std::array<u8, 0x20> keygen_salt;
 };
 static_assert(sizeof(HashSeed) == 0x40, "HashSeed is an invalid size");
 
@@ -71,12 +71,11 @@ u32 GetTagPassword(const TagUuid& uuid);
 HashSeed GetSeed(const NTAG215File& data);
 
 // Middle step on the generation of derived keys
-void PreGenerateKey(const InternalKey& key, const HashSeed& seed, u8* output,
-                    std::size_t& outputLen);
+std::vector<u8> GenerateInternalKey(const InternalKey& key, const HashSeed& seed);
 
 // Initializes mbedtls context
 void CryptoInit(CryptoCtx& ctx, mbedtls_md_context_t& hmac_ctx, const HmacKey& hmac_key,
-                const u8* seed, std::size_t seed_size);
+                const std::vector<u8>& seed);
 
 // Feeds data to mbedtls context to generate the derived key
 void CryptoStep(CryptoCtx& ctx, mbedtls_md_context_t& hmac_ctx, DrgbOutput& output);

--- a/src/core/hle/service/nfp/amiibo_crypto.h
+++ b/src/core/hle/service/nfp/amiibo_crypto.h
@@ -55,9 +55,6 @@ struct DerivedKeys {
 };
 static_assert(sizeof(DerivedKeys) == 0x30, "DerivedKeys is an invalid size");
 
-/// Converts mii data from nintendo 3ds format to nintendo switch format
-Service::Mii::MiiInfo AmiiboRegisterInfoToMii(const AmiiboRegisterInfo& register_info);
-
 /// Validates that the amiibo file is not corrupted
 bool IsAmiiboValid(const EncryptedNTAG215File& ntag_file);
 

--- a/src/core/hle/service/nfp/amiibo_types.h
+++ b/src/core/hle/service/nfp/amiibo_types.h
@@ -5,6 +5,8 @@
 
 #include <array>
 
+#include "core/hle/service/mii/types.h"
+
 namespace Service::NFP {
 enum class ServiceType : u32 {
     User,
@@ -74,13 +76,17 @@ using HashData = std::array<u8, 0x20>;
 using ApplicationArea = std::array<u8, 0xD8>;
 
 struct AmiiboDate {
-    union {
-        u16_be raw{};
+    u16_be raw_date{};
 
-        BitField<0, 5, u16> day;
-        BitField<5, 4, u16> month;
-        BitField<9, 7, u16> year;
-    };
+    u16 GetYear() const {
+        return ((raw_date & 0xFE00) >> 9) + 2000;
+    }
+    u8 GetMonth() const {
+        return ((raw_date & 0x01E0) >> 5) - 1;
+    }
+    u8 GetDay() const {
+        return raw_date & 0x001F;
+    }
 };
 static_assert(sizeof(AmiiboDate) == 2, "AmiiboDate is an invalid size");
 
@@ -123,135 +129,20 @@ struct NTAG215Password {
 };
 static_assert(sizeof(NTAG215Password) == 0x8, "NTAG215Password is an invalid size");
 
-// Based on citra HLE::Applets::MiiData and PretendoNetwork.
-// https://github.com/citra-emu/citra/blob/master/src/core/hle/applets/mii_selector.h#L48
-// https://github.com/PretendoNetwork/mii-js/blob/master/mii.js#L299
 #pragma pack(1)
-struct AmiiboRegisterInfo {
-    u32_be mii_id;
-    u64_be system_id;
-    u32_be specialness_and_creation_date;
-    std::array<u8, 0x6> creator_mac;
-    u16_be padding;
-    union {
-        u16 raw;
-
-        BitField<0, 1, u16> gender;
-        BitField<1, 4, u16> birth_month;
-        BitField<5, 5, u16> birth_day;
-        BitField<10, 4, u16> favorite_color;
-        BitField<14, 1, u16> favorite;
-    } mii_information;
-    std::array<char16_t, 0xA> mii_name;
-    u8 height;
-    u8 build;
-    union {
-        u8 raw;
-
-        BitField<0, 1, u8> disable_sharing;
-        BitField<1, 4, u8> face_shape;
-        BitField<5, 3, u8> skin_color;
-    } appearance_bits1;
-    union {
-        u8 raw;
-
-        BitField<0, 4, u8> wrinkles;
-        BitField<4, 4, u8> makeup;
-    } appearance_bits2;
-    u8 hair_style;
-    union {
-        u8 raw;
-
-        BitField<0, 3, u8> hair_color;
-        BitField<3, 1, u8> flip_hair;
-    } appearance_bits3;
-    union {
-        u32 raw;
-
-        BitField<0, 6, u32> eye_type;
-        BitField<6, 3, u32> eye_color;
-        BitField<9, 4, u32> eye_scale;
-        BitField<13, 3, u32> eye_vertical_stretch;
-        BitField<16, 5, u32> eye_rotation;
-        BitField<21, 4, u32> eye_spacing;
-        BitField<25, 5, u32> eye_y_position;
-    } appearance_bits4;
-    union {
-        u32 raw;
-
-        BitField<0, 5, u32> eyebrow_style;
-        BitField<5, 3, u32> eyebrow_color;
-        BitField<8, 4, u32> eyebrow_scale;
-        BitField<12, 3, u32> eyebrow_yscale;
-        BitField<16, 4, u32> eyebrow_rotation;
-        BitField<21, 4, u32> eyebrow_spacing;
-        BitField<25, 5, u32> eyebrow_y_position;
-    } appearance_bits5;
-    union {
-        u16 raw;
-
-        BitField<0, 5, u16> nose_type;
-        BitField<5, 4, u16> nose_scale;
-        BitField<9, 5, u16> nose_y_position;
-    } appearance_bits6;
-    union {
-        u16 raw;
-
-        BitField<0, 6, u16> mouth_type;
-        BitField<6, 3, u16> mouth_color;
-        BitField<9, 4, u16> mouth_scale;
-        BitField<13, 3, u16> mouth_horizontal_stretch;
-    } appearance_bits7;
-    union {
-        u8 raw;
-
-        BitField<0, 5, u8> mouth_y_position;
-        BitField<5, 3, u8> mustache_type;
-    } appearance_bits8;
-    u8 allow_copying;
-    union {
-        u16 raw;
-
-        BitField<0, 3, u16> bear_type;
-        BitField<3, 3, u16> facial_hair_color;
-        BitField<6, 4, u16> mustache_scale;
-        BitField<10, 5, u16> mustache_y_position;
-    } appearance_bits9;
-    union {
-        u16 raw;
-
-        BitField<0, 4, u16> glasses_type;
-        BitField<4, 3, u16> glasses_color;
-        BitField<7, 4, u16> glasses_scale;
-        BitField<11, 5, u16> glasses_y_position;
-    } appearance_bits10;
-    union {
-        u16 raw;
-
-        BitField<0, 1, u16> mole_enabled;
-        BitField<1, 4, u16> mole_scale;
-        BitField<5, 5, u16> mole_x_position;
-        BitField<10, 5, u16> mole_y_position;
-    } appearance_bits11;
-
-    std::array<u16_le, 0xA> author_name;
-    INSERT_PADDING_BYTES(0x4);
-};
-static_assert(sizeof(AmiiboRegisterInfo) == 0x60, "AmiiboRegisterInfo is an invalid size");
-
 struct EncryptedAmiiboFile {
-    u8 constant_value;               // Must be A5
-    u16 write_counter;               // Number of times the amiibo has been written?
-    INSERT_PADDING_BYTES(0x1);       // Unknown 1
-    AmiiboSettings settings;         // Encrypted amiibo settings
-    HashData locked_hash;            // Hash
-    AmiiboModelInfo model_info;      // Encrypted amiibo model info
-    HashData keygen_salt;            // Salt
-    HashData unfixed_hash;           // Hash
-    AmiiboRegisterInfo owner_mii;    // Encrypted Mii data
-    u64_be title_id;                 // Encrypted Game id
-    u16_be applicaton_write_counter; // Encrypted Counter
-    u32_be application_area_id;      // Encrypted Game id
+    u8 constant_value;                     // Must be A5
+    u16 write_counter;                     // Number of times the amiibo has been written?
+    INSERT_PADDING_BYTES(0x1);             // Unknown 1
+    AmiiboSettings settings;               // Encrypted amiibo settings
+    HashData locked_hash;                  // Hash
+    AmiiboModelInfo model_info;            // Encrypted amiibo model info
+    HashData keygen_salt;                  // Salt
+    HashData unfixed_hash;                 // Hash
+    Service::Mii::Ver3StoreData owner_mii; // Encrypted Mii data
+    u64_be title_id;                       // Encrypted Game id
+    u16_be applicaton_write_counter;       // Encrypted Counter
+    u32_be application_area_id;            // Encrypted Game id
     std::array<u8, 0x2> unknown;
     HashData hash;                    // Probably a SHA256-HMAC hash?
     ApplicationArea application_area; // Encrypted Game data
@@ -267,7 +158,7 @@ struct NTAG215File {
     u16 write_counter;         // Number of times the amiibo has been written?
     INSERT_PADDING_BYTES(0x1); // Unknown 1
     AmiiboSettings settings;
-    AmiiboRegisterInfo owner_mii; // Encrypted Mii data
+    Service::Mii::Ver3StoreData owner_mii; // Encrypted Mii data
     u64_be title_id;
     u16_be applicaton_write_counter; // Encrypted Counter
     u32_be application_area_id;

--- a/src/core/hle/service/nfp/amiibo_types.h
+++ b/src/core/hle/service/nfp/amiibo_types.h
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <array>
+
+namespace Service::NFP {
+enum class ServiceType : u32 {
+    User,
+    Debug,
+    System,
+};
+
+enum class State : u32 {
+    NonInitialized,
+    Initialized,
+};
+
+enum class DeviceState : u32 {
+    Initialized,
+    SearchingForTag,
+    TagFound,
+    TagRemoved,
+    TagMounted,
+    Unaviable,
+    Finalized,
+};
+
+enum class ModelType : u32 {
+    Amiibo,
+};
+
+enum class MountTarget : u32 {
+    Rom,
+    Ram,
+    All,
+};
+
+enum class AmiiboType : u8 {
+    Figure,
+    Card,
+    Yarn,
+};
+
+enum class AmiiboSeries : u8 {
+    SuperSmashBros,
+    SuperMario,
+    ChibiRobo,
+    YoshiWoollyWorld,
+    Splatoon,
+    AnimalCrossing,
+    EightBitMario,
+    Skylanders,
+    Unknown8,
+    TheLegendOfZelda,
+    ShovelKnight,
+    Unknown11,
+    Kiby,
+    Pokemon,
+    MarioSportsSuperstars,
+    MonsterHunter,
+    BoxBoy,
+    Pikmin,
+    FireEmblem,
+    Metroid,
+    Others,
+    MegaMan,
+    Diablo,
+};
+
+using TagUuid = std::array<u8, 10>;
+using HashData = std::array<u8, 0x20>;
+using ApplicationArea = std::array<u8, 0xD8>;
+
+struct AmiiboDate {
+    union {
+        u16_be raw{};
+
+        BitField<0, 5, u16> day;
+        BitField<5, 4, u16> month;
+        BitField<9, 7, u16> year;
+    };
+};
+static_assert(sizeof(AmiiboDate) == 2, "AmiiboDate is an invalid size");
+
+struct Settings {
+    union {
+        u8 raw{};
+
+        BitField<4, 1, u8> amiibo_initialized;
+        BitField<5, 1, u8> appdata_initialized;
+    };
+};
+static_assert(sizeof(Settings) == 1, "AmiiboDate is an invalid size");
+
+struct AmiiboSettings {
+    Settings settings;
+    u8 country_code_id;
+    u16_be crc_counter; // Incremented each time crc is changed
+    AmiiboDate init_date;
+    AmiiboDate write_date;
+    u32_be crc;
+    std::array<u16_be, 0xA> amiibo_name; // UTF-16 text
+};
+static_assert(sizeof(AmiiboSettings) == 0x20, "AmiiboSettings is an invalid size");
+
+struct AmiiboModelInfo {
+    u16 character_id;
+    u8 character_variant;
+    AmiiboType amiibo_type;
+    u16 model_number;
+    AmiiboSeries series;
+    u8 constant_value;         // Must be 02
+    INSERT_PADDING_BYTES(0x4); // Unknown
+};
+static_assert(sizeof(AmiiboModelInfo) == 0xC, "AmiiboModelInfo is an invalid size");
+
+struct NTAG215Password {
+    u32 PWD;  // Password to allow write access
+    u16 PACK; // Password acknowledge reply
+    u16 RFUI; // Reserved for future use
+};
+static_assert(sizeof(NTAG215Password) == 0x8, "NTAG215Password is an invalid size");
+
+// Based on citra HLE::Applets::MiiData and PretendoNetwork.
+// https://github.com/citra-emu/citra/blob/master/src/core/hle/applets/mii_selector.h#L48
+// https://github.com/PretendoNetwork/mii-js/blob/master/mii.js#L299
+#pragma pack(1)
+struct AmiiboRegisterInfo {
+    u32_be mii_id;
+    u64_be system_id;
+    u32_be specialness_and_creation_date;
+    std::array<u8, 0x6> creator_mac;
+    u16_be padding;
+    union {
+        u16 raw;
+
+        BitField<0, 1, u16> gender;
+        BitField<1, 4, u16> birth_month;
+        BitField<5, 5, u16> birth_day;
+        BitField<10, 4, u16> favorite_color;
+        BitField<14, 1, u16> favorite;
+    } mii_information;
+    std::array<char16_t, 0xA> mii_name;
+    u8 height;
+    u8 build;
+    union {
+        u8 raw;
+
+        BitField<0, 1, u8> disable_sharing;
+        BitField<1, 4, u8> face_shape;
+        BitField<5, 3, u8> skin_color;
+    } appearance_bits1;
+    union {
+        u8 raw;
+
+        BitField<0, 4, u8> wrinkles;
+        BitField<4, 4, u8> makeup;
+    } appearance_bits2;
+    u8 hair_style;
+    union {
+        u8 raw;
+
+        BitField<0, 3, u8> hair_color;
+        BitField<3, 1, u8> flip_hair;
+    } appearance_bits3;
+    union {
+        u32 raw;
+
+        BitField<0, 6, u32> eye_type;
+        BitField<6, 3, u32> eye_color;
+        BitField<9, 4, u32> eye_scale;
+        BitField<13, 3, u32> eye_vertical_stretch;
+        BitField<16, 5, u32> eye_rotation;
+        BitField<21, 4, u32> eye_spacing;
+        BitField<25, 5, u32> eye_y_position;
+    } appearance_bits4;
+    union {
+        u32 raw;
+
+        BitField<0, 5, u32> eyebrow_style;
+        BitField<5, 3, u32> eyebrow_color;
+        BitField<8, 4, u32> eyebrow_scale;
+        BitField<12, 3, u32> eyebrow_yscale;
+        BitField<16, 4, u32> eyebrow_rotation;
+        BitField<21, 4, u32> eyebrow_spacing;
+        BitField<25, 5, u32> eyebrow_y_position;
+    } appearance_bits5;
+    union {
+        u16 raw;
+
+        BitField<0, 5, u16> nose_type;
+        BitField<5, 4, u16> nose_scale;
+        BitField<9, 5, u16> nose_y_position;
+    } appearance_bits6;
+    union {
+        u16 raw;
+
+        BitField<0, 6, u16> mouth_type;
+        BitField<6, 3, u16> mouth_color;
+        BitField<9, 4, u16> mouth_scale;
+        BitField<13, 3, u16> mouth_horizontal_stretch;
+    } appearance_bits7;
+    union {
+        u8 raw;
+
+        BitField<0, 5, u8> mouth_y_position;
+        BitField<5, 3, u8> mustache_type;
+    } appearance_bits8;
+    u8 allow_copying;
+    union {
+        u16 raw;
+
+        BitField<0, 3, u16> bear_type;
+        BitField<3, 3, u16> facial_hair_color;
+        BitField<6, 4, u16> mustache_scale;
+        BitField<10, 5, u16> mustache_y_position;
+    } appearance_bits9;
+    union {
+        u16 raw;
+
+        BitField<0, 4, u16> glasses_type;
+        BitField<4, 3, u16> glasses_color;
+        BitField<7, 4, u16> glasses_scale;
+        BitField<11, 5, u16> glasses_y_position;
+    } appearance_bits10;
+    union {
+        u16 raw;
+
+        BitField<0, 1, u16> mole_enabled;
+        BitField<1, 4, u16> mole_scale;
+        BitField<5, 5, u16> mole_x_position;
+        BitField<10, 5, u16> mole_y_position;
+    } appearance_bits11;
+
+    std::array<u16_le, 0xA> author_name;
+    INSERT_PADDING_BYTES(0x4);
+};
+static_assert(sizeof(AmiiboRegisterInfo) == 0x60, "AmiiboRegisterInfo is an invalid size");
+
+struct EncryptedAmiiboFile {
+    u8 constant_value;               // Must be A5
+    u16 write_counter;               // Number of times the amiibo has been written?
+    INSERT_PADDING_BYTES(0x1);       // Unknown 1
+    AmiiboSettings settings;         // Encrypted amiibo settings
+    HashData locked_hash;            // Hash
+    AmiiboModelInfo model_info;      // Encrypted amiibo model info
+    HashData keygen_salt;            // Salt
+    HashData unfixed_hash;           // Hash
+    AmiiboRegisterInfo owner_mii;    // Encrypted Mii data
+    u64_be title_id;                 // Encrypted Game id
+    u16_be applicaton_write_counter; // Encrypted Counter
+    u32_be application_area_id;      // Encrypted Game id
+    std::array<u8, 0x2> unknown;
+    HashData hash;                    // Probably a SHA256-HMAC hash?
+    ApplicationArea application_area; // Encrypted Game data
+};
+static_assert(sizeof(EncryptedAmiiboFile) == 0x1F8, "AmiiboFile is an invalid size");
+
+struct NTAG215File {
+    std::array<u8, 0x2> uuid2;
+    u16 static_lock;           // Set defined pages as read only
+    u32 compability_container; // Defines available memory
+    HashData unfixed_hash;     // Hash
+    u8 constant_value;         // Must be A5
+    u16 write_counter;         // Number of times the amiibo has been written?
+    INSERT_PADDING_BYTES(0x1); // Unknown 1
+    AmiiboSettings settings;
+    AmiiboRegisterInfo owner_mii; // Encrypted Mii data
+    u64_be title_id;
+    u16_be applicaton_write_counter; // Encrypted Counter
+    u32_be application_area_id;
+    std::array<u8, 0x2> unknown;
+    HashData hash;                    // Probably a SHA256-HMAC hash?
+    ApplicationArea application_area; // Encrypted Game data
+    HashData locked_hash;             // Hash
+    std::array<u8, 0x8> uuid;
+    AmiiboModelInfo model_info;
+    HashData keygen_salt;     // Salt
+    u32 dynamic_lock;         // Dynamic lock
+    u32 CFG0;                 // Defines memory protected by password
+    u32 CFG1;                 // Defines number of verification attempts
+    NTAG215Password password; // Password data
+};
+static_assert(sizeof(NTAG215File) == 0x21C, "NTAG215File is an invalid size");
+static_assert(std::is_trivially_copyable_v<NTAG215File>, "NTAG215File must be trivially copyable.");
+#pragma pack()
+
+struct EncryptedNTAG215File {
+    TagUuid uuid;                    // Unique serial number
+    u16 static_lock;                 // Set defined pages as read only
+    u32 compability_container;       // Defines available memory
+    EncryptedAmiiboFile user_memory; // Writable data
+    u32 dynamic_lock;                // Dynamic lock
+    u32 CFG0;                        // Defines memory protected by password
+    u32 CFG1;                        // Defines number of verification attempts
+    NTAG215Password password;        // Password data
+};
+static_assert(sizeof(EncryptedNTAG215File) == 0x21C, "EncryptedNTAG215File is an invalid size");
+static_assert(std::is_trivially_copyable_v<EncryptedNTAG215File>,
+              "EncryptedNTAG215File must be trivially copyable.");
+
+} // namespace Service::NFP

--- a/src/core/hle/service/nfp/amiibo_types.h
+++ b/src/core/hle/service/nfp/amiibo_types.h
@@ -8,6 +8,8 @@
 #include "core/hle/service/mii/types.h"
 
 namespace Service::NFP {
+static constexpr std::size_t amiibo_name_length = 0xA;
+
 enum class ServiceType : u32 {
     User,
     Debug,
@@ -76,16 +78,16 @@ using HashData = std::array<u8, 0x20>;
 using ApplicationArea = std::array<u8, 0xD8>;
 
 struct AmiiboDate {
-    u16_be raw_date{};
+    u16 raw_date{};
 
     u16 GetYear() const {
-        return ((raw_date & 0xFE00) >> 9) + 2000;
+        return static_cast<u16>(((raw_date & 0xFE00) >> 9) + 2000);
     }
     u8 GetMonth() const {
-        return ((raw_date & 0x01E0) >> 5) - 1;
+        return static_cast<u8>(((raw_date & 0x01E0) >> 5) - 1);
     }
     u8 GetDay() const {
-        return raw_date & 0x001F;
+        return static_cast<u8>(raw_date & 0x001F);
     }
 };
 static_assert(sizeof(AmiiboDate) == 2, "AmiiboDate is an invalid size");
@@ -107,7 +109,7 @@ struct AmiiboSettings {
     AmiiboDate init_date;
     AmiiboDate write_date;
     u32_be crc;
-    std::array<u16_be, 0xA> amiibo_name; // UTF-16 text
+    std::array<u16_be, amiibo_name_length> amiibo_name; // UTF-16 text
 };
 static_assert(sizeof(AmiiboSettings) == 0x20, "AmiiboSettings is an invalid size");
 

--- a/src/core/hle/service/nfp/amiibo_types.h
+++ b/src/core/hle/service/nfp/amiibo_types.h
@@ -137,10 +137,10 @@ struct EncryptedAmiiboFile {
     u16 write_counter;                     // Number of times the amiibo has been written?
     INSERT_PADDING_BYTES(0x1);             // Unknown 1
     AmiiboSettings settings;               // Encrypted amiibo settings
-    HashData locked_hash;                  // Hash
+    HashData hmac_tag;                     // Hash
     AmiiboModelInfo model_info;            // Encrypted amiibo model info
     HashData keygen_salt;                  // Salt
-    HashData unfixed_hash;                 // Hash
+    HashData hmac_data;                    // Hash
     Service::Mii::Ver3StoreData owner_mii; // Encrypted Mii data
     u64_be title_id;                       // Encrypted Game id
     u16_be applicaton_write_counter;       // Encrypted Counter
@@ -155,7 +155,7 @@ struct NTAG215File {
     std::array<u8, 0x2> uuid2;
     u16 static_lock;           // Set defined pages as read only
     u32 compability_container; // Defines available memory
-    HashData unfixed_hash;     // Hash
+    HashData hmac_data;        // Hash
     u8 constant_value;         // Must be A5
     u16 write_counter;         // Number of times the amiibo has been written?
     INSERT_PADDING_BYTES(0x1); // Unknown 1
@@ -167,7 +167,7 @@ struct NTAG215File {
     std::array<u8, 0x2> unknown;
     HashData hash;                    // Probably a SHA256-HMAC hash?
     ApplicationArea application_area; // Encrypted Game data
-    HashData locked_hash;             // Hash
+    HashData hmac_tag;                // Hash
     std::array<u8, 0x8> uuid;
     AmiiboModelInfo model_info;
     HashData keygen_salt;     // Salt

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -1069,7 +1069,9 @@ DeviceState Module::Interface::GetCurrentState() const {
 }
 
 Core::HID::NpadIdType Module::Interface::GetNpadId() const {
-    return npad_id;
+    // Return first connected npad id as a workaround for lack of a single nfc interface per
+    // controller
+    return system.HIDCore().GetFirstNpadId();
 }
 
 AmiiboName Module::Interface::GetAmiiboName(const AmiiboSettings& settings) const {

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -4,6 +4,8 @@
 #include <array>
 #include <atomic>
 
+#include "common/fs/file.h"
+#include "common/fs/path_util.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hid/emulated_controller.h"
@@ -12,6 +14,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/service/mii/mii_manager.h"
+#include "core/hle/service/nfp/amiibo_crypto.h"
 #include "core/hle/service/nfp/nfp.h"
 #include "core/hle/service/nfp/nfp_user.h"
 
@@ -19,11 +22,12 @@ namespace Service::NFP {
 namespace ErrCodes {
 constexpr Result DeviceNotFound(ErrorModule::NFP, 64);
 constexpr Result WrongDeviceState(ErrorModule::NFP, 73);
+constexpr Result NfcDisabled(ErrorModule::NFP, 80);
+constexpr Result WriteAmiiboFailed(ErrorModule::NFP, 88);
 constexpr Result ApplicationAreaIsNotInitialized(ErrorModule::NFP, 128);
+constexpr Result WrongApplicationAreaId(ErrorModule::NFP, 152);
 constexpr Result ApplicationAreaExist(ErrorModule::NFP, 168);
 } // namespace ErrCodes
-
-constexpr u32 ApplicationAreaSize = 0xD8;
 
 IUser::IUser(Module::Interface& nfp_interface_, Core::System& system_)
     : ServiceFramework{system_, "NFP::IUser"}, service_context{system_, service_name},
@@ -39,7 +43,7 @@ IUser::IUser(Module::Interface& nfp_interface_, Core::System& system_)
         {7, &IUser::OpenApplicationArea, "OpenApplicationArea"},
         {8, &IUser::GetApplicationArea, "GetApplicationArea"},
         {9, &IUser::SetApplicationArea, "SetApplicationArea"},
-        {10, nullptr, "Flush"},
+        {10, &IUser::Flush, "Flush"},
         {11, nullptr, "Restore"},
         {12, &IUser::CreateApplicationArea, "CreateApplicationArea"},
         {13, &IUser::GetTagInfo, "GetTagInfo"},
@@ -87,10 +91,22 @@ void IUser::Finalize(Kernel::HLERequestContext& ctx) {
 void IUser::ListDevices(Kernel::HLERequestContext& ctx) {
     LOG_INFO(Service_NFP, "called");
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     std::vector<u64> devices;
 
     // TODO(german77): Loop through all interfaces
     devices.push_back(nfp_interface.GetHandle());
+
+    if (devices.size() == 0) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::DeviceNotFound);
+        return;
+    }
 
     ctx.WriteBuffer(devices);
 
@@ -104,6 +120,12 @@ void IUser::StartDetection(Kernel::HLERequestContext& ctx) {
     const auto device_handle{rp.Pop<u64>()};
     const auto nfp_protocol{rp.Pop<s32>()};
     LOG_INFO(Service_NFP, "called, device_handle={}, nfp_protocol={}", device_handle, nfp_protocol);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
 
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
@@ -123,6 +145,12 @@ void IUser::StopDetection(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
     LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
 
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
@@ -146,6 +174,12 @@ void IUser::Mount(Kernel::HLERequestContext& ctx) {
     LOG_INFO(Service_NFP, "called, device_handle={}, model_type={}, mount_target={}", device_handle,
              model_type, mount_target);
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
         const auto result = nfp_interface.Mount();
@@ -164,6 +198,12 @@ void IUser::Unmount(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
     LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
 
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
@@ -186,6 +226,12 @@ void IUser::OpenApplicationArea(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_NFP, "(STUBBED) called, device_handle={}, access_id={}", device_handle,
                 access_id);
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
         const auto result = nfp_interface.OpenApplicationArea(access_id);
@@ -205,9 +251,15 @@ void IUser::GetApplicationArea(Kernel::HLERequestContext& ctx) {
     const auto device_handle{rp.Pop<u64>()};
     LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
-        std::vector<u8> data{};
+        ApplicationArea data{};
         const auto result = nfp_interface.GetApplicationArea(data);
         ctx.WriteBuffer(data);
         IPC::ResponseBuilder rb{ctx, 3};
@@ -229,9 +281,40 @@ void IUser::SetApplicationArea(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_NFP, "(STUBBED) called, device_handle={}, data_size={}", device_handle,
                 data.size());
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
         const auto result = nfp_interface.SetApplicationArea(data);
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(result);
+        return;
+    }
+
+    LOG_ERROR(Service_NFP, "Handle not found, device_handle={}", device_handle);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(ErrCodes::DeviceNotFound);
+}
+
+void IUser::Flush(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    LOG_WARNING(Service_NFP, "(STUBBED) called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
+    // TODO(german77): Loop through all interfaces
+    if (device_handle == nfp_interface.GetHandle()) {
+        const auto result = nfp_interface.Flush();
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(result);
         return;
@@ -251,6 +334,12 @@ void IUser::CreateApplicationArea(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_NFP, "(STUBBED) called, device_handle={}, data_size={}, access_id={}",
                 device_handle, access_id, data.size());
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
         const auto result = nfp_interface.CreateApplicationArea(access_id, data);
@@ -269,6 +358,12 @@ void IUser::GetTagInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
     LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
 
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
@@ -291,6 +386,12 @@ void IUser::GetRegisterInfo(Kernel::HLERequestContext& ctx) {
     const auto device_handle{rp.Pop<u64>()};
     LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
         RegisterInfo register_info{};
@@ -311,6 +412,12 @@ void IUser::GetCommonInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
     LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
 
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
@@ -333,6 +440,12 @@ void IUser::GetModelInfo(Kernel::HLERequestContext& ctx) {
     const auto device_handle{rp.Pop<u64>()};
     LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
         ModelInfo model_info{};
@@ -354,6 +467,12 @@ void IUser::AttachActivateEvent(Kernel::HLERequestContext& ctx) {
     const auto device_handle{rp.Pop<u64>()};
     LOG_DEBUG(Service_NFP, "called, device_handle={}", device_handle);
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
         IPC::ResponseBuilder rb{ctx, 2, 1};
@@ -372,6 +491,12 @@ void IUser::AttachDeactivateEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
     LOG_DEBUG(Service_NFP, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
 
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
@@ -419,6 +544,12 @@ void IUser::GetNpadId(Kernel::HLERequestContext& ctx) {
     const auto device_handle{rp.Pop<u64>()};
     LOG_DEBUG(Service_NFP, "called, device_handle={}", device_handle);
 
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
+
     // TODO(german77): Loop through all interfaces
     if (device_handle == nfp_interface.GetHandle()) {
         IPC::ResponseBuilder rb{ctx, 3};
@@ -442,7 +573,7 @@ void IUser::GetApplicationAreaSize(Kernel::HLERequestContext& ctx) {
     if (device_handle == nfp_interface.GetHandle()) {
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
-        rb.Push(ApplicationAreaSize);
+        rb.Push(sizeof(ApplicationArea));
         return;
     }
 
@@ -454,6 +585,12 @@ void IUser::GetApplicationAreaSize(Kernel::HLERequestContext& ctx) {
 
 void IUser::AttachAvailabilityChangeEvent(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_NFP, "(STUBBED) called");
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ErrCodes::NfcDisabled);
+        return;
+    }
 
     IPC::ResponseBuilder rb{ctx, 2, 1};
     rb.Push(ResultSuccess);
@@ -478,36 +615,42 @@ void Module::Interface::CreateUserInterface(Kernel::HLERequestContext& ctx) {
     rb.PushIpcInterface<IUser>(*this, system);
 }
 
-bool Module::Interface::LoadAmiibo(const std::vector<u8>& buffer) {
+bool Module::Interface::LoadAmiiboFile(const std::string& filename) {
+    constexpr auto tag_size_without_password = sizeof(NTAG215File) - sizeof(NTAG215Password);
+    const Common::FS::IOFile amiibo_file{filename, Common::FS::FileAccessMode::Read,
+                                         Common::FS::FileType::BinaryFile};
+
+    if (!amiibo_file.IsOpen()) {
+        LOG_ERROR(Core, "Amiibo is already on use");
+        return false;
+    }
+
+    // Workaround for files with missing password data
+    std::array<u8, sizeof(EncryptedNTAG215File)> buffer{};
+    if (amiibo_file.Read(buffer) < tag_size_without_password) {
+        LOG_ERROR(Core, "Failed to read amiibo file");
+        return false;
+    }
+    memcpy(&encrypted_tag_data, buffer.data(), sizeof(EncryptedNTAG215File));
+
+    if (!AmiiboCrypto::IsAmiiboValid(encrypted_tag_data)) {
+        LOG_INFO(Service_NFP, "Invalid amiibo");
+        return false;
+    }
+
+    file_path = filename;
+    return true;
+}
+
+bool Module::Interface::LoadAmiibo(const std::string& filename) {
     if (device_state != DeviceState::SearchingForTag) {
         LOG_ERROR(Service_NFP, "Game is not looking for amiibos, current state {}", device_state);
         return false;
     }
 
-    constexpr auto tag_size = sizeof(NTAG215File);
-    constexpr auto tag_size_without_password = sizeof(NTAG215File) - sizeof(NTAG215Password);
-
-    std::vector<u8> amiibo_buffer = buffer;
-
-    if (amiibo_buffer.size() < tag_size_without_password) {
-        LOG_ERROR(Service_NFP, "Wrong file size {}", buffer.size());
+    if (!LoadAmiiboFile(filename)) {
         return false;
     }
-
-    // Ensure it has the correct size
-    if (amiibo_buffer.size() != tag_size) {
-        amiibo_buffer.resize(tag_size, 0);
-    }
-
-    LOG_INFO(Service_NFP, "Amiibo detected");
-    std::memcpy(&tag_data, buffer.data(), tag_size);
-
-    if (!IsAmiiboValid()) {
-        return false;
-    }
-
-    // This value can't be dumped from a tag. Generate it
-    tag_data.password.PWD = GetTagPassword(tag_data.uuid);
 
     device_state = DeviceState::TagFound;
     activate_event->GetWritableEvent().Signal();
@@ -517,53 +660,11 @@ bool Module::Interface::LoadAmiibo(const std::vector<u8>& buffer) {
 void Module::Interface::CloseAmiibo() {
     LOG_INFO(Service_NFP, "Remove amiibo");
     device_state = DeviceState::TagRemoved;
+    is_data_decoded = false;
     is_application_area_initialized = false;
-    application_area_id = 0;
-    application_area_data.clear();
+    encrypted_tag_data = {};
+    tag_data = {};
     deactivate_event->GetWritableEvent().Signal();
-}
-
-bool Module::Interface::IsAmiiboValid() const {
-    const auto& amiibo_data = tag_data.user_memory;
-    LOG_DEBUG(Service_NFP, "uuid_lock=0x{0:x}", tag_data.lock_bytes);
-    LOG_DEBUG(Service_NFP, "compability_container=0x{0:x}", tag_data.compability_container);
-    LOG_DEBUG(Service_NFP, "crypto_init=0x{0:x}", amiibo_data.crypto_init);
-    LOG_DEBUG(Service_NFP, "write_count={}", amiibo_data.write_count);
-
-    LOG_DEBUG(Service_NFP, "character_id=0x{0:x}", amiibo_data.model_info.character_id);
-    LOG_DEBUG(Service_NFP, "character_variant={}", amiibo_data.model_info.character_variant);
-    LOG_DEBUG(Service_NFP, "amiibo_type={}", amiibo_data.model_info.amiibo_type);
-    LOG_DEBUG(Service_NFP, "model_number=0x{0:x}", amiibo_data.model_info.model_number);
-    LOG_DEBUG(Service_NFP, "series={}", amiibo_data.model_info.series);
-    LOG_DEBUG(Service_NFP, "fixed_value=0x{0:x}", amiibo_data.model_info.fixed);
-
-    LOG_DEBUG(Service_NFP, "tag_dynamic_lock=0x{0:x}", tag_data.dynamic_lock);
-    LOG_DEBUG(Service_NFP, "tag_CFG0=0x{0:x}", tag_data.CFG0);
-    LOG_DEBUG(Service_NFP, "tag_CFG1=0x{0:x}", tag_data.CFG1);
-
-    // Check against all know constants on an amiibo binary
-    if (tag_data.lock_bytes != 0xE00F) {
-        return false;
-    }
-    if (tag_data.compability_container != 0xEEFF10F1U) {
-        return false;
-    }
-    if ((amiibo_data.crypto_init & 0xFF) != 0xA5) {
-        return false;
-    }
-    if (amiibo_data.model_info.fixed != 0x02) {
-        return false;
-    }
-    if ((tag_data.dynamic_lock & 0xFFFFFF) != 0x0F0001) {
-        return false;
-    }
-    if (tag_data.CFG0 != 0x04000000U) {
-        return false;
-    }
-    if (tag_data.CFG1 != 0x5F) {
-        return false;
-    }
-    return true;
 }
 
 Kernel::KReadableEvent& Module::Interface::GetActivateEvent() const {
@@ -576,13 +677,20 @@ Kernel::KReadableEvent& Module::Interface::GetDeactivateEvent() const {
 
 void Module::Interface::Initialize() {
     device_state = DeviceState::Initialized;
+    is_data_decoded = false;
+    is_application_area_initialized = false;
+    encrypted_tag_data = {};
+    tag_data = {};
 }
 
 void Module::Interface::Finalize() {
+    if (device_state == DeviceState::TagMounted) {
+        Unmount();
+    }
+    if (device_state == DeviceState::SearchingForTag || device_state == DeviceState::TagRemoved) {
+        StopDetection();
+    }
     device_state = DeviceState::Unaviable;
-    is_application_area_initialized = false;
-    application_area_id = 0;
-    application_area_data.clear();
 }
 
 Result Module::Interface::StartDetection(s32 protocol_) {
@@ -618,42 +726,102 @@ Result Module::Interface::StopDetection() {
     return ErrCodes::WrongDeviceState;
 }
 
-Result Module::Interface::Mount() {
-    if (device_state == DeviceState::TagFound) {
-        device_state = DeviceState::TagMounted;
+Result Module::Interface::Flush() {
+    // Ignore write command if we can't encrypt the data
+    if (!is_data_decoded) {
         return ResultSuccess;
     }
 
-    LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
-    return ErrCodes::WrongDeviceState;
+    constexpr auto tag_size_without_password = sizeof(NTAG215File) - sizeof(NTAG215Password);
+    EncryptedNTAG215File tmp_encrypted_tag_data{};
+    const Common::FS::IOFile amiibo_file{file_path, Common::FS::FileAccessMode::ReadWrite,
+                                         Common::FS::FileType::BinaryFile};
+
+    if (!amiibo_file.IsOpen()) {
+        LOG_ERROR(Core, "Amiibo is already on use");
+        return ErrCodes::WriteAmiiboFailed;
+    }
+
+    // Workaround for files with missing password data
+    std::array<u8, sizeof(EncryptedNTAG215File)> buffer{};
+    if (amiibo_file.Read(buffer) < tag_size_without_password) {
+        LOG_ERROR(Core, "Failed to read amiibo file");
+        return ErrCodes::WriteAmiiboFailed;
+    }
+    memcpy(&tmp_encrypted_tag_data, buffer.data(), sizeof(EncryptedNTAG215File));
+
+    if (!AmiiboCrypto::IsAmiiboValid(tmp_encrypted_tag_data)) {
+        LOG_INFO(Service_NFP, "Invalid amiibo");
+        return ErrCodes::WriteAmiiboFailed;
+    }
+
+    bool is_uuid_equal = memcmp(tmp_encrypted_tag_data.uuid.data(), tag_data.uuid.data(), 8) == 0;
+    bool is_character_equal = tmp_encrypted_tag_data.user_memory.model_info.character_id ==
+                              tag_data.model_info.character_id;
+    if (!is_uuid_equal || !is_character_equal) {
+        LOG_ERROR(Core, "Not the same amiibo");
+        return ErrCodes::WriteAmiiboFailed;
+    }
+
+    if (!AmiiboCrypto::EncodeAmiibo(tag_data, encrypted_tag_data)) {
+        LOG_ERROR(Core, "Failed to encode data");
+        return ErrCodes::WriteAmiiboFailed;
+    }
+
+    // Return to the start of the file
+    if (!amiibo_file.Seek(0)) {
+        LOG_ERROR(Service_NFP, "Error writting to file");
+        return ErrCodes::WriteAmiiboFailed;
+    }
+
+    if (!amiibo_file.Write(encrypted_tag_data)) {
+        LOG_ERROR(Service_NFP, "Error writting to file");
+        return ErrCodes::WriteAmiiboFailed;
+    }
+
+    return ResultSuccess;
+}
+
+Result Module::Interface::Mount() {
+    if (device_state != DeviceState::TagFound) {
+        LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
+        return ErrCodes::WrongDeviceState;
+    }
+
+    is_data_decoded = AmiiboCrypto::DecodeAmiibo(encrypted_tag_data, tag_data);
+    LOG_INFO(Service_NFP, "Is amiibo decoded {}", is_data_decoded);
+
+    is_application_area_initialized = false;
+    device_state = DeviceState::TagMounted;
+    return ResultSuccess;
 }
 
 Result Module::Interface::Unmount() {
-    if (device_state == DeviceState::TagMounted) {
-        is_application_area_initialized = false;
-        application_area_id = 0;
-        application_area_data.clear();
-        device_state = DeviceState::TagFound;
-        return ResultSuccess;
+    if (device_state != DeviceState::TagMounted) {
+        LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
+        return ErrCodes::WrongDeviceState;
     }
 
-    LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
-    return ErrCodes::WrongDeviceState;
+    is_data_decoded = false;
+    is_application_area_initialized = false;
+    device_state = DeviceState::TagFound;
+    return ResultSuccess;
 }
 
 Result Module::Interface::GetTagInfo(TagInfo& tag_info) const {
-    if (device_state == DeviceState::TagFound || device_state == DeviceState::TagMounted) {
-        tag_info = {
-            .uuid = tag_data.uuid,
-            .uuid_length = static_cast<u8>(tag_data.uuid.size()),
-            .protocol = protocol,
-            .tag_type = static_cast<u32>(tag_data.user_memory.model_info.amiibo_type),
-        };
-        return ResultSuccess;
+    if (device_state != DeviceState::TagFound && device_state != DeviceState::TagMounted) {
+        LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
+        return ErrCodes::WrongDeviceState;
     }
 
-    LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
-    return ErrCodes::WrongDeviceState;
+    tag_info = {
+        .uuid = encrypted_tag_data.uuid,
+        .uuid_length = static_cast<u8>(encrypted_tag_data.uuid.size()),
+        .protocol = protocol,
+        .tag_type = static_cast<u32>(encrypted_tag_data.user_memory.model_info.amiibo_type),
+    };
+
+    return ResultSuccess;
 }
 
 Result Module::Interface::GetCommonInfo(CommonInfo& common_info) const {
@@ -662,14 +830,28 @@ Result Module::Interface::GetCommonInfo(CommonInfo& common_info) const {
         return ErrCodes::WrongDeviceState;
     }
 
-    // Read this data from the amiibo save file
+    if (is_data_decoded) {
+        const auto& settings = tag_data.settings;
+        // TODO: Validate this data
+        common_info = {
+            .last_write_year = static_cast<u16>(settings.write_date.year.Value()),
+            .last_write_month = static_cast<u8>(settings.write_date.month.Value()),
+            .last_write_day = static_cast<u8>(settings.write_date.day.Value()),
+            .write_counter = settings.crc_counter,
+            .version = 1,
+            .application_area_size = sizeof(ApplicationArea),
+        };
+        return ResultSuccess;
+    }
+
+    // Generate a generic answer
     common_info = {
         .last_write_year = 2022,
         .last_write_month = 2,
         .last_write_day = 7,
-        .write_counter = tag_data.user_memory.write_count,
+        .write_counter = 0,
         .version = 1,
-        .application_area_size = ApplicationAreaSize,
+        .application_area_size = sizeof(ApplicationArea),
     };
     return ResultSuccess;
 }
@@ -680,7 +862,15 @@ Result Module::Interface::GetModelInfo(ModelInfo& model_info) const {
         return ErrCodes::WrongDeviceState;
     }
 
-    model_info = tag_data.user_memory.model_info;
+    const auto& model_info_data = encrypted_tag_data.user_memory.model_info;
+    model_info = {
+        .character_id = model_info_data.character_id,
+        .character_variant = model_info_data.character_variant,
+        .amiibo_type = model_info_data.amiibo_type,
+        .model_number = model_info_data.model_number,
+        .series = model_info_data.series,
+        .constant_value = model_info_data.constant_value,
+    };
     return ResultSuccess;
 }
 
@@ -690,9 +880,30 @@ Result Module::Interface::GetRegisterInfo(RegisterInfo& register_info) const {
         return ErrCodes::WrongDeviceState;
     }
 
-    Service::Mii::MiiManager manager;
+    if (is_data_decoded) {
+        const auto& settings = tag_data.settings;
 
-    // Read this data from the amiibo save file
+        // Amiibo name is u16 while the register info is u8. Figure out how to handle this properly
+        std::array<u8, 11> amiibo_name{};
+        for (std::size_t i = 0; i < sizeof(amiibo_name) - 1; ++i) {
+            amiibo_name[i] = static_cast<u8>(settings.amiibo_name[i]);
+        }
+
+        // TODO: Validate this data
+        register_info = {
+            .mii_char_info = AmiiboCrypto::AmiiboRegisterInfoToMii(tag_data.owner_mii),
+            .first_write_year = static_cast<u16>(settings.init_date.year.Value()),
+            .first_write_month = static_cast<u8>(settings.init_date.month.Value()),
+            .first_write_day = static_cast<u8>(settings.init_date.day.Value()),
+            .amiibo_name = amiibo_name,
+            .unknown = {},
+        };
+
+        return ResultSuccess;
+    }
+
+    // Generate a generic answer
+    Service::Mii::MiiManager manager;
     register_info = {
         .mii_char_info = manager.BuildDefault(0),
         .first_write_year = 2022,
@@ -709,29 +920,39 @@ Result Module::Interface::OpenApplicationArea(u32 access_id) {
         LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
         return ErrCodes::WrongDeviceState;
     }
-    if (AmiiboApplicationDataExist(access_id)) {
-        application_area_data = LoadAmiiboApplicationData(access_id);
-        application_area_id = access_id;
-        is_application_area_initialized = true;
-    }
-    if (!is_application_area_initialized) {
+
+    // Fallback for lack of amiibo keys
+    if (!is_data_decoded) {
         LOG_WARNING(Service_NFP, "Application area is not initialized");
         return ErrCodes::ApplicationAreaIsNotInitialized;
     }
+
+    if (tag_data.settings.settings.appdata_initialized == 0) {
+        LOG_WARNING(Service_NFP, "Application area is not initialized");
+        return ErrCodes::ApplicationAreaIsNotInitialized;
+    }
+
+    if (tag_data.application_area_id != access_id) {
+        LOG_WARNING(Service_NFP, "Wrong application area id");
+        return ErrCodes::WrongApplicationAreaId;
+    }
+
+    is_application_area_initialized = true;
     return ResultSuccess;
 }
 
-Result Module::Interface::GetApplicationArea(std::vector<u8>& data) const {
+Result Module::Interface::GetApplicationArea(ApplicationArea& data) const {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
         return ErrCodes::WrongDeviceState;
     }
+
     if (!is_application_area_initialized) {
         LOG_ERROR(Service_NFP, "Application area is not initialized");
         return ErrCodes::ApplicationAreaIsNotInitialized;
     }
 
-    data = application_area_data;
+    data = tag_data.application_area;
 
     return ResultSuccess;
 }
@@ -741,12 +962,18 @@ Result Module::Interface::SetApplicationArea(const std::vector<u8>& data) {
         LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
         return ErrCodes::WrongDeviceState;
     }
+
     if (!is_application_area_initialized) {
         LOG_ERROR(Service_NFP, "Application area is not initialized");
         return ErrCodes::ApplicationAreaIsNotInitialized;
     }
-    application_area_data = data;
-    SaveAmiiboApplicationData(application_area_id, application_area_data);
+
+    if (data.size() != sizeof(ApplicationArea)) {
+        LOG_ERROR(Service_NFP, "Wrong data size {}", data.size());
+        return ResultUnknown;
+    }
+
+    std::memcpy(&tag_data.application_area, data.data(), sizeof(ApplicationArea));
     return ResultSuccess;
 }
 
@@ -755,30 +982,21 @@ Result Module::Interface::CreateApplicationArea(u32 access_id, const std::vector
         LOG_ERROR(Service_NFP, "Wrong device state {}", device_state);
         return ErrCodes::WrongDeviceState;
     }
-    if (AmiiboApplicationDataExist(access_id)) {
+
+    if (tag_data.settings.settings.appdata_initialized != 0) {
         LOG_ERROR(Service_NFP, "Application area already exist");
         return ErrCodes::ApplicationAreaExist;
     }
-    application_area_data = data;
-    application_area_id = access_id;
-    SaveAmiiboApplicationData(application_area_id, application_area_data);
+
+    if (data.size() != sizeof(ApplicationArea)) {
+        LOG_ERROR(Service_NFP, "Wrong data size {}", data.size());
+        return ResultUnknown;
+    }
+
+    std::memcpy(&tag_data.application_area, data.data(), sizeof(ApplicationArea));
+    tag_data.application_area_id = access_id;
+
     return ResultSuccess;
-}
-
-bool Module::Interface::AmiiboApplicationDataExist(u32 access_id) const {
-    // TODO(german77): Check if file exist
-    return false;
-}
-
-std::vector<u8> Module::Interface::LoadAmiiboApplicationData(u32 access_id) const {
-    // TODO(german77): Read file
-    std::vector<u8> data(ApplicationAreaSize);
-    return data;
-}
-
-void Module::Interface::SaveAmiiboApplicationData(u32 access_id,
-                                                  const std::vector<u8>& data) const {
-    // TODO(german77): Save file
 }
 
 u64 Module::Interface::GetHandle() const {
@@ -792,15 +1010,6 @@ DeviceState Module::Interface::GetCurrentState() const {
 
 Core::HID::NpadIdType Module::Interface::GetNpadId() const {
     return npad_id;
-}
-
-u32 Module::Interface::GetTagPassword(const TagUuid& uuid) const {
-    // Verifiy that the generated password is correct
-    u32 password = 0xAA ^ (uuid[1] ^ uuid[3]);
-    password &= (0x55 ^ (uuid[2] ^ uuid[4])) << 8;
-    password &= (0xAA ^ (uuid[3] ^ uuid[5])) << 16;
-    password &= (0x55 ^ (uuid[4] ^ uuid[6])) << 24;
-    return password;
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -55,7 +55,7 @@ struct ModelInfo {
 static_assert(sizeof(ModelInfo) == 0x40, "ModelInfo is an invalid size");
 
 struct RegisterInfo {
-    Service::Mii::MiiInfo mii_char_info;
+    Service::Mii::CharInfo mii_char_info;
     u16 first_write_year;
     u8 first_write_month;
     u8 first_write_day;
@@ -96,6 +96,7 @@ public:
         Result GetApplicationArea(ApplicationArea& data) const;
         Result SetApplicationArea(const std::vector<u8>& data);
         Result CreateApplicationArea(u32 access_id, const std::vector<u8>& data);
+        Result RecreateApplicationArea(u32 access_id, const std::vector<u8>& data);
 
         u64 GetHandle() const;
         DeviceState GetCurrentState() const;
@@ -152,6 +153,7 @@ private:
     void GetNpadId(Kernel::HLERequestContext& ctx);
     void GetApplicationAreaSize(Kernel::HLERequestContext& ctx);
     void AttachAvailabilityChangeEvent(Kernel::HLERequestContext& ctx);
+    void RecreateApplicationArea(Kernel::HLERequestContext& ctx);
 
     KernelHelpers::ServiceContext service_context;
 

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -9,6 +9,7 @@
 #include "common/common_funcs.h"
 #include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/mii/types.h"
+#include "core/hle/service/nfp/amiibo_types.h"
 #include "core/hle/service/service.h"
 
 namespace Kernel {
@@ -21,72 +22,6 @@ enum class NpadIdType : u32;
 } // namespace Core::HID
 
 namespace Service::NFP {
-
-enum class ServiceType : u32 {
-    User,
-    Debug,
-    System,
-};
-
-enum class State : u32 {
-    NonInitialized,
-    Initialized,
-};
-
-enum class DeviceState : u32 {
-    Initialized,
-    SearchingForTag,
-    TagFound,
-    TagRemoved,
-    TagMounted,
-    Unaviable,
-    Finalized,
-};
-
-enum class ModelType : u32 {
-    Amiibo,
-};
-
-enum class MountTarget : u32 {
-    Rom,
-    Ram,
-    All,
-};
-
-enum class AmiiboType : u8 {
-    Figure,
-    Card,
-    Yarn,
-};
-
-enum class AmiiboSeries : u8 {
-    SuperSmashBros,
-    SuperMario,
-    ChibiRobo,
-    YoshiWoollyWorld,
-    Splatoon,
-    AnimalCrossing,
-    EightBitMario,
-    Skylanders,
-    Unknown8,
-    TheLegendOfZelda,
-    ShovelKnight,
-    Unknown11,
-    Kiby,
-    Pokemon,
-    MarioSportsSuperstars,
-    MonsterHunter,
-    BoxBoy,
-    Pikmin,
-    FireEmblem,
-    Metroid,
-    Others,
-    MegaMan,
-    Diablo
-};
-
-using TagUuid = std::array<u8, 10>;
-
 struct TagInfo {
     TagUuid uuid;
     u8 uuid_length;
@@ -114,10 +49,8 @@ struct ModelInfo {
     AmiiboType amiibo_type;
     u16 model_number;
     AmiiboSeries series;
-    u8 fixed;                   // Must be 02
-    INSERT_PADDING_BYTES(0x4);  // Unknown
-    INSERT_PADDING_BYTES(0x20); // Probably a SHA256-(HMAC?) hash
-    INSERT_PADDING_BYTES(0x14); // SHA256-HMAC
+    u8 constant_value;          // Must be 02
+    INSERT_PADDING_BYTES(0x38); // Unknown
 };
 static_assert(sizeof(ModelInfo) == 0x40, "ModelInfo is an invalid size");
 
@@ -126,7 +59,7 @@ struct RegisterInfo {
     u16 first_write_year;
     u8 first_write_month;
     u8 first_write_day;
-    std::array<u8, 11> amiibo_name;
+    std::array<u8, 0xA + 1> amiibo_name;
     u8 unknown;
     INSERT_PADDING_BYTES(0x98);
 };
@@ -140,39 +73,9 @@ public:
                            const char* name);
         ~Interface() override;
 
-        struct EncryptedAmiiboFile {
-            u16 crypto_init;             // Must be A5 XX
-            u16 write_count;             // Number of times the amiibo has been written?
-            INSERT_PADDING_BYTES(0x20);  // System crypts
-            INSERT_PADDING_BYTES(0x20);  // SHA256-(HMAC?) hash
-            ModelInfo model_info;        // This struct is bigger than documentation
-            INSERT_PADDING_BYTES(0xC);   // SHA256-HMAC
-            INSERT_PADDING_BYTES(0x114); // section 1 encrypted buffer
-            INSERT_PADDING_BYTES(0x54);  // section 2 encrypted buffer
-        };
-        static_assert(sizeof(EncryptedAmiiboFile) == 0x1F8, "AmiiboFile is an invalid size");
-
-        struct NTAG215Password {
-            u32 PWD;  // Password to allow write access
-            u16 PACK; // Password acknowledge reply
-            u16 RFUI; // Reserved for future use
-        };
-        static_assert(sizeof(NTAG215Password) == 0x8, "NTAG215Password is an invalid size");
-
-        struct NTAG215File {
-            TagUuid uuid;                    // Unique serial number
-            u16 lock_bytes;                  // Set defined pages as read only
-            u32 compability_container;       // Defines available memory
-            EncryptedAmiiboFile user_memory; // Writable data
-            u32 dynamic_lock;                // Dynamic lock
-            u32 CFG0;                        // Defines memory protected by password
-            u32 CFG1;                        // Defines number of verification attempts
-            NTAG215Password password;        // Password data
-        };
-        static_assert(sizeof(NTAG215File) == 0x21C, "NTAG215File is an invalid size");
-
         void CreateUserInterface(Kernel::HLERequestContext& ctx);
-        bool LoadAmiibo(const std::vector<u8>& buffer);
+        bool LoadAmiibo(const std::string& filename);
+        bool LoadAmiiboFile(const std::string& filename);
         void CloseAmiibo();
 
         void Initialize();
@@ -182,6 +85,7 @@ public:
         Result StopDetection();
         Result Mount();
         Result Unmount();
+        Result Flush();
 
         Result GetTagInfo(TagInfo& tag_info) const;
         Result GetCommonInfo(CommonInfo& common_info) const;
@@ -189,7 +93,7 @@ public:
         Result GetRegisterInfo(RegisterInfo& register_info) const;
 
         Result OpenApplicationArea(u32 access_id);
-        Result GetApplicationArea(std::vector<u8>& data) const;
+        Result GetApplicationArea(ApplicationArea& data) const;
         Result SetApplicationArea(const std::vector<u8>& data);
         Result CreateApplicationArea(u32 access_id, const std::vector<u8>& data);
 
@@ -204,27 +108,19 @@ public:
         std::shared_ptr<Module> module;
 
     private:
-        /// Validates that the amiibo file is not corrupted
-        bool IsAmiiboValid() const;
-
-        bool AmiiboApplicationDataExist(u32 access_id) const;
-        std::vector<u8> LoadAmiiboApplicationData(u32 access_id) const;
-        void SaveAmiiboApplicationData(u32 access_id, const std::vector<u8>& data) const;
-
-        /// return password needed to allow write access to protected memory
-        u32 GetTagPassword(const TagUuid& uuid) const;
-
         const Core::HID::NpadIdType npad_id;
 
-        DeviceState device_state{DeviceState::Unaviable};
-        KernelHelpers::ServiceContext service_context;
+        bool is_data_decoded{};
+        bool is_application_area_initialized{};
+        s32 protocol;
+        std::string file_path{};
         Kernel::KEvent* activate_event;
         Kernel::KEvent* deactivate_event;
+        DeviceState device_state{DeviceState::Unaviable};
+        KernelHelpers::ServiceContext service_context;
+
         NTAG215File tag_data{};
-        s32 protocol;
-        bool is_application_area_initialized{};
-        u32 application_area_id;
-        std::vector<u8> application_area_data;
+        EncryptedNTAG215File encrypted_tag_data{};
     };
 };
 
@@ -243,6 +139,7 @@ private:
     void OpenApplicationArea(Kernel::HLERequestContext& ctx);
     void GetApplicationArea(Kernel::HLERequestContext& ctx);
     void SetApplicationArea(Kernel::HLERequestContext& ctx);
+    void Flush(Kernel::HLERequestContext& ctx);
     void CreateApplicationArea(Kernel::HLERequestContext& ctx);
     void GetTagInfo(Kernel::HLERequestContext& ctx);
     void GetRegisterInfo(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -22,6 +22,8 @@ enum class NpadIdType : u32;
 } // namespace Core::HID
 
 namespace Service::NFP {
+using AmiiboName = std::array<char, (amiibo_name_length * 4) + 1>;
+
 struct TagInfo {
     TagUuid uuid;
     u8 uuid_length;
@@ -59,9 +61,9 @@ struct RegisterInfo {
     u16 first_write_year;
     u8 first_write_month;
     u8 first_write_day;
-    std::array<u8, 0xA + 1> amiibo_name;
-    u8 unknown;
-    INSERT_PADDING_BYTES(0x98);
+    AmiiboName amiibo_name;
+    u8 font_region;
+    INSERT_PADDING_BYTES(0x7A);
 };
 static_assert(sizeof(RegisterInfo) == 0x100, "RegisterInfo is an invalid size");
 
@@ -109,6 +111,8 @@ public:
         std::shared_ptr<Module> module;
 
     private:
+        AmiiboName GetAmiiboName(const AmiiboSettings& settings) const;
+
         const Core::HID::NpadIdType npad_id;
 
         bool is_data_decoded{};

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3254,26 +3254,7 @@ void GMainWindow::LoadAmiibo(const QString& filename) {
         return;
     }
 
-    QFile nfc_file{filename};
-    if (!nfc_file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(this, tr("Error opening Amiibo data file"),
-                             tr("Unable to open Amiibo file \"%1\" for reading.").arg(filename));
-        return;
-    }
-
-    const u64 nfc_file_size = nfc_file.size();
-    std::vector<u8> buffer(nfc_file_size);
-    const u64 read_size = nfc_file.read(reinterpret_cast<char*>(buffer.data()), nfc_file_size);
-    if (nfc_file_size != read_size) {
-        QMessageBox::warning(this, tr("Error reading Amiibo data file"),
-                             tr("Unable to fully read Amiibo data. Expected to read %1 bytes, but "
-                                "was only able to read %2 bytes.")
-                                 .arg(nfc_file_size)
-                                 .arg(read_size));
-        return;
-    }
-
-    if (!nfc->LoadAmiibo(buffer)) {
+    if (!nfc->LoadAmiibo(filename.toStdString())) {
         QMessageBox::warning(this, tr("Error loading Amiibo data"),
                              tr("Unable to load Amiibo data."));
     }


### PR DESCRIPTION
After booting SSBU for the 1000th time this PR Implements full amiibo support. You can load and store data from amiibo dumps. A lot of thanks to jonbarrow for providing the data to translate mii data and amiitool that literally made this PR possible. Next implementation will probably implement an interface to manage amiibos. Since this PR only can modify the application area.

To be able to encode or decode amiibos `key_retail.bin` needs to be placed in the keys folder. [LockPick RCM v1.9.8](https://github.com/shchmue/Lockpick_RCM/releases/tag/v1.9.8) added support to dump amiibo keys.

WARNING: Since this feature is experimental it can corrupt your amiibo dumps. Please keep a backup.

![image](https://user-images.githubusercontent.com/5944268/187055472-06b4df50-8c8b-4d93-bde9-e81b68dd3997.png)
