### PR TITLE
build(dedicated_room): don't link to mbedtls

### DIFF
--- a/src/dedicated_room/CMakeLists.txt
+++ b/src/dedicated_room/CMakeLists.txt
@@ -16,7 +16,7 @@ if (ENABLE_WEB_SERVICE)
     target_link_libraries(yuzu-room PRIVATE web_service)
 endif()
 
-target_link_libraries(yuzu-room PRIVATE mbedtls mbedcrypto)
+target_link_libraries(yuzu-room PRIVATE mbedcrypto)
 if (MSVC)
     target_link_libraries(yuzu-room PRIVATE getopt)
 endif()


### PR DESCRIPTION
The code only uses parts of the mbedcrypto library (see https://github.com/yuzu-emu/yuzu/pull/8867#issuecomment-1241299906)