### PR TITLE
audio_device: Make AudioDeviceName constructor constexpr

### DIFF
--- a/src/audio_core/audio_in_manager.cpp
+++ b/src/audio_core/audio_in_manager.cpp
@@ -82,7 +82,7 @@ u32 Manager::GetDeviceNames(std::vector<AudioRenderer::AudioDevice::AudioDeviceN
 
     auto input_devices{Sink::GetDeviceListForSink(Settings::values.sink_id.GetValue(), true)};
     if (input_devices.size() > 1) {
-        names.push_back(AudioRenderer::AudioDevice::AudioDeviceName("Uac"));
+        names.emplace_back("Uac");
         return 1;
     }
     return 0;

--- a/src/audio_core/audio_out_manager.cpp
+++ b/src/audio_core/audio_out_manager.cpp
@@ -74,7 +74,7 @@ void Manager::BufferReleaseAndRegister() {
 
 u32 Manager::GetAudioOutDeviceNames(
     std::vector<AudioRenderer::AudioDevice::AudioDeviceName>& names) const {
-    names.push_back({"DeviceOut"});
+    names.emplace_back("DeviceOut");
     return 1;
 }
 

--- a/src/audio_core/renderer/audio_device.cpp
+++ b/src/audio_core/renderer/audio_device.cpp
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <array>
+#include <span>
+
 #include "audio_core/audio_core.h"
 #include "audio_core/common/feature_support.h"
 #include "audio_core/renderer/audio_device.h"
@@ -9,6 +12,25 @@
 
 namespace AudioCore::AudioRenderer {
 
+constexpr std::array usb_device_names{
+    AudioDevice::AudioDeviceName{"AudioStereoJackOutput"},
+    AudioDevice::AudioDeviceName{"AudioBuiltInSpeakerOutput"},
+    AudioDevice::AudioDeviceName{"AudioTvOutput"},
+    AudioDevice::AudioDeviceName{"AudioUsbDeviceOutput"},
+};
+
+constexpr std::array device_names{
+    AudioDevice::AudioDeviceName{"AudioStereoJackOutput"},
+    AudioDevice::AudioDeviceName{"AudioBuiltInSpeakerOutput"},
+    AudioDevice::AudioDeviceName{"AudioTvOutput"},
+};
+
+constexpr std::array output_device_names{
+    AudioDevice::AudioDeviceName{"AudioBuiltInSpeakerOutput"},
+    AudioDevice::AudioDeviceName{"AudioTvOutput"},
+    AudioDevice::AudioDeviceName{"AudioExternalOutput"},
+};
+
 AudioDevice::AudioDevice(Core::System& system, const u64 applet_resource_user_id_,
                          const u32 revision)
     : output_sink{system.AudioCore().GetOutputSink()},
@@ -16,7 +38,7 @@ AudioDevice::AudioDevice(Core::System& system, const u64 applet_resource_user_id
 
 u32 AudioDevice::ListAudioDeviceName(std::vector<AudioDeviceName>& out_buffer,
                                      const size_t max_count) {
-    std::span<AudioDeviceName> names{};
+    std::span<const AudioDeviceName> names{};
 
     if (CheckFeatureSupported(SupportTags::AudioUsbDeviceOutput, user_revision)) {
         names = usb_device_names;

--- a/src/audio_core/renderer/audio_device.cpp
+++ b/src/audio_core/renderer/audio_device.cpp
@@ -37,7 +37,7 @@ AudioDevice::AudioDevice(Core::System& system, const u64 applet_resource_user_id
       applet_resource_user_id{applet_resource_user_id_}, user_revision{revision} {}
 
 u32 AudioDevice::ListAudioDeviceName(std::vector<AudioDeviceName>& out_buffer,
-                                     const size_t max_count) {
+                                     const size_t max_count) const {
     std::span<const AudioDeviceName> names{};
 
     if (CheckFeatureSupported(SupportTags::AudioUsbDeviceOutput, user_revision)) {
@@ -46,7 +46,7 @@ u32 AudioDevice::ListAudioDeviceName(std::vector<AudioDeviceName>& out_buffer,
         names = device_names;
     }
 
-    u32 out_count{static_cast<u32>(std::min(max_count, names.size()))};
+    const u32 out_count{static_cast<u32>(std::min(max_count, names.size()))};
     for (u32 i = 0; i < out_count; i++) {
         out_buffer.push_back(names[i]);
     }
@@ -54,8 +54,8 @@ u32 AudioDevice::ListAudioDeviceName(std::vector<AudioDeviceName>& out_buffer,
 }
 
 u32 AudioDevice::ListAudioOutputDeviceName(std::vector<AudioDeviceName>& out_buffer,
-                                           const size_t max_count) {
-    u32 out_count{static_cast<u32>(std::min(max_count, output_device_names.size()))};
+                                           const size_t max_count) const {
+    const u32 out_count{static_cast<u32>(std::min(max_count, output_device_names.size()))};
 
     for (u32 i = 0; i < out_count; i++) {
         out_buffer.push_back(output_device_names[i]);
@@ -67,7 +67,7 @@ void AudioDevice::SetDeviceVolumes(const f32 volume) {
     output_sink.SetDeviceVolume(volume);
 }
 
-f32 AudioDevice::GetDeviceVolume([[maybe_unused]] std::string_view name) {
+f32 AudioDevice::GetDeviceVolume([[maybe_unused]] std::string_view name) const {
     return output_sink.GetDeviceVolume();
 }
 

--- a/src/audio_core/renderer/audio_device.h
+++ b/src/audio_core/renderer/audio_device.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <span>
+#include <string_view>
 
 #include "audio_core/audio_render_manager.h"
 
@@ -23,20 +23,12 @@ namespace AudioRenderer {
 class AudioDevice {
 public:
     struct AudioDeviceName {
-        std::array<char, 0x100> name;
+        std::array<char, 0x100> name{};
 
-        AudioDeviceName(const char* name_) {
-            std::strncpy(name.data(), name_, name.size());
+        constexpr AudioDeviceName(std::string_view name_) {
+            name_.copy(name.data(), name.size() - 1);
         }
     };
-
-    std::array<AudioDeviceName, 4> usb_device_names{"AudioStereoJackOutput",
-                                                    "AudioBuiltInSpeakerOutput", "AudioTvOutput",
-                                                    "AudioUsbDeviceOutput"};
-    std::array<AudioDeviceName, 3> device_names{"AudioStereoJackOutput",
-                                                "AudioBuiltInSpeakerOutput", "AudioTvOutput"};
-    std::array<AudioDeviceName, 3> output_device_names{"AudioBuiltInSpeakerOutput", "AudioTvOutput",
-                                                       "AudioExternalOutput"};
 
     explicit AudioDevice(Core::System& system, u64 applet_resource_user_id, u32 revision);
 

--- a/src/audio_core/renderer/audio_device.h
+++ b/src/audio_core/renderer/audio_device.h
@@ -39,7 +39,7 @@ public:
      * @param max_count  - Maximum number of devices to write (count of out_buffer).
      * @return Number of device names written.
      */
-    u32 ListAudioDeviceName(std::vector<AudioDeviceName>& out_buffer, size_t max_count);
+    u32 ListAudioDeviceName(std::vector<AudioDeviceName>& out_buffer, size_t max_count) const;
 
     /**
      * Get a list of the available output devices.
@@ -49,7 +49,7 @@ public:
      * @param max_count  - Maximum number of devices to write (count of out_buffer).
      * @return Number of device names written.
      */
-    u32 ListAudioOutputDeviceName(std::vector<AudioDeviceName>& out_buffer, size_t max_count);
+    u32 ListAudioOutputDeviceName(std::vector<AudioDeviceName>& out_buffer, size_t max_count) const;
 
     /**
      * Set the volume of all streams in the backend sink.
@@ -65,7 +65,7 @@ public:
      * @param name - Name of the device to check. Unused.
      * @return Volume of the device.
      */
-    f32 GetDeviceVolume(std::string_view name);
+    f32 GetDeviceVolume(std::string_view name) const;
 
 private:
     /// Backend output sink for the device

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -246,9 +246,8 @@ void AudOutU::ListAudioOuts(Kernel::HLERequestContext& ctx) {
     const auto write_count =
         static_cast<u32>(ctx.GetWriteBufferSize() / sizeof(AudioDevice::AudioDeviceName));
     std::vector<AudioDevice::AudioDeviceName> device_names{};
-    std::string print_names{};
     if (write_count > 0) {
-        device_names.push_back(AudioDevice::AudioDeviceName("DeviceOut"));
+        device_names.emplace_back("DeviceOut");
         LOG_DEBUG(Service_Audio, "called. \nName=DeviceOut");
     } else {
         LOG_DEBUG(Service_Audio, "called. Empty buffer passed in.");

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -252,7 +252,7 @@ private:
 
         std::vector<AudioDevice::AudioDeviceName> out_names{};
 
-        u32 out_count = impl->ListAudioDeviceName(out_names, in_count);
+        const u32 out_count = impl->ListAudioDeviceName(out_names, in_count);
 
         std::string out{};
         for (u32 i = 0; i < out_count; i++) {
@@ -365,7 +365,7 @@ private:
 
         std::vector<AudioDevice::AudioDeviceName> out_names{};
 
-        u32 out_count = impl->ListAudioOutputDeviceName(out_names, in_count);
+        const u32 out_count = impl->ListAudioOutputDeviceName(out_names, in_count);
 
         std::string out{};
         for (u32 i = 0; i < out_count; i++) {


### PR DESCRIPTION
Allows the construction of the device name tables at compile-time and moves them to be internal to the audio_device.cpp file.

