### PR TITLE
Fix Cmake warning for CMP0077

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 
 # Dynarmic
 if (ARCHITECTURE_x86_64)
-    set(DYNARMIC_TESTS OFF)
     set(DYNARMIC_NO_BUNDLED_FMT ON)
     set(DYNARMIC_IGNORE_ASSERTS ON CACHE BOOL "" FORCE)
     add_subdirectory(dynarmic)


### PR DESCRIPTION
Relevant Info: 
> CMake Warning (dev) at externals/dynarmic/CMakeLists.txt:16 (option):
>   Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
>   --help-policy CMP0077" for policy details.  Use the cmake_policy command to
>   set the policy and suppress this warning.
> 
>   For compatibility with older versions of CMake, option is clearing the
>   normal variable 'DYNARMIC_TESTS'.
> This warning is for project developers.  Use -Wno-dev to suppress it.

***
Thanks @lioncash for providing the fix.
> Reason for the warning is we're setting a normal cmake variable with the same name as an option before the option itself has been introduced.
> Since dynarmic already disables tests if it's not the main project, we can remove this line.