### PR TITLE
input_common: cache vibration tests

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -100,7 +100,6 @@ enum class CameraError {
 enum class VibrationAmplificationType {
     Linear,
     Exponential,
-    Test,
 };
 
 // Analog properties for calibration
@@ -323,6 +322,10 @@ public:
 
     virtual VibrationError SetVibration([[maybe_unused]] const VibrationStatus& vibration_status) {
         return VibrationError::NotSupported;
+    }
+
+    virtual bool IsVibrationEnabled() {
+        return false;
     }
 
     virtual PollingError SetPollingMode([[maybe_unused]] PollingMode polling_mode) {

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -970,14 +970,7 @@ bool EmulatedController::SetVibration(std::size_t device_index, VibrationValue v
            Common::Input::VibrationError::None;
 }
 
-bool EmulatedController::TestVibration(std::size_t device_index) {
-    if (device_index >= output_devices.size()) {
-        return false;
-    }
-    if (!output_devices[device_index]) {
-        return false;
-    }
-
+bool EmulatedController::IsVibrationEnabled(std::size_t device_index) {
     const auto player_index = NpadIdTypeToIndex(npad_id_type);
     const auto& player = Settings::values.players.GetValue()[player_index];
 
@@ -985,31 +978,15 @@ bool EmulatedController::TestVibration(std::size_t device_index) {
         return false;
     }
 
-    const Common::Input::VibrationStatus test_vibration = {
-        .low_amplitude = 0.001f,
-        .low_frequency = DEFAULT_VIBRATION_VALUE.low_frequency,
-        .high_amplitude = 0.001f,
-        .high_frequency = DEFAULT_VIBRATION_VALUE.high_frequency,
-        .type = Common::Input::VibrationAmplificationType::Test,
-    };
+    if (device_index >= output_devices.size()) {
+        return false;
+    }
 
-    const Common::Input::VibrationStatus zero_vibration = {
-        .low_amplitude = DEFAULT_VIBRATION_VALUE.low_amplitude,
-        .low_frequency = DEFAULT_VIBRATION_VALUE.low_frequency,
-        .high_amplitude = DEFAULT_VIBRATION_VALUE.high_amplitude,
-        .high_frequency = DEFAULT_VIBRATION_VALUE.high_frequency,
-        .type = Common::Input::VibrationAmplificationType::Test,
-    };
+    if (!output_devices[device_index]) {
+        return false;
+    }
 
-    // Send a slight vibration to test for rumble support
-    output_devices[device_index]->SetVibration(test_vibration);
-
-    // Wait for about 15ms to ensure the controller is ready for the stop command
-    std::this_thread::sleep_for(std::chrono::milliseconds(15));
-
-    // Stop any vibration and return the result
-    return output_devices[device_index]->SetVibration(zero_vibration) ==
-           Common::Input::VibrationError::None;
+    return output_devices[device_index]->IsVibrationEnabled();
 }
 
 bool EmulatedController::SetPollingMode(Common::Input::PollingMode polling_mode) {
@@ -1232,12 +1209,6 @@ bool EmulatedController::IsConnected(bool get_temporary_value) const {
         return tmp_is_connected;
     }
     return is_connected;
-}
-
-bool EmulatedController::IsVibrationEnabled() const {
-    const auto player_index = NpadIdTypeToIndex(npad_id_type);
-    const auto& player = Settings::values.players.GetValue()[player_index];
-    return player.vibration_enabled;
 }
 
 NpadIdType EmulatedController::GetNpadIdType() const {

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -206,9 +206,6 @@ public:
      */
     bool IsConnected(bool get_temporary_value = false) const;
 
-    /// Returns true if vibration is enabled
-    bool IsVibrationEnabled() const;
-
     /// Removes all callbacks created from input devices
     void UnloadInput();
 
@@ -339,7 +336,7 @@ public:
      * Sends a small vibration to the output device
      * @return true if SetVibration was successfull
      */
-    bool TestVibration(std::size_t device_index);
+    bool IsVibrationEnabled(std::size_t device_index);
 
     /**
      * Sets the desired data to be polled from a controller

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -867,7 +867,7 @@ bool Controller_NPad::VibrateControllerAtIndex(Core::HID::NpadIdType npad_id,
         return false;
     }
 
-    if (!controller.device->IsVibrationEnabled()) {
+    if (!controller.device->IsVibrationEnabled(device_index)) {
         if (controller.vibration[device_index].latest_vibration_value.low_amplitude != 0.0f ||
             controller.vibration[device_index].latest_vibration_value.high_amplitude != 0.0f) {
             // Send an empty vibration to stop any vibrations.
@@ -1000,7 +1000,7 @@ void Controller_NPad::InitializeVibrationDeviceAtIndex(Core::HID::NpadIdType npa
     }
 
     controller.vibration[device_index].device_mounted =
-        controller.device->TestVibration(device_index);
+        controller.device->IsVibrationEnabled(device_index);
 }
 
 void Controller_NPad::SetPermitVibrationSession(bool permit_vibration_session) {

--- a/src/input_common/drivers/gc_adapter.cpp
+++ b/src/input_common/drivers/gc_adapter.cpp
@@ -324,7 +324,7 @@ bool GCAdapter::GetGCEndpoint(libusb_device* device) {
     return true;
 }
 
-Common::Input::VibrationError GCAdapter::SetRumble(
+Common::Input::VibrationError GCAdapter::SetVibration(
     const PadIdentifier& identifier, const Common::Input::VibrationStatus& vibration) {
     const auto mean_amplitude = (vibration.low_amplitude + vibration.high_amplitude) * 0.5f;
     const auto processed_amplitude =
@@ -336,6 +336,10 @@ Common::Input::VibrationError GCAdapter::SetRumble(
         return Common::Input::VibrationError::Disabled;
     }
     return Common::Input::VibrationError::None;
+}
+
+bool GCAdapter::IsVibrationEnabled([[maybe_unused]] const PadIdentifier& identifier) {
+    return rumble_enabled;
 }
 
 void GCAdapter::UpdateVibrations() {

--- a/src/input_common/drivers/gc_adapter.h
+++ b/src/input_common/drivers/gc_adapter.h
@@ -25,8 +25,10 @@ public:
     explicit GCAdapter(std::string input_engine_);
     ~GCAdapter() override;
 
-    Common::Input::VibrationError SetRumble(
+    Common::Input::VibrationError SetVibration(
         const PadIdentifier& identifier, const Common::Input::VibrationStatus& vibration) override;
+
+    bool IsVibrationEnabled(const PadIdentifier& identifier) override;
 
     /// Used for automapping features
     std::vector<Common::ParamPackage> GetInputDevices() const override;

--- a/src/input_common/drivers/sdl_driver.h
+++ b/src/input_common/drivers/sdl_driver.h
@@ -61,8 +61,10 @@ public:
 
     bool IsStickInverted(const Common::ParamPackage& params) override;
 
-    Common::Input::VibrationError SetRumble(
+    Common::Input::VibrationError SetVibration(
         const PadIdentifier& identifier, const Common::Input::VibrationStatus& vibration) override;
+
+    bool IsVibrationEnabled(const PadIdentifier& identifier) override;
 
 private:
     struct VibrationRequest {

--- a/src/input_common/input_engine.h
+++ b/src/input_common/input_engine.h
@@ -108,10 +108,15 @@ public:
                          [[maybe_unused]] const Common::Input::LedStatus& led_status) {}
 
     // Sets rumble to a controller
-    virtual Common::Input::VibrationError SetRumble(
+    virtual Common::Input::VibrationError SetVibration(
         [[maybe_unused]] const PadIdentifier& identifier,
         [[maybe_unused]] const Common::Input::VibrationStatus& vibration) {
         return Common::Input::VibrationError::NotSupported;
+    }
+
+    // Returns true if device supports vibrations
+    virtual bool IsVibrationEnabled([[maybe_unused]] const PadIdentifier& identifier) {
+        return false;
     }
 
     // Sets polling mode to a controller

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -763,7 +763,11 @@ public:
 
     Common::Input::VibrationError SetVibration(
         const Common::Input::VibrationStatus& vibration_status) override {
-        return input_engine->SetRumble(identifier, vibration_status);
+        return input_engine->SetVibration(identifier, vibration_status);
+    }
+
+    bool IsVibrationEnabled() override {
+        return input_engine->IsVibrationEnabled(identifier);
     }
 
     Common::Input::PollingError SetPollingMode(Common::Input::PollingMode polling_mode) override {


### PR DESCRIPTION
Due to controller compatibility reasons vibration test take a bit of time.  For this reason we only test once then return the cached value afterwards. This fixes once more fps drops caused by the game testing vibration all the time.