### PR TITLE
service: nfp: Allow amiibos without keys

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -1048,6 +1048,7 @@ bool EmulatedController::HasNfc() const {
     case NpadStyleIndex::JoyconRight:
     case NpadStyleIndex::JoyconDual:
     case NpadStyleIndex::ProController:
+    case NpadStyleIndex::Handheld:
         break;
     default:
         return false;

--- a/src/core/hle/service/nfp/amiibo_crypto.cpp
+++ b/src/core/hle/service/nfp/amiibo_crypto.cpp
@@ -9,6 +9,7 @@
 #include <mbedtls/hmac_drbg.h>
 
 #include "common/fs/file.h"
+#include "common/fs/fs.h"
 #include "common/fs/path_util.h"
 #include "common/logging/log.h"
 #include "core/hle/service/mii/mii_manager.h"
@@ -279,7 +280,7 @@ bool LoadKeys(InternalKey& locked_secret, InternalKey& unfixed_info) {
                                        Common::FS::FileType::BinaryFile};
 
     if (!keys_file.IsOpen()) {
-        LOG_ERROR(Service_NFP, "No keys detected");
+        LOG_ERROR(Service_NFP, "Failed to open key file");
         return false;
     }
 
@@ -293,6 +294,11 @@ bool LoadKeys(InternalKey& locked_secret, InternalKey& unfixed_info) {
     }
 
     return true;
+}
+
+bool IsKeyAvailable() {
+    const auto yuzu_keys_dir = Common::FS::GetYuzuPath(Common::FS::YuzuPath::KeysDir);
+    return Common::FS::Exists(yuzu_keys_dir / "key_retail.bin");
 }
 
 bool DecodeAmiibo(const EncryptedNTAG215File& encrypted_tag_data, NTAG215File& tag_data) {

--- a/src/core/hle/service/nfp/amiibo_crypto.h
+++ b/src/core/hle/service/nfp/amiibo_crypto.h
@@ -91,6 +91,9 @@ void Cipher(const DerivedKeys& keys, const NTAG215File& in_data, NTAG215File& ou
 /// Loads both amiibo keys from key_retail.bin
 bool LoadKeys(InternalKey& locked_secret, InternalKey& unfixed_info);
 
+/// Returns true if key_retail.bin exist
+bool IsKeyAvailable();
+
 /// Decodes encripted amiibo data returns true if output is valid
 bool DecodeAmiibo(const EncryptedNTAG215File& encrypted_tag_data, NTAG215File& tag_data);
 

--- a/src/core/hle/service/nfp/nfp_device.cpp
+++ b/src/core/hle/service/nfp/nfp_device.cpp
@@ -17,6 +17,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/service/mii/mii_manager.h"
+#include "core/hle/service/mii/types.h"
 #include "core/hle/service/nfp/amiibo_crypto.h"
 #include "core/hle/service/nfp/nfp.h"
 #include "core/hle/service/nfp/nfp_device.h"

--- a/src/core/hle/service/nfp/nfp_device.cpp
+++ b/src/core/hle/service/nfp/nfp_device.cpp
@@ -234,6 +234,14 @@ Result NfpDevice::Mount(MountTarget mount_target_) {
         return NotAnAmiibo;
     }
 
+    // Mark amiibos as read only when keys are missing
+    if (!AmiiboCrypto::IsKeyAvailable()) {
+        LOG_ERROR(Service_NFP, "No keys detected");
+        device_state = DeviceState::TagMounted;
+        mount_target = MountTarget::Rom;
+        return ResultSuccess;
+    }
+
     if (!AmiiboCrypto::DecodeAmiibo(encrypted_tag_data, tag_data)) {
         LOG_ERROR(Service_NFP, "Can't decode amiibo {}", device_state);
         return CorruptedData;

--- a/src/core/hle/service/nfp/nfp_device.h
+++ b/src/core/hle/service/nfp/nfp_device.h
@@ -8,7 +8,6 @@
 
 #include "common/common_funcs.h"
 #include "core/hle/service/kernel_helpers.h"
-#include "core/hle/service/mii/types.h"
 #include "core/hle/service/nfp/nfp_types.h"
 #include "core/hle/service/service.h"
 

--- a/src/core/hle/service/nfp/nfp_types.h
+++ b/src/core/hle/service/nfp/nfp_types.h
@@ -17,11 +17,6 @@ enum class ServiceType : u32 {
     System,
 };
 
-enum class State : u32 {
-    NonInitialized,
-    Initialized,
-};
-
 enum class DeviceState : u32 {
     Initialized,
     SearchingForTag,

--- a/src/core/hle/service/nfp/nfp_user.cpp
+++ b/src/core/hle/service/nfp/nfp_user.cpp
@@ -6,12 +6,9 @@
 
 #include "common/logging/log.h"
 #include "core/core.h"
-#include "core/hid/emulated_controller.h"
-#include "core/hid/hid_core.h"
 #include "core/hid/hid_types.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/k_event.h"
-#include "core/hle/service/mii/mii_manager.h"
 #include "core/hle/service/nfp/nfp_device.h"
 #include "core/hle/service/nfp/nfp_result.h"
 #include "core/hle/service/nfp/nfp_user.h"

--- a/src/core/hle/service/nfp/nfp_user.h
+++ b/src/core/hle/service/nfp/nfp_user.h
@@ -4,8 +4,7 @@
 #pragma once
 
 #include "core/hle/service/kernel_helpers.h"
-#include "core/hle/service/nfp/nfp.h"
-#include "core/hle/service/nfp/nfp_types.h"
+#include "core/hle/service/service.h"
 
 namespace Service::NFP {
 class NfpDevice;
@@ -15,6 +14,11 @@ public:
     explicit IUser(Core::System& system_);
 
 private:
+    enum class State : u32 {
+        NonInitialized,
+        Initialized,
+    };
+
     void Initialize(Kernel::HLERequestContext& ctx);
     void Finalize(Kernel::HLERequestContext& ctx);
     void ListDevices(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
Since many users  started using outdated builds instead of dumping the amiibo keys. I decided to add a little workaround by marking amiibos as read only when keys are missing. This enables basic detection of amiibos.

No fallbacks are given to keep the code accurate. Games that use decrypted data will still need keys. 