### PR TITLE
Set TX_TOKEN for transifex client

### DIFF
--- a/.ci/scripts/transifex/docker.sh
+++ b/.ci/scripts/transifex/docker.sh
@@ -3,14 +3,6 @@
 # SPDX-FileCopyrightText: 2021 yuzu Emulator Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Setup RC file for tx
-cat << EOF > ~/.transifexrc
-[https://www.transifex.com]
-rest_hostname = https://rest.api.transifex.com
-token         = $TRANSIFEX_API_TOKEN
-EOF
-
-
 set -x
 
 echo -e "\e[1m\e[33mBuild tools information:\e[0m"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-          fetch-depth: 0   
+          fetch-depth: 0
       - name: Update Translation
         run: ./.ci/scripts/transifex/docker.sh
         env:
-          TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
+          TX_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
 
   reuse:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pushing to transifex didn't work in https://github.com/yuzu-emu/yuzu/pull/9058

I did some tests on my own fork, and we're writing to ~/.transifexrc but the client can't seem to read that file. maybe issue with $HOME or something.

Workaround is to set TX_TOKEN environment variable and now the pesky ~/.transifexrc file is not needed.


-----

Took me awhile to figure out, but basically GHA sets HOME to /github/home regardless of how the particular container wants to do things. Most tools read the environment (from the failed log, at least the shell and vcpkg read $HOME), but the transifex tool is going to /etc/passwd and looking up the home directory for the current user, so in our case its looking for /root/.transifexrc instead of /github/home/.transifexrc

https://github.com/transifex/cli/issues/109

So we can a) merge this or b) wait and see