### PR TITLE
audio_renderer: Make GetCommandBuffer() take a u32

### DIFF
--- a/src/audio_core/renderer/adsp/audio_renderer.cpp
+++ b/src/audio_core/renderer/adsp/audio_renderer.cpp
@@ -47,7 +47,7 @@ RenderMessage AudioRenderer_Mailbox::ADSPWaitMessage() {
     return msg;
 }
 
-CommandBuffer& AudioRenderer_Mailbox::GetCommandBuffer(const s32 session_id) {
+CommandBuffer& AudioRenderer_Mailbox::GetCommandBuffer(const u32 session_id) {
     return command_buffers[session_id];
 }
 

--- a/src/audio_core/renderer/adsp/audio_renderer.h
+++ b/src/audio_core/renderer/adsp/audio_renderer.h
@@ -83,7 +83,7 @@ public:
      * @param session_id - The session id to get (0 or 1).
      * @return The command buffer.
      */
-    CommandBuffer& GetCommandBuffer(s32 session_id);
+    CommandBuffer& GetCommandBuffer(u32 session_id);
 
     /**
      * Set the command buffer with the given session id (0 or 1).


### PR DESCRIPTION
This function is only ever called with unsigned types, and all of the other class functions take session_id as a u32, so this makes the class a little more consistent.