### PR TITLE
yuzu qt: Add option to disable startup Vulkan check

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -531,6 +531,7 @@ struct Values {
     Setting<bool> use_auto_stub{false, "use_auto_stub"};
     Setting<bool> enable_all_controllers{false, "enable_all_controllers"};
     Setting<bool> create_crash_dumps{false, "create_crash_dumps"};
+    Setting<bool> perform_vulkan_check{true, "perform_vulkan_check"};
 
     // Miscellaneous
     Setting<std::string> log_filter{"*:Info", "log_filter"};

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -546,6 +546,7 @@ void Config::ReadDebuggingValues() {
     ReadBasicSetting(Settings::values.use_auto_stub);
     ReadBasicSetting(Settings::values.enable_all_controllers);
     ReadBasicSetting(Settings::values.create_crash_dumps);
+    ReadBasicSetting(Settings::values.perform_vulkan_check);
 
     qt_config->endGroup();
 }
@@ -1162,6 +1163,7 @@ void Config::SaveDebuggingValues() {
     WriteBasicSetting(Settings::values.disable_macro_jit);
     WriteBasicSetting(Settings::values.enable_all_controllers);
     WriteBasicSetting(Settings::values.create_crash_dumps);
+    WriteBasicSetting(Settings::values.perform_vulkan_check);
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -77,6 +77,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->disable_loop_safety_checks->setChecked(
         Settings::values.disable_shader_loop_safety_checks.GetValue());
     ui->extended_logging->setChecked(Settings::values.extended_logging.GetValue());
+    ui->perform_vulkan_check->setChecked(Settings::values.perform_vulkan_check.GetValue());
 
 #ifdef YUZU_USE_QT_WEB_ENGINE
     ui->disable_web_applet->setChecked(UISettings::values.disable_web_applet.GetValue());
@@ -117,6 +118,7 @@ void ConfigureDebug::ApplyConfiguration() {
         ui->disable_loop_safety_checks->isChecked();
     Settings::values.disable_macro_jit = ui->disable_macro_jit->isChecked();
     Settings::values.extended_logging = ui->extended_logging->isChecked();
+    Settings::values.perform_vulkan_check = ui->perform_vulkan_check->isChecked();
     UISettings::values.disable_web_applet = ui->disable_web_applet->isChecked();
     Debugger::ToggleConsole();
     Common::Log::Filter filter;

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -313,6 +313,16 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="perform_vulkan_check">
+        <property name="toolTip">
+         <string>Enables yuzu to check for a working Vulkan environment when the program starts up. Disable this if this is causing issues with external programs seeing yuzu.</string>
+        </property>
+        <property name="text">
+         <string>Perform Startup Vulkan Check</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -4086,7 +4086,8 @@ int main(int argc, char* argv[]) {
     }
 #endif
 
-    if (StartupChecks(argv[0], &has_broken_vulkan)) {
+    if (StartupChecks(argv[0], &has_broken_vulkan,
+                      Settings::values.perform_vulkan_check.GetValue())) {
         return 0;
     }
 

--- a/src/yuzu/startup_checks.h
+++ b/src/yuzu/startup_checks.h
@@ -13,7 +13,7 @@ constexpr char ENV_VAR_ENABLED_TEXT[] = "ON";
 
 void CheckVulkan();
 bool CheckEnvVars(bool* is_child);
-bool StartupChecks(const char* arg0, bool* has_broken_vulkan);
+bool StartupChecks(const char* arg0, bool* has_broken_vulkan, bool perform_vulkan_check);
 
 #ifdef _WIN32
 bool SpawnChild(const char* arg0, PROCESS_INFORMATION* pi, int flags);


### PR DESCRIPTION
The startup check apparently confuses other programs when yuzu launches 2 processes and then quickly closes one of them. Though this isn't really our issue it's also not a big deal for me to add an option to work around that issue.

Notably Steam on Linux considers yuzu closed when the child process closes.