### PR TITLE
macro_jit_x64: cancel exit for taken branch

### DIFF
--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -429,17 +429,11 @@ void MacroJITx64Impl::Compile_Branch(Macro::Opcode opcode) {
             Xbyak::Label handle_post_exit{};
             Xbyak::Label skip{};
             jmp(skip, T_NEAR);
-            if (opcode.is_exit) {
-                L(handle_post_exit);
-                // Execute 1 instruction
-                mov(BRANCH_HOLDER, end_of_code);
-                // Jump to next instruction to skip delay slot check
-                jmp(labels[jump_address], T_NEAR);
-            } else {
-                L(handle_post_exit);
-                xor_(BRANCH_HOLDER, BRANCH_HOLDER);
-                jmp(labels[jump_address], T_NEAR);
-            }
+
+            L(handle_post_exit);
+            xor_(BRANCH_HOLDER, BRANCH_HOLDER);
+            jmp(labels[jump_address], T_NEAR);
+
             L(skip);
             mov(BRANCH_HOLDER, handle_post_exit);
             jmp(delay_skip[pc], T_NEAR);


### PR DESCRIPTION
In the following macro, used by deko3d, the `bnz` instruction expects to cancel the exit flag when taken.
```
DrawIndexed::
	fetch r6 # Fetch index count
	1 to r2 # r2 = 1 (needed for later)
	fetch r7 # Fetch instance count
	DrawElementsFirst'0 to addr; fetch mem # Fetch first index
	fetch r3 # Fetch vertex offset
	*bnz r7 .cancelExit # Early exit if instance count is zero
	DrawBaseVertex'1 to addr; fetch r4 # Fetch base instance
.cancelExit
	r3 to mem # Update DrawBaseVertex
        # ...
```
This PR fixes the branch emission to avoid exiting after executing a taken branch. Now it will only exit after executing a non-taken branch. The delay slot is still respected for both cases.