### PR TITLE
Preliminary support for nx-hbloader

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -111,6 +111,7 @@ public:
         LOG_ERROR(Core_ARM,
                   "Unimplemented instruction @ 0x{:X} for {} instructions (instr = {:08X})", pc,
                   num_instructions, memory.Read32(pc));
+        ReturnException(pc, ARM_Interface::no_execute);
     }
 
     void InstructionCacheOperationRaised(Dynarmic::A64::InstructionCacheOperation op,

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -152,7 +152,8 @@ public:
                 Kernel::LimitableResource::Sessions, 1);
 
             auto* session = Kernel::KSession::Create(kernel);
-            session->Initialize(nullptr, iface->GetServiceName());
+            session->Initialize(nullptr, iface->GetServiceName(),
+                                std::make_shared<Kernel::SessionRequestManager>(kernel));
 
             context->AddMoveObject(&session->GetClientSession());
             iface->ClientConnected(&session->GetServerSession());

--- a/src/core/hle/kernel/k_client_session.cpp
+++ b/src/core/hle/kernel/k_client_session.cpp
@@ -21,10 +21,9 @@ void KClientSession::Destroy() {
 
 void KClientSession::OnServerClosed() {}
 
-Result KClientSession::SendSyncRequest(KThread* thread, Core::Memory::Memory& memory,
-                                       Core::Timing::CoreTiming& core_timing) {
+Result KClientSession::SendSyncRequest() {
     // Signal the server session that new data is available
-    return parent->GetServerSession().HandleSyncRequest(thread, memory, core_timing);
+    return parent->GetServerSession().OnRequest();
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_client_session.h
+++ b/src/core/hle/kernel/k_client_session.h
@@ -46,8 +46,7 @@ public:
         return parent;
     }
 
-    Result SendSyncRequest(KThread* thread, Core::Memory::Memory& memory,
-                           Core::Timing::CoreTiming& core_timing);
+    Result SendSyncRequest();
 
     void OnServerClosed();
 

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -7,6 +7,8 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
+#include "common/scope_exit.h"
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
@@ -18,13 +20,19 @@
 #include "core/hle/kernel/k_server_session.h"
 #include "core/hle/kernel/k_session.h"
 #include "core/hle/kernel/k_thread.h"
+#include "core/hle/kernel/k_thread_queue.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/service_thread.h"
 #include "core/memory.h"
 
 namespace Kernel {
 
-KServerSession::KServerSession(KernelCore& kernel_) : KSynchronizationObject{kernel_} {}
+using ThreadQueueImplForKServerSessionRequest = KThreadQueue;
+
+static constexpr u32 MessageBufferSize = 0x100;
+
+KServerSession::KServerSession(KernelCore& kernel_)
+    : KSynchronizationObject{kernel_}, m_lock{kernel_} {}
 
 KServerSession::~KServerSession() = default;
 
@@ -33,16 +41,13 @@ void KServerSession::Initialize(KSession* parent_session_, std::string&& name_,
     // Set member variables.
     parent = parent_session_;
     name = std::move(name_);
-
-    if (manager_) {
-        manager = manager_;
-    } else {
-        manager = std::make_shared<SessionRequestManager>(kernel);
-    }
+    manager = manager_;
 }
 
 void KServerSession::Destroy() {
     parent->OnServerClosed();
+
+    this->CleanupRequests();
 
     parent->Close();
 
@@ -54,13 +59,13 @@ void KServerSession::Destroy() {
 }
 
 void KServerSession::OnClientClosed() {
-    if (manager->HasSessionHandler()) {
+    if (manager && manager->HasSessionHandler()) {
         manager->SessionHandler().ClientDisconnected(this);
     }
 }
 
 bool KServerSession::IsSignaled() const {
-    ASSERT(kernel.GlobalSchedulerContext().IsLocked());
+    ASSERT(KScheduler::IsSchedulerLockedByCurrentThread(kernel));
 
     // If the client is closed, we're always signaled.
     if (parent->IsClientClosed()) {
@@ -68,7 +73,7 @@ bool KServerSession::IsSignaled() const {
     }
 
     // Otherwise, we're signaled if we have a request and aren't handling one.
-    return false;
+    return !m_thread_request_list.empty() && m_current_thread_request == nullptr;
 }
 
 void KServerSession::AppendDomainHandler(SessionRequestHandlerPtr handler) {
@@ -173,9 +178,221 @@ Result KServerSession::CompleteSyncRequest(HLERequestContext& context) {
     return result;
 }
 
-Result KServerSession::HandleSyncRequest(KThread* thread, Core::Memory::Memory& memory,
-                                         Core::Timing::CoreTiming& core_timing) {
-    return QueueSyncRequest(thread, memory);
+Result KServerSession::OnRequest() {
+    // Create the wait queue.
+    ThreadQueueImplForKServerSessionRequest wait_queue{kernel};
+
+    {
+        // Lock the scheduler.
+        KScopedSchedulerLock sl{kernel};
+
+        // Ensure that we can handle new requests.
+        R_UNLESS(!parent->IsServerClosed(), ResultSessionClosed);
+
+        // Check that we're not terminating.
+        R_UNLESS(!GetCurrentThread(kernel).IsTerminationRequested(), ResultTerminationRequested);
+
+        if (manager) {
+            // HLE request.
+            auto& memory{kernel.System().Memory()};
+            this->QueueSyncRequest(GetCurrentThreadPointer(kernel), memory);
+        } else {
+            // Non-HLE request.
+            auto* thread{GetCurrentThreadPointer(kernel)};
+
+            // Get whether we're empty.
+            const bool was_empty = m_thread_request_list.empty();
+
+            // Add the thread to the list.
+            thread->Open();
+            m_thread_request_list.push_back(thread);
+
+            // If we were empty, signal.
+            if (was_empty) {
+                this->NotifyAvailable();
+            }
+        }
+
+        // This is a synchronous request, so we should wait for our request to complete.
+        GetCurrentThread(kernel).SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::IPC);
+        GetCurrentThread(kernel).BeginWait(&wait_queue);
+    }
+
+    return GetCurrentThread(kernel).GetWaitResult();
+}
+
+Result KServerSession::SendReply() {
+    // Lock the session.
+    KScopedLightLock lk(m_lock);
+
+    // Get the request.
+    KThread* client_thread;
+    {
+        KScopedSchedulerLock sl{kernel};
+
+        // Get the current request.
+        client_thread = m_current_thread_request;
+        R_UNLESS(client_thread != nullptr, ResultInvalidState);
+
+        // Clear the current request, since we're processing it.
+        m_current_thread_request = nullptr;
+        if (!m_thread_request_list.empty()) {
+            this->NotifyAvailable();
+        }
+    }
+
+    // Close reference to the request once we're done processing it.
+    SCOPE_EXIT({ client_thread->Close(); });
+
+    // Extract relevant information from the request.
+    // const uintptr_t client_message  = request->GetAddress();
+    // const size_t client_buffer_size = request->GetSize();
+    // KThread *client_thread          = request->GetThread();
+    // KEvent *event                   = request->GetEvent();
+
+    // Check whether we're closed.
+    const bool closed = (client_thread == nullptr || parent->IsClientClosed());
+
+    Result result = ResultSuccess;
+    if (!closed) {
+        // If we're not closed, send the reply.
+        Core::Memory::Memory& memory{kernel.System().Memory()};
+        KThread* server_thread{GetCurrentThreadPointer(kernel)};
+        UNIMPLEMENTED_IF(server_thread->GetOwnerProcess() != client_thread->GetOwnerProcess());
+
+        auto* src_msg_buffer = memory.GetPointer(server_thread->GetTLSAddress());
+        auto* dst_msg_buffer = memory.GetPointer(client_thread->GetTLSAddress());
+        std::memcpy(dst_msg_buffer, src_msg_buffer, MessageBufferSize);
+    } else {
+        result = ResultSessionClosed;
+    }
+
+    // Select a result for the client.
+    Result client_result = result;
+    if (closed && R_SUCCEEDED(result)) {
+        result = ResultSessionClosed;
+        client_result = ResultSessionClosed;
+    } else {
+        result = ResultSuccess;
+    }
+
+    // If there's a client thread, update it.
+    if (client_thread != nullptr) {
+        // End the client thread's wait.
+        KScopedSchedulerLock sl{kernel};
+
+        if (!client_thread->IsTerminationRequested()) {
+            client_thread->EndWait(client_result);
+        }
+    }
+
+    return result;
+}
+
+Result KServerSession::ReceiveRequest() {
+    // Lock the session.
+    KScopedLightLock lk(m_lock);
+
+    // Get the request and client thread.
+    // KSessionRequest *request;
+    KThread* client_thread;
+
+    {
+        KScopedSchedulerLock sl{kernel};
+
+        // Ensure that we can service the request.
+        R_UNLESS(!parent->IsClientClosed(), ResultSessionClosed);
+
+        // Ensure we aren't already servicing a request.
+        R_UNLESS(m_current_thread_request == nullptr, ResultNotFound);
+
+        // Ensure we have a request to service.
+        R_UNLESS(!m_thread_request_list.empty(), ResultNotFound);
+
+        // Pop the first request from the list.
+        client_thread = m_thread_request_list.front();
+        m_thread_request_list.pop_front();
+
+        // Get the thread for the request.
+        R_UNLESS(client_thread != nullptr, ResultSessionClosed);
+
+        // Open the client thread.
+        client_thread->Open();
+    }
+
+    // SCOPE_EXIT({ client_thread->Close(); });
+
+    // Set the request as our current.
+    m_current_thread_request = client_thread;
+
+    // Receive the message.
+    Core::Memory::Memory& memory{kernel.System().Memory()};
+    KThread* server_thread{GetCurrentThreadPointer(kernel)};
+    UNIMPLEMENTED_IF(server_thread->GetOwnerProcess() != client_thread->GetOwnerProcess());
+
+    auto* src_msg_buffer = memory.GetPointer(client_thread->GetTLSAddress());
+    auto* dst_msg_buffer = memory.GetPointer(server_thread->GetTLSAddress());
+    std::memcpy(dst_msg_buffer, src_msg_buffer, MessageBufferSize);
+
+    // We succeeded.
+    return ResultSuccess;
+}
+
+void KServerSession::CleanupRequests() {
+    KScopedLightLock lk(m_lock);
+
+    // Clean up any pending requests.
+    while (true) {
+        // Get the next request.
+        // KSessionRequest *request = nullptr;
+        KThread* client_thread = nullptr;
+        {
+            KScopedSchedulerLock sl{kernel};
+
+            if (m_current_thread_request) {
+                // Choose the current request if we have one.
+                client_thread = m_current_thread_request;
+                m_current_thread_request = nullptr;
+            } else if (!m_thread_request_list.empty()) {
+                // Pop the request from the front of the list.
+                client_thread = m_thread_request_list.front();
+                m_thread_request_list.pop_front();
+            }
+        }
+
+        // If there's no request, we're done.
+        if (client_thread == nullptr) {
+            break;
+        }
+
+        // Close a reference to the request once it's cleaned up.
+        SCOPE_EXIT({ client_thread->Close(); });
+
+        // Extract relevant information from the request.
+        // const uintptr_t client_message  = request->GetAddress();
+        // const size_t client_buffer_size = request->GetSize();
+        // KThread *client_thread          = request->GetThread();
+        // KEvent *event                   = request->GetEvent();
+
+        // KProcess *server_process             = request->GetServerProcess();
+        // KProcess *client_process             = (client_thread != nullptr) ?
+        //                                         client_thread->GetOwnerProcess() : nullptr;
+        // KProcessPageTable *client_page_table = (client_process != nullptr) ?
+        //                                         &client_process->GetPageTable() : nullptr;
+
+        // Cleanup the mappings.
+        // Result result = CleanupMap(request, server_process, client_page_table);
+
+        // If there's a client thread, update it.
+        if (client_thread != nullptr) {
+            // End the client thread's wait.
+            KScopedSchedulerLock sl{kernel};
+
+            if (!client_thread->IsTerminationRequested()) {
+                client_thread->EndWait(ResultSessionClosed);
+            }
+        }
+    }
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -346,6 +346,20 @@ void SvcWrap64(Core::System& system) {
     FuncReturn(system, retval);
 }
 
+// Used by CreateSession
+template <Result func(Core::System&, Handle*, Handle*, u32, u64)>
+void SvcWrap64(Core::System& system) {
+    Handle param_1 = 0;
+    Handle param_2 = 0;
+    const u32 retval = func(system, &param_1, &param_2, static_cast<u32>(Param(system, 2)),
+                            static_cast<u32>(Param(system, 3)))
+                           .raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    system.CurrentArmInterface().SetReg(2, param_2);
+    FuncReturn(system, retval);
+}
+
 // Used by WaitForAddress
 template <Result func(Core::System&, u64, Svc::ArbitrationType, s32, s64)>
 void SvcWrap64(Core::System& system) {

--- a/src/core/hle/service/ns/ns.h
+++ b/src/core/hle/service/ns/ns.h
@@ -78,6 +78,9 @@ class IReadOnlyApplicationControlDataInterface final
 public:
     explicit IReadOnlyApplicationControlDataInterface(Core::System& system_);
     ~IReadOnlyApplicationControlDataInterface() override;
+
+private:
+    void GetApplicationControlData(Kernel::HLERequestContext& ctx);
 };
 
 class NS final : public ServiceFramework<NS> {

--- a/src/core/hle/service/ptm/ts.cpp
+++ b/src/core/hle/service/ptm/ts.cpp
@@ -15,7 +15,7 @@ TS::TS(Core::System& system_) : ServiceFramework{system_, "ts"} {
         {0, nullptr, "GetTemperatureRange"},
         {1, &TS::GetTemperature, "GetTemperature"},
         {2, nullptr, "SetMeasurementMode"},
-        {3, nullptr, "GetTemperatureMilliC"},
+        {3, &TS::GetTemperatureMilliC, "GetTemperatureMilliC"},
         {4, nullptr, "OpenSession"},
     };
     // clang-format on
@@ -29,9 +29,18 @@ void TS::GetTemperature(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto location{rp.PopEnum<Location>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called. location={}", location);
-
     const s32 temperature = location == Location::Internal ? 35 : 20;
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push(temperature);
+}
+
+void TS::GetTemperatureMilliC(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto location{rp.PopEnum<Location>()};
+
+    const s32 temperature = location == Location::Internal ? 35000 : 20000;
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);

--- a/src/core/hle/service/ptm/ts.h
+++ b/src/core/hle/service/ptm/ts.h
@@ -20,6 +20,7 @@ private:
     };
 
     void GetTemperature(Kernel::HLERequestContext& ctx);
+    void GetTemperatureMilliC(Kernel::HLERequestContext& ctx);
 };
 
 } // namespace Service::PTM

--- a/src/core/hle/service/set/set_sys.h
+++ b/src/core/hle/service/set/set_sys.h
@@ -23,6 +23,8 @@ private:
         BasicBlack = 1,
     };
 
+    void GetSettingsItemValueSize(Kernel::HLERequestContext& ctx);
+    void GetSettingsItemValue(Kernel::HLERequestContext& ctx);
     void GetFirmwareVersion(Kernel::HLERequestContext& ctx);
     void GetFirmwareVersion2(Kernel::HLERequestContext& ctx);
     void GetColorSetId(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -156,7 +156,8 @@ ResultVal<Kernel::KClientSession*> SM::GetServiceImpl(Kernel::HLERequestContext&
 
     // Create a new session.
     Kernel::KClientSession* session{};
-    if (const auto result = port->GetClientPort().CreateSession(std::addressof(session));
+    if (const auto result = port->GetClientPort().CreateSession(
+            std::addressof(session), std::make_shared<Kernel::SessionRequestManager>(kernel));
         result.IsError()) {
         LOG_ERROR(Service_SM, "called service={} -> error 0x{:08X}", name, result.raw);
         return result;


### PR DESCRIPTION
[nx-hbloader](https://github.com/switchbrew/nx-hbloader/), or hbl.nsp, sets up the launch arguments for all .nro style homebrew and performs the jump to the running application. These changes allow unmodified versions of nx-hbloader and [nx-hbmenu](https://github.com/switchbrew/nx-hbmenu) to work, but launching applications from nx-hbmenu is not yet working (needs extra support from nvnflinger).

![Screenshot from 2022-10-11 16-57-29](https://user-images.githubusercontent.com/9658600/195204819-836ea290-68c3-4101-834c-552440743fec.png)
