### PR TITLE
renderer_(opengl/vulkan): Fix tessellation clockwise parameter

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -390,7 +390,7 @@ public:
                 FractionalEven = 2,
             };
 
-            enum class OutputPrimitves : u32 {
+            enum class OutputPrimitives : u32 {
                 Points = 0,
                 Lines = 1,
                 Triangles_CW = 2,
@@ -401,7 +401,7 @@ public:
                 union {
                     BitField<0, 2, DomainType> domain_type;
                     BitField<4, 2, Spacing> spacing;
-                    BitField<8, 2, OutputPrimitves> output_primitives;
+                    BitField<8, 2, OutputPrimitives> output_primitives;
                 };
             } params;
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -317,8 +317,8 @@ GraphicsPipeline* ShaderCache::CurrentGraphicsPipeline() {
     graphics_key.tessellation_primitive.Assign(regs.tessellation.params.domain_type.Value());
     graphics_key.tessellation_spacing.Assign(regs.tessellation.params.spacing.Value());
     graphics_key.tessellation_clockwise.Assign(
-        regs.tessellation.params.output_primitives.Value() !=
-        Maxwell::Tessellation::OutputPrimitves::Triangles_CCW);
+        regs.tessellation.params.output_primitives.Value() ==
+        Maxwell::Tessellation::OutputPrimitives::Triangles_CW);
     graphics_key.xfb_enabled.Assign(regs.transform_feedback_enabled != 0 ? 1 : 0);
     if (graphics_key.xfb_enabled) {
         SetXfbState(graphics_key.xfb_state, regs);

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -73,8 +73,8 @@ void FixedPipelineState::Refresh(Tegra::Engines::Maxwell3D& maxwell3d,
     patch_control_points_minus_one.Assign(regs.patch_vertices - 1);
     tessellation_primitive.Assign(static_cast<u32>(regs.tessellation.params.domain_type.Value()));
     tessellation_spacing.Assign(static_cast<u32>(regs.tessellation.params.spacing.Value()));
-    tessellation_clockwise.Assign(regs.tessellation.params.output_primitives.Value() !=
-                                  Maxwell::Tessellation::OutputPrimitves::Triangles_CCW);
+    tessellation_clockwise.Assign(regs.tessellation.params.output_primitives.Value() ==
+                                  Maxwell::Tessellation::OutputPrimitives::Triangles_CW);
     logic_op_enable.Assign(regs.logic_op.enable != 0 ? 1 : 0);
     logic_op.Assign(PackLogicOp(regs.logic_op.op));
     topology.Assign(regs.draw.topology);


### PR DESCRIPTION
This should be assigned CW only on `Triangles_CW` rather than not `Triangles_CCW`, making CCW the default winding order rather than CW.