### PR TITLE
UI: Add option to hide the compatibility list

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -819,6 +819,7 @@ void Config::ReadUIGamelistValues() {
     qt_config->beginGroup(QStringLiteral("UIGameList"));
 
     ReadBasicSetting(UISettings::values.show_add_ons);
+    ReadBasicSetting(UISettings::values.show_compat);
     ReadBasicSetting(UISettings::values.game_icon_size);
     ReadBasicSetting(UISettings::values.folder_icon_size);
     ReadBasicSetting(UISettings::values.row_1_text_id);
@@ -1414,6 +1415,7 @@ void Config::SaveUIGamelistValues() {
     qt_config->beginGroup(QStringLiteral("UIGameList"));
 
     WriteBasicSetting(UISettings::values.show_add_ons);
+    WriteBasicSetting(UISettings::values.show_compat);
     WriteBasicSetting(UISettings::values.game_icon_size);
     WriteBasicSetting(UISettings::values.folder_icon_size);
     WriteBasicSetting(UISettings::values.row_1_text_id);

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -72,6 +72,7 @@ ConfigureUi::ConfigureUi(Core::System& system_, QWidget* parent)
 
     // Force game list reload if any of the relevant settings are changed.
     connect(ui->show_add_ons, &QCheckBox::stateChanged, this, &ConfigureUi::RequestGameListUpdate);
+    connect(ui->show_compat, &QCheckBox::stateChanged, this, &ConfigureUi::RequestGameListUpdate);
     connect(ui->game_icon_size_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &ConfigureUi::RequestGameListUpdate);
     connect(ui->folder_icon_size_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -109,6 +110,7 @@ void ConfigureUi::ApplyConfiguration() {
     UISettings::values.theme =
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
     UISettings::values.show_add_ons = ui->show_add_ons->isChecked();
+    UISettings::values.show_compat = ui->show_compat->isChecked();
     UISettings::values.game_icon_size = ui->game_icon_size_combobox->currentData().toUInt();
     UISettings::values.folder_icon_size = ui->folder_icon_size_combobox->currentData().toUInt();
     UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
@@ -129,6 +131,7 @@ void ConfigureUi::SetConfiguration() {
     ui->language_combobox->setCurrentIndex(
         ui->language_combobox->findData(UISettings::values.language));
     ui->show_add_ons->setChecked(UISettings::values.show_add_ons.GetValue());
+    ui->show_compat->setChecked(UISettings::values.show_compat.GetValue());
     ui->game_icon_size_combobox->setCurrentIndex(
         ui->game_icon_size_combobox->findData(UISettings::values.game_icon_size.GetValue()));
     ui->folder_icon_size_combobox->setCurrentIndex(

--- a/src/yuzu/configuration/configure_ui.ui
+++ b/src/yuzu/configuration/configure_ui.ui
@@ -77,6 +77,13 @@
       <item>
        <layout class="QVBoxLayout" name="GeneralVerticalLayout">
         <item>
+         <widget class="QCheckBox" name="show_compat">
+          <property name="text">
+           <string>Show Compatibility List</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="show_add_ons">
           <property name="text">
            <string>Show Add-Ons Column</string>

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -335,6 +335,7 @@ GameList::GameList(FileSys::VirtualFilesystem vfs_, FileSys::ManualContentProvid
     RetranslateUI();
 
     tree_view->setColumnHidden(COLUMN_ADD_ONS, !UISettings::values.show_add_ons);
+    tree_view->setColumnHidden(COLUMN_COMPATIBILITY, !UISettings::values.show_compat);
     item_model->setSortRole(GameListItemPath::SortRole);
 
     connect(main_window, &GMainWindow::UpdateThemedIcons, this, &GameList::OnUpdateThemedIcons);
@@ -786,6 +787,7 @@ void GameList::PopulateAsync(QVector<UISettings::GameDir>& game_dirs) {
 
     // Update the columns in case UISettings has changed
     tree_view->setColumnHidden(COLUMN_ADD_ONS, !UISettings::values.show_add_ons);
+    tree_view->setColumnHidden(COLUMN_COMPATIBILITY, !UISettings::values.show_compat);
 
     // Delete any rows that might already exist if we're repopulating
     item_model->removeRows(0, item_model->rowCount());

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -129,6 +129,9 @@ struct Values {
     Settings::Setting<bool> favorites_expanded{true, "favorites_expanded"};
     QVector<u64> favorited_ids;
 
+    // Compatibility List
+    Settings::Setting<bool> show_compat{false, "show_compat"};
+
     bool configuration_applied;
     bool reset_to_defaults;
     Settings::Setting<bool> disable_web_applet{true, "disable_web_applet"};


### PR DESCRIPTION
Option is added directly below the option for the addons column

Defaulting to hide compatibility list. Changing default works properly.

-----

New option
![image](https://user-images.githubusercontent.com/190571/196300096-812cbfac-14fd-4f64-acc7-d4bcf85be039.png)

I made sure to test the default because I don't want to see users needing help turning the compatibility list back on when we're ready to show it again.