### PR TITLE
yuzu: Add 16:10 aspect ratio

### DIFF
--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -67,6 +67,8 @@ float EmulationAspectRatio(AspectRatio aspect, float window_aspect_ratio) {
         return 3.0f / 4.0f;
     case AspectRatio::R21_9:
         return 9.0f / 21.0f;
+    case AspectRatio::R16_10:
+        return 10.0f / 16.0f;
     case AspectRatio::StretchToWindow:
         return window_aspect_ratio;
     default:

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -27,6 +27,7 @@ enum class AspectRatio {
     Default,
     R4_3,
     R21_9,
+    R16_10,
     StretchToWindow,
 };
 

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -301,6 +301,11 @@
              </item>
              <item>
               <property name="text">
+               <string>Force 16:10</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
                <string>Stretch to Window</string>
               </property>
              </item>


### PR DESCRIPTION
Since steam deck is popular, I want to add this aspect ratio. With proper game mods it will look more natural on those devices