### PR TITLE
core: barrier service thread shutdown

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -384,6 +384,7 @@ struct System::Impl {
         kernel.ShutdownCores();
         cpu_manager.Shutdown();
         debugger.reset();
+        services->KillNVNFlinger();
         kernel.CloseServices();
         services.reset();
         service_manager.reset();

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -102,14 +102,18 @@ NVFlinger::~NVFlinger() {
         system.CoreTiming().UnscheduleEvent(single_composition_event, {});
     }
 
+    ShutdownLayers();
+
+    if (nvdrv) {
+        nvdrv->Close(disp_fd);
+    }
+}
+
+void NVFlinger::ShutdownLayers() {
     for (auto& display : displays) {
         for (size_t layer = 0; layer < display.GetNumLayers(); ++layer) {
             display.GetLayer(layer).Core().NotifyShutdown();
         }
-    }
-
-    if (nvdrv) {
-        nvdrv->Close(disp_fd);
     }
 }
 

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -48,6 +48,8 @@ public:
     explicit NVFlinger(Core::System& system_, HosBinderDriverServer& hos_binder_driver_server_);
     ~NVFlinger();
 
+    void ShutdownLayers();
+
     /// Sets the NVDrv module instance to use to send buffers to the GPU.
     void SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance);
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -303,4 +303,8 @@ Services::Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system
 
 Services::~Services() = default;
 
+void Services::KillNVNFlinger() {
+    nv_flinger->ShutdownLayers();
+}
+
 } // namespace Service

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -238,6 +238,8 @@ public:
     explicit Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system);
     ~Services();
 
+    void KillNVNFlinger();
+
 private:
     std::unique_ptr<NVFlinger::HosBinderDriverServer> hos_binder_driver_server;
     std::unique_ptr<NVFlinger::NVFlinger> nv_flinger;


### PR DESCRIPTION
Service threads are managed by a separate thread worker to force serialization. This includes their shutdown. This meant previously that if there was too long of a delay between core shutting down and the service thread shutting down, it could continue to use objects that belonged to the now-destroyed system instance, which would crash.

To prevent this, I added a barrier. However, due to waiting on a host mutex, sometimes an IHOSBinderDriver thread would get stuck. If this was a guest thread, this would not be an issue, since it could just be killed. However, it is a host thread, so I have added some improper hierarchy to ensure that NVNFlinger forces all binder layers to stop waiting before shutdown.