### PR TITLE
cmake: Fix FindPkgConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,7 @@ if(ENABLE_QT)
             endif()
 
             # Check for headers
-            Include(FindPkgConfig REQUIRED)
+            find_package(PkgConfig REQUIRED)
             pkg_check_modules(QT_DEP_GLU QUIET glu>=9.0.0)
             if (NOT QT_DEP_GLU_FOUND)
                 message(FATAL_ERROR "Qt bundled pacakge dependency `glu` not found. \
@@ -386,7 +386,7 @@ endif()
 
 # Ensure libusb is properly configured (based on dolphin libusb include)
 if(NOT APPLE AND NOT YUZU_USE_BUNDLED_LIBUSB)
-    include(FindPkgConfig)
+    find_package(PkgConfig)
     if (PKG_CONFIG_FOUND AND NOT CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD")
         pkg_check_modules(LIBUSB QUIET libusb-1.0>=1.0.24)
     else()
@@ -410,7 +410,7 @@ set(FFmpeg_COMPONENTS
     swscale)
 
 if (UNIX AND NOT APPLE)
-    Include(FindPkgConfig REQUIRED)
+    find_package(PkgConfig REQUIRED)
     pkg_check_modules(LIBVA libva)
 endif()
 if (NOT YUZU_USE_BUNDLED_FFMPEG)

--- a/externals/ffmpeg/CMakeLists.txt
+++ b/externals/ffmpeg/CMakeLists.txt
@@ -43,7 +43,7 @@ if (NOT WIN32)
             CACHE PATH "Paths to FFmpeg libraries" FORCE)
     endforeach()
 
-    Include(FindPkgConfig REQUIRED)
+    find_package(PkgConfig REQUIRED)
     pkg_check_modules(LIBVA libva)
     pkg_check_modules(CUDA cuda)
     pkg_check_modules(FFNVCODEC ffnvcodec)

--- a/externals/libusb/CMakeLists.txt
+++ b/externals/libusb/CMakeLists.txt
@@ -108,7 +108,7 @@ if (MINGW OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux") OR APPLE)
     target_include_directories(usb INTERFACE "${LIBUSB_INCLUDE_DIRS}")
 
     if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-        Include(FindPkgConfig)
+        find_package(PkgConfig)
         pkg_check_modules(LIBUDEV REQUIRED libudev)
 
         if (LIBUDEV_FOUND)


### PR DESCRIPTION
The keyword `REQUIRED` is valid for [find_package](https://cmake.org/cmake/help/latest/command/find_package.html), not for [include](https://cmake.org/cmake/help/latest/command/include.html).