### PR TITLE
Fix "controller.colors_state.right" being "left"

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -93,7 +93,7 @@ void EmulatedController::ReloadFromSettings() {
         .body = GetNpadColor(player.body_color_left),
         .button = GetNpadColor(player.button_color_left),
     };
-    controller.colors_state.left = {
+    controller.colors_state.right = {
         .body = GetNpadColor(player.body_color_right),
         .button = GetNpadColor(player.button_color_right),
     };


### PR DESCRIPTION
#8724 fixed controller colours in `controller.colors_state.left` and copy-pasted the changes to `controller.colors_state.right`. However, while copy-pasting it, `controller.colors_state.right` was replaced with `controller.colors_state.left`!  
This pull request fixes that.