### PR TITLE
Maxwell3D/Puller: Fix regressions and syncing issues.

### DIFF
--- a/src/video_core/engines/puller.cpp
+++ b/src/video_core/engines/puller.cpp
@@ -75,11 +75,10 @@ void Puller::ProcessSemaphoreTriggerMethod() {
     if (op == GpuSemaphoreOperation::WriteLong) {
         const GPUVAddr sequence_address{regs.semaphore_address.SemaphoreAddress()};
         const u32 payload = regs.semaphore_sequence;
-        std::function<void()> operation([this, sequence_address, payload] {
+        [this, sequence_address, payload] {
             memory_manager.Write<u64>(sequence_address + sizeof(u64), gpu.GetTicks());
             memory_manager.Write<u64>(sequence_address, payload);
-        });
-        rasterizer->SignalFence(std::move(operation));
+        }();
     } else {
         do {
             const u32 word{memory_manager.Read<u32>(regs.semaphore_address.SemaphoreAddress())};


### PR DESCRIPTION
This fixes up the remaining YFc Part 1 regressions on ACNH and Splatoon 2. Additionally (with nvidia's 3d engine docs) we fixed somethings that were incoherent or made no sense according to official docs.