### PR TITLE
service: ldn: Always initialize successfully

### DIFF
--- a/src/core/hle/service/ldn/lan_discovery.cpp
+++ b/src/core/hle/service/ldn/lan_discovery.cpp
@@ -487,7 +487,7 @@ void LANDiscovery::ReceivePacket(const Network::LDNPacket& packet) {
     std::scoped_lock lock{packet_mutex};
     switch (packet.type) {
     case Network::LDNPacketType::Scan: {
-        LOG_INFO(Frontend, "Scan packet received!");
+        LOG_DEBUG(Frontend, "Scan packet received!");
         if (state == State::AccessPointCreated) {
             // Reply to the sender
             SendPacket(Network::LDNPacketType::ScanResp, network_info, packet.local_ip);
@@ -495,7 +495,7 @@ void LANDiscovery::ReceivePacket(const Network::LDNPacket& packet) {
         break;
     }
     case Network::LDNPacketType::ScanResp: {
-        LOG_INFO(Frontend, "ScanResp packet received!");
+        LOG_DEBUG(Frontend, "ScanResp packet received!");
 
         NetworkInfo info{};
         std::memcpy(&info, packet.data.data(), sizeof(NetworkInfo));
@@ -611,13 +611,6 @@ MacAddress LANDiscovery::GetFakeMac() const {
 
 Result LANDiscovery::GetNodeInfo(NodeInfo& node, const UserConfig& userConfig,
                                  u16 localCommunicationVersion) {
-    const auto network_interface = Network::GetSelectedNetworkInterface();
-
-    if (!network_interface) {
-        LOG_ERROR(Service_LDN, "No network interface available");
-        return ResultNoIpAddress;
-    }
-
     node.mac_address = GetFakeMac();
     node.is_connected = 1;
     std::memcpy(node.user_name.data(), userConfig.user_name.data(), UserNameBytesMax + 1);

--- a/src/core/internal_network/network_interface.cpp
+++ b/src/core/internal_network/network_interface.cpp
@@ -200,7 +200,7 @@ std::optional<NetworkInterface> GetSelectedNetworkInterface() {
         });
 
     if (res == network_interfaces.end()) {
-        LOG_ERROR(Network, "Couldn't find selected interface \"{}\"", selected_network_interface);
+        LOG_DEBUG(Network, "Couldn't find selected interface \"{}\"", selected_network_interface);
         return std::nullopt;
     }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -948,7 +948,6 @@ void GMainWindow::InitializeWidgets() {
         statusBar()->addPermanentWidget(label);
     }
 
-    // TODO (flTobi): Add the widget when multiplayer is fully implemented
     statusBar()->addPermanentWidget(multiplayer_state->GetStatusText(), 0);
     statusBar()->addPermanentWidget(multiplayer_state->GetStatusIcon(), 0);
 


### PR DESCRIPTION
This PR aims to fix a weird issue with pokemon sword that causes crashes in the first 10 minutes by always initializing the service even when no network is available. At the same time silences log entries that aren't meaningful for support.