### PR TITLE
add game image to discord rpc

### DIFF
--- a/src/yuzu/discord_impl.cpp
+++ b/src/yuzu/discord_impl.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <string>
 #include <discord_rpc.h>
+#include <fmt/format.h>
 #include "common/common_types.h"
 #include "core/core.h"
 #include "core/loader/loader.h"
@@ -34,16 +35,31 @@ void DiscordImpl::Update() {
                          std::chrono::system_clock::now().time_since_epoch())
                          .count();
     std::string title;
+    u64 titleId;
+
     if (system.IsPoweredOn()) {
         system.GetAppLoader().ReadTitle(title);
+        system.GetAppLoader().ReadProgramId(titleId);
     }
+
     DiscordRichPresence presence{};
-    presence.largeImageKey = "yuzu_logo";
-    presence.largeImageText = "yuzu is an emulator for the Nintendo Switch";
+
     if (system.IsPoweredOn()) {
+        std::string gameCoverUrl = "https://tinfoil.media/ti/";
+        gameCoverUrl += QString::fromStdString(fmt::format("{:016X}", titleId)).toStdString();
+        gameCoverUrl += "/512/512";
+
+        presence.largeImageKey = gameCoverUrl.c_str();
+        presence.largeImageText = title.c_str();
+
+        presence.smallImageKey = "yuzu_logo";
+        presence.smallImageText = "yuzu is an emulator for the Nintendo Switch";
+
         presence.state = title.c_str();
         presence.details = "Currently in game";
     } else {
+        presence.largeImageKey = "yuzu_logo";
+        presence.largeImageText = "yuzu is an emulator for the Nintendo Switch";
         presence.details = "Not in game";
     }
     presence.startTimestamp = start_time;

--- a/src/yuzu/discord_impl.cpp
+++ b/src/yuzu/discord_impl.cpp
@@ -34,32 +34,33 @@ void DiscordImpl::Update() {
     s64 start_time = std::chrono::duration_cast<std::chrono::seconds>(
                          std::chrono::system_clock::now().time_since_epoch())
                          .count();
+    std::string default_text = "yuzu is an emulator for the Nintendo Switch";
+    std::string game_cover_url = "https://tinfoil.media/ti/";
     std::string title;
-    u64 titleId;
+    u64 title_id;
 
     if (system.IsPoweredOn()) {
         system.GetAppLoader().ReadTitle(title);
-        system.GetAppLoader().ReadProgramId(titleId);
+        system.GetAppLoader().ReadProgramId(title_id);
     }
 
     DiscordRichPresence presence{};
 
     if (system.IsPoweredOn()) {
-        std::string gameCoverUrl = "https://tinfoil.media/ti/";
-        gameCoverUrl += QString::fromStdString(fmt::format("{:016X}", titleId)).toStdString();
-        gameCoverUrl += "/512/512";
+        game_cover_url += fmt::format("{:016X}", title_id);
+        game_cover_url += "/512/512";
 
-        presence.largeImageKey = gameCoverUrl.c_str();
+        presence.largeImageKey = game_cover_url.c_str();
         presence.largeImageText = title.c_str();
 
         presence.smallImageKey = "yuzu_logo";
-        presence.smallImageText = "yuzu is an emulator for the Nintendo Switch";
+        presence.smallImageText = default_text.c_str();
 
         presence.state = title.c_str();
         presence.details = "Currently in game";
     } else {
         presence.largeImageKey = "yuzu_logo";
-        presence.largeImageText = "yuzu is an emulator for the Nintendo Switch";
+        presence.largeImageText = default_text.c_str();
         presence.details = "Not in game";
     }
     presence.startTimestamp = start_time;


### PR DESCRIPTION
Hello,
This pull request changes a tiny bit the Discord RPC when being in game.

Before (current version):
![image](https://user-images.githubusercontent.com/75615715/195168183-030cb141-ee0a-424a-a172-868033c5ecdb.png)

After:
![image](https://cdn.discordapp.com/attachments/700692154334445591/1029454825932455958/unknown.png)