### PR TITLE
core_timing: use high-precision sleeps on non-Windows targets

### DIFF
--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -270,6 +270,7 @@ void CoreTiming::ThreadLoop() {
                 // There are more events left in the queue, wait until the next event.
                 const auto wait_time = *next_time - GetGlobalTimeNs().count();
                 if (wait_time > 0) {
+#ifdef _WIN32
                     // Assume a timer resolution of 1ms.
                     static constexpr s64 TimerResolutionNS = 1000000;
 
@@ -287,6 +288,9 @@ void CoreTiming::ThreadLoop() {
                     if (event.IsSet()) {
                         event.Reset();
                     }
+#else
+                    event.WaitFor(std::chrono::nanoseconds(wait_time));
+#endif
                 }
             } else {
                 // Queue is empty, wait until another event is scheduled and signals us to continue.


### PR DESCRIPTION
It is not necessary to perform extra spinning on other platforms since Linux has working high-precision sleeps, and hurts performance in lower-end setups. Might fix #9037.