### PR TITLE
video_core: Catch vulkan clear op not all channel need clear

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -305,14 +305,19 @@ void RasterizerVulkan::Clear() {
             }
         }
 
-        scheduler.Record([color_attachment, clear_value, clear_rect](vk::CommandBuffer cmdbuf) {
-            const VkClearAttachment attachment{
-                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-                .colorAttachment = color_attachment,
-                .clearValue = clear_value,
-            };
-            cmdbuf.ClearAttachments(attachment, clear_rect);
-        });
+        if (regs.clear_surface.R && regs.clear_surface.G && regs.clear_surface.B &&
+            regs.clear_surface.A) {
+            scheduler.Record([color_attachment, clear_value, clear_rect](vk::CommandBuffer cmdbuf) {
+                const VkClearAttachment attachment{
+                    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                    .colorAttachment = color_attachment,
+                    .clearValue = clear_value,
+                };
+                cmdbuf.ClearAttachments(attachment, clear_rect);
+            });
+        } else {
+            UNIMPLEMENTED_MSG("Unimplemented Clear only the specified channel");
+        }
     }
 
     if (!use_depth && !use_stencil) {


### PR DESCRIPTION
This is just a temporary solution,  Auxiliary shader needs to be added to perform specified channel clear.

Fix p5r's battle scenes black.

![image](https://user-images.githubusercontent.com/3349963/197804537-2cec06af-c642-4f54-9abf-35a5dfb95e1a.png)
