### PR TITLE
common/fixed_point: Minor interface improvements

### DIFF
--- a/src/common/concepts.h
+++ b/src/common/concepts.h
@@ -34,4 +34,12 @@ concept DerivedFrom = requires {
 template <typename From, typename To>
 concept ConvertibleTo = std::is_convertible_v<From, To>;
 
+// No equivalents in the stdlib
+
+template <typename T>
+concept IsArithmetic = std::is_arithmetic_v<T>;
+
+template <typename T>
+concept IsIntegral = std::is_integral_v<T>;
+
 } // namespace Common

--- a/src/common/fixed_point.h
+++ b/src/common/fixed_point.h
@@ -268,9 +268,12 @@ public:
 
 public: // constructors
     FixedPoint() = default;
-    FixedPoint(const FixedPoint&) = default;
-    FixedPoint(FixedPoint&&) noexcept = default;
-    FixedPoint& operator=(const FixedPoint&) = default;
+
+    constexpr FixedPoint(const FixedPoint&) = default;
+    constexpr FixedPoint& operator=(const FixedPoint&) = default;
+
+    constexpr FixedPoint(FixedPoint&&) noexcept = default;
+    constexpr FixedPoint& operator=(FixedPoint&&) noexcept = default;
 
     template <IsArithmetic Number>
     constexpr FixedPoint(Number n) : data_(static_cast<base_type>(n * one)) {}

--- a/src/common/fixed_point.h
+++ b/src/common/fixed_point.h
@@ -267,7 +267,7 @@ public:
     static constexpr base_type one = base_type(1) << fractional_bits;
 
 public: // constructors
-    FixedPoint() = default;
+    constexpr FixedPoint() = default;
 
     constexpr FixedPoint(const FixedPoint&) = default;
     constexpr FixedPoint& operator=(const FixedPoint&) = default;
@@ -463,7 +463,7 @@ public:
     }
 
 public:
-    base_type data_;
+    base_type data_{};
 };
 
 // if we have the same fractional portion, but differing integer portions, we trivially upgrade the

--- a/src/common/fixed_point.h
+++ b/src/common/fixed_point.h
@@ -411,7 +411,7 @@ public: // conversion to basic types
         return static_cast<int>((data_ & integer_mask) >> fractional_bits);
     }
 
-    constexpr unsigned int to_uint() const {
+    constexpr unsigned int to_uint() {
         round_up();
         return static_cast<unsigned int>((data_ & integer_mask) >> fractional_bits);
     }
@@ -425,7 +425,7 @@ public: // conversion to basic types
         return static_cast<int>((data_ & integer_mask) >> fractional_bits);
     }
 
-    constexpr int64_t to_long_floor() {
+    constexpr int64_t to_long_floor() const {
         return static_cast<int64_t>((data_ & integer_mask) >> fractional_bits);
     }
 

--- a/src/common/fixed_point.h
+++ b/src/common/fixed_point.h
@@ -304,11 +304,11 @@ public: // comparison operators
     friend constexpr auto operator<=>(FixedPoint lhs, FixedPoint rhs) = default;
 
 public: // unary operators
-    constexpr bool operator!() const {
+    [[nodiscard]] constexpr bool operator!() const {
         return !data_;
     }
 
-    constexpr FixedPoint operator~() const {
+    [[nodiscard]] constexpr FixedPoint operator~() const {
         // NOTE(eteran): this will often appear to "just negate" the value
         // that is not an error, it is because -x == (~x+1)
         // and that "+1" is adding an infinitesimally small fraction to the
@@ -316,11 +316,11 @@ public: // unary operators
         return FixedPoint::from_base(~data_);
     }
 
-    constexpr FixedPoint operator-() const {
+    [[nodiscard]] constexpr FixedPoint operator-() const {
         return FixedPoint::from_base(-data_);
     }
 
-    constexpr FixedPoint operator+() const {
+    [[nodiscard]] constexpr FixedPoint operator+() const {
         return FixedPoint::from_base(+data_);
     }
 
@@ -406,42 +406,42 @@ public: // conversion to basic types
         data_ += (data_ & fractional_mask) >> 1;
     }
 
-    constexpr int to_int() {
+    [[nodiscard]] constexpr int to_int() {
         round_up();
         return static_cast<int>((data_ & integer_mask) >> fractional_bits);
     }
 
-    constexpr unsigned int to_uint() {
+    [[nodiscard]] constexpr unsigned int to_uint() {
         round_up();
         return static_cast<unsigned int>((data_ & integer_mask) >> fractional_bits);
     }
 
-    constexpr int64_t to_long() {
+    [[nodiscard]] constexpr int64_t to_long() {
         round_up();
         return static_cast<int64_t>((data_ & integer_mask) >> fractional_bits);
     }
 
-    constexpr int to_int_floor() const {
+    [[nodiscard]] constexpr int to_int_floor() const {
         return static_cast<int>((data_ & integer_mask) >> fractional_bits);
     }
 
-    constexpr int64_t to_long_floor() const {
+    [[nodiscard]] constexpr int64_t to_long_floor() const {
         return static_cast<int64_t>((data_ & integer_mask) >> fractional_bits);
     }
 
-    constexpr unsigned int to_uint_floor() const {
+    [[nodiscard]] constexpr unsigned int to_uint_floor() const {
         return static_cast<unsigned int>((data_ & integer_mask) >> fractional_bits);
     }
 
-    constexpr float to_float() const {
+    [[nodiscard]] constexpr float to_float() const {
         return static_cast<float>(data_) / FixedPoint::one;
     }
 
-    constexpr double to_double() const {
+    [[nodiscard]] constexpr double to_double() const {
         return static_cast<double>(data_) / FixedPoint::one;
     }
 
-    constexpr base_type to_raw() const {
+    [[nodiscard]] constexpr base_type to_raw() const {
         return data_;
     }
 
@@ -449,7 +449,7 @@ public: // conversion to basic types
         data_ &= fractional_mask;
     }
 
-    constexpr base_type get_frac() const {
+    [[nodiscard]] constexpr base_type get_frac() const {
         return data_ & fractional_mask;
     }
 

--- a/src/common/fixed_point.h
+++ b/src/common/fixed_point.h
@@ -301,29 +301,7 @@ public:
     }
 
 public: // comparison operators
-    constexpr bool operator==(FixedPoint rhs) const {
-        return data_ == rhs.data_;
-    }
-
-    constexpr bool operator!=(FixedPoint rhs) const {
-        return data_ != rhs.data_;
-    }
-
-    constexpr bool operator<(FixedPoint rhs) const {
-        return data_ < rhs.data_;
-    }
-
-    constexpr bool operator>(FixedPoint rhs) const {
-        return data_ > rhs.data_;
-    }
-
-    constexpr bool operator<=(FixedPoint rhs) const {
-        return data_ <= rhs.data_;
-    }
-
-    constexpr bool operator>=(FixedPoint rhs) const {
-        return data_ >= rhs.data_;
-    }
+    friend constexpr auto operator<=>(FixedPoint lhs, FixedPoint rhs) = default;
 
 public: // unary operators
     constexpr bool operator!() const {

--- a/src/common/fixed_point.h
+++ b/src/common/fixed_point.h
@@ -269,7 +269,7 @@ public:
 public: // constructors
     FixedPoint() = default;
     FixedPoint(const FixedPoint&) = default;
-    FixedPoint(FixedPoint&&) = default;
+    FixedPoint(FixedPoint&&) noexcept = default;
     FixedPoint& operator=(const FixedPoint&) = default;
 
     template <IsArithmetic Number>
@@ -454,7 +454,7 @@ public: // conversion to basic types
     }
 
 public:
-    constexpr void swap(FixedPoint& rhs) {
+    constexpr void swap(FixedPoint& rhs) noexcept {
         using std::swap;
         swap(data_, rhs.data_);
     }


### PR DESCRIPTION
We can use concepts to make all of the SFINAE shenanigans significantly less noisy and also collapse the implemented comparison functions in the class down to a single line.

While we're at it, we can make several other functions constexpr, and also make `to_uint()` actually work if it ever gets instantiated.

Also resolves some uninitialized reads that take place in several parts of the audio codebase with the last commit.