### PR TITLE
kernel: refactor dummy thread wakeups

### DIFF
--- a/src/core/hle/kernel/global_scheduler_context.cpp
+++ b/src/core/hle/kernel/global_scheduler_context.cpp
@@ -49,4 +49,26 @@ bool GlobalSchedulerContext::IsLocked() const {
     return scheduler_lock.IsLockedByCurrentThread();
 }
 
+void GlobalSchedulerContext::RegisterDummyThreadForWakeup(KThread* thread) {
+    ASSERT(IsLocked());
+
+    woken_dummy_threads.insert(thread);
+}
+
+void GlobalSchedulerContext::UnregisterDummyThreadForWakeup(KThread* thread) {
+    ASSERT(IsLocked());
+
+    woken_dummy_threads.erase(thread);
+}
+
+void GlobalSchedulerContext::WakeupWaitingDummyThreads() {
+    ASSERT(IsLocked());
+
+    for (auto* thread : woken_dummy_threads) {
+        thread->DummyThreadEndWait();
+    }
+
+    woken_dummy_threads.clear();
+}
+
 } // namespace Kernel

--- a/src/core/hle/kernel/global_scheduler_context.h
+++ b/src/core/hle/kernel/global_scheduler_context.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <atomic>
+#include <set>
 #include <vector>
 
 #include "common/common_types.h"
@@ -58,6 +59,10 @@ public:
     /// Returns true if the global scheduler lock is acquired
     bool IsLocked() const;
 
+    void UnregisterDummyThreadForWakeup(KThread* thread);
+    void RegisterDummyThreadForWakeup(KThread* thread);
+    void WakeupWaitingDummyThreads();
+
     [[nodiscard]] LockType& SchedulerLock() {
         return scheduler_lock;
     }
@@ -75,6 +80,9 @@ private:
     std::atomic_bool scheduler_update_needed{};
     KSchedulerPriorityQueue priority_queue;
     LockType scheduler_lock;
+
+    /// Lists dummy threads pending wakeup on lock release
+    std::set<KThread*> woken_dummy_threads;
 
     /// Lists all thread ids that aren't deleted/etc.
     std::vector<KThread*> thread_list;

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -643,8 +643,9 @@ public:
     // therefore will not block on guest kernel synchronization primitives. These methods handle
     // blocking as needed.
 
-    void IfDummyThreadTryWait();
-    void IfDummyThreadEndWait();
+    void RequestDummyThreadWait();
+    void DummyThreadBeginWait();
+    void DummyThreadEndWait();
 
     [[nodiscard]] uintptr_t GetArgument() const {
         return argument;
@@ -777,8 +778,7 @@ private:
     bool is_single_core{};
     ThreadType thread_type{};
     StepState step_state{};
-    std::mutex dummy_wait_lock;
-    std::condition_variable dummy_wait_cv;
+    std::atomic<bool> dummy_thread_runnable{true};
 
     // For debugging
     std::vector<KSynchronizationObject*> wait_objects_for_debugging;


### PR DESCRIPTION
This allows host threads to call KSynchronizationObject::Wait without crashing, which is required to implement the HIPC server manager. V2, actually works this time.