### PR TITLE
yuzu: sort input profiles by name

### DIFF
--- a/src/yuzu/configuration/input_profiles.cpp
+++ b/src/yuzu/configuration/input_profiles.cpp
@@ -67,6 +67,8 @@ std::vector<std::string> InputProfiles::GetInputProfileNames() {
         profile_names.push_back(profile_name);
     }
 
+    std::stable_sort(profile_names.begin(), profile_names.end());
+
     return profile_names;
 }
 


### PR DESCRIPTION
Currently the list order is kind of random. Sort profiles by name so it's easier to search a specific one