### PR TITLE
input_common: have an unique vector in callback status

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -277,8 +277,9 @@ struct CallbackStatus {
     BodyColorStatus color_status{};
     BatteryStatus battery_status{};
     VibrationStatus vibration_status{};
-    CameraStatus camera_status{};
-    NfcStatus nfc_status{};
+    CameraFormat camera_status{CameraFormat::None};
+    NfcState nfc_status{NfcState::Unknown};
+    std::vector<u8> raw_data{};
 };
 
 // Triggered once every input change

--- a/src/core/hid/input_converter.cpp
+++ b/src/core/hid/input_converter.cpp
@@ -277,7 +277,10 @@ Common::Input::CameraStatus TransformToCamera(const Common::Input::CallbackStatu
     Common::Input::CameraStatus camera{};
     switch (callback.type) {
     case Common::Input::InputType::IrSensor:
-        camera = callback.camera_status;
+        camera = {
+            .format = callback.camera_status,
+            .data = callback.raw_data,
+        };
         break;
     default:
         LOG_ERROR(Input, "Conversion from type {} to camera not implemented", callback.type);
@@ -291,7 +294,10 @@ Common::Input::NfcStatus TransformToNfc(const Common::Input::CallbackStatus& cal
     Common::Input::NfcStatus nfc{};
     switch (callback.type) {
     case Common::Input::InputType::Nfc:
-        return callback.nfc_status;
+        nfc = {
+            .state = callback.nfc_status,
+            .data = callback.raw_data,
+        };
         break;
     default:
         LOG_ERROR(Input, "Conversion from type {} to NFC not implemented", callback.type);

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -691,9 +691,12 @@ public:
     }
 
     void OnChange() {
+        const auto camera_status = GetStatus();
+
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::IrSensor,
-            .camera_status = GetStatus(),
+            .camera_status = camera_status.format,
+            .raw_data = camera_status.data,
         };
 
         TriggerOnChange(status);
@@ -732,9 +735,12 @@ public:
     }
 
     void OnChange() {
+        const auto nfc_status = GetStatus();
+
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::Nfc,
-            .nfc_status = GetStatus(),
+            .nfc_status = nfc_status.state,
+            .raw_data = nfc_status.data,
         };
 
         TriggerOnChange(status);


### PR DESCRIPTION
Gcc 12 and 13 complain that the camera vector is not initialized when it's initialized by default. Since we don't really need two vectors in this struct we simply have one that is shared to all input types and split and join the data as needed.