### PR TITLE
Add option "Accept any Internet access"

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -529,6 +529,7 @@ struct Values {
     Setting<bool> extended_logging{false, "extended_logging"};
     Setting<bool> use_debug_asserts{false, "use_debug_asserts"};
     Setting<bool> use_auto_stub{false, "use_auto_stub"};
+    Setting<bool> accept_any_net{false, "accept_any_net"};
     Setting<bool> enable_all_controllers{false, "enable_all_controllers"};
 
     // Miscellaneous

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -6,6 +6,7 @@
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/nifm/nifm.h"
+#include "common/settings.h"
 
 namespace {
 
@@ -483,7 +484,7 @@ void IGeneralService::IsAnyInternetRequestAccepted(Kernel::HLERequestContext& ct
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
-    if (Network::GetHostIPv4Address().has_value()) {
+    if (Network::GetHostIPv4Address().has_value() && Settings::values.accept_any_net) {
         rb.Push<u8>(1);
     } else {
         rb.Push<u8>(0);

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright 2018 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/settings.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/nifm/nifm.h"
-#include "common/settings.h"
 
 namespace {
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -545,6 +545,7 @@ void Config::ReadDebuggingValues() {
     ReadBasicSetting(Settings::values.extended_logging);
     ReadBasicSetting(Settings::values.use_debug_asserts);
     ReadBasicSetting(Settings::values.use_auto_stub);
+    ReadBasicSetting(Settings::values.accept_any_net);
     ReadBasicSetting(Settings::values.enable_all_controllers);
 
     qt_config->endGroup();

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -47,6 +47,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->quest_flag->setChecked(Settings::values.quest_flag.GetValue());
     ui->use_debug_asserts->setChecked(Settings::values.use_debug_asserts.GetValue());
     ui->use_auto_stub->setChecked(Settings::values.use_auto_stub.GetValue());
+    ui->accept_any_net->setChecked(Settings::values.accept_any_net.GetValue());
     ui->enable_all_controllers->setChecked(Settings::values.enable_all_controllers.GetValue());
     ui->enable_graphics_debugging->setEnabled(runtime_lock);
     ui->enable_graphics_debugging->setChecked(Settings::values.renderer_debug.GetValue());

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -306,6 +306,13 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="2">
+       <widget class="QCheckBox" name="accept_any_net">
+        <property name="text">
+         <string>Accept any Internet access**</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -341,6 +341,7 @@ void Config::ReadValues() {
     ReadSetting("Debugging", Settings::values.quest_flag);
     ReadSetting("Debugging", Settings::values.use_debug_asserts);
     ReadSetting("Debugging", Settings::values.use_auto_stub);
+    ReadSetting("Debugging", Settings::values.accept_any_net);
     ReadSetting("Debugging", Settings::values.disable_macro_jit);
     ReadSetting("Debugging", Settings::values.use_gdbstub);
     ReadSetting("Debugging", Settings::values.gdbstub_port);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -431,6 +431,8 @@ use_debug_asserts =
 # Determines whether unimplemented HLE service calls should be automatically stubbed.
 # false: Disabled (default), true: Enabled
 use_auto_stub =
+# false: Disabled, true: Enabled (default)
+accept_any_net=true
 # Enables/Disables the macro JIT compiler
 disable_macro_jit=false
 # Determines whether to enable the GDB stub and wait for the debugger to attach before running.


### PR DESCRIPTION
This setting, which you can change at runtime unlike "Network Interface", is a workaround for Splatoon 3.
Along with the Project London pull request and the "Enable Auto-Stub" option enabled, this should allow the user to at least enter The Shoal and create a LAN lobby (not a LDN lobby which errors out for some reason).
I have not tested if this allows users to enter each others' games, since I don't have a computer with enough memory to run 2 Yuzu instances.

To elaborate on using this option/toggle:
- **Uncheck** "Accept any Internet access" and **check** "Enable Auto-Stub"
- Launch Splatoon 3
- Once you enter the game, **check** "Accept any Internet access"
- Enter the Shoal
- Hold ZL+ZR+Left Stick to enter LAN mode
- You should be able to create a room now.