### PR TITLE
ci: Enable building with Visual Studio 2022 (again)

### DIFF
--- a/.ci/templates/build-msvc.yml
+++ b/.ci/templates/build-msvc.yml
@@ -9,7 +9,7 @@ parameters:
 steps:
 - script: choco install vulkan-sdk
   displayName: 'Install vulkan-sdk'
-- script: refreshenv && mkdir build && cd build && cmake -G "Visual Studio 16 2019" -A x64 -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_BUNDLED_SDL2=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${COMPAT} -DYUZU_TESTS=OFF -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON -DDISPLAY_VERSION=${{ parameters['version'] }} -DCMAKE_BUILD_TYPE=Release .. && cd ..
+- script: refreshenv && mkdir build && cd build && cmake -G "Visual Studio 17 2022" -A x64 -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_BUNDLED_SDL2=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${COMPAT} -DYUZU_TESTS=OFF -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON -DDISPLAY_VERSION=${{ parameters['version'] }} -DCMAKE_BUILD_TYPE=Release .. && cd ..
   displayName: 'Configure CMake'
 - task: MSBuild@1
   displayName: 'Build'

--- a/.ci/yuzu-mainline-step2.yml
+++ b/.ci/yuzu-mainline-step2.yml
@@ -50,7 +50,7 @@ stages:
     timeoutInMinutes: 120
     displayName: 'msvc'
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
     - template: ./templates/sync-source.yml
       parameters:

--- a/.ci/yuzu-patreon-step2.yml
+++ b/.ci/yuzu-patreon-step2.yml
@@ -15,7 +15,7 @@ stages:
     timeoutInMinutes: 120
     displayName: 'windows-msvc'
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
     - template: ./templates/sync-source.yml
       parameters:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -71,7 +71,7 @@ jobs:
   build-msvc:
     name: 'test build (windows, msvc)'
     needs: format
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Set up cache
         uses: actions/cache@v3


### PR DESCRIPTION
Since the following https://developercommunity.visualstudio.com/t/Type-alias-lookup-failure-within-paramet/10039150 compiler bug has been fixed, we can finally build with VS 2022 again.