### PR TITLE
Demote services from warning/info to debug to reduce log spam

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -754,7 +754,7 @@ void ICommonStateGetter::ReceiveMessage(Kernel::HLERequestContext& ctx) {
 }
 
 void ICommonStateGetter::GetCurrentFocusState(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_DEBUG(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);

--- a/src/core/hle/service/apm/apm_controller.cpp
+++ b/src/core/hle/service/apm/apm_controller.cpp
@@ -80,7 +80,7 @@ PerformanceConfiguration Controller::GetCurrentPerformanceConfiguration(Performa
 }
 
 void Controller::SetClockSpeed(u32 mhz) {
-    LOG_INFO(Service_APM, "called, mhz={:08X}", mhz);
+    LOG_DEBUG(Service_APM, "called, mhz={:08X}", mhz);
     // TODO(DarkLordZach): Actually signal core_timing to change clock speed.
     // TODO(Rodrigo): Remove [[maybe_unused]] when core_timing is used.
 }

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -819,12 +819,12 @@ void Hid::EnableSixAxisSensorUnalteredPassthrough(Kernel::HLERequestContext& ctx
     const auto result = controller.EnableSixAxisSensorUnalteredPassthrough(
         parameters.sixaxis_handle, parameters.enabled);
 
-    LOG_WARNING(Service_HID,
-                "(STUBBED) called, enabled={}, npad_type={}, npad_id={}, device_index={}, "
-                "applet_resource_user_id={}",
-                parameters.enabled, parameters.sixaxis_handle.npad_type,
-                parameters.sixaxis_handle.npad_id, parameters.sixaxis_handle.device_index,
-                parameters.applet_resource_user_id);
+    LOG_DEBUG(Service_HID,
+              "(STUBBED) called, enabled={}, npad_type={}, npad_id={}, device_index={}, "
+              "applet_resource_user_id={}",
+              parameters.enabled, parameters.sixaxis_handle.npad_type,
+              parameters.sixaxis_handle.npad_id, parameters.sixaxis_handle.device_index,
+              parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(result);
@@ -846,7 +846,7 @@ void Hid::IsSixAxisSensorUnalteredPassthroughEnabled(Kernel::HLERequestContext& 
     const auto result = controller.IsSixAxisSensorUnalteredPassthroughEnabled(
         parameters.sixaxis_handle, is_unaltered_sisxaxis_enabled);
 
-    LOG_WARNING(
+    LOG_DEBUG(
         Service_HID,
         "(STUBBED) called, npad_type={}, npad_id={}, device_index={}, applet_resource_user_id={}",
         parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,

--- a/src/core/hle/service/mm/mm_u.cpp
+++ b/src/core/hle/service/mm/mm_u.cpp
@@ -46,7 +46,7 @@ private:
         IPC::RequestParser rp{ctx};
         min = rp.Pop<u32>();
         max = rp.Pop<u32>();
-        LOG_WARNING(Service_MM, "(STUBBED) called, min=0x{:X}, max=0x{:X}", min, max);
+        LOG_DEBUG(Service_MM, "(STUBBED) called, min=0x{:X}, max=0x{:X}", min, max);
 
         current = min;
         IPC::ResponseBuilder rb{ctx, 2};
@@ -54,7 +54,7 @@ private:
     }
 
     void GetOld(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_MM, "(STUBBED) called");
+        LOG_DEBUG(Service_MM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
@@ -81,8 +81,8 @@ private:
         u32 input_id = rp.Pop<u32>();
         min = rp.Pop<u32>();
         max = rp.Pop<u32>();
-        LOG_WARNING(Service_MM, "(STUBBED) called, input_id=0x{:X}, min=0x{:X}, max=0x{:X}",
-                    input_id, min, max);
+        LOG_DEBUG(Service_MM, "(STUBBED) called, input_id=0x{:X}, min=0x{:X}, max=0x{:X}", input_id,
+                  min, max);
 
         current = min;
         IPC::ResponseBuilder rb{ctx, 2};
@@ -90,7 +90,7 @@ private:
     }
 
     void Get(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_MM, "(STUBBED) called");
+        LOG_DEBUG(Service_MM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -198,7 +198,7 @@ NvResult nvmap::IocParam(const std::vector<u8>& input, std::vector<u8>& output) 
     IocParamParams params;
     std::memcpy(&params, input.data(), sizeof(params));
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called type={}", params.param);
+    LOG_DEBUG(Service_NVDRV, "(STUBBED) called type={}", params.param);
 
     auto object = GetObject(params.handle);
     if (!object) {
@@ -243,7 +243,7 @@ NvResult nvmap::IocFree(const std::vector<u8>& input, std::vector<u8>& output) {
     IocFreeParams params;
     std::memcpy(&params, input.data(), sizeof(params));
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_DEBUG(Service_NVDRV, "(STUBBED) called");
 
     auto itr = handles.find(params.handle);
     if (itr == handles.end()) {


### PR DESCRIPTION
These get spammed very often for many games and can end up taking 90+% of logs. Demote them down to debug instead of warning/info.

Demotes:
* GetCurrentFocusState
* SetClockSpeed
* EnableSixAxisSensorUnalteredPassthrough
* IsSixAxisSensorUnalteredPassthroughEnabled
* Get, GetOld
* SetAndWait, SetAndWaitOld
* IocParam
* IocFree