### PR TITLE
build(room): simplify yuzu-room installation

### DIFF
--- a/src/dedicated_room/CMakeLists.txt
+++ b/src/dedicated_room/CMakeLists.txt
@@ -23,5 +23,5 @@ endif()
 target_link_libraries(yuzu-room PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if(UNIX AND NOT APPLE)
-    install(TARGETS yuzu-room RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+    install(TARGETS yuzu-room)
 endif()


### PR DESCRIPTION
CMake is able to automatically install binaries in the correct location. Also see my older patch, https://github.com/yuzu-emu/yuzu/commit/af94bf4a594b6a3599fae1d78e5d283b9f602032

Cc: @FearlessTobi