### PR TITLE
core: implement HwOpus GetWorkBufferSizeForMultiStreamEx

### DIFF
--- a/src/core/hle/service/audio/hwopus.h
+++ b/src/core/hle/service/audio/hwopus.h
@@ -11,6 +11,16 @@ class System;
 
 namespace Service::Audio {
 
+struct OpusMultiStreamParametersEx {
+    u32 sample_rate;
+    u32 channel_count;
+    u32 number_streams;
+    u32 number_stereo_streams;
+    u32 use_large_frame_size;
+    u32 padding;
+    std::array<u32, 64> channel_mappings;
+};
+
 class HwOpus final : public ServiceFramework<HwOpus> {
 public:
     explicit HwOpus(Core::System& system_);
@@ -21,6 +31,7 @@ private:
     void OpenHardwareOpusDecoderEx(Kernel::HLERequestContext& ctx);
     void GetWorkBufferSize(Kernel::HLERequestContext& ctx);
     void GetWorkBufferSizeEx(Kernel::HLERequestContext& ctx);
+    void GetWorkBufferSizeForMultiStreamEx(Kernel::HLERequestContext& ctx);
 };
 
 } // namespace Service::Audio


### PR DESCRIPTION
In order to fix the problem that DQX cannot enter the game.

![image](https://user-images.githubusercontent.com/3349963/190686771-cbe74e99-abb2-4dab-a702-4843aa384015.png)
