### PR TITLE
CMake: explicitly link mbedcrypto for yuzu-room

### DIFF
--- a/src/dedicated_room/CMakeLists.txt
+++ b/src/dedicated_room/CMakeLists.txt
@@ -16,7 +16,7 @@ if (ENABLE_WEB_SERVICE)
     target_link_libraries(yuzu-room PRIVATE web_service)
 endif()
 
-target_link_libraries(yuzu-room PRIVATE mbedtls)
+target_link_libraries(yuzu-room PRIVATE mbedtls mbedcrypto)
 if (MSVC)
     target_link_libraries(yuzu-room PRIVATE getopt)
 endif()


### PR DESCRIPTION
Doesn't appear to effect anything regular, but in both Linux and Windows builds it looks like our project has all the libraries available for linking. If this feature is turned off, there is only one thing that quit working, when linking yuzu-room it couldn't find a function called mbedtls_base64_decode

mbedtls is split into three libraries for some reason: 
mbedtls
mbedx509
mbedcrypto

mbedtls_base64_decode is in mbedcrypto

-----

fixes #8866  

ebuild in question https://github.com/gentoo-mirror/guru/blob/master/games-emulation/yuzu/yuzu-9999.ebuild