### PR TITLE
video_core: Modify astc texture decode error fill value

### DIFF
--- a/src/video_core/host_shaders/astc_decoder.comp
+++ b/src/video_core/host_shaders/astc_decoder.comp
@@ -1065,7 +1065,7 @@ TexelWeightParams DecodeBlockInfo() {
 void FillError(ivec3 coord) {
     for (uint j = 0; j < block_dims.y; j++) {
         for (uint i = 0; i < block_dims.x; i++) {
-            imageStore(dest_image, coord + ivec3(i, j, 0), vec4(1.0, 1.0, 0.0, 1.0));
+            imageStore(dest_image, coord + ivec3(i, j, 0), vec4(0.0, 0.0, 0.0, 0.0));
         }
     }
 }

--- a/src/video_core/textures/astc.cpp
+++ b/src/video_core/textures/astc.cpp
@@ -1411,7 +1411,7 @@ static void FillVoidExtentLDR(InputBitStream& strm, std::span<u32> outBuf, u32 b
 static void FillError(std::span<u32> outBuf, u32 blockWidth, u32 blockHeight) {
     for (u32 j = 0; j < blockHeight; j++) {
         for (u32 i = 0; i < blockWidth; i++) {
-            outBuf[j * blockWidth + i] = 0xFFFF00FF;
+            outBuf[j * blockWidth + i] = 0x00000000;
         }
     }
 }


### PR DESCRIPTION
The moon of LIVE A LIVE is a 9-layer astc texture, but the data to be decoded is very strange, only the first two layers are normal, from the third layer onwards all are 0. I have not found the essential cause of this problem so far.

The current solution is to modify the fill value when an error occurs to prevent the wrong texture from being mixed in when sampling.

Before:
![image](https://user-images.githubusercontent.com/3349963/190372083-e57e3b3f-99e1-4bc9-8845-d5dd308106cf.png)

After:
![image](https://user-images.githubusercontent.com/3349963/190371593-3bcb0b17-2d88-4cfb-a31f-cea8ea996b24.png)
