### PR TITLE
Qt: Make General->Debug scrollable

### DIFF
--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -14,7 +14,7 @@
 #include "yuzu/uisettings.h"
 
 ConfigureDebug::ConfigureDebug(const Core::System& system_, QWidget* parent)
-    : QWidget(parent), ui{std::make_unique<Ui::ConfigureDebug>()}, system{system_} {
+    : QScrollArea(parent), ui{std::make_unique<Ui::ConfigureDebug>()}, system{system_} {
     ui->setupUi(this);
     SetConfiguration();
 

--- a/src/yuzu/configuration/configure_debug.h
+++ b/src/yuzu/configuration/configure_debug.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <memory>
-#include <QWidget>
+#include <QScrollArea>
 
 namespace Core {
 class System;
@@ -14,7 +14,7 @@ namespace Ui {
 class ConfigureDebug;
 }
 
-class ConfigureDebug : public QWidget {
+class ConfigureDebug : public QScrollArea {
     Q_OBJECT
 
 public:

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ConfigureDebug</class>
- <widget class="QWidget" name="ConfigureDebug">
+ <widget class="QScrollArea" name="ConfigureDebug">
+  <property name="widgetResizable">
+   <bool>true</bool>
+  </property>
+ <widget class="QWidget">
   <layout class="QVBoxLayout" name="verticalLayout_1">
     <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -321,6 +325,7 @@
     </widget>
    </item>
   </layout>
+ </widget>
  </widget>
  <tabstops>
   <tabstop>log_filter_edit</tabstop>


### PR DESCRIPTION
Configuration -> General -> Debug is getting a bit crowded.

yzct12345 submit this originally, so I'm tagging them as a co-author.
The original #6714 also modifies the Controls -> Player N sections,
but it looks like more work is needed to make the current area scrollable.

------

Looking at the pictures it seems like the size of the Configuration window is based on the default theme

Before 
![image](https://user-images.githubusercontent.com/190571/188268900-5cc9eaeb-01ab-4205-967b-c8f96d8ca371.png)

After
![image](https://user-images.githubusercontent.com/190571/188268914-8527dac6-ae5d-4c3f-a86f-e5d6c2d0b1f4.png)

Before Bright mode
![image](https://user-images.githubusercontent.com/190571/188269067-4227e758-caed-4717-8049-a1cb19a1bc4b.png)


After (default theme)
![image](https://user-images.githubusercontent.com/190571/188268942-c5cc248c-42c6-4ef5-ad62-cbc4b50a222d.png)

Before Midnight theme
![image](https://user-images.githubusercontent.com/190571/188269290-0dff012c-0d63-4bc2-a24f-e9175c7c53de.png)


