### PR TITLE
ci/linux: Drop linuxdeploy usage

### DIFF
--- a/.ci/scripts/linux/docker.sh
+++ b/.ci/scripts/linux/docker.sh
@@ -33,16 +33,14 @@ DESTDIR="$PWD/AppDir" ninja install
 rm -vf AppDir/usr/bin/yuzu-cmd AppDir/usr/bin/yuzu-tester
 
 # Download tools needed to build an AppImage
-wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/linuxdeploy-x86_64.AppImage
-wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/linuxdeploy-plugin-qt-x86_64.AppImage
+wget -nc https://raw.githubusercontent.com/lat9nq/deploy/main/linux/deploy-linux.sh
 wget -nc https://raw.githubusercontent.com/yuzu-emu/AppImageKit-checkrt/old/AppRun.sh
 wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/exec-x86_64.so
 # Set executable bit
 chmod 755 \
+    deploy-linux.sh \
     AppRun.sh \
     exec-x86_64.so \
-    linuxdeploy-x86_64.AppImage \
-    linuxdeploy-plugin-qt-x86_64.AppImage
 
 # Workaround for https://github.com/AppImage/AppImageKit/issues/828
 export APPIMAGE_EXTRACT_AND_RUN=1
@@ -52,7 +50,7 @@ mkdir -p AppDir/usr/optional/libstdc++
 mkdir -p AppDir/usr/optional/libgcc_s
 
 # Deploy yuzu's needed dependencies
-./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin qt
+DEPLOY_QT=1 ./deploy-linux.sh AppDir/usr/bin/yuzu AppDir
 
 # Workaround for libQt5MultimediaGstTools indirectly requiring libwayland-client and breaking Vulkan usage on end-user systems
 find AppDir -type f -regex '.*libwayland-client\.so.*' -delete -print


### PR DESCRIPTION
Recent versions of Docker appear to cause the Qt linuxdeploy plugin to throw a boost file copy error in some of our build containers (at the moment, specifically on the Patreon releases, but it's also happened on Mainline at least once? So mostly Azure.)

This switches from linuxdeploy to a [script of mine](https://github.com/lat9nq/deploy/blob/main/linux/deploy-linux.sh) I've been working on for a while.