### PR TITLE
Show error from cpp-httplib when we don't have a response to read (report errors while connecting to API)

### DIFF
--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -111,7 +111,8 @@ struct Client::Impl {
         httplib::Error error;
 
         if (!cli->send(request, response, error)) {
-            LOG_ERROR(WebService, "{} to {} returned null", method, host + path);
+            LOG_ERROR(WebService, "{} to {} returned null (httplib Error: {})", method, host + path,
+                      httplib::to_string(error));
             return WebResult{WebResult::Code::LibError, "Null response", ""};
         }
 


### PR DESCRIPTION
httplib.h has enum class Error, I suspect Connection might be most common

This might help if SSL issues crop up again

------
Intent here is to get more information out into logs without a bother.

Before
`[  10.674559] WebService <Error> web_service\web_backend.cpp:GenericRequest:115: POST to https://api.yuzu-emu.org/jwt/internal returned null`

After
`[  10.674559] WebService <Error> web_service\web_backend.cpp:GenericRequest:115: POST to https://api.yuzu-emu.org/jwt/internal returned null (httplib Error:Connection)`


When verification button is pressed, get three lines, only touching first line. 
```
[  10.674559] WebService <Error> web_service\web_backend.cpp:GenericRequest:115: POST to https://api.yuzu-emu.org/jwt/internal returned null (httplib Error:Connection)
[  10.674642] WebService <Error> web_service\web_backend.cpp:UpdateJWT:148: UpdateJWT failed
[  10.674644] WebService <Error> web_service\web_backend.cpp:GenericRequest:49: Credentials must be provided for authenticated requests
```
![new error better than old error](https://user-images.githubusercontent.com/190571/193947519-bf9bdf4b-35af-4a71-a39c-d09c066d681f.png)

Not being able to reach the server (for example using a VM without internet access) gives ERRNO 2 which would be Connection

Not having SSL Certs is ERRNO 10 SSLServerVerification



