### PR TITLE
Allow hostnames in LDN direct connect

### DIFF
--- a/src/yuzu/multiplayer/direct_connect.ui
+++ b/src/yuzu/multiplayer/direct_connect.ui
@@ -63,7 +63,7 @@
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="maxLength">
-               <number>16</number>
+               <number>253</number>
               </property>
              </widget>
             </item>

--- a/src/yuzu/multiplayer/validation.h
+++ b/src/yuzu/multiplayer/validation.h
@@ -36,11 +36,9 @@ private:
     QRegExp nickname_regex = QRegExp(QStringLiteral("^[a-zA-Z0-9._- ]{4,20}$"));
     QRegExpValidator nickname;
 
-    /// ipv4 address only
-    // TODO remove this when we support hostnames in direct connect
+    /// ipv4 address and hostname
     QRegExp ip_regex = QRegExp(QStringLiteral(
-        "(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|"
-        "2[0-4][0-9]|25[0-5])"));
+        "[a-zA-Z0-9.-]{2,253}$"));
     QRegExpValidator ip;
 
     /// port must be between 0 and 65535

--- a/src/yuzu/multiplayer/validation.h
+++ b/src/yuzu/multiplayer/validation.h
@@ -17,12 +17,15 @@ public:
     const QValidator* GetRoomName() const {
         return &room_name;
     }
+
     const QValidator* GetNickname() const {
         return &nickname;
     }
+
     const QValidator* GetIP() const {
         return &ip;
     }
+
     const QValidator* GetPort() const {
         return &port;
     }
@@ -36,9 +39,11 @@ private:
     QRegExp nickname_regex = QRegExp(QStringLiteral("^[a-zA-Z0-9._- ]{4,20}$"));
     QRegExpValidator nickname;
 
-    /// ipv4 address and hostname
-    QRegExp ip_regex = QRegExp(QStringLiteral(
-        "[a-zA-Z0-9.-]{2,253}$"));
+    /// Allow ip address and hostname
+    QRegExp ip_regex =
+        QRegExp(QStringLiteral("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4]"
+                               "[0-9]|[01]?[0-9][0-9]?)$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*["
+                               "a-zA-Z0-9])\.)+([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"));
     QRegExpValidator ip;
 
     /// port must be between 0 and 65535


### PR DESCRIPTION
Tested on windows 11 release build, working without problems.

Would be great for ease of use to be able to connect by hostname instead of ip only. 