### PR TITLE
nvdrv: fix container destruction order

### DIFF
--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -53,7 +53,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger
 }
 
 Module::Module(Core::System& system)
-    : service_context{system, "nvdrv"}, events_interface{*this}, container{system.Host1x()} {
+    : container{system.Host1x()}, service_context{system, "nvdrv"}, events_interface{*this} {
     builders["/dev/nvhost-as-gpu"] = [this, &system](DeviceFD fd) {
         std::shared_ptr<Devices::nvdevice> device =
             std::make_shared<Devices::nvhost_as_gpu>(system, *this, container);

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -97,6 +97,9 @@ private:
     friend class EventInterface;
     friend class Service::NVFlinger::NVFlinger;
 
+    /// Manages syncpoints on the host
+    NvCore::Container container;
+
     /// Id to use for the next open file descriptor.
     DeviceFD next_fd = 1;
 
@@ -107,9 +110,6 @@ private:
     KernelHelpers::ServiceContext service_context;
 
     EventInterface events_interface;
-
-    /// Manages syncpoints on the host
-    NvCore::Container container;
 
     std::unordered_map<std::string, std::function<FilesContainerType::iterator(DeviceFD)>> builders;
 };


### PR DESCRIPTION
If nvdrv got destroyed before guest code closed all open fds to nvdec, then an unavoidable crash would occur with libstdc++, because the nvdec common destructor would attempt to access the NvCore::Container belonging to nvdrv, but it had been destroyed already due to the order of its class members. This fixes that.