### PR TITLE
vulkan: configure staging buffer size

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -61,6 +61,8 @@ void LogSettings() {
     log_setting("Renderer_ShaderBackend", values.shader_backend.GetValue());
     log_setting("Renderer_UseAsynchronousShaders", values.use_asynchronous_shaders.GetValue());
     log_setting("Renderer_AnisotropicFilteringLevel", values.max_anisotropy.GetValue());
+    log_setting("Renderer_StagingBufferSize",
+                (1ULL << static_cast<u32>(values.staging_buffer_size.GetValue())) * 128);
     log_setting("Audio_OutputEngine", values.sink_id.GetValue());
     log_setting("Audio_OutputDevice", values.audio_output_device_id.GetValue());
     log_setting("Audio_InputDevice", values.audio_input_device_id.GetValue());
@@ -196,6 +198,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_asynchronous_shaders.SetGlobal(true);
     values.use_fast_gpu_time.SetGlobal(true);
     values.use_pessimistic_flushes.SetGlobal(true);
+    values.staging_buffer_size.SetGlobal(true);
     values.bg_red.SetGlobal(true);
     values.bg_green.SetGlobal(true);
     values.bg_blue.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -33,6 +33,14 @@ enum class GPUAccuracy : u32 {
     Extreme = 2,
 };
 
+enum class StagingBufferSize : u32 {
+    Size_128MiB = 0,
+    Size_256MiB = 1,
+    Size_512MiB = 2,
+    Size_1024MiB = 3,
+    Size_2048MiB = 4,
+};
+
 enum class CPUAccuracy : u32 {
     Auto = 0,
     Accurate = 1,
@@ -447,6 +455,9 @@ struct Values {
     SwitchableSetting<bool> use_asynchronous_shaders{false, "use_asynchronous_shaders"};
     SwitchableSetting<bool> use_fast_gpu_time{true, "use_fast_gpu_time"};
     SwitchableSetting<bool> use_pessimistic_flushes{false, "use_pessimistic_flushes"};
+    SwitchableSetting<StagingBufferSize, true> staging_buffer_size{
+        StagingBufferSize::Size_128MiB, StagingBufferSize::Size_128MiB,
+        StagingBufferSize::Size_2048MiB, "staging_buffer_size"};
 
     SwitchableSetting<u8> bg_red{0, "bg_red"};
     SwitchableSetting<u8> bg_green{0, "bg_green"};

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
@@ -93,6 +93,9 @@ private:
     size_t free_iterator = 0;
     std::array<u64, NUM_SYNCS> sync_ticks{};
 
+    size_t staging_buffer_size = 0;
+    size_t region_size = 0;
+
     StagingBuffersCache device_local_cache;
     StagingBuffersCache upload_cache;
     StagingBuffersCache download_cache;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -673,6 +673,7 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.scaling_filter);
     ReadGlobalSetting(Settings::values.anti_aliasing);
     ReadGlobalSetting(Settings::values.max_anisotropy);
+    ReadGlobalSetting(Settings::values.staging_buffer_size);
     ReadGlobalSetting(Settings::values.use_speed_limit);
     ReadGlobalSetting(Settings::values.speed_limit);
     ReadGlobalSetting(Settings::values.use_disk_shader_cache);
@@ -1281,6 +1282,10 @@ void Config::SaveRendererValues() {
                  static_cast<u32>(Settings::values.anti_aliasing.GetDefault()),
                  Settings::values.anti_aliasing.UsingGlobal());
     WriteGlobalSetting(Settings::values.max_anisotropy);
+    WriteSetting(QString::fromStdString(Settings::values.staging_buffer_size.GetLabel()),
+                 static_cast<u32>(Settings::values.staging_buffer_size.GetValue(global)),
+                 static_cast<u32>(Settings::values.staging_buffer_size.GetDefault()),
+                 Settings::values.staging_buffer_size.UsingGlobal());
     WriteGlobalSetting(Settings::values.use_speed_limit);
     WriteGlobalSetting(Settings::values.speed_limit);
     WriteGlobalSetting(Settings::values.use_disk_shader_cache);

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -208,3 +208,4 @@ Q_DECLARE_METATYPE(Settings::ScalingFilter);
 Q_DECLARE_METATYPE(Settings::AntiAliasing);
 Q_DECLARE_METATYPE(Settings::RendererBackend);
 Q_DECLARE_METATYPE(Settings::ShaderBackend);
+Q_DECLARE_METATYPE(Settings::StagingBufferSize);

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -35,14 +35,20 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
             static_cast<int>(Settings::values.gpu_accuracy.GetValue()));
         ui->anisotropic_filtering_combobox->setCurrentIndex(
             Settings::values.max_anisotropy.GetValue());
+        ui->staging_buffer_size->setCurrentIndex(
+            static_cast<u32>(Settings::values.staging_buffer_size.GetValue()));
     } else {
         ConfigurationShared::SetPerGameSetting(ui->gpu_accuracy, &Settings::values.gpu_accuracy);
         ConfigurationShared::SetPerGameSetting(ui->anisotropic_filtering_combobox,
                                                &Settings::values.max_anisotropy);
+        ConfigurationShared::SetPerGameSetting(ui->staging_buffer_size,
+                                               &Settings::values.staging_buffer_size);
         ConfigurationShared::SetHighlight(ui->label_gpu_accuracy,
                                           !Settings::values.gpu_accuracy.UsingGlobal());
         ConfigurationShared::SetHighlight(ui->af_label,
                                           !Settings::values.max_anisotropy.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_staging_buffer_size,
+                                          !Settings::values.staging_buffer_size.UsingGlobal());
     }
 }
 
@@ -58,6 +64,8 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
                                              ui->use_fast_gpu_time, use_fast_gpu_time);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_pessimistic_flushes,
                                              ui->use_pessimistic_flushes, use_pessimistic_flushes);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.staging_buffer_size,
+                                             ui->staging_buffer_size);
 }
 
 void ConfigureGraphicsAdvanced::changeEvent(QEvent* event) {
@@ -84,6 +92,7 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
             Settings::values.use_pessimistic_flushes.UsingGlobal());
         ui->anisotropic_filtering_combobox->setEnabled(
             Settings::values.max_anisotropy.UsingGlobal());
+        ui->staging_buffer_size->setEnabled(Settings::values.staging_buffer_size.UsingGlobal());
 
         return;
     }
@@ -103,4 +112,7 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->anisotropic_filtering_combobox, ui->af_label,
         static_cast<int>(Settings::values.max_anisotropy.GetValue(true)));
+    ConfigurationShared::SetColoredComboBox(
+        ui->staging_buffer_size, ui->label_staging_buffer_size,
+        static_cast<u32>(Settings::values.staging_buffer_size.GetValue(true)));
 }

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -168,6 +168,60 @@
           </layout>
          </widget>
         </item>
+        <item>
+         <widget class="QWidget" name="staging_buffer_size_layout" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_staging_buffer_size">
+             <property name="text">
+              <string>Vulkan staging buffer size:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="staging_buffer_size">
+             <item>
+              <property name="text">
+               <string>128 MiB</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>256 MiB</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>512 MiB</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>1024 MiB</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2048 MiB</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>


### PR DESCRIPTION
Larger staging buffers can give performance gains in certain games. This will have the most performance improvement on systems that support resizable BAR, as it will result in a single device local mapping.

256MiB
XCDE: 30fps
XC2: 43fps
XC3: 42fps
Astral Chain: 51fps
SMTV: 28fps

128MiB
XCDE: 28fps
XC2: 40fps
XC3: 28fps
Astral Chain: 48fps
SMTV: 23fps