### PR TITLE
(shader/pipeline)_cache: Raise shader/pipeline cache version

### DIFF
--- a/src/shader_recompiler/ir_opt/texture_pass.cpp
+++ b/src/shader_recompiler/ir_opt/texture_pass.cpp
@@ -415,11 +415,11 @@ void TexturePass(Environment& env, IR::Program& program) {
             inst->SetFlags(flags);
             break;
         case IR::Opcode::ImageSampleImplicitLod:
-            if (flags.type == TextureType::Color2D) {
-                auto texture_type = ReadTextureType(env, cbuf);
-                if (texture_type == TextureType::Color2DRect) {
-                    PatchImageSampleImplicitLod(*texture_inst.block, *texture_inst.inst);
-                }
+            if (flags.type != TextureType::Color2D) {
+                break;
+            }
+            if (ReadTextureType(env, cbuf) == TextureType::Color2DRect) {
+                PatchImageSampleImplicitLod(*texture_inst.block, *texture_inst.inst);
             }
             break;
         case IR::Opcode::ImageFetch:

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -49,7 +49,7 @@ using VideoCommon::LoadPipelines;
 using VideoCommon::SerializePipeline;
 using Context = ShaderContext::Context;
 
-constexpr u32 CACHE_VERSION = 5;
+constexpr u32 CACHE_VERSION = 6;
 
 template <typename Container>
 auto MakeSpan(Container& container) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -53,7 +53,7 @@ using VideoCommon::FileEnvironment;
 using VideoCommon::GenericEnvironment;
 using VideoCommon::GraphicsEnvironment;
 
-constexpr u32 CACHE_VERSION = 5;
+constexpr u32 CACHE_VERSION = 6;
 
 template <typename Container>
 auto MakeSpan(Container& container) {

--- a/src/video_core/shader_environment.cpp
+++ b/src/video_core/shader_environment.cpp
@@ -39,11 +39,8 @@ static Shader::TextureType ConvertType(const Tegra::Texture::TICEntry& entry) {
         return Shader::TextureType::Color1D;
     case Tegra::Texture::TextureType::Texture2D:
     case Tegra::Texture::TextureType::Texture2DNoMipmap:
-        if (entry.normalized_coords) {
-            return Shader::TextureType::Color2D;
-        } else {
-            return Shader::TextureType::Color2DRect;
-        }
+        return entry.normalized_coords ? Shader::TextureType::Color2D
+                                       : Shader::TextureType::Color2DRect;
     case Tegra::Texture::TextureType::Texture3D:
         return Shader::TextureType::Color3D;
     case Tegra::Texture::TextureType::TextureCubemap:


### PR DESCRIPTION
Since the following commit: https://github.com/yuzu-emu/yuzu/commit/a83a5d2e4c8932df864dd4cea2b04d87a12c8760 , many games will refuse to boot unless the shader/pipeline cache has been invalidated.
Raises the shader/pipeline cache version to force an invalidation.