### PR TITLE
GIT: Modify .gitignore to ignore wildcard for build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Build directory
-[Bb]uild/
+[Bb]uild*/
 doc-build/
 
 # Generated source files


### PR DESCRIPTION
Helps if you have multiple build folders. There are other, dark ways to hide extra build folders from git, but this is better.

See: https://github.com/citra-emu/citra/pull/6130

-----
I forgot to note it in the commit message, but git snooping in build folders is bad for performance. 