### PR TITLE
cmake: fix git detection

### DIFF
--- a/CMakeModules/GenerateSCMRev.cmake
+++ b/CMakeModules/GenerateSCMRev.cmake
@@ -7,11 +7,6 @@ function(get_timestamp _var)
     set(${_var} "${timestamp}" PARENT_SCOPE)
 endfunction()
 
-list(APPEND CMAKE_MODULE_PATH "${SRC_DIR}/externals/cmake-modules")
-
-# Find the package here with the known path so that the GetGit commands can find it as well
-find_package(Git QUIET PATHS "${GIT_EXECUTABLE}")
-
 # generate git/build information
 include(GetGitRevisionDescription)
 if(NOT GIT_REF_SPEC)
@@ -29,6 +24,7 @@ get_timestamp(BUILD_DATE)
 # Also if this is a CI build, add the build name (ie: Nightly, Canary) to the scm_rev file as well
 set(REPO_NAME "")
 set(BUILD_VERSION "0")
+set(BUILD_ID ${DISPLAY_VERSION})
 if (BUILD_REPOSITORY)
   # regex capture the string nightly or canary into CMAKE_MATCH_1
   string(REGEX MATCH "yuzu-emu/yuzu-?(.*)" OUTVAR ${BUILD_REPOSITORY})
@@ -57,6 +53,4 @@ if (BUILD_REPOSITORY)
   endif()
 endif()
 
-# The variable SRC_DIR must be passed into the script
-# (since it uses the current build directory for all values of CMAKE_*_DIR)
-configure_file("${SRC_DIR}/src/common/scm_rev.cpp.in" "scm_rev.cpp" @ONLY)
+configure_file(scm_rev.cpp.in scm_rev.cpp @ONLY)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -14,32 +14,7 @@ if (DEFINED ENV{DISPLAYVERSION})
   set(DISPLAY_VERSION $ENV{DISPLAYVERSION})
 endif ()
 
-# Pass the path to git to the GenerateSCMRev.cmake as well
-find_package(Git QUIET)
-
-add_custom_command(OUTPUT scm_rev.cpp
-    COMMAND ${CMAKE_COMMAND}
-      -DSRC_DIR=${PROJECT_SOURCE_DIR}
-      -DBUILD_REPOSITORY=${BUILD_REPOSITORY}
-      -DTITLE_BAR_FORMAT_IDLE=${TITLE_BAR_FORMAT_IDLE}
-      -DTITLE_BAR_FORMAT_RUNNING=${TITLE_BAR_FORMAT_RUNNING}
-      -DBUILD_TAG=${BUILD_TAG}
-      -DBUILD_ID=${DISPLAY_VERSION}
-      -DGIT_REF_SPEC=${GIT_REF_SPEC}
-      -DGIT_REV=${GIT_REV}
-      -DGIT_DESC=${GIT_DESC}
-      -DGIT_BRANCH=${GIT_BRANCH}
-      -DBUILD_FULLNAME=${BUILD_FULLNAME}
-      -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
-      -P ${PROJECT_SOURCE_DIR}/CMakeModules/GenerateSCMRev.cmake
-    DEPENDS
-      # Check that the scm_rev files haven't changed
-      "${CMAKE_CURRENT_SOURCE_DIR}/scm_rev.cpp.in"
-      "${CMAKE_CURRENT_SOURCE_DIR}/scm_rev.h"
-      # technically we should regenerate if the git version changed, but its not worth the effort imo
-      "${PROJECT_SOURCE_DIR}/CMakeModules/GenerateSCMRev.cmake"
-    VERBATIM
-)
+include(GenerateSCMRev)
 
 add_library(common STATIC
     algorithm.h
@@ -117,7 +92,7 @@ add_library(common STATIC
     quaternion.h
     reader_writer_queue.h
     ring_buffer.h
-    scm_rev.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/scm_rev.cpp
     scm_rev.h
     scope_exit.h
     settings.cpp


### PR DESCRIPTION
> When run in -P script mode, CMake sets the variables [CMAKE_BINARY_DIR](https://cmake.org/cmake/help/latest/variable/CMAKE_BINARY_DIR.html#variable:CMAKE_BINARY_DIR), [CMAKE_SOURCE_DIR](https://cmake.org/cmake/help/latest/variable/CMAKE_SOURCE_DIR.html#variable:CMAKE_SOURCE_DIR), [CMAKE_CURRENT_BINARY_DIR](https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_BINARY_DIR.html?highlight=cmake_current#variable:CMAKE_CURRENT_BINARY_DIR) and [CMAKE_CURRENT_SOURCE_DIR](https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_SOURCE_DIR.html#variable:CMAKE_CURRENT_SOURCE_DIR) to the current working directory.

So if doing an out-of-source build, the `GetGitRevisionDescription` module will search the `.git` directory inside the build/binary directory and will not find it (hence the `*-NOTFOUND` value for some variables).
The other solution is to copy the `.git` directory, before the compilation, inside the future build/binary directory. But including `GenerateSCMRev` is more straight forward than passing every CMake variable to an external (CMake) script.