### PR TITLE
sockets: Make fd member variable protected

### DIFF
--- a/src/core/internal_network/network.cpp
+++ b/src/core/internal_network/network.cpp
@@ -364,7 +364,7 @@ std::pair<s32, Errno> Poll(std::vector<PollFD>& pollfds, s32 timeout) {
     std::vector<WSAPOLLFD> host_pollfds(pollfds.size());
     std::transform(pollfds.begin(), pollfds.end(), host_pollfds.begin(), [](PollFD fd) {
         WSAPOLLFD result;
-        result.fd = fd.socket->fd;
+        result.fd = fd.socket->GetFD();
         result.events = TranslatePollEvents(fd.events);
         result.revents = 0;
         return result;
@@ -430,12 +430,12 @@ std::pair<SocketBase::AcceptResult, Errno> Socket::Accept() {
         return {AcceptResult{}, GetAndLogLastError()};
     }
 
-    AcceptResult result;
-    result.socket = std::make_unique<Socket>();
-    result.socket->fd = new_socket;
-
     ASSERT(addrlen == sizeof(sockaddr_in));
-    result.sockaddr_in = TranslateToSockAddrIn(addr);
+
+    AcceptResult result{
+        .socket = std::make_unique<Socket>(new_socket),
+        .sockaddr_in = TranslateToSockAddrIn(addr),
+    };
 
     return {std::move(result), Errno::SUCCESS};
 }

--- a/src/core/internal_network/sockets.h
+++ b/src/core/internal_network/sockets.h
@@ -32,6 +32,10 @@ public:
         std::unique_ptr<SocketBase> socket;
         SockAddrIn sockaddr_in;
     };
+
+    SocketBase() = default;
+    explicit SocketBase(SOCKET fd_) : fd{fd_} {}
+
     virtual ~SocketBase() = default;
 
     virtual SocketBase& operator=(const SocketBase&) = delete;
@@ -89,12 +93,19 @@ public:
 
     virtual void HandleProxyPacket(const ProxyPacket& packet) = 0;
 
+    [[nodiscard]] SOCKET GetFD() const {
+        return fd;
+    }
+
+protected:
     SOCKET fd = INVALID_SOCKET;
 };
 
 class Socket : public SocketBase {
 public:
     Socket() = default;
+    explicit Socket(SOCKET fd_) : SocketBase{fd_} {}
+
     ~Socket() override;
 
     Socket(const Socket&) = delete;


### PR DESCRIPTION
Other things shouldn't be able to directly mess around with the descriptor