### PR TITLE
Align index buffe size when vertex_buffer_unified_memory enable

### DIFF
--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -168,7 +168,7 @@ void BufferCacheRuntime::BindIndexBuffer(Buffer& buffer, u32 offset, u32 size) {
     if (has_unified_vertex_buffers) {
         buffer.MakeResident(GL_READ_ONLY);
         glBufferAddressRangeNV(GL_ELEMENT_ARRAY_ADDRESS_NV, 0, buffer.HostGpuAddr() + offset,
-                               static_cast<GLsizeiptr>(size));
+                               static_cast<GLsizeiptr>(Common::AlignUp(size, 4)));
     } else {
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffer.Handle());
         index_buffer_offset = offset;


### PR DESCRIPTION
Close #7171

Before：
![image](https://user-images.githubusercontent.com/3349963/189482563-97458dbd-b886-4356-9bab-d3e7ca5f35f6.png)

After：
![3](https://user-images.githubusercontent.com/3349963/189482546-05dba384-8e98-44f9-88a4-efea3df87abf.jpg)

Before：
![image](https://user-images.githubusercontent.com/3349963/189482761-89794a15-c235-42cd-a7d7-7863f7fe62ae.png)
After：
![image](https://user-images.githubusercontent.com/3349963/189482764-71ba2484-6f6b-4cb5-8bd2-70fbcac36c5c.png)

This should fix more other games, more tests are welcome