### PR TITLE
sdl2_sink: Avoid loading a null string into a vector

### DIFF
--- a/src/audio_core/sink/sdl2_sink.cpp
+++ b/src/audio_core/sink/sdl2_sink.cpp
@@ -230,8 +230,7 @@ std::vector<std::string> ListSDLSinkDevices(bool capture) {
 
     const int device_count = SDL_GetNumAudioDevices(capture);
     for (int i = 0; i < device_count; ++i) {
-        const char* name = SDL_GetAudioDeviceName(i, capture);
-        if (name != nullptr) {
+        if (const char* name = SDL_GetAudioDeviceName(i, capture)) {
             device_list.emplace_back(name);
         }
     }

--- a/src/audio_core/sink/sdl2_sink.cpp
+++ b/src/audio_core/sink/sdl2_sink.cpp
@@ -230,7 +230,10 @@ std::vector<std::string> ListSDLSinkDevices(bool capture) {
 
     const int device_count = SDL_GetNumAudioDevices(capture);
     for (int i = 0; i < device_count; ++i) {
-        device_list.emplace_back(SDL_GetAudioDeviceName(i, 0));
+        const char* name = SDL_GetAudioDeviceName(i, 0);
+        if (name != nullptr) {
+            device_list.emplace_back(name);
+        }
     }
 
     return device_list;

--- a/src/audio_core/sink/sdl2_sink.cpp
+++ b/src/audio_core/sink/sdl2_sink.cpp
@@ -230,7 +230,7 @@ std::vector<std::string> ListSDLSinkDevices(bool capture) {
 
     const int device_count = SDL_GetNumAudioDevices(capture);
     for (int i = 0; i < device_count; ++i) {
-        const char* name = SDL_GetAudioDeviceName(i, 0);
+        const char* name = SDL_GetAudioDeviceName(i, capture);
         if (name != nullptr) {
             device_list.emplace_back(name);
         }


### PR DESCRIPTION
Attempting to place a null string into a vector of strings causes an error that closes the application, which SDL_GetAudioDeviceName will return in case of error, so don't do that.

Additionally, ListSDLSinkDevices's prototype appears to care whether we are loading capture devices or not, and SDL_GetAudioDeviceName has a parameter to use that information, but for some reason we just default to loading non-capture devices in both cases. Instead, tell it to distinguish either case.

Addresses a regression by #9039