### PR TITLE
common: do not link to xbyak on non-amd64 architectures

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -166,6 +166,7 @@ if(ARCHITECTURE_x86_64)
             x64/xbyak_abi.h
             x64/xbyak_util.h
     )
+    target_link_libraries(common PRIVATE xbyak)
 endif()
 
 if (MSVC)
@@ -189,7 +190,7 @@ endif()
 create_target_directory_groups(common)
 
 target_link_libraries(common PUBLIC ${Boost_LIBRARIES} fmt::fmt microprofile Threads::Threads)
-target_link_libraries(common PRIVATE lz4::lz4 xbyak)
+target_link_libraries(common PRIVATE lz4::lz4)
 if (TARGET zstd::zstd)
   target_link_libraries(common PRIVATE zstd::zstd)
 else()


### PR DESCRIPTION
This pull request will gate the `xbyak` linkage behind an architecture detection for at least one part of yuzu buildable under non-x86_64 architectures (e.g. ARM).

This pull request is needed to build `yuzu-room` for aarch64 targets (see https://github.com/yuzu-emu/yuzu-multiplayer-dedicated/ for more details).