### PR TITLE
audio_core: Mark several member functions as const

### DIFF
--- a/src/audio_core/audio_render_manager.cpp
+++ b/src/audio_core/audio_render_manager.cpp
@@ -25,8 +25,8 @@ SystemManager& Manager::GetSystemManager() {
     return *system_manager;
 }
 
-auto Manager::GetWorkBufferSize(const AudioRendererParameterInternal& params, u64& out_count)
-    -> Result {
+Result Manager::GetWorkBufferSize(const AudioRendererParameterInternal& params,
+                                  u64& out_count) const {
     if (!CheckValidRevision(params.revision)) {
         return Service::Audio::ERR_INVALID_REVISION;
     }
@@ -54,7 +54,7 @@ void Manager::ReleaseSessionId(const s32 session_id) {
     session_ids[--session_count] = session_id;
 }
 
-u32 Manager::GetSessionCount() {
+u32 Manager::GetSessionCount() const {
     std::scoped_lock l{session_lock};
     return session_count;
 }

--- a/src/audio_core/audio_render_manager.h
+++ b/src/audio_core/audio_render_manager.h
@@ -46,7 +46,7 @@ public:
      * @param out_count - Output size of the required workbuffer.
      * @return Result code.
      */
-    Result GetWorkBufferSize(const AudioRendererParameterInternal& params, u64& out_count);
+    Result GetWorkBufferSize(const AudioRendererParameterInternal& params, u64& out_count) const;
 
     /**
      * Get a new session id.
@@ -60,7 +60,7 @@ public:
      *
      * @return The number of active sessions.
      */
-    u32 GetSessionCount();
+    u32 GetSessionCount() const;
 
     /**
      * Add a renderer system to the manager.
@@ -94,7 +94,7 @@ private:
     /// Number of active renderers
     u32 session_count{};
     /// Lock for interacting with the sessions
-    std::mutex session_lock{};
+    mutable std::mutex session_lock{};
     /// Regularly generates commands from the registered systems for the AudioRenderer
     std::unique_ptr<SystemManager> system_manager{};
 };

--- a/src/audio_core/device/audio_buffers.h
+++ b/src/audio_core/device/audio_buffers.h
@@ -36,7 +36,7 @@ public:
      *
      * @param buffer - The new buffer.
      */
-    void AppendBuffer(AudioBuffer& buffer) {
+    void AppendBuffer(const AudioBuffer& buffer) {
         std::scoped_lock l{lock};
         buffers[appended_index] = buffer;
         appended_count++;

--- a/src/audio_core/device/audio_buffers.h
+++ b/src/audio_core/device/audio_buffers.h
@@ -93,7 +93,7 @@ public:
      *
      * @return Is the buffer was released.
      */
-    bool ReleaseBuffers(Core::Timing::CoreTiming& core_timing, DeviceSession& session) {
+    bool ReleaseBuffers(const Core::Timing::CoreTiming& core_timing, const DeviceSession& session) {
         std::scoped_lock l{lock};
         bool buffer_released{false};
         while (registered_count > 0) {

--- a/src/audio_core/device/device_session.cpp
+++ b/src/audio_core/device/device_session.cpp
@@ -74,11 +74,11 @@ void DeviceSession::Stop() {
 }
 
 void DeviceSession::AppendBuffers(std::span<const AudioBuffer> buffers) const {
-    for (size_t i = 0; i < buffers.size(); i++) {
+    for (const auto& buffer : buffers) {
         Sink::SinkBuffer new_buffer{
-            .frames = buffers[i].size / (channel_count * sizeof(s16)),
+            .frames = buffer.size / (channel_count * sizeof(s16)),
             .frames_played = 0,
-            .tag = buffers[i].tag,
+            .tag = buffer.tag,
             .consumed = false,
         };
 
@@ -86,8 +86,8 @@ void DeviceSession::AppendBuffers(std::span<const AudioBuffer> buffers) const {
             std::vector<s16> samples{};
             stream->AppendBuffer(new_buffer, samples);
         } else {
-            std::vector<s16> samples(buffers[i].size / sizeof(s16));
-            system.Memory().ReadBlockUnsafe(buffers[i].samples, samples.data(), buffers[i].size);
+            std::vector<s16> samples(buffer.size / sizeof(s16));
+            system.Memory().ReadBlockUnsafe(buffer.samples, samples.data(), buffer.size);
             stream->AppendBuffer(new_buffer, samples);
         }
     }

--- a/src/audio_core/device/device_session.cpp
+++ b/src/audio_core/device/device_session.cpp
@@ -73,7 +73,7 @@ void DeviceSession::Stop() {
     }
 }
 
-void DeviceSession::AppendBuffers(std::span<AudioBuffer> buffers) const {
+void DeviceSession::AppendBuffers(std::span<const AudioBuffer> buffers) const {
     for (size_t i = 0; i < buffers.size(); i++) {
         Sink::SinkBuffer new_buffer{
             .frames = buffers[i].size / (channel_count * sizeof(s16)),
@@ -93,14 +93,14 @@ void DeviceSession::AppendBuffers(std::span<AudioBuffer> buffers) const {
     }
 }
 
-void DeviceSession::ReleaseBuffer(AudioBuffer& buffer) const {
+void DeviceSession::ReleaseBuffer(const AudioBuffer& buffer) const {
     if (type == Sink::StreamType::In) {
         auto samples{stream->ReleaseBuffer(buffer.size / sizeof(s16))};
         system.Memory().WriteBlockUnsafe(buffer.samples, samples.data(), buffer.size);
     }
 }
 
-bool DeviceSession::IsBufferConsumed(AudioBuffer& buffer) const {
+bool DeviceSession::IsBufferConsumed(const AudioBuffer& buffer) const {
     return played_sample_count >= buffer.end_timestamp;
 }
 

--- a/src/audio_core/device/device_session.h
+++ b/src/audio_core/device/device_session.h
@@ -62,14 +62,14 @@ public:
      *
      * @param buffers - The buffers to play.
      */
-    void AppendBuffers(std::span<AudioBuffer> buffers) const;
+    void AppendBuffers(std::span<const AudioBuffer> buffers) const;
 
     /**
      * (Audio In only) Pop samples from the backend, and write them back to this buffer's address.
      *
      * @param buffer - The buffer to write to.
      */
-    void ReleaseBuffer(AudioBuffer& buffer) const;
+    void ReleaseBuffer(const AudioBuffer& buffer) const;
 
     /**
      * Check if the buffer for the given tag has been consumed by the backend.
@@ -78,7 +78,7 @@ public:
      *
      * @return true if the buffer has been consumed, otherwise false.
      */
-    bool IsBufferConsumed(AudioBuffer& buffer) const;
+    bool IsBufferConsumed(const AudioBuffer& buffer) const;
 
     /**
      * Start this device session, starting the backend stream.

--- a/src/audio_core/in/audio_in.cpp
+++ b/src/audio_core/in/audio_in.cpp
@@ -72,7 +72,7 @@ Kernel::KReadableEvent& In::GetBufferEvent() {
     return event->GetReadableEvent();
 }
 
-f32 In::GetVolume() {
+f32 In::GetVolume() const {
     std::scoped_lock l{parent_mutex};
     return system.GetVolume();
 }
@@ -82,17 +82,17 @@ void In::SetVolume(f32 volume) {
     system.SetVolume(volume);
 }
 
-bool In::ContainsAudioBuffer(u64 tag) {
+bool In::ContainsAudioBuffer(u64 tag) const {
     std::scoped_lock l{parent_mutex};
     return system.ContainsAudioBuffer(tag);
 }
 
-u32 In::GetBufferCount() {
+u32 In::GetBufferCount() const {
     std::scoped_lock l{parent_mutex};
     return system.GetBufferCount();
 }
 
-u64 In::GetPlayedSampleCount() {
+u64 In::GetPlayedSampleCount() const {
     std::scoped_lock l{parent_mutex};
     return system.GetPlayedSampleCount();
 }

--- a/src/audio_core/in/audio_in.h
+++ b/src/audio_core/in/audio_in.h
@@ -102,7 +102,7 @@ public:
      *
      * @return The current volume.
      */
-    f32 GetVolume();
+    f32 GetVolume() const;
 
     /**
      * Set the system volume.
@@ -117,21 +117,21 @@ public:
      * @param tag - The tag to search for.
      * @return True if the buffer is in the system, otherwise false.
      */
-    bool ContainsAudioBuffer(u64 tag);
+    bool ContainsAudioBuffer(u64 tag) const;
 
     /**
      * Get the maximum number of buffers.
      *
      * @return The maximum number of buffers.
      */
-    u32 GetBufferCount();
+    u32 GetBufferCount() const;
 
     /**
      * Get the total played sample count for this audio in.
      *
      * @return The played sample count.
      */
-    u64 GetPlayedSampleCount();
+    u64 GetPlayedSampleCount() const;
 
 private:
     /// The AudioIn::Manager this audio in is registered with

--- a/src/audio_core/in/audio_in_system.cpp
+++ b/src/audio_core/in/audio_in_system.cpp
@@ -114,12 +114,14 @@ bool System::AppendBuffer(const AudioInBuffer& buffer, const u64 tag) {
     }
 
     const auto timestamp{buffers.GetNextTimestamp()};
-    AudioBuffer new_buffer{.start_timestamp = timestamp,
-                           .end_timestamp = timestamp + buffer.size / (channel_count * sizeof(s16)),
-                           .played_timestamp = 0,
-                           .samples = buffer.samples,
-                           .tag = tag,
-                           .size = buffer.size};
+    const AudioBuffer new_buffer{
+        .start_timestamp = timestamp,
+        .end_timestamp = timestamp + buffer.size / (channel_count * sizeof(s16)),
+        .played_timestamp = 0,
+        .samples = buffer.samples,
+        .tag = tag,
+        .size = buffer.size,
+    };
 
     buffers.AppendBuffer(new_buffer);
     RegisterBuffers();

--- a/src/audio_core/in/audio_in_system.cpp
+++ b/src/audio_core/in/audio_in_system.cpp
@@ -34,16 +34,16 @@ size_t System::GetSessionId() const {
     return session_id;
 }
 
-std::string_view System::GetDefaultDeviceName() {
+std::string_view System::GetDefaultDeviceName() const {
     return "BuiltInHeadset";
 }
 
-std::string_view System::GetDefaultUacDeviceName() {
+std::string_view System::GetDefaultUacDeviceName() const {
     return "Uac";
 }
 
 Result System::IsConfigValid(const std::string_view device_name,
-                             const AudioInParameter& in_params) {
+                             const AudioInParameter& in_params) const {
     if ((device_name.size() > 0) &&
         (device_name != GetDefaultDeviceName() && device_name != GetDefaultUacDeviceName())) {
         return Service::Audio::ERR_INVALID_DEVICE_NAME;
@@ -202,11 +202,11 @@ void System::SetVolume(const f32 volume_) {
     session->SetVolume(volume_);
 }
 
-bool System::ContainsAudioBuffer(const u64 tag) {
+bool System::ContainsAudioBuffer(const u64 tag) const {
     return buffers.ContainsBuffer(tag);
 }
 
-u32 System::GetBufferCount() {
+u32 System::GetBufferCount() const {
     return buffers.GetAppendedRegisteredCount();
 }
 

--- a/src/audio_core/in/audio_in_system.h
+++ b/src/audio_core/in/audio_in_system.h
@@ -68,7 +68,7 @@ public:
      *
      * @return The default audio input device name.
      */
-    std::string_view GetDefaultDeviceName();
+    std::string_view GetDefaultDeviceName() const;
 
     /**
      * Get the default USB audio input device name.
@@ -77,7 +77,7 @@ public:
      *
      * @return The default USB audio input device name.
      */
-    std::string_view GetDefaultUacDeviceName();
+    std::string_view GetDefaultUacDeviceName() const;
 
     /**
      * Is the given initialize config valid?
@@ -86,7 +86,7 @@ public:
      * @param in_params   - Input parameters, see AudioInParameter.
      * @return Result code.
      */
-    Result IsConfigValid(std::string_view device_name, const AudioInParameter& in_params);
+    Result IsConfigValid(std::string_view device_name, const AudioInParameter& in_params) const;
 
     /**
      * Initialize this system.
@@ -218,14 +218,14 @@ public:
      * @param tag - Unique tag to search for.
      * @return True if the buffer is in the system, otherwise false.
      */
-    bool ContainsAudioBuffer(u64 tag);
+    bool ContainsAudioBuffer(u64 tag) const;
 
     /**
      * Get the maximum number of usable buffers (default 32).
      *
      * @return The number of buffers.
      */
-    u32 GetBufferCount();
+    u32 GetBufferCount() const;
 
     /**
      * Get the total number of samples played by this system.

--- a/src/audio_core/out/audio_out.cpp
+++ b/src/audio_core/out/audio_out.cpp
@@ -72,7 +72,7 @@ Kernel::KReadableEvent& Out::GetBufferEvent() {
     return event->GetReadableEvent();
 }
 
-f32 Out::GetVolume() {
+f32 Out::GetVolume() const {
     std::scoped_lock l{parent_mutex};
     return system.GetVolume();
 }
@@ -82,17 +82,17 @@ void Out::SetVolume(const f32 volume) {
     system.SetVolume(volume);
 }
 
-bool Out::ContainsAudioBuffer(const u64 tag) {
+bool Out::ContainsAudioBuffer(const u64 tag) const {
     std::scoped_lock l{parent_mutex};
     return system.ContainsAudioBuffer(tag);
 }
 
-u32 Out::GetBufferCount() {
+u32 Out::GetBufferCount() const {
     std::scoped_lock l{parent_mutex};
     return system.GetBufferCount();
 }
 
-u64 Out::GetPlayedSampleCount() {
+u64 Out::GetPlayedSampleCount() const {
     std::scoped_lock l{parent_mutex};
     return system.GetPlayedSampleCount();
 }

--- a/src/audio_core/out/audio_out.h
+++ b/src/audio_core/out/audio_out.h
@@ -102,7 +102,7 @@ public:
      *
      * @return The current volume.
      */
-    f32 GetVolume();
+    f32 GetVolume() const;
 
     /**
      * Set the system volume.
@@ -117,21 +117,21 @@ public:
      * @param tag - The tag to search for.
      * @return True if the buffer is in the system, otherwise false.
      */
-    bool ContainsAudioBuffer(u64 tag);
+    bool ContainsAudioBuffer(u64 tag) const;
 
     /**
      * Get the maximum number of buffers.
      *
      * @return The maximum number of buffers.
      */
-    u32 GetBufferCount();
+    u32 GetBufferCount() const;
 
     /**
      * Get the total played sample count for this audio out.
      *
      * @return The played sample count.
      */
-    u64 GetPlayedSampleCount();
+    u64 GetPlayedSampleCount() const;
 
 private:
     /// The AudioOut::Manager this audio out is registered with

--- a/src/audio_core/out/audio_out_system.cpp
+++ b/src/audio_core/out/audio_out_system.cpp
@@ -27,11 +27,12 @@ void System::Finalize() {
     buffer_event->GetWritableEvent().Signal();
 }
 
-std::string_view System::GetDefaultOutputDeviceName() {
+std::string_view System::GetDefaultOutputDeviceName() const {
     return "DeviceOut";
 }
 
-Result System::IsConfigValid(std::string_view device_name, const AudioOutParameter& in_params) {
+Result System::IsConfigValid(std::string_view device_name,
+                             const AudioOutParameter& in_params) const {
     if ((device_name.size() > 0) && (device_name != GetDefaultOutputDeviceName())) {
         return Service::Audio::ERR_INVALID_DEVICE_NAME;
     }
@@ -200,11 +201,11 @@ void System::SetVolume(const f32 volume_) {
     session->SetVolume(volume_);
 }
 
-bool System::ContainsAudioBuffer(const u64 tag) {
+bool System::ContainsAudioBuffer(const u64 tag) const {
     return buffers.ContainsBuffer(tag);
 }
 
-u32 System::GetBufferCount() {
+u32 System::GetBufferCount() const {
     return buffers.GetAppendedRegisteredCount();
 }
 

--- a/src/audio_core/out/audio_out_system.cpp
+++ b/src/audio_core/out/audio_out_system.cpp
@@ -113,12 +113,14 @@ bool System::AppendBuffer(const AudioOutBuffer& buffer, u64 tag) {
     }
 
     const auto timestamp{buffers.GetNextTimestamp()};
-    AudioBuffer new_buffer{.start_timestamp = timestamp,
-                           .end_timestamp = timestamp + buffer.size / (channel_count * sizeof(s16)),
-                           .played_timestamp = 0,
-                           .samples = buffer.samples,
-                           .tag = tag,
-                           .size = buffer.size};
+    const AudioBuffer new_buffer{
+        .start_timestamp = timestamp,
+        .end_timestamp = timestamp + buffer.size / (channel_count * sizeof(s16)),
+        .played_timestamp = 0,
+        .samples = buffer.samples,
+        .tag = tag,
+        .size = buffer.size,
+    };
 
     buffers.AppendBuffer(new_buffer);
     RegisterBuffers();

--- a/src/audio_core/out/audio_out_system.h
+++ b/src/audio_core/out/audio_out_system.h
@@ -68,7 +68,7 @@ public:
      *
      * @return The default audio output device name.
      */
-    std::string_view GetDefaultOutputDeviceName();
+    std::string_view GetDefaultOutputDeviceName() const;
 
     /**
      * Is the given initialize config valid?
@@ -77,7 +77,7 @@ public:
      * @param in_params   - Input parameters, see AudioOutParameter.
      * @return Result code.
      */
-    Result IsConfigValid(std::string_view device_name, const AudioOutParameter& in_params);
+    Result IsConfigValid(std::string_view device_name, const AudioOutParameter& in_params) const;
 
     /**
      * Initialize this system.
@@ -209,14 +209,14 @@ public:
      * @param tag - Unique tag to search for.
      * @return True if the buffer is in the system, otherwise false.
      */
-    bool ContainsAudioBuffer(u64 tag);
+    bool ContainsAudioBuffer(u64 tag) const;
 
     /**
      * Get the maximum number of usable buffers (default 32).
      *
      * @return The number of buffers.
      */
-    u32 GetBufferCount();
+    u32 GetBufferCount() const;
 
     /**
      * Get the total number of samples played by this system.

--- a/src/audio_core/renderer/adsp/adsp.cpp
+++ b/src/audio_core/renderer/adsp/adsp.cpp
@@ -50,7 +50,7 @@ u32 ADSP::GetRemainCommandCount(const u32 session_id) const {
     return render_mailbox.GetRemainCommandCount(session_id);
 }
 
-void ADSP::SendCommandBuffer(const u32 session_id, CommandBuffer& command_buffer) {
+void ADSP::SendCommandBuffer(const u32 session_id, const CommandBuffer& command_buffer) {
     render_mailbox.SetCommandBuffer(session_id, command_buffer);
 }
 

--- a/src/audio_core/renderer/adsp/adsp.h
+++ b/src/audio_core/renderer/adsp/adsp.h
@@ -131,7 +131,7 @@ public:
      * @param session_id     - The session id to check (0 or 1).
      * @param command_buffer - The command buffer to process.
      */
-    void SendCommandBuffer(u32 session_id, CommandBuffer& command_buffer);
+    void SendCommandBuffer(u32 session_id, const CommandBuffer& command_buffer);
 
     /**
      * Clear the command buffers (does not clear the time taken or the remaining command count)

--- a/src/audio_core/renderer/adsp/audio_renderer.cpp
+++ b/src/audio_core/renderer/adsp/audio_renderer.cpp
@@ -51,7 +51,7 @@ CommandBuffer& AudioRenderer_Mailbox::GetCommandBuffer(const s32 session_id) {
     return command_buffers[session_id];
 }
 
-void AudioRenderer_Mailbox::SetCommandBuffer(const u32 session_id, CommandBuffer& buffer) {
+void AudioRenderer_Mailbox::SetCommandBuffer(const u32 session_id, const CommandBuffer& buffer) {
     command_buffers[session_id] = buffer;
 }
 

--- a/src/audio_core/renderer/adsp/audio_renderer.h
+++ b/src/audio_core/renderer/adsp/audio_renderer.h
@@ -91,7 +91,7 @@ public:
      * @param session_id - The session id to get (0 or 1).
      * @param buffer     - The command buffer to set.
      */
-    void SetCommandBuffer(u32 session_id, CommandBuffer& buffer);
+    void SetCommandBuffer(u32 session_id, const CommandBuffer& buffer);
 
     /**
      * Get the total render time taken for the last command lists sent.

--- a/src/audio_core/renderer/audio_device.cpp
+++ b/src/audio_core/renderer/audio_device.cpp
@@ -45,7 +45,7 @@ void AudioDevice::SetDeviceVolumes(const f32 volume) {
     output_sink.SetDeviceVolume(volume);
 }
 
-f32 AudioDevice::GetDeviceVolume([[maybe_unused]] std::string_view name) {
+f32 AudioDevice::GetDeviceVolume([[maybe_unused]] std::string_view name) const {
     return output_sink.GetDeviceVolume();
 }
 

--- a/src/audio_core/renderer/audio_device.h
+++ b/src/audio_core/renderer/audio_device.h
@@ -73,7 +73,7 @@ public:
      * @param name - Name of the device to check. Unused.
      * @return Volume of the device.
      */
-    f32 GetDeviceVolume(std::string_view name);
+    f32 GetDeviceVolume(std::string_view name) const;
 
 private:
     /// Backend output sink for the device

--- a/src/audio_core/renderer/behavior/behavior_info.cpp
+++ b/src/audio_core/renderer/behavior/behavior_info.cpp
@@ -34,7 +34,7 @@ void BehaviorInfo::ClearError() {
     error_count = 0;
 }
 
-void BehaviorInfo::AppendError(ErrorInfo& error) {
+void BehaviorInfo::AppendError(const ErrorInfo& error) {
     LOG_ERROR(Service_Audio, "Error during RequestUpdate, reporting code {:04X} address {:08X}",
               error.error_code.raw, error.address);
     if (error_count < MaxErrors) {
@@ -42,7 +42,7 @@ void BehaviorInfo::AppendError(ErrorInfo& error) {
     }
 }
 
-void BehaviorInfo::CopyErrorInfo(std::span<ErrorInfo> out_errors, u32& out_count) {
+void BehaviorInfo::CopyErrorInfo(std::span<ErrorInfo> out_errors, u32& out_count) const {
     out_count = std::min(error_count, MaxErrors);
 
     for (size_t i = 0; i < MaxErrors; i++) {

--- a/src/audio_core/renderer/behavior/behavior_info.h
+++ b/src/audio_core/renderer/behavior/behavior_info.h
@@ -94,7 +94,7 @@ public:
      *
      * @param error - The new error.
      */
-    void AppendError(ErrorInfo& error);
+    void AppendError(const ErrorInfo& error);
 
     /**
      * Copy errors to the given output container.
@@ -102,7 +102,7 @@ public:
      * @param out_errors - Output container to receive the errors.
      * @param out_count  - The number of errors written.
      */
-    void CopyErrorInfo(std::span<ErrorInfo> out_errors, u32& out_count);
+    void CopyErrorInfo(std::span<ErrorInfo> out_errors, u32& out_count) const;
 
     /**
      * Update the behaviour flags.

--- a/src/audio_core/renderer/behavior/info_updater.cpp
+++ b/src/audio_core/renderer/behavior/info_updater.cpp
@@ -485,7 +485,7 @@ Result InfoUpdater::UpdateBehaviorInfo(BehaviorInfo& behaviour_) {
     return ResultSuccess;
 }
 
-Result InfoUpdater::UpdateErrorInfo(BehaviorInfo& behaviour_) {
+Result InfoUpdater::UpdateErrorInfo(const BehaviorInfo& behaviour_) {
     auto out_params{reinterpret_cast<BehaviorInfo::OutStatus*>(output)};
     behaviour_.CopyErrorInfo(out_params->errors, out_params->error_count);
 

--- a/src/audio_core/renderer/behavior/info_updater.h
+++ b/src/audio_core/renderer/behavior/info_updater.h
@@ -130,7 +130,7 @@ public:
      * @param behaviour - Behaviour to update.
      * @return Result code.
      */
-    Result UpdateErrorInfo(BehaviorInfo& behaviour);
+    Result UpdateErrorInfo(const BehaviorInfo& behaviour);
 
     /**
      * Update splitter.

--- a/src/audio_core/renderer/effect/i3dl2.h
+++ b/src/audio_core/renderer/effect/i3dl2.h
@@ -99,7 +99,7 @@ public:
             return out_sample;
         }
 
-        Common::FixedPoint<50, 14> Read() {
+        Common::FixedPoint<50, 14> Read() const {
             return *output;
         }
 
@@ -110,7 +110,7 @@ public:
             }
         }
 
-        Common::FixedPoint<50, 14> TapOut(const s32 index) {
+        Common::FixedPoint<50, 14> TapOut(const s32 index) const {
             auto out{input - (index + 1)};
             if (out < buffer.data()) {
                 out += max_delay + 1;

--- a/src/audio_core/renderer/effect/reverb.h
+++ b/src/audio_core/renderer/effect/reverb.h
@@ -95,7 +95,7 @@ public:
             return out_sample;
         }
 
-        Common::FixedPoint<50, 14> Read() {
+        Common::FixedPoint<50, 14> Read() const {
             return *output;
         }
 
@@ -106,7 +106,7 @@ public:
             }
         }
 
-        Common::FixedPoint<50, 14> TapOut(const s32 index) {
+        Common::FixedPoint<50, 14> TapOut(const s32 index) const {
             auto out{input - (index + 1)};
             if (out < buffer.data()) {
                 out += sample_count;

--- a/src/audio_core/renderer/nodes/node_states.h
+++ b/src/audio_core/renderer/nodes/node_states.h
@@ -56,7 +56,7 @@ class NodeStates {
          *
          * @return The current stack position.
          */
-        u32 Count() {
+        u32 Count() const {
             return pos;
         }
 
@@ -83,7 +83,7 @@ class NodeStates {
          *
          * @return The node on the top of the stack.
          */
-        u32 top() {
+        u32 top() const {
             return stack[pos - 1];
         }
 

--- a/src/audio_core/sink/sink_stream.h
+++ b/src/audio_core/sink/sink_stream.h
@@ -151,7 +151,7 @@ public:
      *
      * @return The number of queued buffers.
      */
-    u32 GetQueueSize() {
+    u32 GetQueueSize() const {
         return queued_buffers.load();
     }
 


### PR DESCRIPTION
Quite a bit of functions that don't modify member state weren't marked as const. This makes the interface a little more explicit about intended modifications.