### PR TITLE
sdl_driver: Added Joy-Cons to the HD rumble list

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -109,7 +109,7 @@ public:
     bool HasHDRumble() const {
         if (sdl_controller) {
             const auto type = SDL_GameControllerGetType(sdl_controller.get());
-            return (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO)  || 
+            return (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO) || 
                    (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_LEFT) ||
                    (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT) ||
                    (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_PAIR) ||

--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -109,7 +109,10 @@ public:
     bool HasHDRumble() const {
         if (sdl_controller) {
             const auto type = SDL_GameControllerGetType(sdl_controller.get());
-            return (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO) ||
+            return (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO)  || 
+                   (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_LEFT) ||
+                   (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT) ||
+                   (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_PAIR) ||
                    (type == SDL_CONTROLLER_TYPE_PS5);
         }
         return false;


### PR DESCRIPTION
New SDL includes Joy-Cons support, and they weren't mentioned on the HasHDRumble() function, which resulted on a return of false.