### PR TITLE
Controller Applet had instance of Undocked, make Handheld

### DIFF
--- a/src/yuzu/applets/qt_controller.ui
+++ b/src/yuzu/applets/qt_controller.ui
@@ -2300,7 +2300,7 @@
             <item>
              <widget class="QRadioButton" name="radioUndocked">
               <property name="text">
-               <string>Undocked</string>
+               <string>Handheld</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Remember that time we renamed the Undocked option to Handheld in the status bar, and then later remembered the Controller Configuration?

Scrolling through Transifex I noticed that we still have one instance of "Undocked" in the text.