### PR TITLE
kernel: refactor dummy thread wakeups

### DIFF
--- a/src/core/hle/kernel/global_scheduler_context.cpp
+++ b/src/core/hle/kernel/global_scheduler_context.cpp
@@ -49,4 +49,19 @@ bool GlobalSchedulerContext::IsLocked() const {
     return scheduler_lock.IsLockedByCurrentThread();
 }
 
+void GlobalSchedulerContext::RegisterDummyThreadForWakeup(KThread* thread) {
+    ASSERT(IsLocked());
+    woken_dummy_thread_list.push_back(thread);
+}
+
+void GlobalSchedulerContext::WakeupWaitingDummyThreads() {
+    ASSERT(IsLocked());
+
+    for (auto* thread : woken_dummy_thread_list) {
+        thread->IfDummyThreadEndWait();
+    }
+
+    woken_dummy_thread_list.clear();
+}
+
 } // namespace Kernel

--- a/src/core/hle/kernel/global_scheduler_context.h
+++ b/src/core/hle/kernel/global_scheduler_context.h
@@ -58,6 +58,9 @@ public:
     /// Returns true if the global scheduler lock is acquired
     bool IsLocked() const;
 
+    void RegisterDummyThreadForWakeup(KThread* thread);
+    void WakeupWaitingDummyThreads();
+
     [[nodiscard]] LockType& SchedulerLock() {
         return scheduler_lock;
     }
@@ -75,6 +78,9 @@ private:
     std::atomic_bool scheduler_update_needed{};
     KSchedulerPriorityQueue priority_queue;
     LockType scheduler_lock;
+
+    /// Lists dummy threads pending wakeup on lock release
+    std::vector<KThread*> woken_dummy_thread_list;
 
     /// Lists all thread ids that aren't deleted/etc.
     std::vector<KThread*> thread_list;

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -148,7 +148,9 @@ Result KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_stack
     physical_affinity_mask.SetAffinity(phys_core, true);
 
     // Set the thread state.
-    thread_state = (type == ThreadType::Main) ? ThreadState::Runnable : ThreadState::Initialized;
+    thread_state = (type == ThreadType::Main || type == ThreadType::Dummy)
+                       ? ThreadState::Runnable
+                       : ThreadState::Initialized;
 
     // Set TLS address.
     tls_address = 0;
@@ -1231,9 +1233,6 @@ void KThread::EndWait(Result wait_result_) {
         }
 
         wait_queue->EndWait(this, wait_result_);
-
-        // Special case for dummy threads to wakeup if necessary.
-        IfDummyThreadEndWait();
     }
 }
 


### PR DESCRIPTION
This allows host threads to call KSynchronizationObject::Wait, which is required to implement the HIPC server manager.