### PR TITLE
ci/windows: Revert to using GCC for MinGW builds

### DIFF
--- a/.ci/scripts/windows/docker.sh
+++ b/.ci/scripts/windows/docker.sh
@@ -10,13 +10,9 @@ set -e
 ccache -sv
 
 mkdir -p build && cd build
-export LDFLAGS="-fuse-ld=lld"
-# -femulated-tls required due to an incompatibility between GCC and Clang
-# TODO(lat9nq): If this is widespread, we probably need to add this to CMakeLists where appropriate
-export CXXFLAGS="-femulated-tls"
 cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_TOOLCHAIN_FILE="${PWD}/../CMakeModules/MinGWClangCross.cmake" \
+    -DCMAKE_TOOLCHAIN_FILE="${PWD}/../CMakeModules/MinGWCross.cmake" \
     -DDISPLAY_VERSION="$1" \
     -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON \
     -DENABLE_QT_TRANSLATION=ON \


### PR DESCRIPTION
Conceptually a revert of #8455

Using MinGW in the future may not be ideal as it does not work very well with crash dumps (#8682).

Switch back to GCC on MinGW. This also gives CI a way to check GCC 12 (as of writing, or whatever version of mingw-gcc Arch happens to be shipping on a given week).