### PR TITLE
core/CMakeLists.txt: Remove duplicate files.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,12 +4,6 @@
 add_library(core STATIC
     arm/arm_interface.h
     arm/arm_interface.cpp
-    arm/dynarmic/arm_dynarmic_32.cpp
-    arm/dynarmic/arm_dynarmic_32.h
-    arm/dynarmic/arm_dynarmic_64.cpp
-    arm/dynarmic/arm_dynarmic_64.h
-    arm/dynarmic/arm_dynarmic_cp15.cpp
-    arm/dynarmic/arm_dynarmic_cp15.h
     arm/dynarmic/arm_exclusive_monitor.cpp
     arm/dynarmic/arm_exclusive_monitor.h
     arm/exclusive_monitor.cpp


### PR DESCRIPTION
These are already present at the [bottom of the file](https://github.com/yuzu-emu/yuzu/blob/master/src/core/CMakeLists.txt#L799-L804) and guarded by the `ARCHITECTURE_x86_64` check.