### PR TITLE
Kernel Multiprocess (Part 1) - Persist memory & core timing

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -191,6 +191,7 @@ add_library(core STATIC
     hle/kernel/k_condition_variable.cpp
     hle/kernel/k_condition_variable.h
     hle/kernel/k_dynamic_page_manager.h
+    hle/kernel/k_dynamic_slab_heap.h
     hle/kernel/k_event.cpp
     hle/kernel/k_event.h
     hle/kernel/k_handle_table.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -190,6 +190,7 @@ add_library(core STATIC
     hle/kernel/k_code_memory.h
     hle/kernel/k_condition_variable.cpp
     hle/kernel/k_condition_variable.h
+    hle/kernel/k_dynamic_page_manager.h
     hle/kernel/k_event.cpp
     hle/kernel/k_event.h
     hle/kernel/k_handle_table.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -191,6 +191,7 @@ add_library(core STATIC
     hle/kernel/k_condition_variable.cpp
     hle/kernel/k_condition_variable.h
     hle/kernel/k_dynamic_page_manager.h
+    hle/kernel/k_dynamic_resource_manager.h
     hle/kernel/k_dynamic_slab_heap.h
     hle/kernel/k_event.cpp
     hle/kernel/k_event.h

--- a/src/core/arm/arm_interface.cpp
+++ b/src/core/arm/arm_interface.cpp
@@ -134,6 +134,14 @@ void ARM_Interface::Run() {
         }
         system.ExitDynarmicProfile();
 
+        // If the thread is scheduled for termination, exit the thread.
+        if (current_thread->HasDpc()) {
+            if (current_thread->IsTerminationRequested()) {
+                current_thread->Exit();
+                UNREACHABLE();
+            }
+        }
+
         // Notify the debugger and go to sleep if a breakpoint was hit,
         // or if the thread is unable to continue for any reason.
         if (Has(hr, breakpoint) || Has(hr, no_execute)) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -148,10 +148,12 @@ struct System::Impl {
             Settings::values.custom_rtc.value_or(current_time) - current_time;
 
         // Create a default fs if one doesn't already exist.
-        if (virtual_filesystem == nullptr)
+        if (virtual_filesystem == nullptr) {
             virtual_filesystem = std::make_shared<FileSys::RealVfsFilesystem>();
-        if (content_provider == nullptr)
+        }
+        if (content_provider == nullptr) {
             content_provider = std::make_unique<FileSys::ContentProviderUnion>();
+        }
 
         // Create default implementations of applets if one is not provided.
         applet_manager.SetDefaultAppletsIfMissing();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -133,6 +133,30 @@ struct System::Impl {
         : kernel{system}, fs_controller{system}, memory{system}, hid_core{}, room_network{},
           cpu_manager{system}, reporter{system}, applet_manager{system}, time_manager{system} {}
 
+    void Initialize(System& system) {
+        device_memory = std::make_unique<Core::DeviceMemory>();
+
+        is_multicore = Settings::values.use_multi_core.GetValue();
+
+        core_timing.SetMulticore(is_multicore);
+        core_timing.Initialize([&system]() { system.RegisterHostThread(); });
+
+        const auto posix_time = std::chrono::system_clock::now().time_since_epoch();
+        const auto current_time =
+            std::chrono::duration_cast<std::chrono::seconds>(posix_time).count();
+        Settings::values.custom_rtc_differential =
+            Settings::values.custom_rtc.value_or(current_time) - current_time;
+
+        // Create a default fs if one doesn't already exist.
+        if (virtual_filesystem == nullptr)
+            virtual_filesystem = std::make_shared<FileSys::RealVfsFilesystem>();
+        if (content_provider == nullptr)
+            content_provider = std::make_unique<FileSys::ContentProviderUnion>();
+
+        // Create default implementations of applets if one is not provided.
+        applet_manager.SetDefaultAppletsIfMissing();
+    }
+
     SystemResultStatus Run() {
         std::unique_lock<std::mutex> lk(suspend_guard);
         status = SystemResultStatus::Success;
@@ -178,37 +202,17 @@ struct System::Impl {
         debugger = std::make_unique<Debugger>(system, port);
     }
 
-    SystemResultStatus Init(System& system, Frontend::EmuWindow& emu_window) {
+    SystemResultStatus SetupForMainProcess(System& system, Frontend::EmuWindow& emu_window) {
         LOG_DEBUG(Core, "initialized OK");
 
-        device_memory = std::make_unique<Core::DeviceMemory>();
-
-        is_multicore = Settings::values.use_multi_core.GetValue();
         is_async_gpu = Settings::values.use_asynchronous_gpu_emulation.GetValue();
 
         kernel.SetMulticore(is_multicore);
         cpu_manager.SetMulticore(is_multicore);
         cpu_manager.SetAsyncGpu(is_async_gpu);
-        core_timing.SetMulticore(is_multicore);
 
         kernel.Initialize();
         cpu_manager.Initialize();
-        core_timing.Initialize([&system]() { system.RegisterHostThread(); });
-
-        const auto posix_time = std::chrono::system_clock::now().time_since_epoch();
-        const auto current_time =
-            std::chrono::duration_cast<std::chrono::seconds>(posix_time).count();
-        Settings::values.custom_rtc_differential =
-            Settings::values.custom_rtc.value_or(current_time) - current_time;
-
-        // Create a default fs if one doesn't already exist.
-        if (virtual_filesystem == nullptr)
-            virtual_filesystem = std::make_shared<FileSys::RealVfsFilesystem>();
-        if (content_provider == nullptr)
-            content_provider = std::make_unique<FileSys::ContentProviderUnion>();
-
-        /// Create default implementations of applets if one is not provided.
-        applet_manager.SetDefaultAppletsIfMissing();
 
         /// Reset all glue registrations
         arp_manager.ResetAll();
@@ -253,11 +257,11 @@ struct System::Impl {
             return SystemResultStatus::ErrorGetLoader;
         }
 
-        SystemResultStatus init_result{Init(system, emu_window)};
+        SystemResultStatus init_result{SetupForMainProcess(system, emu_window)};
         if (init_result != SystemResultStatus::Success) {
             LOG_CRITICAL(Core, "Failed to initialize system (Error {})!",
                          static_cast<int>(init_result));
-            Shutdown();
+            ShutdownMainProcess();
             return init_result;
         }
 
@@ -276,7 +280,7 @@ struct System::Impl {
         const auto [load_result, load_parameters] = app_loader->Load(*main_process, system);
         if (load_result != Loader::ResultStatus::Success) {
             LOG_CRITICAL(Core, "Failed to load ROM (Error {})!", load_result);
-            Shutdown();
+            ShutdownMainProcess();
 
             return static_cast<SystemResultStatus>(
                 static_cast<u32>(SystemResultStatus::ErrorLoader) + static_cast<u32>(load_result));
@@ -335,7 +339,7 @@ struct System::Impl {
         return status;
     }
 
-    void Shutdown() {
+    void ShutdownMainProcess() {
         SetShuttingDown(true);
 
         // Log last frame performance stats if game was loded
@@ -369,7 +373,7 @@ struct System::Impl {
         cheat_engine.reset();
         telemetry_session.reset();
         time_manager.Shutdown();
-        core_timing.Shutdown();
+        core_timing.ClearPendingEvents();
         app_loader.reset();
         audio_core.reset();
         gpu_core.reset();
@@ -377,7 +381,6 @@ struct System::Impl {
         perf_stats.reset();
         kernel.Shutdown();
         memory.Reset();
-        applet_manager.ClearAll();
 
         if (auto room_member = room_network.GetRoomMember().lock()) {
             Network::GameInfo game_info{};
@@ -520,6 +523,10 @@ const CpuManager& System::GetCpuManager() const {
     return impl->cpu_manager;
 }
 
+void System::Initialize() {
+    impl->Initialize(*this);
+}
+
 SystemResultStatus System::Run() {
     return impl->Run();
 }
@@ -540,8 +547,8 @@ void System::InvalidateCpuInstructionCacheRange(VAddr addr, std::size_t size) {
     impl->kernel.InvalidateCpuInstructionCacheRange(addr, size);
 }
 
-void System::Shutdown() {
-    impl->Shutdown();
+void System::ShutdownMainProcess() {
+    impl->ShutdownMainProcess();
 }
 
 bool System::IsShuttingDown() const {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -143,6 +143,12 @@ public:
     System& operator=(System&&) = delete;
 
     /**
+     * Initializes the system
+     * This function will initialize core functionaility used for system emulation
+     */
+    void Initialize();
+
+    /**
      * Run the OS and Application
      * This function will start emulation and run the relevant devices
      */
@@ -166,8 +172,8 @@ public:
 
     void InvalidateCpuInstructionCacheRange(VAddr addr, std::size_t size);
 
-    /// Shutdown the emulated system.
-    void Shutdown();
+    /// Shutdown the main emulated process.
+    void ShutdownMainProcess();
 
     /// Check if the core is shutting down.
     [[nodiscard]] bool IsShuttingDown() const;

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -41,15 +41,7 @@ CoreTiming::CoreTiming()
     : clock{Common::CreateBestMatchingClock(Hardware::BASE_CLOCK_RATE, Hardware::CNTFREQ)} {}
 
 CoreTiming::~CoreTiming() {
-    paused = true;
-    shutting_down = true;
-    pause_event.Set();
-    event.Set();
-    if (timer_thread) {
-        timer_thread->join();
-    }
-    timer_thread.reset();
-    has_started = false;
+    Reset();
 }
 
 void CoreTiming::ThreadEntry(CoreTiming& instance) {
@@ -63,6 +55,7 @@ void CoreTiming::ThreadEntry(CoreTiming& instance) {
 }
 
 void CoreTiming::Initialize(std::function<void()>&& on_thread_init_) {
+    Reset();
     on_thread_init = std::move(on_thread_init_);
     event_fifo_id = 0;
     shutting_down = false;
@@ -302,6 +295,18 @@ void CoreTiming::ThreadLoop() {
         pause_event.Wait();
         clock->Pause(false);
     }
+}
+
+void CoreTiming::Reset() {
+    paused = true;
+    shutting_down = true;
+    pause_event.Set();
+    event.Set();
+    if (timer_thread) {
+        timer_thread->join();
+    }
+    timer_thread.reset();
+    has_started = false;
 }
 
 std::chrono::nanoseconds CoreTiming::GetGlobalTimeNs() const {

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -134,6 +134,8 @@ private:
     static void ThreadEntry(CoreTiming& instance);
     void ThreadLoop();
 
+    void Reset();
+
     std::unique_ptr<Common::WallClock> clock;
 
     s64 global_timer = 0;

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -69,11 +69,6 @@ public:
         is_multicore = is_multicore_;
     }
 
-    /// Check if it's using host timing.
-    bool IsHostTiming() const {
-        return is_multicore;
-    }
-
     /// Pauses/Unpauses the execution of the timer thread.
     void Pause(bool is_paused);
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -61,8 +61,8 @@ public:
     /// required to end slice - 1 and start slice 0 before the first cycle of code is executed.
     void Initialize(std::function<void()>&& on_thread_init_);
 
-    /// Tears down all timing related functionality.
-    void Shutdown();
+    /// Clear all pending events. This should ONLY be done on exit.
+    void ClearPendingEvents();
 
     /// Sets if emulation is multicore or single core, must be set before Initialize
     void SetMulticore(bool is_multicore_) {
@@ -135,9 +135,6 @@ public:
 
 private:
     struct Event;
-
-    /// Clear all pending events. This should ONLY be done on exit.
-    void ClearPendingEvents();
 
     static void ThreadEntry(CoreTiming& instance);
     void ThreadLoop();

--- a/src/core/device_memory.h
+++ b/src/core/device_memory.h
@@ -31,12 +31,14 @@ public:
                DramMemoryMap::Base;
     }
 
-    u8* GetPointer(PAddr addr) {
-        return buffer.BackingBasePointer() + (addr - DramMemoryMap::Base);
+    template <typename T>
+    T* GetPointer(PAddr addr) {
+        return reinterpret_cast<T*>(buffer.BackingBasePointer() + (addr - DramMemoryMap::Base));
     }
 
-    const u8* GetPointer(PAddr addr) const {
-        return buffer.BackingBasePointer() + (addr - DramMemoryMap::Base);
+    template <typename T>
+    const T* GetPointer(PAddr addr) const {
+        return reinterpret_cast<T*>(buffer.BackingBasePointer() + (addr - DramMemoryMap::Base));
     }
 
     Common::HostMemory buffer;

--- a/src/core/hle/kernel/init/init_slab_setup.cpp
+++ b/src/core/hle/kernel/init/init_slab_setup.cpp
@@ -94,8 +94,8 @@ VAddr InitializeSlabHeap(Core::System& system, KMemoryLayout& memory_layout, VAd
     // TODO(bunnei): Fix this once we support the kernel virtual memory layout.
 
     if (size > 0) {
-        void* backing_kernel_memory{
-            system.DeviceMemory().GetPointer(TranslateSlabAddrToPhysical(memory_layout, start))};
+        void* backing_kernel_memory{system.DeviceMemory().GetPointer<void>(
+            TranslateSlabAddrToPhysical(memory_layout, start))};
 
         const KMemoryRegion* region = memory_layout.FindVirtual(start + size - 1);
         ASSERT(region != nullptr);
@@ -181,7 +181,7 @@ void InitializeKPageBufferSlabHeap(Core::System& system) {
     ASSERT(slab_address != 0);
 
     // Initialize the slabheap.
-    KPageBuffer::InitializeSlabHeap(kernel, system.DeviceMemory().GetPointer(slab_address),
+    KPageBuffer::InitializeSlabHeap(kernel, system.DeviceMemory().GetPointer<void>(slab_address),
                                     slab_size);
 }
 

--- a/src/core/hle/kernel/k_code_memory.cpp
+++ b/src/core/hle/kernel/k_code_memory.cpp
@@ -34,7 +34,7 @@ Result KCodeMemory::Initialize(Core::DeviceMemory& device_memory, VAddr addr, si
 
     // Clear the memory.
     for (const auto& block : m_page_group.Nodes()) {
-        std::memset(device_memory.GetPointer(block.GetAddress()), 0xFF, block.GetSize());
+        std::memset(device_memory.GetPointer<void>(block.GetAddress()), 0xFF, block.GetSize());
     }
 
     // Set remaining tracking members.

--- a/src/core/hle/kernel/k_dynamic_page_manager.h
+++ b/src/core/hle/kernel/k_dynamic_page_manager.h
@@ -65,7 +65,7 @@ public:
             m_page_bitmap.SetBit(i);
         }
 
-        return ResultSuccess;
+        R_SUCCEED();
     }
 
     VAddr GetAddress() const {

--- a/src/core/hle/kernel/k_dynamic_page_manager.h
+++ b/src/core/hle/kernel/k_dynamic_page_manager.h
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/alignment.h"
+#include "common/common_types.h"
+#include "core/hle/kernel/k_page_bitmap.h"
+#include "core/hle/kernel/k_spin_lock.h"
+#include "core/hle/kernel/memory_types.h"
+#include "core/hle/kernel/svc_results.h"
+
+namespace Kernel {
+
+class KDynamicPageManager {
+public:
+    class PageBuffer {
+    private:
+        u8 m_buffer[PageSize];
+    };
+    static_assert(sizeof(PageBuffer) == PageSize);
+
+public:
+    KDynamicPageManager() = default;
+
+    template <typename T>
+    T* GetPointer(VAddr addr) {
+        return reinterpret_cast<T*>(m_backing_memory.data() + (addr - m_address));
+    }
+
+    template <typename T>
+    const T* GetPointer(VAddr addr) const {
+        return reinterpret_cast<T*>(m_backing_memory.data() + (addr - m_address));
+    }
+
+    Result Initialize(VAddr addr, size_t sz) {
+        // We need to have positive size.
+        R_UNLESS(sz > 0, ResultOutOfMemory);
+        m_backing_memory.resize(sz);
+
+        // Calculate management overhead.
+        const size_t management_size =
+            KPageBitmap::CalculateManagementOverheadSize(sz / sizeof(PageBuffer));
+        const size_t allocatable_size = sz - management_size;
+
+        // Set tracking fields.
+        m_address = addr;
+        m_size = Common::AlignDown(allocatable_size, sizeof(PageBuffer));
+        m_count = allocatable_size / sizeof(PageBuffer);
+        R_UNLESS(m_count > 0, ResultOutOfMemory);
+
+        // Clear the management region.
+        u64* management_ptr = GetPointer<u64>(m_address + allocatable_size);
+        std::memset(management_ptr, 0, management_size);
+
+        // Initialize the bitmap.
+        m_page_bitmap.Initialize(management_ptr, m_count);
+
+        // Free the pages to the bitmap.
+        for (size_t i = 0; i < m_count; i++) {
+            // Ensure the freed page is all-zero.
+            std::memset(GetPointer<PageBuffer>(m_address) + i, 0, PageSize);
+
+            // Set the bit for the free page.
+            m_page_bitmap.SetBit(i);
+        }
+
+        return ResultSuccess;
+    }
+
+    VAddr GetAddress() const {
+        return m_address;
+    }
+    size_t GetSize() const {
+        return m_size;
+    }
+    size_t GetUsed() const {
+        return m_used;
+    }
+    size_t GetPeak() const {
+        return m_peak;
+    }
+    size_t GetCount() const {
+        return m_count;
+    }
+
+    PageBuffer* Allocate() {
+        // Take the lock.
+        // TODO(bunnei): We should disable interrupts here via KScopedInterruptDisable.
+        KScopedSpinLock lk(m_lock);
+
+        // Find a random free block.
+        s64 soffset = m_page_bitmap.FindFreeBlock(true);
+        if (soffset < 0) [[unlikely]] {
+            return nullptr;
+        }
+
+        const size_t offset = static_cast<size_t>(soffset);
+
+        // Update our tracking.
+        m_page_bitmap.ClearBit(offset);
+        m_peak = std::max(m_peak, (++m_used));
+
+        return GetPointer<PageBuffer>(m_address) + offset;
+    }
+
+    void Free(PageBuffer* pb) {
+        // Ensure all pages in the heap are zero.
+        std::memset(pb, 0, PageSize);
+
+        // Take the lock.
+        // TODO(bunnei): We should disable interrupts here via KScopedInterruptDisable.
+        KScopedSpinLock lk(m_lock);
+
+        // Set the bit for the free page.
+        size_t offset = (reinterpret_cast<uintptr_t>(pb) - m_address) / sizeof(PageBuffer);
+        m_page_bitmap.SetBit(offset);
+
+        // Decrement our used count.
+        --m_used;
+    }
+
+private:
+    KSpinLock m_lock;
+    KPageBitmap m_page_bitmap;
+    size_t m_used{};
+    size_t m_peak{};
+    size_t m_count{};
+    VAddr m_address{};
+    size_t m_size{};
+
+    // TODO(bunnei): Back by host memory until we emulate kernel virtual address space.
+    std::vector<u8> m_backing_memory;
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_dynamic_resource_manager.h
+++ b/src/core/hle/kernel/k_dynamic_resource_manager.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/common_funcs.h"
+#include "core/hle/kernel/k_dynamic_slab_heap.h"
+#include "core/hle/kernel/k_memory_block.h"
+
+namespace Kernel {
+
+template <typename T, bool ClearNode = false>
+class KDynamicResourceManager {
+    YUZU_NON_COPYABLE(KDynamicResourceManager);
+    YUZU_NON_MOVEABLE(KDynamicResourceManager);
+
+public:
+    using DynamicSlabType = KDynamicSlabHeap<T, ClearNode>;
+
+public:
+    constexpr KDynamicResourceManager() = default;
+
+    constexpr size_t GetSize() const {
+        return m_slab_heap->GetSize();
+    }
+    constexpr size_t GetUsed() const {
+        return m_slab_heap->GetUsed();
+    }
+    constexpr size_t GetPeak() const {
+        return m_slab_heap->GetPeak();
+    }
+    constexpr size_t GetCount() const {
+        return m_slab_heap->GetCount();
+    }
+
+    void Initialize(KDynamicPageManager* page_allocator, DynamicSlabType* slab_heap) {
+        m_page_allocator = page_allocator;
+        m_slab_heap = slab_heap;
+    }
+
+    T* Allocate() const {
+        return m_slab_heap->Allocate(m_page_allocator);
+    }
+
+    void Free(T* t) const {
+        m_slab_heap->Free(t);
+    }
+
+private:
+    KDynamicPageManager* m_page_allocator{};
+    DynamicSlabType* m_slab_heap{};
+};
+
+class KMemoryBlockSlabManager : public KDynamicResourceManager<KMemoryBlock> {};
+
+using KMemoryBlockSlabHeap = typename KMemoryBlockSlabManager::DynamicSlabType;
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_dynamic_slab_heap.h
+++ b/src/core/hle/kernel/k_dynamic_slab_heap.h
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <atomic>
+
+#include "common/common_funcs.h"
+#include "core/hle/kernel/k_dynamic_page_manager.h"
+#include "core/hle/kernel/k_slab_heap.h"
+
+namespace Kernel {
+
+template <typename T, bool ClearNode = false>
+class KDynamicSlabHeap : protected impl::KSlabHeapImpl {
+    YUZU_NON_COPYABLE(KDynamicSlabHeap);
+    YUZU_NON_MOVEABLE(KDynamicSlabHeap);
+
+public:
+    constexpr KDynamicSlabHeap() = default;
+
+    constexpr VAddr GetAddress() const {
+        return m_address;
+    }
+    constexpr size_t GetSize() const {
+        return m_size;
+    }
+    constexpr size_t GetUsed() const {
+        return m_used.load();
+    }
+    constexpr size_t GetPeak() const {
+        return m_peak.load();
+    }
+    constexpr size_t GetCount() const {
+        return m_count.load();
+    }
+
+    constexpr bool IsInRange(VAddr addr) const {
+        return this->GetAddress() <= addr && addr <= this->GetAddress() + this->GetSize() - 1;
+    }
+
+    void Initialize(KDynamicPageManager* page_allocator, size_t num_objects) {
+        ASSERT(page_allocator != nullptr);
+
+        // Initialize members.
+        m_address = page_allocator->GetAddress();
+        m_size = page_allocator->GetSize();
+
+        // Initialize the base allocator.
+        KSlabHeapImpl::Initialize();
+
+        // Allocate until we have the correct number of objects.
+        while (m_count.load() < num_objects) {
+            auto* allocated = reinterpret_cast<T*>(page_allocator->Allocate());
+            ASSERT(allocated != nullptr);
+
+            for (size_t i = 0; i < sizeof(PageBuffer) / sizeof(T); i++) {
+                KSlabHeapImpl::Free(allocated + i);
+            }
+
+            m_count += sizeof(PageBuffer) / sizeof(T);
+        }
+    }
+
+    T* Allocate(KDynamicPageManager* page_allocator) {
+        T* allocated = static_cast<T*>(KSlabHeapImpl::Allocate());
+
+        // If we successfully allocated and we should clear the node, do so.
+        if constexpr (ClearNode) {
+            if (allocated != nullptr) [[likely]] {
+                reinterpret_cast<KSlabHeapImpl::Node*>(allocated)->next = nullptr;
+            }
+        }
+
+        // If we fail to allocate, try to get a new page from our next allocator.
+        if (allocated == nullptr) [[unlikely]] {
+            if (page_allocator != nullptr) {
+                allocated = reinterpret_cast<T*>(page_allocator->Allocate());
+                if (allocated != nullptr) {
+                    // If we succeeded in getting a page, free the rest to our slab.
+                    for (size_t i = 1; i < sizeof(PageBuffer) / sizeof(T); i++) {
+                        KSlabHeapImpl::Free(allocated + i);
+                    }
+                    m_count += sizeof(PageBuffer) / sizeof(T);
+                }
+            }
+        }
+
+        if (allocated != nullptr) [[likely]] {
+            // Construct the object.
+            std::construct_at(allocated);
+
+            // Update our tracking.
+            const size_t used = ++m_used;
+            size_t peak = m_peak.load();
+            while (peak < used) {
+                if (m_peak.compare_exchange_weak(peak, used, std::memory_order_relaxed)) {
+                    break;
+                }
+            }
+        }
+
+        return allocated;
+    }
+
+    void Free(T* t) {
+        KSlabHeapImpl::Free(t);
+        --m_used;
+    }
+
+private:
+    using PageBuffer = KDynamicPageManager::PageBuffer;
+
+private:
+    std::atomic<size_t> m_used{};
+    std::atomic<size_t> m_peak{};
+    std::atomic<size_t> m_count{};
+    VAddr m_address{};
+    size_t m_size{};
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_interrupt_manager.cpp
+++ b/src/core/hle/kernel/k_interrupt_manager.cpp
@@ -11,25 +11,22 @@
 namespace Kernel::KInterruptManager {
 
 void HandleInterrupt(KernelCore& kernel, s32 core_id) {
-    auto* process = kernel.CurrentProcess();
-    if (!process) {
-        return;
-    }
-
     // Acknowledge the interrupt.
     kernel.PhysicalCore(core_id).ClearInterrupt();
 
     auto& current_thread = GetCurrentThread(kernel);
 
-    // If the user disable count is set, we may need to pin the current thread.
-    if (current_thread.GetUserDisableCount() && !process->GetPinnedThread(core_id)) {
-        KScopedSchedulerLock sl{kernel};
+    if (auto* process = kernel.CurrentProcess(); process) {
+        // If the user disable count is set, we may need to pin the current thread.
+        if (current_thread.GetUserDisableCount() && !process->GetPinnedThread(core_id)) {
+            KScopedSchedulerLock sl{kernel};
 
-        // Pin the current thread.
-        process->PinCurrentThread(core_id);
+            // Pin the current thread.
+            process->PinCurrentThread(core_id);
 
-        // Set the interrupt flag for the thread.
-        GetCurrentThread(kernel).SetInterruptFlag();
+            // Set the interrupt flag for the thread.
+            GetCurrentThread(kernel).SetInterruptFlag();
+        }
     }
 
     // Request interrupt scheduling.

--- a/src/core/hle/kernel/k_interrupt_manager.cpp
+++ b/src/core/hle/kernel/k_interrupt_manager.cpp
@@ -36,4 +36,12 @@ void HandleInterrupt(KernelCore& kernel, s32 core_id) {
     kernel.CurrentScheduler()->RequestScheduleOnInterrupt();
 }
 
+void SendInterProcessorInterrupt(KernelCore& kernel, u64 core_mask) {
+    for (std::size_t core_id = 0; core_id < Core::Hardware::NUM_CPU_CORES; ++core_id) {
+        if (core_mask & (1ULL << core_id)) {
+            kernel.PhysicalCore(core_id).Interrupt();
+        }
+    }
+}
+
 } // namespace Kernel::KInterruptManager

--- a/src/core/hle/kernel/k_interrupt_manager.h
+++ b/src/core/hle/kernel/k_interrupt_manager.h
@@ -11,6 +11,8 @@ class KernelCore;
 
 namespace KInterruptManager {
 void HandleInterrupt(KernelCore& kernel, s32 core_id);
-}
+void SendInterProcessorInterrupt(KernelCore& kernel, u64 core_mask);
+
+} // namespace KInterruptManager
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_memory_block_manager.cpp
+++ b/src/core/hle/kernel/k_memory_block_manager.cpp
@@ -2,221 +2,336 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "core/hle/kernel/k_memory_block_manager.h"
-#include "core/hle/kernel/memory_types.h"
 
 namespace Kernel {
 
-KMemoryBlockManager::KMemoryBlockManager(VAddr start_addr_, VAddr end_addr_)
-    : start_addr{start_addr_}, end_addr{end_addr_} {
-    const u64 num_pages{(end_addr - start_addr) / PageSize};
-    memory_block_tree.emplace_back(start_addr, num_pages, KMemoryState::Free,
-                                   KMemoryPermission::None, KMemoryAttribute::None);
+KMemoryBlockManager::KMemoryBlockManager() = default;
+
+Result KMemoryBlockManager::Initialize(VAddr st, VAddr nd, KMemoryBlockSlabManager* slab_manager) {
+    // Allocate a block to encapsulate the address space, insert it into the tree.
+    KMemoryBlock* start_block = slab_manager->Allocate();
+    R_UNLESS(start_block != nullptr, ResultOutOfResource);
+
+    // Set our start and end.
+    m_start_address = st;
+    m_end_address = nd;
+    ASSERT(Common::IsAligned(m_start_address, PageSize));
+    ASSERT(Common::IsAligned(m_end_address, PageSize));
+
+    // Initialize and insert the block.
+    start_block->Initialize(m_start_address, (m_end_address - m_start_address) / PageSize,
+                            KMemoryState::Free, KMemoryPermission::None, KMemoryAttribute::None);
+    m_memory_block_tree.insert(*start_block);
+
+    return ResultSuccess;
 }
 
-KMemoryBlockManager::iterator KMemoryBlockManager::FindIterator(VAddr addr) {
-    auto node{memory_block_tree.begin()};
-    while (node != end()) {
-        const VAddr node_end_addr{node->GetNumPages() * PageSize + node->GetAddress()};
-        if (node->GetAddress() <= addr && node_end_addr - 1 >= addr) {
-            return node;
-        }
-        node = std::next(node);
+void KMemoryBlockManager::Finalize(KMemoryBlockSlabManager* slab_manager,
+                                   HostUnmapCallback&& host_unmap_callback) {
+    // Erase every block until we have none left.
+    auto it = m_memory_block_tree.begin();
+    while (it != m_memory_block_tree.end()) {
+        KMemoryBlock* block = std::addressof(*it);
+        it = m_memory_block_tree.erase(it);
+        slab_manager->Free(block);
+        host_unmap_callback(block->GetAddress(), block->GetSize());
     }
-    return end();
+
+    ASSERT(m_memory_block_tree.empty());
 }
 
-VAddr KMemoryBlockManager::FindFreeArea(VAddr region_start, std::size_t region_num_pages,
-                                        std::size_t num_pages, std::size_t align,
-                                        std::size_t offset, std::size_t guard_pages) {
-    if (num_pages == 0) {
-        return {};
-    }
+VAddr KMemoryBlockManager::FindFreeArea(VAddr region_start, size_t region_num_pages,
+                                        size_t num_pages, size_t alignment, size_t offset,
+                                        size_t guard_pages) const {
+    if (num_pages > 0) {
+        const VAddr region_end = region_start + region_num_pages * PageSize;
+        const VAddr region_last = region_end - 1;
+        for (const_iterator it = this->FindIterator(region_start); it != m_memory_block_tree.cend();
+             it++) {
+            const KMemoryInfo info = it->GetMemoryInfo();
+            if (region_last < info.GetAddress()) {
+                break;
+            }
+            if (info.m_state != KMemoryState::Free) {
+                continue;
+            }
 
-    const VAddr region_end{region_start + region_num_pages * PageSize};
-    const VAddr region_last{region_end - 1};
-    for (auto it{FindIterator(region_start)}; it != memory_block_tree.cend(); it++) {
-        const auto info{it->GetMemoryInfo()};
-        if (region_last < info.GetAddress()) {
-            break;
-        }
+            VAddr area = (info.GetAddress() <= region_start) ? region_start : info.GetAddress();
+            area += guard_pages * PageSize;
 
-        if (info.state != KMemoryState::Free) {
-            continue;
-        }
+            const VAddr offset_area = Common::AlignDown(area, alignment) + offset;
+            area = (area <= offset_area) ? offset_area : offset_area + alignment;
 
-        VAddr area{(info.GetAddress() <= region_start) ? region_start : info.GetAddress()};
-        area += guard_pages * PageSize;
+            const VAddr area_end = area + num_pages * PageSize + guard_pages * PageSize;
+            const VAddr area_last = area_end - 1;
 
-        const VAddr offset_area{Common::AlignDown(area, align) + offset};
-        area = (area <= offset_area) ? offset_area : offset_area + align;
-
-        const VAddr area_end{area + num_pages * PageSize + guard_pages * PageSize};
-        const VAddr area_last{area_end - 1};
-
-        if (info.GetAddress() <= area && area < area_last && area_last <= region_last &&
-            area_last <= info.GetLastAddress()) {
-            return area;
+            if (info.GetAddress() <= area && area < area_last && area_last <= region_last &&
+                area_last <= info.GetLastAddress()) {
+                return area;
+            }
         }
     }
 
     return {};
 }
 
-void KMemoryBlockManager::Update(VAddr addr, std::size_t num_pages, KMemoryState prev_state,
-                                 KMemoryPermission prev_perm, KMemoryAttribute prev_attribute,
-                                 KMemoryState state, KMemoryPermission perm,
-                                 KMemoryAttribute attribute) {
-    const VAddr update_end_addr{addr + num_pages * PageSize};
-    iterator node{memory_block_tree.begin()};
+void KMemoryBlockManager::CoalesceForUpdate(KMemoryBlockManagerUpdateAllocator* allocator,
+                                            VAddr address, size_t num_pages) {
+    // Find the iterator now that we've updated.
+    iterator it = this->FindIterator(address);
+    if (address != m_start_address) {
+        it--;
+    }
 
-    prev_attribute |= KMemoryAttribute::IpcAndDeviceMapped;
-
-    while (node != memory_block_tree.end()) {
-        KMemoryBlock* block{&(*node)};
-        iterator next_node{std::next(node)};
-        const VAddr cur_addr{block->GetAddress()};
-        const VAddr cur_end_addr{block->GetNumPages() * PageSize + cur_addr};
-
-        if (addr < cur_end_addr && cur_addr < update_end_addr) {
-            if (!block->HasProperties(prev_state, prev_perm, prev_attribute)) {
-                node = next_node;
-                continue;
-            }
-
-            iterator new_node{node};
-            if (addr > cur_addr) {
-                memory_block_tree.insert(node, block->Split(addr));
-            }
-
-            if (update_end_addr < cur_end_addr) {
-                new_node = memory_block_tree.insert(node, block->Split(update_end_addr));
-            }
-
-            new_node->Update(state, perm, attribute);
-
-            MergeAdjacent(new_node, next_node);
-        }
-
-        if (cur_end_addr - 1 >= update_end_addr - 1) {
+    // Coalesce blocks that we can.
+    while (true) {
+        iterator prev = it++;
+        if (it == m_memory_block_tree.end()) {
             break;
         }
 
-        node = next_node;
-    }
-}
-
-void KMemoryBlockManager::Update(VAddr addr, std::size_t num_pages, KMemoryState state,
-                                 KMemoryPermission perm, KMemoryAttribute attribute) {
-    const VAddr update_end_addr{addr + num_pages * PageSize};
-    iterator node{memory_block_tree.begin()};
-
-    while (node != memory_block_tree.end()) {
-        KMemoryBlock* block{&(*node)};
-        iterator next_node{std::next(node)};
-        const VAddr cur_addr{block->GetAddress()};
-        const VAddr cur_end_addr{block->GetNumPages() * PageSize + cur_addr};
-
-        if (addr < cur_end_addr && cur_addr < update_end_addr) {
-            iterator new_node{node};
-
-            if (addr > cur_addr) {
-                memory_block_tree.insert(node, block->Split(addr));
-            }
-
-            if (update_end_addr < cur_end_addr) {
-                new_node = memory_block_tree.insert(node, block->Split(update_end_addr));
-            }
-
-            new_node->Update(state, perm, attribute);
-
-            MergeAdjacent(new_node, next_node);
+        if (prev->CanMergeWith(*it)) {
+            KMemoryBlock* block = std::addressof(*it);
+            m_memory_block_tree.erase(it);
+            prev->Add(*block);
+            allocator->Free(block);
+            it = prev;
         }
 
-        if (cur_end_addr - 1 >= update_end_addr - 1) {
+        if (address + num_pages * PageSize < it->GetMemoryInfo().GetEndAddress()) {
             break;
         }
-
-        node = next_node;
     }
 }
 
-void KMemoryBlockManager::UpdateLock(VAddr addr, std::size_t num_pages, LockFunc&& lock_func,
+void KMemoryBlockManager::Update(KMemoryBlockManagerUpdateAllocator* allocator, VAddr address,
+                                 size_t num_pages, KMemoryState state, KMemoryPermission perm,
+                                 KMemoryAttribute attr,
+                                 KMemoryBlockDisableMergeAttribute set_disable_attr,
+                                 KMemoryBlockDisableMergeAttribute clear_disable_attr) {
+    // Ensure for auditing that we never end up with an invalid tree.
+    KScopedMemoryBlockManagerAuditor auditor(this);
+    ASSERT(Common::IsAligned(address, PageSize));
+    ASSERT((attr & (KMemoryAttribute::IpcLocked | KMemoryAttribute::DeviceShared)) ==
+           KMemoryAttribute::None);
+
+    VAddr cur_address = address;
+    size_t remaining_pages = num_pages;
+    iterator it = this->FindIterator(address);
+
+    while (remaining_pages > 0) {
+        const size_t remaining_size = remaining_pages * PageSize;
+        KMemoryInfo cur_info = it->GetMemoryInfo();
+        if (it->HasProperties(state, perm, attr)) {
+            // If we already have the right properties, just advance.
+            if (cur_address + remaining_size < cur_info.GetEndAddress()) {
+                remaining_pages = 0;
+                cur_address += remaining_size;
+            } else {
+                remaining_pages =
+                    (cur_address + remaining_size - cur_info.GetEndAddress()) / PageSize;
+                cur_address = cur_info.GetEndAddress();
+            }
+        } else {
+            // If we need to, create a new block before and insert it.
+            if (cur_info.GetAddress() != cur_address) {
+                KMemoryBlock* new_block = allocator->Allocate();
+
+                it->Split(new_block, cur_address);
+                it = m_memory_block_tree.insert(*new_block);
+                it++;
+
+                cur_info = it->GetMemoryInfo();
+                cur_address = cur_info.GetAddress();
+            }
+
+            // If we need to, create a new block after and insert it.
+            if (cur_info.GetSize() > remaining_size) {
+                KMemoryBlock* new_block = allocator->Allocate();
+
+                it->Split(new_block, cur_address + remaining_size);
+                it = m_memory_block_tree.insert(*new_block);
+
+                cur_info = it->GetMemoryInfo();
+            }
+
+            // Update block state.
+            it->Update(state, perm, attr, cur_address == address, static_cast<u8>(set_disable_attr),
+                       static_cast<u8>(clear_disable_attr));
+            cur_address += cur_info.GetSize();
+            remaining_pages -= cur_info.GetNumPages();
+        }
+        it++;
+    }
+
+    this->CoalesceForUpdate(allocator, address, num_pages);
+}
+
+void KMemoryBlockManager::UpdateIfMatch(KMemoryBlockManagerUpdateAllocator* allocator,
+                                        VAddr address, size_t num_pages, KMemoryState test_state,
+                                        KMemoryPermission test_perm, KMemoryAttribute test_attr,
+                                        KMemoryState state, KMemoryPermission perm,
+                                        KMemoryAttribute attr) {
+    // Ensure for auditing that we never end up with an invalid tree.
+    KScopedMemoryBlockManagerAuditor auditor(this);
+    ASSERT(Common::IsAligned(address, PageSize));
+    ASSERT((attr & (KMemoryAttribute::IpcLocked | KMemoryAttribute::DeviceShared)) ==
+           KMemoryAttribute::None);
+
+    VAddr cur_address = address;
+    size_t remaining_pages = num_pages;
+    iterator it = this->FindIterator(address);
+
+    while (remaining_pages > 0) {
+        const size_t remaining_size = remaining_pages * PageSize;
+        KMemoryInfo cur_info = it->GetMemoryInfo();
+        if (it->HasProperties(test_state, test_perm, test_attr) &&
+            !it->HasProperties(state, perm, attr)) {
+            // If we need to, create a new block before and insert it.
+            if (cur_info.GetAddress() != cur_address) {
+                KMemoryBlock* new_block = allocator->Allocate();
+
+                it->Split(new_block, cur_address);
+                it = m_memory_block_tree.insert(*new_block);
+                it++;
+
+                cur_info = it->GetMemoryInfo();
+                cur_address = cur_info.GetAddress();
+            }
+
+            // If we need to, create a new block after and insert it.
+            if (cur_info.GetSize() > remaining_size) {
+                KMemoryBlock* new_block = allocator->Allocate();
+
+                it->Split(new_block, cur_address + remaining_size);
+                it = m_memory_block_tree.insert(*new_block);
+
+                cur_info = it->GetMemoryInfo();
+            }
+
+            // Update block state.
+            it->Update(state, perm, attr, false, 0, 0);
+            cur_address += cur_info.GetSize();
+            remaining_pages -= cur_info.GetNumPages();
+        } else {
+            // If we already have the right properties, just advance.
+            if (cur_address + remaining_size < cur_info.GetEndAddress()) {
+                remaining_pages = 0;
+                cur_address += remaining_size;
+            } else {
+                remaining_pages =
+                    (cur_address + remaining_size - cur_info.GetEndAddress()) / PageSize;
+                cur_address = cur_info.GetEndAddress();
+            }
+        }
+        it++;
+    }
+
+    this->CoalesceForUpdate(allocator, address, num_pages);
+}
+
+void KMemoryBlockManager::UpdateLock(KMemoryBlockManagerUpdateAllocator* allocator, VAddr address,
+                                     size_t num_pages, MemoryBlockLockFunction lock_func,
                                      KMemoryPermission perm) {
-    const VAddr update_end_addr{addr + num_pages * PageSize};
-    iterator node{memory_block_tree.begin()};
+    // Ensure for auditing that we never end up with an invalid tree.
+    KScopedMemoryBlockManagerAuditor auditor(this);
+    ASSERT(Common::IsAligned(address, PageSize));
 
-    while (node != memory_block_tree.end()) {
-        KMemoryBlock* block{&(*node)};
-        iterator next_node{std::next(node)};
-        const VAddr cur_addr{block->GetAddress()};
-        const VAddr cur_end_addr{block->GetNumPages() * PageSize + cur_addr};
+    VAddr cur_address = address;
+    size_t remaining_pages = num_pages;
+    iterator it = this->FindIterator(address);
 
-        if (addr < cur_end_addr && cur_addr < update_end_addr) {
-            iterator new_node{node};
+    const VAddr end_address = address + (num_pages * PageSize);
 
-            if (addr > cur_addr) {
-                memory_block_tree.insert(node, block->Split(addr));
-            }
+    while (remaining_pages > 0) {
+        const size_t remaining_size = remaining_pages * PageSize;
+        KMemoryInfo cur_info = it->GetMemoryInfo();
 
-            if (update_end_addr < cur_end_addr) {
-                new_node = memory_block_tree.insert(node, block->Split(update_end_addr));
-            }
+        // If we need to, create a new block before and insert it.
+        if (cur_info.m_address != cur_address) {
+            KMemoryBlock* new_block = allocator->Allocate();
 
-            lock_func(new_node, perm);
+            it->Split(new_block, cur_address);
+            it = m_memory_block_tree.insert(*new_block);
+            it++;
 
-            MergeAdjacent(new_node, next_node);
+            cur_info = it->GetMemoryInfo();
+            cur_address = cur_info.GetAddress();
         }
 
-        if (cur_end_addr - 1 >= update_end_addr - 1) {
-            break;
+        if (cur_info.GetSize() > remaining_size) {
+            // If we need to, create a new block after and insert it.
+            KMemoryBlock* new_block = allocator->Allocate();
+
+            it->Split(new_block, cur_address + remaining_size);
+            it = m_memory_block_tree.insert(*new_block);
+
+            cur_info = it->GetMemoryInfo();
         }
 
-        node = next_node;
+        // Call the locked update function.
+        (std::addressof(*it)->*lock_func)(perm, cur_info.GetAddress() == address,
+                                          cur_info.GetEndAddress() == end_address);
+        cur_address += cur_info.GetSize();
+        remaining_pages -= cur_info.GetNumPages();
+        it++;
     }
+
+    this->CoalesceForUpdate(allocator, address, num_pages);
 }
 
-void KMemoryBlockManager::IterateForRange(VAddr start, VAddr end, IterateFunc&& func) {
-    const_iterator it{FindIterator(start)};
-    KMemoryInfo info{};
-    do {
-        info = it->GetMemoryInfo();
-        func(info);
-        it = std::next(it);
-    } while (info.addr + info.size - 1 < end - 1 && it != cend());
-}
+// Debug.
+bool KMemoryBlockManager::CheckState() const {
+    // Loop over every block, ensuring that we are sorted and coalesced.
+    auto it = m_memory_block_tree.cbegin();
+    auto prev = it++;
+    while (it != m_memory_block_tree.cend()) {
+        const KMemoryInfo prev_info = prev->GetMemoryInfo();
+        const KMemoryInfo cur_info = it->GetMemoryInfo();
 
-void KMemoryBlockManager::MergeAdjacent(iterator it, iterator& next_it) {
-    KMemoryBlock* block{&(*it)};
-
-    auto EraseIt = [&](const iterator it_to_erase) {
-        if (next_it == it_to_erase) {
-            next_it = std::next(next_it);
+        // Sequential blocks which can be merged should be merged.
+        if (prev->CanMergeWith(*it)) {
+            return false;
         }
-        memory_block_tree.erase(it_to_erase);
-    };
 
-    if (it != memory_block_tree.begin()) {
-        KMemoryBlock* prev{&(*std::prev(it))};
+        // Sequential blocks should be sequential.
+        if (prev_info.GetEndAddress() != cur_info.GetAddress()) {
+            return false;
+        }
 
-        if (block->HasSameProperties(*prev)) {
-            const iterator prev_it{std::prev(it)};
+        // If the block is ipc locked, it must have a count.
+        if ((cur_info.m_attribute & KMemoryAttribute::IpcLocked) != KMemoryAttribute::None &&
+            cur_info.m_ipc_lock_count == 0) {
+            return false;
+        }
 
-            prev->Add(block->GetNumPages());
-            EraseIt(it);
+        // If the block is device shared, it must have a count.
+        if ((cur_info.m_attribute & KMemoryAttribute::DeviceShared) != KMemoryAttribute::None &&
+            cur_info.m_device_use_count == 0) {
+            return false;
+        }
 
-            it = prev_it;
-            block = prev;
+        // Advance the iterator.
+        prev = it++;
+    }
+
+    // Our loop will miss checking the last block, potentially, so check it.
+    if (prev != m_memory_block_tree.cend()) {
+        const KMemoryInfo prev_info = prev->GetMemoryInfo();
+        // If the block is ipc locked, it must have a count.
+        if ((prev_info.m_attribute & KMemoryAttribute::IpcLocked) != KMemoryAttribute::None &&
+            prev_info.m_ipc_lock_count == 0) {
+            return false;
+        }
+
+        // If the block is device shared, it must have a count.
+        if ((prev_info.m_attribute & KMemoryAttribute::DeviceShared) != KMemoryAttribute::None &&
+            prev_info.m_device_use_count == 0) {
+            return false;
         }
     }
 
-    if (it != cend()) {
-        const KMemoryBlock* const next{&(*std::next(it))};
-
-        if (block->HasSameProperties(*next)) {
-            block->Add(next->GetNumPages());
-            EraseIt(std::next(it));
-        }
-    }
+    return true;
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_memory_block_manager.cpp
+++ b/src/core/hle/kernel/k_memory_block_manager.cpp
@@ -23,7 +23,7 @@ Result KMemoryBlockManager::Initialize(VAddr st, VAddr nd, KMemoryBlockSlabManag
                             KMemoryState::Free, KMemoryPermission::None, KMemoryAttribute::None);
     m_memory_block_tree.insert(*start_block);
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 void KMemoryBlockManager::Finalize(KMemoryBlockSlabManager* slab_manager,

--- a/src/core/hle/kernel/k_memory_block_manager.h
+++ b/src/core/hle/kernel/k_memory_block_manager.h
@@ -35,7 +35,7 @@ private:
             R_UNLESS(m_blocks[m_index + i] != nullptr, ResultOutOfResource);
         }
 
-        return ResultSuccess;
+        R_SUCCEED();
     }
 
 public:

--- a/src/core/hle/kernel/k_memory_block_manager.h
+++ b/src/core/hle/kernel/k_memory_block_manager.h
@@ -4,63 +4,154 @@
 #pragma once
 
 #include <functional>
-#include <list>
 
+#include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "core/hle/kernel/k_dynamic_resource_manager.h"
 #include "core/hle/kernel/k_memory_block.h"
 
 namespace Kernel {
 
+class KMemoryBlockManagerUpdateAllocator {
+public:
+    static constexpr size_t MaxBlocks = 2;
+
+private:
+    KMemoryBlock* m_blocks[MaxBlocks];
+    size_t m_index;
+    KMemoryBlockSlabManager* m_slab_manager;
+
+private:
+    Result Initialize(size_t num_blocks) {
+        // Check num blocks.
+        ASSERT(num_blocks <= MaxBlocks);
+
+        // Set index.
+        m_index = MaxBlocks - num_blocks;
+
+        // Allocate the blocks.
+        for (size_t i = 0; i < num_blocks && i < MaxBlocks; ++i) {
+            m_blocks[m_index + i] = m_slab_manager->Allocate();
+            R_UNLESS(m_blocks[m_index + i] != nullptr, ResultOutOfResource);
+        }
+
+        return ResultSuccess;
+    }
+
+public:
+    KMemoryBlockManagerUpdateAllocator(Result* out_result, KMemoryBlockSlabManager* sm,
+                                       size_t num_blocks = MaxBlocks)
+        : m_blocks(), m_index(MaxBlocks), m_slab_manager(sm) {
+        *out_result = this->Initialize(num_blocks);
+    }
+
+    ~KMemoryBlockManagerUpdateAllocator() {
+        for (const auto& block : m_blocks) {
+            if (block != nullptr) {
+                m_slab_manager->Free(block);
+            }
+        }
+    }
+
+    KMemoryBlock* Allocate() {
+        ASSERT(m_index < MaxBlocks);
+        ASSERT(m_blocks[m_index] != nullptr);
+        KMemoryBlock* block = nullptr;
+        std::swap(block, m_blocks[m_index++]);
+        return block;
+    }
+
+    void Free(KMemoryBlock* block) {
+        ASSERT(m_index <= MaxBlocks);
+        ASSERT(block != nullptr);
+        if (m_index == 0) {
+            m_slab_manager->Free(block);
+        } else {
+            m_blocks[--m_index] = block;
+        }
+    }
+};
+
 class KMemoryBlockManager final {
 public:
-    using MemoryBlockTree = std::list<KMemoryBlock>;
+    using MemoryBlockTree =
+        Common::IntrusiveRedBlackTreeBaseTraits<KMemoryBlock>::TreeType<KMemoryBlock>;
+    using MemoryBlockLockFunction = void (KMemoryBlock::*)(KMemoryPermission new_perm, bool left,
+                                                           bool right);
     using iterator = MemoryBlockTree::iterator;
     using const_iterator = MemoryBlockTree::const_iterator;
 
 public:
-    KMemoryBlockManager(VAddr start_addr_, VAddr end_addr_);
+    KMemoryBlockManager();
+
+    using HostUnmapCallback = std::function<void(VAddr, u64)>;
+
+    Result Initialize(VAddr st, VAddr nd, KMemoryBlockSlabManager* slab_manager);
+    void Finalize(KMemoryBlockSlabManager* slab_manager, HostUnmapCallback&& host_unmap_callback);
 
     iterator end() {
-        return memory_block_tree.end();
+        return m_memory_block_tree.end();
     }
     const_iterator end() const {
-        return memory_block_tree.end();
+        return m_memory_block_tree.end();
     }
     const_iterator cend() const {
-        return memory_block_tree.cend();
+        return m_memory_block_tree.cend();
     }
 
-    iterator FindIterator(VAddr addr);
+    VAddr FindFreeArea(VAddr region_start, size_t region_num_pages, size_t num_pages,
+                       size_t alignment, size_t offset, size_t guard_pages) const;
 
-    VAddr FindFreeArea(VAddr region_start, std::size_t region_num_pages, std::size_t num_pages,
-                       std::size_t align, std::size_t offset, std::size_t guard_pages);
+    void Update(KMemoryBlockManagerUpdateAllocator* allocator, VAddr address, size_t num_pages,
+                KMemoryState state, KMemoryPermission perm, KMemoryAttribute attr,
+                KMemoryBlockDisableMergeAttribute set_disable_attr,
+                KMemoryBlockDisableMergeAttribute clear_disable_attr);
+    void UpdateLock(KMemoryBlockManagerUpdateAllocator* allocator, VAddr address, size_t num_pages,
+                    MemoryBlockLockFunction lock_func, KMemoryPermission perm);
 
-    void Update(VAddr addr, std::size_t num_pages, KMemoryState prev_state,
-                KMemoryPermission prev_perm, KMemoryAttribute prev_attribute, KMemoryState state,
-                KMemoryPermission perm, KMemoryAttribute attribute);
+    void UpdateIfMatch(KMemoryBlockManagerUpdateAllocator* allocator, VAddr address,
+                       size_t num_pages, KMemoryState test_state, KMemoryPermission test_perm,
+                       KMemoryAttribute test_attr, KMemoryState state, KMemoryPermission perm,
+                       KMemoryAttribute attr);
 
-    void Update(VAddr addr, std::size_t num_pages, KMemoryState state,
-                KMemoryPermission perm = KMemoryPermission::None,
-                KMemoryAttribute attribute = KMemoryAttribute::None);
+    iterator FindIterator(VAddr address) const {
+        return m_memory_block_tree.find(KMemoryBlock(
+            address, 1, KMemoryState::Free, KMemoryPermission::None, KMemoryAttribute::None));
+    }
 
-    using LockFunc = std::function<void(iterator, KMemoryPermission)>;
-    void UpdateLock(VAddr addr, std::size_t num_pages, LockFunc&& lock_func,
-                    KMemoryPermission perm);
+    const KMemoryBlock* FindBlock(VAddr address) const {
+        if (const_iterator it = this->FindIterator(address); it != m_memory_block_tree.end()) {
+            return std::addressof(*it);
+        }
 
-    using IterateFunc = std::function<void(const KMemoryInfo&)>;
-    void IterateForRange(VAddr start, VAddr end, IterateFunc&& func);
+        return nullptr;
+    }
 
-    KMemoryBlock& FindBlock(VAddr addr) {
-        return *FindIterator(addr);
+    // Debug.
+    bool CheckState() const;
+
+private:
+    void CoalesceForUpdate(KMemoryBlockManagerUpdateAllocator* allocator, VAddr address,
+                           size_t num_pages);
+
+    MemoryBlockTree m_memory_block_tree;
+    VAddr m_start_address{};
+    VAddr m_end_address{};
+};
+
+class KScopedMemoryBlockManagerAuditor {
+public:
+    explicit KScopedMemoryBlockManagerAuditor(KMemoryBlockManager* m) : m_manager(m) {
+        ASSERT(m_manager->CheckState());
+    }
+    explicit KScopedMemoryBlockManagerAuditor(KMemoryBlockManager& m)
+        : KScopedMemoryBlockManagerAuditor(std::addressof(m)) {}
+    ~KScopedMemoryBlockManagerAuditor() {
+        ASSERT(m_manager->CheckState());
     }
 
 private:
-    void MergeAdjacent(iterator it, iterator& next_it);
-
-    [[maybe_unused]] const VAddr start_addr;
-    [[maybe_unused]] const VAddr end_addr;
-
-    MemoryBlockTree memory_block_tree;
+    KMemoryBlockManager* m_manager;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_memory_manager.cpp
+++ b/src/core/hle/kernel/k_memory_manager.cpp
@@ -331,7 +331,7 @@ Result KMemoryManager::AllocateAndOpenForProcess(KPageGroup* out, size_t num_pag
 
     // Set all the allocated memory.
     for (const auto& block : out->Nodes()) {
-        std::memset(system.DeviceMemory().GetPointer(block.GetAddress()), fill_pattern,
+        std::memset(system.DeviceMemory().GetPointer<void>(block.GetAddress()), fill_pattern,
                     block.GetSize());
     }
 

--- a/src/core/hle/kernel/k_page_buffer.cpp
+++ b/src/core/hle/kernel/k_page_buffer.cpp
@@ -12,7 +12,7 @@ namespace Kernel {
 
 KPageBuffer* KPageBuffer::FromPhysicalAddress(Core::System& system, PAddr phys_addr) {
     ASSERT(Common::IsAligned(phys_addr, PageSize));
-    return reinterpret_cast<KPageBuffer*>(system.DeviceMemory().GetPointer(phys_addr));
+    return system.DeviceMemory().GetPointer<KPageBuffer>(phys_addr);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -1648,7 +1648,7 @@ Result KPageTable::SetHeapSize(VAddr* out, std::size_t size) {
 
     // Clear all the newly allocated pages.
     for (const auto& it : pg.Nodes()) {
-        std::memset(system.DeviceMemory().GetPointer(it.GetAddress()), heap_fill_value,
+        std::memset(system.DeviceMemory().GetPointer<void>(it.GetAddress()), heap_fill_value,
                     it.GetSize());
     }
 
@@ -1805,9 +1805,9 @@ bool KPageTable::IsRegionMapped(VAddr address, u64 size) {
 }
 
 bool KPageTable::IsRegionContiguous(VAddr addr, u64 size) const {
-    auto start_ptr = system.Memory().GetPointer(addr);
+    auto start_ptr = system.DeviceMemory().GetPointer<u8>(addr);
     for (u64 offset{}; offset < size; offset += PageSize) {
-        if (start_ptr != system.Memory().GetPointer(addr + offset)) {
+        if (start_ptr != system.DeviceMemory().GetPointer<u8>(addr + offset)) {
             return false;
         }
         start_ptr += PageSize;

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -88,11 +88,11 @@ public:
                                 KMemoryAttribute attr_mask, KMemoryAttribute attr);
 
     Common::PageTable& PageTableImpl() {
-        return m_page_table_impl;
+        return *m_page_table_impl;
     }
 
     const Common::PageTable& PageTableImpl() const {
-        return m_page_table_impl;
+        return *m_page_table_impl;
     }
 
     bool CanContain(VAddr addr, size_t size, KMemoryState state) const;
@@ -303,7 +303,7 @@ public:
         return IsKernel() ? 1 : 4;
     }
     PAddr GetPhysicalAddr(VAddr addr) const {
-        const auto backing_addr = m_page_table_impl.backing_addr[addr >> PageBits];
+        const auto backing_addr = m_page_table_impl->backing_addr[addr >> PageBits];
         ASSERT(backing_addr);
         return backing_addr + addr;
     }
@@ -365,7 +365,7 @@ private:
     KMemoryManager::Pool m_memory_pool{KMemoryManager::Pool::Application};
     KMemoryManager::Direction m_allocation_option{KMemoryManager::Direction::FromFront};
 
-    Common::PageTable m_page_table_impl;
+    std::unique_ptr<Common::PageTable> m_page_table_impl;
 
     Core::System& m_system;
 };

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -57,9 +57,9 @@ public:
                     KMemoryPermission perm);
     Result MapPages(VAddr* out_addr, size_t num_pages, size_t alignment, PAddr phys_addr,
                     KMemoryState state, KMemoryPermission perm) {
-        return this->MapPages(out_addr, num_pages, alignment, phys_addr, true,
-                              this->GetRegionAddress(state), this->GetRegionSize(state) / PageSize,
-                              state, perm);
+        R_RETURN(this->MapPages(out_addr, num_pages, alignment, phys_addr, true,
+                                this->GetRegionAddress(state),
+                                this->GetRegionSize(state) / PageSize, state, perm));
     }
     Result UnmapPages(VAddr addr, KPageGroup& page_linked_list, KMemoryState state);
     Result UnmapPages(VAddr address, size_t num_pages, KMemoryState state);
@@ -137,8 +137,8 @@ private:
                                       KMemoryState state, KMemoryPermission perm_mask,
                                       KMemoryPermission perm, KMemoryAttribute attr_mask,
                                       KMemoryAttribute attr) const {
-        return this->CheckMemoryStateContiguous(nullptr, addr, size, state_mask, state, perm_mask,
-                                                perm, attr_mask, attr);
+        R_RETURN(this->CheckMemoryStateContiguous(nullptr, addr, size, state_mask, state, perm_mask,
+                                                  perm, attr_mask, attr));
     }
 
     Result CheckMemoryState(const KMemoryInfo& info, KMemoryState state_mask, KMemoryState state,
@@ -155,15 +155,16 @@ private:
                             KMemoryPermission perm_mask, KMemoryPermission perm,
                             KMemoryAttribute attr_mask, KMemoryAttribute attr,
                             KMemoryAttribute ignore_attr = DefaultMemoryIgnoreAttr) const {
-        return CheckMemoryState(nullptr, nullptr, nullptr, out_blocks_needed, addr, size,
-                                state_mask, state, perm_mask, perm, attr_mask, attr, ignore_attr);
+        R_RETURN(CheckMemoryState(nullptr, nullptr, nullptr, out_blocks_needed, addr, size,
+                                  state_mask, state, perm_mask, perm, attr_mask, attr,
+                                  ignore_attr));
     }
     Result CheckMemoryState(VAddr addr, size_t size, KMemoryState state_mask, KMemoryState state,
                             KMemoryPermission perm_mask, KMemoryPermission perm,
                             KMemoryAttribute attr_mask, KMemoryAttribute attr,
                             KMemoryAttribute ignore_attr = DefaultMemoryIgnoreAttr) const {
-        return this->CheckMemoryState(nullptr, addr, size, state_mask, state, perm_mask, perm,
-                                      attr_mask, attr, ignore_attr);
+        R_RETURN(this->CheckMemoryState(nullptr, addr, size, state_mask, state, perm_mask, perm,
+                                        attr_mask, attr, ignore_attr));
     }
 
     Result LockMemoryAndOpen(KPageGroup* out_pg, PAddr* out_paddr, VAddr addr, size_t size,

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -36,60 +36,66 @@ public:
     ~KPageTable();
 
     Result InitializeForProcess(FileSys::ProgramAddressSpaceType as_type, bool enable_aslr,
-                                VAddr code_addr, std::size_t code_size,
+                                VAddr code_addr, size_t code_size,
                                 KMemoryBlockSlabManager* mem_block_slab_manager,
                                 KMemoryManager::Pool pool);
 
     void Finalize();
 
-    Result MapProcessCode(VAddr addr, std::size_t pages_count, KMemoryState state,
+    Result MapProcessCode(VAddr addr, size_t pages_count, KMemoryState state,
                           KMemoryPermission perm);
-    Result MapCodeMemory(VAddr dst_address, VAddr src_address, std::size_t size);
-    Result UnmapCodeMemory(VAddr dst_address, VAddr src_address, std::size_t size,
+    Result MapCodeMemory(VAddr dst_address, VAddr src_address, size_t size);
+    Result UnmapCodeMemory(VAddr dst_address, VAddr src_address, size_t size,
                            ICacheInvalidationStrategy icache_invalidation_strategy);
-    Result UnmapProcessMemory(VAddr dst_addr, std::size_t size, KPageTable& src_page_table,
+    Result UnmapProcessMemory(VAddr dst_addr, size_t size, KPageTable& src_page_table,
                               VAddr src_addr);
-    Result MapPhysicalMemory(VAddr addr, std::size_t size);
-    Result UnmapPhysicalMemory(VAddr addr, std::size_t size);
-    Result MapMemory(VAddr dst_addr, VAddr src_addr, std::size_t size);
-    Result UnmapMemory(VAddr dst_addr, VAddr src_addr, std::size_t size);
+    Result MapPhysicalMemory(VAddr addr, size_t size);
+    Result UnmapPhysicalMemory(VAddr addr, size_t size);
+    Result MapMemory(VAddr dst_addr, VAddr src_addr, size_t size);
+    Result UnmapMemory(VAddr dst_addr, VAddr src_addr, size_t size);
     Result MapPages(VAddr addr, KPageGroup& page_linked_list, KMemoryState state,
                     KMemoryPermission perm);
-    Result MapPages(VAddr* out_addr, std::size_t num_pages, std::size_t alignment, PAddr phys_addr,
+    Result MapPages(VAddr* out_addr, size_t num_pages, size_t alignment, PAddr phys_addr,
                     KMemoryState state, KMemoryPermission perm) {
         return this->MapPages(out_addr, num_pages, alignment, phys_addr, true,
                               this->GetRegionAddress(state), this->GetRegionSize(state) / PageSize,
                               state, perm);
     }
     Result UnmapPages(VAddr addr, KPageGroup& page_linked_list, KMemoryState state);
-    Result UnmapPages(VAddr address, std::size_t num_pages, KMemoryState state);
-    Result SetProcessMemoryPermission(VAddr addr, std::size_t size, Svc::MemoryPermission svc_perm);
+    Result UnmapPages(VAddr address, size_t num_pages, KMemoryState state);
+    Result SetProcessMemoryPermission(VAddr addr, size_t size, Svc::MemoryPermission svc_perm);
     KMemoryInfo QueryInfo(VAddr addr);
-    Result SetMemoryPermission(VAddr addr, std::size_t size, Svc::MemoryPermission perm);
-    Result SetMemoryAttribute(VAddr addr, std::size_t size, u32 mask, u32 attr);
-    Result SetMaxHeapSize(std::size_t size);
-    Result SetHeapSize(VAddr* out, std::size_t size);
-    ResultVal<VAddr> AllocateAndMapMemory(std::size_t needed_num_pages, std::size_t align,
-                                          bool is_map_only, VAddr region_start,
-                                          std::size_t region_num_pages, KMemoryState state,
-                                          KMemoryPermission perm, PAddr map_addr = 0);
-    Result UnlockForDeviceAddressSpace(VAddr addr, std::size_t size);
-    Result LockForCodeMemory(KPageGroup* out, VAddr addr, std::size_t size);
-    Result UnlockForCodeMemory(VAddr addr, std::size_t size, const KPageGroup& pg);
+    Result SetMemoryPermission(VAddr addr, size_t size, Svc::MemoryPermission perm);
+    Result SetMemoryAttribute(VAddr addr, size_t size, u32 mask, u32 attr);
+    Result SetMaxHeapSize(size_t size);
+    Result SetHeapSize(VAddr* out, size_t size);
+    ResultVal<VAddr> AllocateAndMapMemory(size_t needed_num_pages, size_t align, bool is_map_only,
+                                          VAddr region_start, size_t region_num_pages,
+                                          KMemoryState state, KMemoryPermission perm,
+                                          PAddr map_addr = 0);
+
+    Result LockForMapDeviceAddressSpace(VAddr address, size_t size, KMemoryPermission perm,
+                                        bool is_aligned);
+    Result LockForUnmapDeviceAddressSpace(VAddr address, size_t size);
+
+    Result UnlockForDeviceAddressSpace(VAddr addr, size_t size);
+
+    Result LockForCodeMemory(KPageGroup* out, VAddr addr, size_t size);
+    Result UnlockForCodeMemory(VAddr addr, size_t size, const KPageGroup& pg);
     Result MakeAndOpenPageGroup(KPageGroup* out, VAddr address, size_t num_pages,
                                 KMemoryState state_mask, KMemoryState state,
                                 KMemoryPermission perm_mask, KMemoryPermission perm,
                                 KMemoryAttribute attr_mask, KMemoryAttribute attr);
 
     Common::PageTable& PageTableImpl() {
-        return page_table_impl;
+        return m_page_table_impl;
     }
 
     const Common::PageTable& PageTableImpl() const {
-        return page_table_impl;
+        return m_page_table_impl;
     }
 
-    bool CanContain(VAddr addr, std::size_t size, KMemoryState state) const;
+    bool CanContain(VAddr addr, size_t size, KMemoryState state) const;
 
 private:
     enum class OperationType : u32 {
@@ -104,30 +110,30 @@ private:
         KMemoryAttribute::IpcLocked | KMemoryAttribute::DeviceShared;
 
     Result MapPages(VAddr addr, const KPageGroup& page_linked_list, KMemoryPermission perm);
-    Result MapPages(VAddr* out_addr, std::size_t num_pages, std::size_t alignment, PAddr phys_addr,
-                    bool is_pa_valid, VAddr region_start, std::size_t region_num_pages,
+    Result MapPages(VAddr* out_addr, size_t num_pages, size_t alignment, PAddr phys_addr,
+                    bool is_pa_valid, VAddr region_start, size_t region_num_pages,
                     KMemoryState state, KMemoryPermission perm);
     Result UnmapPages(VAddr addr, const KPageGroup& page_linked_list);
     bool IsRegionContiguous(VAddr addr, u64 size) const;
-    void AddRegionToPages(VAddr start, std::size_t num_pages, KPageGroup& page_linked_list);
+    void AddRegionToPages(VAddr start, size_t num_pages, KPageGroup& page_linked_list);
     KMemoryInfo QueryInfoImpl(VAddr addr);
-    VAddr AllocateVirtualMemory(VAddr start, std::size_t region_num_pages, u64 needed_num_pages,
-                                std::size_t align);
-    Result Operate(VAddr addr, std::size_t num_pages, const KPageGroup& page_group,
+    VAddr AllocateVirtualMemory(VAddr start, size_t region_num_pages, u64 needed_num_pages,
+                                size_t align);
+    Result Operate(VAddr addr, size_t num_pages, const KPageGroup& page_group,
                    OperationType operation);
-    Result Operate(VAddr addr, std::size_t num_pages, KMemoryPermission perm,
-                   OperationType operation, PAddr map_addr = 0);
+    Result Operate(VAddr addr, size_t num_pages, KMemoryPermission perm, OperationType operation,
+                   PAddr map_addr = 0);
     VAddr GetRegionAddress(KMemoryState state) const;
-    std::size_t GetRegionSize(KMemoryState state) const;
+    size_t GetRegionSize(KMemoryState state) const;
 
-    VAddr FindFreeArea(VAddr region_start, std::size_t region_num_pages, std::size_t num_pages,
-                       std::size_t alignment, std::size_t offset, std::size_t guard_pages);
+    VAddr FindFreeArea(VAddr region_start, size_t region_num_pages, size_t num_pages,
+                       size_t alignment, size_t offset, size_t guard_pages);
 
-    Result CheckMemoryStateContiguous(std::size_t* out_blocks_needed, VAddr addr, std::size_t size,
+    Result CheckMemoryStateContiguous(size_t* out_blocks_needed, VAddr addr, size_t size,
                                       KMemoryState state_mask, KMemoryState state,
                                       KMemoryPermission perm_mask, KMemoryPermission perm,
                                       KMemoryAttribute attr_mask, KMemoryAttribute attr) const;
-    Result CheckMemoryStateContiguous(VAddr addr, std::size_t size, KMemoryState state_mask,
+    Result CheckMemoryStateContiguous(VAddr addr, size_t size, KMemoryState state_mask,
                                       KMemoryState state, KMemoryPermission perm_mask,
                                       KMemoryPermission perm, KMemoryAttribute attr_mask,
                                       KMemoryAttribute attr) const {
@@ -139,12 +145,12 @@ private:
                             KMemoryPermission perm_mask, KMemoryPermission perm,
                             KMemoryAttribute attr_mask, KMemoryAttribute attr) const;
     Result CheckMemoryState(KMemoryState* out_state, KMemoryPermission* out_perm,
-                            KMemoryAttribute* out_attr, std::size_t* out_blocks_needed, VAddr addr,
-                            std::size_t size, KMemoryState state_mask, KMemoryState state,
+                            KMemoryAttribute* out_attr, size_t* out_blocks_needed, VAddr addr,
+                            size_t size, KMemoryState state_mask, KMemoryState state,
                             KMemoryPermission perm_mask, KMemoryPermission perm,
                             KMemoryAttribute attr_mask, KMemoryAttribute attr,
                             KMemoryAttribute ignore_attr = DefaultMemoryIgnoreAttr) const;
-    Result CheckMemoryState(std::size_t* out_blocks_needed, VAddr addr, std::size_t size,
+    Result CheckMemoryState(size_t* out_blocks_needed, VAddr addr, size_t size,
                             KMemoryState state_mask, KMemoryState state,
                             KMemoryPermission perm_mask, KMemoryPermission perm,
                             KMemoryAttribute attr_mask, KMemoryAttribute attr,
@@ -152,8 +158,8 @@ private:
         return CheckMemoryState(nullptr, nullptr, nullptr, out_blocks_needed, addr, size,
                                 state_mask, state, perm_mask, perm, attr_mask, attr, ignore_attr);
     }
-    Result CheckMemoryState(VAddr addr, std::size_t size, KMemoryState state_mask,
-                            KMemoryState state, KMemoryPermission perm_mask, KMemoryPermission perm,
+    Result CheckMemoryState(VAddr addr, size_t size, KMemoryState state_mask, KMemoryState state,
+                            KMemoryPermission perm_mask, KMemoryPermission perm,
                             KMemoryAttribute attr_mask, KMemoryAttribute attr,
                             KMemoryAttribute ignore_attr = DefaultMemoryIgnoreAttr) const {
         return this->CheckMemoryState(nullptr, addr, size, state_mask, state, perm_mask, perm,
@@ -175,13 +181,13 @@ private:
     bool IsValidPageGroup(const KPageGroup& pg, VAddr addr, size_t num_pages);
 
     bool IsLockedByCurrentThread() const {
-        return general_lock.IsLockedByCurrentThread();
+        return m_general_lock.IsLockedByCurrentThread();
     }
 
     bool IsHeapPhysicalAddress(const KMemoryLayout& layout, PAddr phys_addr) {
         ASSERT(this->IsLockedByCurrentThread());
 
-        return layout.IsHeapPhysicalAddress(cached_physical_heap_region, phys_addr);
+        return layout.IsHeapPhysicalAddress(m_cached_physical_heap_region, phys_addr);
     }
 
     bool GetPhysicalAddressLocked(PAddr* out, VAddr virt_addr) const {
@@ -192,93 +198,93 @@ private:
         return *out != 0;
     }
 
-    mutable KLightLock general_lock;
-    mutable KLightLock map_physical_memory_lock;
+    mutable KLightLock m_general_lock;
+    mutable KLightLock m_map_physical_memory_lock;
 
 public:
     constexpr VAddr GetAddressSpaceStart() const {
-        return address_space_start;
+        return m_address_space_start;
     }
     constexpr VAddr GetAddressSpaceEnd() const {
-        return address_space_end;
+        return m_address_space_end;
     }
-    constexpr std::size_t GetAddressSpaceSize() const {
-        return address_space_end - address_space_start;
+    constexpr size_t GetAddressSpaceSize() const {
+        return m_address_space_end - m_address_space_start;
     }
     constexpr VAddr GetHeapRegionStart() const {
-        return heap_region_start;
+        return m_heap_region_start;
     }
     constexpr VAddr GetHeapRegionEnd() const {
-        return heap_region_end;
+        return m_heap_region_end;
     }
-    constexpr std::size_t GetHeapRegionSize() const {
-        return heap_region_end - heap_region_start;
+    constexpr size_t GetHeapRegionSize() const {
+        return m_heap_region_end - m_heap_region_start;
     }
     constexpr VAddr GetAliasRegionStart() const {
-        return alias_region_start;
+        return m_alias_region_start;
     }
     constexpr VAddr GetAliasRegionEnd() const {
-        return alias_region_end;
+        return m_alias_region_end;
     }
-    constexpr std::size_t GetAliasRegionSize() const {
-        return alias_region_end - alias_region_start;
+    constexpr size_t GetAliasRegionSize() const {
+        return m_alias_region_end - m_alias_region_start;
     }
     constexpr VAddr GetStackRegionStart() const {
-        return stack_region_start;
+        return m_stack_region_start;
     }
     constexpr VAddr GetStackRegionEnd() const {
-        return stack_region_end;
+        return m_stack_region_end;
     }
-    constexpr std::size_t GetStackRegionSize() const {
-        return stack_region_end - stack_region_start;
+    constexpr size_t GetStackRegionSize() const {
+        return m_stack_region_end - m_stack_region_start;
     }
     constexpr VAddr GetKernelMapRegionStart() const {
-        return kernel_map_region_start;
+        return m_kernel_map_region_start;
     }
     constexpr VAddr GetKernelMapRegionEnd() const {
-        return kernel_map_region_end;
+        return m_kernel_map_region_end;
     }
     constexpr VAddr GetCodeRegionStart() const {
-        return code_region_start;
+        return m_code_region_start;
     }
     constexpr VAddr GetCodeRegionEnd() const {
-        return code_region_end;
+        return m_code_region_end;
     }
     constexpr VAddr GetAliasCodeRegionStart() const {
-        return alias_code_region_start;
+        return m_alias_code_region_start;
     }
     constexpr VAddr GetAliasCodeRegionSize() const {
-        return alias_code_region_end - alias_code_region_start;
+        return m_alias_code_region_end - m_alias_code_region_start;
     }
-    std::size_t GetNormalMemorySize() {
-        KScopedLightLock lk(general_lock);
-        return GetHeapSize() + mapped_physical_memory_size;
+    size_t GetNormalMemorySize() {
+        KScopedLightLock lk(m_general_lock);
+        return GetHeapSize() + m_mapped_physical_memory_size;
     }
-    constexpr std::size_t GetAddressSpaceWidth() const {
-        return address_space_width;
+    constexpr size_t GetAddressSpaceWidth() const {
+        return m_address_space_width;
     }
-    constexpr std::size_t GetHeapSize() const {
-        return current_heap_end - heap_region_start;
+    constexpr size_t GetHeapSize() const {
+        return m_current_heap_end - m_heap_region_start;
     }
-    constexpr bool IsInsideAddressSpace(VAddr address, std::size_t size) const {
-        return address_space_start <= address && address + size - 1 <= address_space_end - 1;
+    constexpr bool IsInsideAddressSpace(VAddr address, size_t size) const {
+        return m_address_space_start <= address && address + size - 1 <= m_address_space_end - 1;
     }
-    constexpr bool IsOutsideAliasRegion(VAddr address, std::size_t size) const {
-        return alias_region_start > address || address + size - 1 > alias_region_end - 1;
+    constexpr bool IsOutsideAliasRegion(VAddr address, size_t size) const {
+        return m_alias_region_start > address || address + size - 1 > m_alias_region_end - 1;
     }
-    constexpr bool IsOutsideStackRegion(VAddr address, std::size_t size) const {
-        return stack_region_start > address || address + size - 1 > stack_region_end - 1;
+    constexpr bool IsOutsideStackRegion(VAddr address, size_t size) const {
+        return m_stack_region_start > address || address + size - 1 > m_stack_region_end - 1;
     }
-    constexpr bool IsInvalidRegion(VAddr address, std::size_t size) const {
+    constexpr bool IsInvalidRegion(VAddr address, size_t size) const {
         return address + size - 1 > GetAliasCodeRegionStart() + GetAliasCodeRegionSize() - 1;
     }
-    constexpr bool IsInsideHeapRegion(VAddr address, std::size_t size) const {
-        return address + size > heap_region_start && heap_region_end > address;
+    constexpr bool IsInsideHeapRegion(VAddr address, size_t size) const {
+        return address + size > m_heap_region_start && m_heap_region_end > address;
     }
-    constexpr bool IsInsideAliasRegion(VAddr address, std::size_t size) const {
-        return address + size > alias_region_start && alias_region_end > address;
+    constexpr bool IsInsideAliasRegion(VAddr address, size_t size) const {
+        return address + size > m_alias_region_start && m_alias_region_end > address;
     }
-    constexpr bool IsOutsideASLRRegion(VAddr address, std::size_t size) const {
+    constexpr bool IsOutsideASLRRegion(VAddr address, size_t size) const {
         if (IsInvalidRegion(address, size)) {
             return true;
         }
@@ -290,77 +296,78 @@ public:
         }
         return {};
     }
-    constexpr bool IsInsideASLRRegion(VAddr address, std::size_t size) const {
+    constexpr bool IsInsideASLRRegion(VAddr address, size_t size) const {
         return !IsOutsideASLRRegion(address, size);
     }
-    constexpr std::size_t GetNumGuardPages() const {
+    constexpr size_t GetNumGuardPages() const {
         return IsKernel() ? 1 : 4;
     }
     PAddr GetPhysicalAddr(VAddr addr) const {
-        const auto backing_addr = page_table_impl.backing_addr[addr >> PageBits];
+        const auto backing_addr = m_page_table_impl.backing_addr[addr >> PageBits];
         ASSERT(backing_addr);
         return backing_addr + addr;
     }
     constexpr bool Contains(VAddr addr) const {
-        return address_space_start <= addr && addr <= address_space_end - 1;
+        return m_address_space_start <= addr && addr <= m_address_space_end - 1;
     }
-    constexpr bool Contains(VAddr addr, std::size_t size) const {
-        return address_space_start <= addr && addr < addr + size &&
-               addr + size - 1 <= address_space_end - 1;
+    constexpr bool Contains(VAddr addr, size_t size) const {
+        return m_address_space_start <= addr && addr < addr + size &&
+               addr + size - 1 <= m_address_space_end - 1;
     }
 
 private:
     constexpr bool IsKernel() const {
-        return is_kernel;
+        return m_is_kernel;
     }
     constexpr bool IsAslrEnabled() const {
-        return is_aslr_enabled;
+        return m_enable_aslr;
     }
 
-    constexpr bool ContainsPages(VAddr addr, std::size_t num_pages) const {
-        return (address_space_start <= addr) &&
-               (num_pages <= (address_space_end - address_space_start) / PageSize) &&
-               (addr + num_pages * PageSize - 1 <= address_space_end - 1);
+    constexpr bool ContainsPages(VAddr addr, size_t num_pages) const {
+        return (m_address_space_start <= addr) &&
+               (num_pages <= (m_address_space_end - m_address_space_start) / PageSize) &&
+               (addr + num_pages * PageSize - 1 <= m_address_space_end - 1);
     }
 
 private:
-    VAddr address_space_start{};
-    VAddr address_space_end{};
-    VAddr heap_region_start{};
-    VAddr heap_region_end{};
-    VAddr current_heap_end{};
-    VAddr alias_region_start{};
-    VAddr alias_region_end{};
-    VAddr stack_region_start{};
-    VAddr stack_region_end{};
-    VAddr kernel_map_region_start{};
-    VAddr kernel_map_region_end{};
-    VAddr code_region_start{};
-    VAddr code_region_end{};
-    VAddr alias_code_region_start{};
-    VAddr alias_code_region_end{};
+    VAddr m_address_space_start{};
+    VAddr m_address_space_end{};
+    VAddr m_heap_region_start{};
+    VAddr m_heap_region_end{};
+    VAddr m_current_heap_end{};
+    VAddr m_alias_region_start{};
+    VAddr m_alias_region_end{};
+    VAddr m_stack_region_start{};
+    VAddr m_stack_region_end{};
+    VAddr m_kernel_map_region_start{};
+    VAddr m_kernel_map_region_end{};
+    VAddr m_code_region_start{};
+    VAddr m_code_region_end{};
+    VAddr m_alias_code_region_start{};
+    VAddr m_alias_code_region_end{};
 
-    std::size_t mapped_physical_memory_size{};
-    std::size_t max_heap_size{};
-    std::size_t max_physical_memory_size{};
-    std::size_t address_space_width{};
+    size_t m_mapped_physical_memory_size{};
+    size_t m_max_heap_size{};
+    size_t m_max_physical_memory_size{};
+    size_t m_address_space_width{};
 
-    KMemoryBlockManager memory_block_manager;
+    KMemoryBlockManager m_memory_block_manager;
 
-    bool is_kernel{};
-    bool is_aslr_enabled{};
+    bool m_is_kernel{};
+    bool m_enable_aslr{};
+    bool m_enable_device_address_space_merge{};
 
-    KMemoryBlockSlabManager* memory_block_slab_manager{};
+    KMemoryBlockSlabManager* m_memory_block_slab_manager{};
 
-    u32 heap_fill_value{};
-    const KMemoryRegion* cached_physical_heap_region{};
+    u32 m_heap_fill_value{};
+    const KMemoryRegion* m_cached_physical_heap_region{};
 
-    KMemoryManager::Pool memory_pool{KMemoryManager::Pool::Application};
-    KMemoryManager::Direction allocation_option{KMemoryManager::Direction::FromFront};
+    KMemoryManager::Pool m_memory_pool{KMemoryManager::Pool::Application};
+    KMemoryManager::Direction m_allocation_option{KMemoryManager::Direction::FromFront};
 
-    Common::PageTable page_table_impl;
+    Common::PageTable m_page_table_impl;
 
-    Core::System& system;
+    Core::System& m_system;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -356,9 +356,9 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
         return ResultLimitReached;
     }
     // Initialize proces address space
-    if (const Result result{page_table->InitializeForProcess(metadata.GetAddressSpaceType(), false,
-                                                             0x8000000, code_size,
-                                                             KMemoryManager::Pool::Application)};
+    if (const Result result{page_table->InitializeForProcess(
+            metadata.GetAddressSpaceType(), false, 0x8000000, code_size,
+            &kernel.GetApplicationMemoryBlockManager(), KMemoryManager::Pool::Application)};
         result.IsError()) {
         return result;
     }

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -72,6 +72,7 @@ Result KProcess::Initialize(KProcess* process, Core::System& system, std::string
 
     process->name = std::move(process_name);
     process->resource_limit = res_limit;
+    process->system_resource_address = 0;
     process->state = State::Created;
     process->program_id = 0;
     process->process_id = type == ProcessType::KernelInternal ? kernel.CreateNewKernelProcessID()
@@ -92,6 +93,7 @@ Result KProcess::Initialize(KProcess* process, Core::System& system, std::string
     process->exception_thread = nullptr;
     process->is_suspended = false;
     process->schedule_count = 0;
+    process->is_handle_table_initialized = false;
 
     // Open a reference to the resource limit.
     process->resource_limit->Open();
@@ -121,9 +123,9 @@ void KProcess::DecrementRunningThreadCount() {
     }
 }
 
-u64 KProcess::GetTotalPhysicalMemoryAvailable() const {
+u64 KProcess::GetTotalPhysicalMemoryAvailable() {
     const u64 capacity{resource_limit->GetFreeValue(LimitableResource::PhysicalMemory) +
-                       page_table->GetNormalMemorySize() + GetSystemResourceSize() + image_size +
+                       page_table.GetNormalMemorySize() + GetSystemResourceSize() + image_size +
                        main_thread_stack_size};
     if (const auto pool_size = kernel.MemoryManager().GetSize(KMemoryManager::Pool::Application);
         capacity != pool_size) {
@@ -135,16 +137,16 @@ u64 KProcess::GetTotalPhysicalMemoryAvailable() const {
     return memory_usage_capacity;
 }
 
-u64 KProcess::GetTotalPhysicalMemoryAvailableWithoutSystemResource() const {
+u64 KProcess::GetTotalPhysicalMemoryAvailableWithoutSystemResource() {
     return GetTotalPhysicalMemoryAvailable() - GetSystemResourceSize();
 }
 
-u64 KProcess::GetTotalPhysicalMemoryUsed() const {
-    return image_size + main_thread_stack_size + page_table->GetNormalMemorySize() +
+u64 KProcess::GetTotalPhysicalMemoryUsed() {
+    return image_size + main_thread_stack_size + page_table.GetNormalMemorySize() +
            GetSystemResourceSize();
 }
 
-u64 KProcess::GetTotalPhysicalMemoryUsedWithoutSystemResource() const {
+u64 KProcess::GetTotalPhysicalMemoryUsedWithoutSystemResource() {
     return GetTotalPhysicalMemoryUsed() - GetSystemResourceUsage();
 }
 
@@ -348,6 +350,9 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
     system_resource_size = metadata.GetSystemResourceSize();
     image_size = code_size;
 
+    // We currently do not support process-specific system resource
+    UNIMPLEMENTED_IF(system_resource_size != 0);
+
     KScopedResourceReservation memory_reservation(resource_limit, LimitableResource::PhysicalMemory,
                                                   code_size + system_resource_size);
     if (!memory_reservation.Succeeded()) {
@@ -356,7 +361,7 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
         return ResultLimitReached;
     }
     // Initialize proces address space
-    if (const Result result{page_table->InitializeForProcess(
+    if (const Result result{page_table.InitializeForProcess(
             metadata.GetAddressSpaceType(), false, 0x8000000, code_size,
             &kernel.GetApplicationMemoryBlockManager(), KMemoryManager::Pool::Application)};
         result.IsError()) {
@@ -364,9 +369,9 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
     }
 
     // Map process code region
-    if (const Result result{page_table->MapProcessCode(page_table->GetCodeRegionStart(),
-                                                       code_size / PageSize, KMemoryState::Code,
-                                                       KMemoryPermission::None)};
+    if (const Result result{page_table.MapProcessCode(page_table.GetCodeRegionStart(),
+                                                      code_size / PageSize, KMemoryState::Code,
+                                                      KMemoryPermission::None)};
         result.IsError()) {
         return result;
     }
@@ -374,7 +379,7 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
     // Initialize process capabilities
     const auto& caps{metadata.GetKernelCapabilities()};
     if (const Result result{
-            capabilities.InitializeForUserProcess(caps.data(), caps.size(), *page_table)};
+            capabilities.InitializeForUserProcess(caps.data(), caps.size(), page_table)};
         result.IsError()) {
         return result;
     }
@@ -384,12 +389,12 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
     case FileSys::ProgramAddressSpaceType::Is32Bit:
     case FileSys::ProgramAddressSpaceType::Is36Bit:
     case FileSys::ProgramAddressSpaceType::Is39Bit:
-        memory_usage_capacity = page_table->GetHeapRegionEnd() - page_table->GetHeapRegionStart();
+        memory_usage_capacity = page_table.GetHeapRegionEnd() - page_table.GetHeapRegionStart();
         break;
 
     case FileSys::ProgramAddressSpaceType::Is32BitNoMap:
-        memory_usage_capacity = page_table->GetHeapRegionEnd() - page_table->GetHeapRegionStart() +
-                                page_table->GetAliasRegionEnd() - page_table->GetAliasRegionStart();
+        memory_usage_capacity = page_table.GetHeapRegionEnd() - page_table.GetHeapRegionStart() +
+                                page_table.GetAliasRegionEnd() - page_table.GetAliasRegionStart();
         break;
 
     default:
@@ -397,7 +402,7 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
     }
 
     // Create TLS region
-    R_TRY(this->CreateThreadLocalRegion(std::addressof(tls_region_address)));
+    R_TRY(this->CreateThreadLocalRegion(std::addressof(plr_address)));
     memory_reservation.Commit();
 
     return handle_table.Initialize(capabilities.GetHandleTableSize());
@@ -409,7 +414,7 @@ void KProcess::Run(s32 main_thread_priority, u64 stack_size) {
     resource_limit->Reserve(LimitableResource::PhysicalMemory, main_thread_stack_size);
 
     const std::size_t heap_capacity{memory_usage_capacity - (main_thread_stack_size + image_size)};
-    ASSERT(!page_table->SetMaxHeapSize(heap_capacity).IsError());
+    ASSERT(!page_table.SetMaxHeapSize(heap_capacity).IsError());
 
     ChangeState(State::Running);
 
@@ -437,8 +442,8 @@ void KProcess::PrepareForTermination() {
 
     stop_threads(kernel.System().GlobalSchedulerContext().GetThreadList());
 
-    this->DeleteThreadLocalRegion(tls_region_address);
-    tls_region_address = 0;
+    this->DeleteThreadLocalRegion(plr_address);
+    plr_address = 0;
 
     if (resource_limit) {
         resource_limit->Release(LimitableResource::PhysicalMemory,
@@ -474,7 +479,7 @@ void KProcess::Finalize() {
     }
 
     // Finalize the page table.
-    page_table.reset();
+    page_table.Finalize();
 
     // Perform inherited finalization.
     KAutoObjectWithSlabHeapAndContainer<KProcess, KWorkerTask>::Finalize();
@@ -628,7 +633,7 @@ bool KProcess::RemoveWatchpoint(Core::System& system, VAddr addr, u64 size,
 void KProcess::LoadModule(CodeSet code_set, VAddr base_addr) {
     const auto ReprotectSegment = [&](const CodeSet::Segment& segment,
                                       Svc::MemoryPermission permission) {
-        page_table->SetProcessMemoryPermission(segment.addr + base_addr, segment.size, permission);
+        page_table.SetProcessMemoryPermission(segment.addr + base_addr, segment.size, permission);
     };
 
     kernel.System().Memory().WriteBlock(*this, base_addr, code_set.memory.data(),
@@ -645,8 +650,7 @@ bool KProcess::IsSignaled() const {
 }
 
 KProcess::KProcess(KernelCore& kernel_)
-    : KAutoObjectWithSlabHeapAndContainer{kernel_}, page_table{std::make_unique<KPageTable>(
-                                                        kernel_.System())},
+    : KAutoObjectWithSlabHeapAndContainer{kernel_}, page_table{kernel_.System()},
       handle_table{kernel_}, address_arbiter{kernel_.System()}, condition_var{kernel_.System()},
       state_lock{kernel_}, list_lock{kernel_} {}
 
@@ -668,17 +672,25 @@ Result KProcess::AllocateMainThreadStack(std::size_t stack_size) {
     // The kernel always ensures that the given stack size is page aligned.
     main_thread_stack_size = Common::AlignUp(stack_size, PageSize);
 
-    const VAddr start{page_table->GetStackRegionStart()};
-    const std::size_t size{page_table->GetStackRegionEnd() - start};
+    const VAddr start{page_table.GetStackRegionStart()};
+    const std::size_t size{page_table.GetStackRegionEnd() - start};
 
     CASCADE_RESULT(main_thread_stack_top,
-                   page_table->AllocateAndMapMemory(
+                   page_table.AllocateAndMapMemory(
                        main_thread_stack_size / PageSize, PageSize, false, start, size / PageSize,
                        KMemoryState::Stack, KMemoryPermission::UserReadWrite));
 
     main_thread_stack_top += main_thread_stack_size;
 
     return ResultSuccess;
+}
+
+void KProcess::FinalizeHandleTable() {
+    // Finalize the table.
+    handle_table.Finalize();
+
+    // Note that the table is finalized.
+    is_handle_table_initialized = false;
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -72,14 +72,14 @@ public:
     ~KProcess() override;
 
     enum class State {
-        Created = Svc::ProcessState_Created,
-        CreatedAttached = Svc::ProcessState_CreatedAttached,
-        Running = Svc::ProcessState_Running,
-        Crashed = Svc::ProcessState_Crashed,
-        RunningAttached = Svc::ProcessState_RunningAttached,
-        Terminating = Svc::ProcessState_Terminating,
-        Terminated = Svc::ProcessState_Terminated,
-        DebugBreak = Svc::ProcessState_DebugBreak,
+        Created = static_cast<u32>(Svc::ProcessState::Created),
+        CreatedAttached = static_cast<u32>(Svc::ProcessState::CreatedAttached),
+        Running = static_cast<u32>(Svc::ProcessState::Running),
+        Crashed = static_cast<u32>(Svc::ProcessState::Crashed),
+        RunningAttached = static_cast<u32>(Svc::ProcessState::RunningAttached),
+        Terminating = static_cast<u32>(Svc::ProcessState::Terminating),
+        Terminated = static_cast<u32>(Svc::ProcessState::Terminated),
+        DebugBreak = static_cast<u32>(Svc::ProcessState::DebugBreak),
     };
 
     enum : u64 {

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -138,16 +138,16 @@ public:
     }
 
     Result WaitConditionVariable(VAddr address, u64 cv_key, u32 tag, s64 ns) {
-        return condition_var.Wait(address, cv_key, tag, ns);
+        R_RETURN(condition_var.Wait(address, cv_key, tag, ns));
     }
 
     Result SignalAddressArbiter(VAddr address, Svc::SignalType signal_type, s32 value, s32 count) {
-        return address_arbiter.SignalToAddress(address, signal_type, value, count);
+        R_RETURN(address_arbiter.SignalToAddress(address, signal_type, value, count));
     }
 
     Result WaitAddressArbiter(VAddr address, Svc::ArbitrationType arb_type, s32 value,
                               s64 timeout) {
-        return address_arbiter.WaitForAddress(address, arb_type, value, timeout);
+        R_RETURN(address_arbiter.WaitForAddress(address, arb_type, value, timeout));
     }
 
     VAddr GetProcessLocalRegionAddress() const {
@@ -407,12 +407,18 @@ private:
         pinned_threads[core_id] = nullptr;
     }
 
+    void FinalizeHandleTable() {
+        // Finalize the table.
+        handle_table.Finalize();
+
+        // Note that the table is finalized.
+        is_handle_table_initialized = false;
+    }
+
     void ChangeState(State new_state);
 
     /// Allocates the main thread stack for the process, given the stack size in bytes.
     Result AllocateMainThreadStack(std::size_t stack_size);
-
-    void FinalizeHandleTable();
 
     /// Memory manager for this process
     KPageTable page_table;

--- a/src/core/hle/kernel/k_shared_memory.cpp
+++ b/src/core/hle/kernel/k_shared_memory.cpp
@@ -50,7 +50,7 @@ Result KSharedMemory::Initialize(Core::DeviceMemory& device_memory_, KProcess* o
     is_initialized = true;
 
     // Clear all pages in the memory.
-    std::memset(device_memory_.GetPointer(physical_address_), 0, size_);
+    std::memset(device_memory_.GetPointer<void>(physical_address_), 0, size_);
 
     return ResultSuccess;
 }

--- a/src/core/hle/kernel/k_shared_memory.h
+++ b/src/core/hle/kernel/k_shared_memory.h
@@ -54,7 +54,7 @@ public:
      * @return A pointer to the shared memory block from the specified offset
      */
     u8* GetPointer(std::size_t offset = 0) {
-        return device_memory->GetPointer(physical_address + offset);
+        return device_memory->GetPointer<u8>(physical_address + offset);
     }
 
     /**
@@ -63,7 +63,7 @@ public:
      * @return A pointer to the shared memory block from the specified offset
      */
     const u8* GetPointer(std::size_t offset = 0) const {
-        return device_memory->GetPointer(physical_address + offset);
+        return device_memory->GetPointer<u8>(physical_address + offset);
     }
 
     void Finalize() override;

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -245,7 +245,7 @@ Result KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_stack
         }
     }
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 Result KThread::InitializeThread(KThread* thread, KThreadFunction func, uintptr_t arg,
@@ -258,7 +258,7 @@ Result KThread::InitializeThread(KThread* thread, KThreadFunction func, uintptr_
     thread->host_context = std::make_shared<Common::Fiber>(std::move(init_func));
     thread->is_single_core = !Settings::values.use_multi_core.GetValue();
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 Result KThread::InitializeDummyThread(KThread* thread) {
@@ -268,31 +268,32 @@ Result KThread::InitializeDummyThread(KThread* thread) {
     // Initialize emulation parameters.
     thread->stack_parameters.disable_count = 0;
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 Result KThread::InitializeMainThread(Core::System& system, KThread* thread, s32 virt_core) {
-    return InitializeThread(thread, {}, {}, {}, IdleThreadPriority, virt_core, {}, ThreadType::Main,
-                            system.GetCpuManager().GetGuestActivateFunc());
+    R_RETURN(InitializeThread(thread, {}, {}, {}, IdleThreadPriority, virt_core, {},
+                              ThreadType::Main, system.GetCpuManager().GetGuestActivateFunc()));
 }
 
 Result KThread::InitializeIdleThread(Core::System& system, KThread* thread, s32 virt_core) {
-    return InitializeThread(thread, {}, {}, {}, IdleThreadPriority, virt_core, {}, ThreadType::Main,
-                            system.GetCpuManager().GetIdleThreadStartFunc());
+    R_RETURN(InitializeThread(thread, {}, {}, {}, IdleThreadPriority, virt_core, {},
+                              ThreadType::Main, system.GetCpuManager().GetIdleThreadStartFunc()));
 }
 
 Result KThread::InitializeHighPriorityThread(Core::System& system, KThread* thread,
                                              KThreadFunction func, uintptr_t arg, s32 virt_core) {
-    return InitializeThread(thread, func, arg, {}, {}, virt_core, nullptr, ThreadType::HighPriority,
-                            system.GetCpuManager().GetShutdownThreadStartFunc());
+    R_RETURN(InitializeThread(thread, func, arg, {}, {}, virt_core, nullptr,
+                              ThreadType::HighPriority,
+                              system.GetCpuManager().GetShutdownThreadStartFunc()));
 }
 
 Result KThread::InitializeUserThread(Core::System& system, KThread* thread, KThreadFunction func,
                                      uintptr_t arg, VAddr user_stack_top, s32 prio, s32 virt_core,
                                      KProcess* owner) {
     system.Kernel().GlobalSchedulerContext().AddThread(thread);
-    return InitializeThread(thread, func, arg, user_stack_top, prio, virt_core, owner,
-                            ThreadType::User, system.GetCpuManager().GetGuestThreadFunc());
+    R_RETURN(InitializeThread(thread, func, arg, user_stack_top, prio, virt_core, owner,
+                              ThreadType::User, system.GetCpuManager().GetGuestThreadFunc()));
 }
 
 void KThread::PostDestroy(uintptr_t arg) {
@@ -542,7 +543,7 @@ Result KThread::GetCoreMask(s32* out_ideal_core, u64* out_affinity_mask) {
     *out_ideal_core = virtual_ideal_core_id;
     *out_affinity_mask = virtual_affinity_mask;
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 Result KThread::GetPhysicalCoreMask(s32* out_ideal_core, u64* out_affinity_mask) {
@@ -558,7 +559,7 @@ Result KThread::GetPhysicalCoreMask(s32* out_ideal_core, u64* out_affinity_mask)
         *out_affinity_mask = original_physical_affinity_mask.GetAffinityMask();
     }
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 Result KThread::SetCoreMask(s32 core_id_, u64 v_affinity_mask) {
@@ -670,7 +671,7 @@ Result KThread::SetCoreMask(s32 core_id_, u64 v_affinity_mask) {
         } while (retry_update);
     }
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 void KThread::SetBasePriority(s32 value) {
@@ -843,7 +844,7 @@ Result KThread::SetActivity(Svc::ThreadActivity activity) {
         } while (thread_is_current);
     }
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 Result KThread::GetThreadContext3(std::vector<u8>& out) {
@@ -878,7 +879,7 @@ Result KThread::GetThreadContext3(std::vector<u8>& out) {
         }
     }
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 void KThread::AddWaiterImpl(KThread* thread) {
@@ -1042,7 +1043,7 @@ Result KThread::Run() {
         // Set our state and finish.
         SetState(ThreadState::Runnable);
 
-        return ResultSuccess;
+        R_SUCCEED();
     }
 }
 
@@ -1089,7 +1090,7 @@ Result KThread::Terminate() {
                                            Svc::WaitInfinite));
     }
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 ThreadState KThread::RequestTerminate() {
@@ -1162,7 +1163,7 @@ Result KThread::Sleep(s64 timeout) {
         // Check if the thread should terminate.
         if (this->IsTerminationRequested()) {
             slp.CancelSleep();
-            return ResultTerminationRequested;
+            R_THROW(ResultTerminationRequested);
         }
 
         // Wait for the sleep to end.
@@ -1170,7 +1171,7 @@ Result KThread::Sleep(s64 timeout) {
         SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::Sleep);
     }
 
-    return ResultSuccess;
+    R_SUCCEED();
 }
 
 void KThread::IfDummyThreadTryWait() {

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -180,6 +180,10 @@ public:
 
     void Exit();
 
+    Result Terminate();
+
+    ThreadState RequestTerminate();
+
     [[nodiscard]] u32 GetSuspendFlags() const {
         return suspend_allowed_flags & suspend_request_flags;
     }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -74,8 +74,8 @@ struct KernelCore::Impl {
         InitializeMemoryLayout();
         Init::InitializeKPageBufferSlabHeap(system);
         InitializeShutdownThreads();
-        InitializePreemption(kernel);
         InitializePhysicalCores();
+        InitializePreemption(kernel);
 
         // Initialize the Dynamic Slab Heaps.
         {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -108,10 +108,6 @@ struct KernelCore::Impl {
         next_user_process_id = KProcess::ProcessIDMin;
         next_thread_id = 1;
 
-        for (auto& core : cores) {
-            core = nullptr;
-        }
-
         global_handle_table->Finalize();
         global_handle_table.reset();
 
@@ -365,11 +361,6 @@ struct KernelCore::Impl {
     static inline thread_local KThread* current_thread{nullptr};
 
     KThread* GetCurrentEmuThread() {
-        // If we are shutting down the kernel, none of this is relevant anymore.
-        if (IsShuttingDown()) {
-            return {};
-        }
-
         const auto thread_id = GetCurrentHostThreadID();
         if (thread_id >= Core::Hardware::NUM_CPU_CORES) {
             return GetHostDummyThread();

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -37,6 +37,7 @@ class KClientSession;
 class KEvent;
 class KHandleTable;
 class KLinkedListNode;
+class KMemoryBlockSlabManager;
 class KMemoryLayout;
 class KMemoryManager;
 class KPageBuffer;
@@ -237,6 +238,12 @@ public:
 
     /// Gets the virtual memory manager for the kernel.
     const KMemoryManager& MemoryManager() const;
+
+    /// Gets the application memory block manager for the kernel.
+    KMemoryBlockSlabManager& GetApplicationMemoryBlockManager();
+
+    /// Gets the application memory block manager for the kernel.
+    const KMemoryBlockSlabManager& GetApplicationMemoryBlockManager() const;
 
     /// Gets the shared memory object for HID services.
     Kernel::KSharedMemory& GetHidSharedMem();

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -131,6 +131,9 @@ public:
     /// Retrieves a const pointer to the current process.
     const KProcess* CurrentProcess() const;
 
+    /// Closes the current process.
+    void CloseCurrentProcess();
+
     /// Retrieves the list of processes.
     const std::vector<KProcess*>& GetProcessList() const;
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1888,7 +1888,7 @@ static void ExitProcess(Core::System& system) {
     auto* current_process = system.Kernel().CurrentProcess();
 
     LOG_INFO(Kernel_SVC, "Process {} exiting", current_process->GetProcessID());
-    ASSERT_MSG(current_process->GetStatus() == ProcessStatus::Running,
+    ASSERT_MSG(current_process->GetState() == KProcess::State::Running,
                "Process has already exited");
 
     system.Exit();
@@ -2557,7 +2557,7 @@ static Result GetProcessInfo(Core::System& system, u64* out, Handle process_hand
         return ResultInvalidEnumValue;
     }
 
-    *out = static_cast<u64>(process->GetStatus());
+    *out = static_cast<u64>(process->GetState());
     return ResultSuccess;
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -933,7 +933,7 @@ static Result GetInfo(Core::System& system, u64* result, u64 info_id, Handle han
             return ResultSuccess;
 
         case GetInfoType::UserExceptionContextAddr:
-            *result = process->GetTLSRegionAddress();
+            *result = process->GetProcessLocalRegionAddress();
             return ResultSuccess;
 
         case GetInfoType::TotalPhysicalMemoryAvailableWithoutSystemResource:

--- a/src/core/hle/kernel/svc_common.h
+++ b/src/core/hle/kernel/svc_common.h
@@ -14,8 +14,11 @@ namespace Kernel::Svc {
 
 using namespace Common::Literals;
 
-constexpr s32 ArgumentHandleCountMax = 0x40;
-constexpr u32 HandleWaitMask{1u << 30};
+constexpr inline s32 ArgumentHandleCountMax = 0x40;
+
+constexpr inline u32 HandleWaitMask = 1u << 30;
+
+constexpr inline s64 WaitInfinite = -1;
 
 constexpr inline std::size_t HeapSizeAlignment = 2_MiB;
 

--- a/src/core/hle/kernel/svc_types.h
+++ b/src/core/hle/kernel/svc_types.h
@@ -95,6 +95,19 @@ constexpr inline s32 IdealCoreNoUpdate = -3;
 constexpr inline s32 LowestThreadPriority = 63;
 constexpr inline s32 HighestThreadPriority = 0;
 
+constexpr inline s32 SystemThreadPriorityHighest = 16;
+
+enum ProcessState : u32 {
+    ProcessState_Created = 0,
+    ProcessState_CreatedAttached = 1,
+    ProcessState_Running = 2,
+    ProcessState_Crashed = 3,
+    ProcessState_RunningAttached = 4,
+    ProcessState_Terminating = 5,
+    ProcessState_Terminated = 6,
+    ProcessState_DebugBreak = 7,
+};
+
 constexpr inline size_t ThreadLocalRegionSize = 0x200;
 
 } // namespace Kernel::Svc

--- a/src/core/hle/kernel/svc_types.h
+++ b/src/core/hle/kernel/svc_types.h
@@ -97,15 +97,15 @@ constexpr inline s32 HighestThreadPriority = 0;
 
 constexpr inline s32 SystemThreadPriorityHighest = 16;
 
-enum ProcessState : u32 {
-    ProcessState_Created = 0,
-    ProcessState_CreatedAttached = 1,
-    ProcessState_Running = 2,
-    ProcessState_Crashed = 3,
-    ProcessState_RunningAttached = 4,
-    ProcessState_Terminating = 5,
-    ProcessState_Terminated = 6,
-    ProcessState_DebugBreak = 7,
+enum class ProcessState : u32 {
+    Created = 0,
+    CreatedAttached = 1,
+    Running = 2,
+    Crashed = 3,
+    RunningAttached = 4,
+    Terminating = 5,
+    Terminated = 6,
+    DebugBreak = 7,
 };
 
 constexpr inline size_t ThreadLocalRegionSize = 0x200;

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -135,6 +135,14 @@ union Result {
     [[nodiscard]] constexpr bool IsFailure() const {
         return !IsSuccess();
     }
+
+    [[nodiscard]] constexpr u32 GetInnerValue() const {
+        return static_cast<u32>(module.Value()) | (description << module.bits);
+    }
+
+    [[nodiscard]] constexpr bool Includes(Result result) const {
+        return GetInnerValue() == result.GetInnerValue();
+    }
 };
 static_assert(std::is_trivial_v<Result>);
 

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -470,9 +470,6 @@ constexpr inline Result __TmpCurrentResultReference = ResultSuccess;
 #define R_UNLESS(expr, res)                                                                        \
     {                                                                                              \
         if (!(expr)) {                                                                             \
-            if (res.IsError()) {                                                                   \
-                LOG_ERROR(Kernel, "Failed with result: {}", res.raw);                              \
-            }                                                                                      \
             R_THROW(res);                                                                          \
         }                                                                                          \
     }

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -290,7 +290,7 @@ public:
         const std::size_t padding_size{page_table.GetNumGuardPages() * Kernel::PageSize};
         const auto start_info{page_table.QueryInfo(start - 1)};
 
-        if (start_info.state != Kernel::KMemoryState::Free) {
+        if (start_info.GetState() != Kernel::KMemoryState::Free) {
             return {};
         }
 
@@ -300,7 +300,7 @@ public:
 
         const auto end_info{page_table.QueryInfo(start + size)};
 
-        if (end_info.state != Kernel::KMemoryState::Free) {
+        if (end_info.GetState() != Kernel::KMemoryState::Free) {
             return {};
         }
 

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -128,7 +128,8 @@ NvResult nvmap::IocAlloc(const std::vector<u8>& input, std::vector<u8>& output) 
     }
     ASSERT(system.CurrentProcess()
                ->PageTable()
-               .LockForDeviceAddressSpace(handle_description->address, handle_description->size)
+               .LockForMapDeviceAddressSpace(handle_description->address, handle_description->size,
+                                             Kernel::KMemoryPermission::None, true)
                .IsSuccess());
     std::memcpy(output.data(), &params, sizeof(params));
     return result;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -65,7 +65,7 @@ struct Memory::Impl {
             return {};
         }
 
-        return system.DeviceMemory().GetPointer(paddr) + vaddr;
+        return system.DeviceMemory().GetPointer<u8>(paddr) + vaddr;
     }
 
     [[nodiscard]] u8* GetPointerFromDebugMemory(VAddr vaddr) const {
@@ -75,7 +75,7 @@ struct Memory::Impl {
             return {};
         }
 
-        return system.DeviceMemory().GetPointer(paddr) + vaddr;
+        return system.DeviceMemory().GetPointer<u8>(paddr) + vaddr;
     }
 
     u8 Read8(const VAddr addr) {
@@ -499,7 +499,7 @@ struct Memory::Impl {
         } else {
             while (base != end) {
                 page_table.pointers[base].Store(
-                    system.DeviceMemory().GetPointer(target) - (base << YUZU_PAGEBITS), type);
+                    system.DeviceMemory().GetPointer<u8>(target) - (base << YUZU_PAGEBITS), type);
                 page_table.backing_addr[base] = target - (base << YUZU_PAGEBITS);
 
                 ASSERT_MSG(page_table.pointers[base].Pointer(),

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -40,9 +40,6 @@ struct ScopeInit final {
         core_timing.SetMulticore(true);
         core_timing.Initialize([]() {});
     }
-    ~ScopeInit() {
-        core_timing.Shutdown();
-    }
 
     Core::Timing::CoreTiming core_timing;
 };

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -59,10 +59,11 @@ void QueryPool::Reserve(std::pair<VkQueryPool, u32> query) {
         std::find_if(pools.begin(), pools.end(), [query_pool = query.first](vk::QueryPool& pool) {
             return query_pool == *pool;
         });
-    ASSERT(it != std::end(pools));
 
-    const std::ptrdiff_t pool_index = std::distance(std::begin(pools), it);
-    usage[pool_index * GROW_STEP + static_cast<std::ptrdiff_t>(query.second)] = false;
+    if (it != std::end(pools)) {
+        const std::ptrdiff_t pool_index = std::distance(std::begin(pools), it);
+        usage[pool_index * GROW_STEP + static_cast<std::ptrdiff_t>(query.second)] = false;
+    }
 }
 
 QueryCache::QueryCache(VideoCore::RasterizerInterface& rasterizer_, const Device& device_,

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -120,8 +120,8 @@ void EmuThread::run() {
         }
     }
 
-    // Shutdown the core emulation
-    system.Shutdown();
+    // Shutdown the main emulated process
+    system.ShutdownMainProcess();
 
 #if MICROPROFILE_ENABLED
     MicroProfileOnThreadExit();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -294,6 +294,7 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
 #ifdef __linux__
     SetupSigInterrupts();
 #endif
+    system->Initialize();
 
     Common::Log::Initialize();
     LoadTranslation();

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -302,6 +302,8 @@ int main(int argc, char** argv) {
     }
 
     Core::System system{};
+    system.Initialize();
+
     InputCommon::InputSubsystem input_subsystem{};
 
     // Apply the command line arguments
@@ -392,7 +394,7 @@ int main(int argc, char** argv) {
     }
     system.DetachDebugger();
     void(system.Pause());
-    system.Shutdown();
+    system.ShutdownMainProcess();
 
     detached_tasks.WaitForAllTasks();
     return 0;


### PR DESCRIPTION
This is the first batch of changes in support of multi-process emulation.

### Background

Previously, a single "emulation session" (i.e., running a game) would consist of emulating Switch boot (initializing memory, kernel, services, GPU, etc.), creating a single new process (for the emulated title), and then running that process. Ending that session would consist of forcefully tearing all of that down at once, such that we are back at the initial state. Launching a subsequent title would repeat all of this.

We're planning to rearchitect emulation such that launching yuzu is much like booting Switch, and what was previously an emulation session is purely launching a new process for the chosen title. Furthermore, shutting down is closing just the running title process. The intent of these changes is more accurate full system emulation, such as by allowing us to emulate multiple processes at once. Furthermore, this should allow a better user-experience -- faster and more stable game launches, eventual support for system apps such as qlaunch, etc.

### Change summary

With this first set of changes, we focus on partially persisting system emulation across game boots. Now, when you launch yuzu, we will instantiate:
* Device memory (Switch's 4GB DRAM)
* Core timing

These will subsequently be re-used on subsequent game launches.

For these changes, we mostly needed to focus on improving our memory emulation. These changes include:
* Accurately tracking memory allocations, to ensure they are freed on process shutdown.
* Adding/refreshing various kernel memory modules to latest RE (KMemoryBlock, KMemoryBlockManager, KDynamicPageManager, KDynamicSlabHeap, KDyamicResourceManager, KPageTable).
* Reworking CoreTiming to allow multiple emulation sessions.
* Improved emulation of KThread shutdown & DPC.

Some collateral changes from these include:
* Some yuzu settings change the fundamental nature of full-system emulation (e.g. multicore vs. singlecore). For these settings changes, we introduce a new path to fully re-initialize the system on game launch if necessary. Hopefully this can go away one day.
* All new/changed code has been updated to use the newly introduced result macros.
* Various other code cleanups & improvements.

### Testing & expectations
Components of kernel emulation have been refreshed for accuracy (primarily around memory management), so it's possible some bugs are fixed. That being said, I do not expect these changes to have much of a noticeable impact on game compatibility. Instead, please focus on:
* Improved game launch performance & reliably, particularly across multiple game launches.
* Game shutdown performance & reliability. These changes will introduce some lag in game shutdown, as we are now doing more work in an attempt to emulate process shutdown (still a work in progress), rather than just terminating the full emulation state forcibly.
* Overall memory usage -- Expect it to be higher when yuzu is idle, but unchanged or lower during emulation.