### PR TITLE
common: remove "yuzu:" prefix from thread names

### DIFF
--- a/src/audio_core/renderer/adsp/audio_renderer.cpp
+++ b/src/audio_core/renderer/adsp/audio_renderer.cpp
@@ -132,7 +132,7 @@ void AudioRenderer::CreateSinkStreams() {
 }
 
 void AudioRenderer::ThreadFunc() {
-    constexpr char name[]{"yuzu:AudioRenderer"};
+    constexpr char name[]{"AudioRenderer"};
     MicroProfileOnThreadCreate(name);
     Common::SetCurrentThreadName(name);
     Common::SetCurrentThreadPriority(Common::ThreadPriority::Critical);

--- a/src/audio_core/renderer/system_manager.cpp
+++ b/src/audio_core/renderer/system_manager.cpp
@@ -94,7 +94,7 @@ bool SystemManager::Remove(System& system_) {
 }
 
 void SystemManager::ThreadFunc() {
-    constexpr char name[]{"yuzu:AudioRenderSystemManager"};
+    constexpr char name[]{"AudioRenderSystemManager"};
     MicroProfileOnThreadCreate(name);
     Common::SetCurrentThreadName(name);
     Common::SetCurrentThreadPriority(Common::ThreadPriority::High);

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -219,7 +219,7 @@ private:
 
     void StartBackendThread() {
         backend_thread = std::jthread([this](std::stop_token stop_token) {
-            Common::SetCurrentThreadName("yuzu:Log");
+            Common::SetCurrentThreadName("Logger");
             Entry entry;
             const auto write_logs = [this, &entry]() {
                 ForEachBackend([&entry](Backend& backend) { backend.Write(entry); });

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -43,7 +43,7 @@ CoreTiming::CoreTiming()
 CoreTiming::~CoreTiming() = default;
 
 void CoreTiming::ThreadEntry(CoreTiming& instance) {
-    constexpr char name[] = "yuzu:HostTiming";
+    constexpr char name[] = "HostTiming";
     MicroProfileOnThreadCreate(name);
     Common::SetCurrentThreadName(name);
     Common::SetCurrentThreadPriority(Common::ThreadPriority::Critical);

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -189,9 +189,9 @@ void CpuManager::RunThread(std::size_t core) {
     system.RegisterCoreThread(core);
     std::string name;
     if (is_multicore) {
-        name = "yuzu:CPUCore_" + std::to_string(core);
+        name = "CPUCore_" + std::to_string(core);
     } else {
-        name = "yuzu:CPUThread";
+        name = "CPUThread";
     }
     MicroProfileOnThreadCreate(name.c_str());
     Common::SetCurrentThreadName(name.c_str());

--- a/src/core/debugger/debugger.cpp
+++ b/src/core/debugger/debugger.cpp
@@ -140,7 +140,7 @@ private:
     }
 
     void ThreadLoop(std::stop_token stop_token) {
-        Common::SetCurrentThreadName("yuzu:Debugger");
+        Common::SetCurrentThreadName("Debugger");
 
         // Set up the client signals for new data.
         AsyncReceiveInto(signal_pipe, pipe_data, [&](auto d) { PipeData(d); });

--- a/src/core/hle/kernel/k_worker_task_manager.cpp
+++ b/src/core/hle/kernel/k_worker_task_manager.cpp
@@ -23,7 +23,7 @@ void KWorkerTask::DoWorkerTask() {
     }
 }
 
-KWorkerTaskManager::KWorkerTaskManager() : m_waiting_thread(1, "yuzu:KWorkerTaskManager") {}
+KWorkerTaskManager::KWorkerTaskManager() : m_waiting_thread(1, "KWorkerTaskManager") {}
 
 void KWorkerTaskManager::AddTask(KernelCore& kernel, WorkerType type, KWorkerTask* task) {
     ASSERT(type <= WorkerType::Count);

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -48,7 +48,7 @@ namespace Kernel {
 struct KernelCore::Impl {
     explicit Impl(Core::System& system_, KernelCore& kernel_)
         : time_manager{system_},
-          service_threads_manager{1, "yuzu:ServiceThreadsManager"}, system{system_} {}
+          service_threads_manager{1, "ServiceThreadsManager"}, system{system_} {}
 
     void SetMulticore(bool is_multi) {
         is_multicore = is_multi;

--- a/src/core/hle/kernel/service_thread.cpp
+++ b/src/core/hle/kernel/service_thread.cpp
@@ -36,7 +36,7 @@ ServiceThread::Impl::Impl(KernelCore& kernel, std::size_t num_threads, const std
     : service_name{name} {
     for (std::size_t i = 0; i < num_threads; ++i) {
         threads.emplace_back([this, &kernel](std::stop_token stop_token) {
-            Common::SetCurrentThreadName(std::string{"yuzu:HleService:" + service_name}.c_str());
+            Common::SetCurrentThreadName(std::string{service_name}.c_str());
 
             // Wait for first request before trying to acquire a render context
             {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -31,7 +31,7 @@ constexpr auto frame_ns = std::chrono::nanoseconds{1000000000 / 60};
 
 void NVFlinger::SplitVSync(std::stop_token stop_token) {
     system.RegisterHostThread();
-    std::string name = "yuzu:VSyncThread";
+    std::string name = "VSyncThread";
     MicroProfileOnThreadCreate(name.c_str());
 
     // Cleanup

--- a/src/input_common/drivers/gc_adapter.cpp
+++ b/src/input_common/drivers/gc_adapter.cpp
@@ -90,7 +90,7 @@ GCAdapter::~GCAdapter() {
 
 void GCAdapter::AdapterInputThread(std::stop_token stop_token) {
     LOG_DEBUG(Input, "Input thread started");
-    Common::SetCurrentThreadName("yuzu:input:GCAdapter");
+    Common::SetCurrentThreadName("GCAdapter");
     s32 payload_size{};
     AdapterPayload adapter_payload{};
 
@@ -214,7 +214,7 @@ void GCAdapter::UpdateStateAxes(std::size_t port, const AdapterPayload& adapter_
 }
 
 void GCAdapter::AdapterScanThread(std::stop_token stop_token) {
-    Common::SetCurrentThreadName("yuzu:input:ScanGCAdapter");
+    Common::SetCurrentThreadName("ScanGCAdapter");
     usb_adapter_handle = nullptr;
     pads = {};
     while (!stop_token.stop_requested() && !Setup()) {

--- a/src/input_common/drivers/mouse.cpp
+++ b/src/input_common/drivers/mouse.cpp
@@ -37,7 +37,7 @@ Mouse::Mouse(std::string input_engine_) : InputEngine(std::move(input_engine_)) 
 }
 
 void Mouse::UpdateThread(std::stop_token stop_token) {
-    Common::SetCurrentThreadName("yuzu:input:Mouse");
+    Common::SetCurrentThreadName("Mouse");
     constexpr int update_time = 10;
     while (!stop_token.stop_requested()) {
         if (Settings::values.mouse_panning && !Settings::values.mouse_enabled) {

--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -436,7 +436,7 @@ SDLDriver::SDLDriver(std::string input_engine_) : InputEngine(std::move(input_en
     initialized = true;
     if (start_thread) {
         poll_thread = std::thread([this] {
-            Common::SetCurrentThreadName("yuzu:input:SDL");
+            Common::SetCurrentThreadName("SDL_MainLoop");
             using namespace std::chrono_literals;
             while (initialized) {
                 SDL_PumpEvents();
@@ -444,7 +444,7 @@ SDLDriver::SDLDriver(std::string input_engine_) : InputEngine(std::move(input_en
             }
         });
         vibration_thread = std::thread([this] {
-            Common::SetCurrentThreadName("yuzu:input:SDL_Vibration");
+            Common::SetCurrentThreadName("SDL_Vibration");
             using namespace std::chrono_literals;
             while (initialized) {
                 SendVibrations();

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -19,7 +19,7 @@ namespace VideoCommon::GPUThread {
 static void RunThread(std::stop_token stop_token, Core::System& system,
                       VideoCore::RendererBase& renderer, Core::Frontend::GraphicsContext& context,
                       Tegra::DmaPusher& dma_pusher, SynchState& state) {
-    std::string name = "yuzu:GPU";
+    std::string name = "GPU";
     MicroProfileOnThreadCreate(name.c_str());
     SCOPE_EXIT({ MicroProfileOnThreadExit(); });
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -546,7 +546,7 @@ std::unique_ptr<ComputePipeline> ShaderCache::CreateComputePipeline(
 
 std::unique_ptr<ShaderWorker> ShaderCache::CreateWorkers() const {
     return std::make_unique<ShaderWorker>(std::max(std::thread::hardware_concurrency(), 2U) - 1,
-                                          "yuzu:ShaderBuilder",
+                                          "GlShaderBuilder",
                                           [this] { return Context{emu_window}; });
 }
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -271,8 +271,8 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, Tegra::Engines::Maxw
       update_descriptor_queue{update_descriptor_queue_}, render_pass_cache{render_pass_cache_},
       buffer_cache{buffer_cache_}, texture_cache{texture_cache_}, shader_notify{shader_notify_},
       use_asynchronous_shaders{Settings::values.use_asynchronous_shaders.GetValue()},
-      workers(std::max(std::thread::hardware_concurrency(), 2U) - 1, "yuzu:PipelineBuilder"),
-      serialization_thread(1, "yuzu:PipelineSerialization") {
+      workers(std::max(std::thread::hardware_concurrency(), 2U) - 1, "VkPipelineBuilder"),
+      serialization_thread(1, "VkPipelineSerialization") {
     const auto& float_control{device.FloatControlProperties()};
     const VkDriverIdKHR driver_id{device.GetDriverID()};
     profile = Shader::Profile{

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -136,7 +136,7 @@ bool Scheduler::UpdateRescaling(bool is_rescaling) {
 }
 
 void Scheduler::WorkerThread(std::stop_token stop_token) {
-    Common::SetCurrentThreadName("yuzu:VulkanWorker");
+    Common::SetCurrentThreadName("VulkanWorker");
     do {
         std::unique_ptr<CommandChunk> work;
         {

--- a/src/video_core/textures/astc.cpp
+++ b/src/video_core/textures/astc.cpp
@@ -1656,7 +1656,7 @@ void Decompress(std::span<const uint8_t> data, uint32_t width, uint32_t height, 
     const u32 cols = Common::DivideUp(width, block_width);
 
     Common::ThreadWorker workers{std::max(std::thread::hardware_concurrency(), 2U) / 2,
-                                 "yuzu:ASTCDecompress"};
+                                 "ASTCDecompress"};
 
     for (u32 z = 0; z < depth; ++z) {
         const u32 depth_offset = z * height * width * 4;

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -47,7 +47,7 @@ EmuThread::EmuThread(Core::System& system_) : system{system_} {}
 EmuThread::~EmuThread() = default;
 
 void EmuThread::run() {
-    std::string name = "yuzu:EmuControlThread";
+    std::string name = "EmuControlThread";
     MicroProfileOnThreadCreate(name.c_str());
     Common::SetCurrentThreadName(name.c_str());
 


### PR DESCRIPTION
Thread names in certain platforms are limited to [15 safe characters](https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html), for unfathomable reasons. This change helps more thread names stay intact when debugging.