### PR TITLE
yuzu/compatdb: Improve compatibility submission system

### DIFF
--- a/src/yuzu/compatdb.cpp
+++ b/src/yuzu/compatdb.cpp
@@ -15,12 +15,22 @@ CompatDB::CompatDB(Core::TelemetrySession& telemetry_session_, QWidget* parent)
     : QWizard(parent, Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint),
       ui{std::make_unique<Ui::CompatDB>()}, telemetry_session{telemetry_session_} {
     ui->setupUi(this);
-    connect(ui->radioButton_Perfect, &QRadioButton::clicked, this, &CompatDB::EnableNext);
-    connect(ui->radioButton_Great, &QRadioButton::clicked, this, &CompatDB::EnableNext);
-    connect(ui->radioButton_Okay, &QRadioButton::clicked, this, &CompatDB::EnableNext);
-    connect(ui->radioButton_Bad, &QRadioButton::clicked, this, &CompatDB::EnableNext);
-    connect(ui->radioButton_IntroMenu, &QRadioButton::clicked, this, &CompatDB::EnableNext);
-    connect(ui->radioButton_WontBoot, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+
+    connect(ui->radioButton_GameBoot_Yes, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_GameBoot_No, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Gameplay_Yes, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Gameplay_No, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_NoFreeze_Yes, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_NoFreeze_No, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Complete_Yes, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Complete_No, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Graphical_Major, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Graphical_Minor, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Graphical_No, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Audio_Major, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Audio_Minor, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+    connect(ui->radioButton_Audio_No, &QRadioButton::clicked, this, &CompatDB::EnableNext);
+
     connect(button(NextButton), &QPushButton::clicked, this, &CompatDB::Submit);
     connect(&testcase_watcher, &QFutureWatcher<bool>::finished, this,
             &CompatDB::OnTestcaseSubmitted);
@@ -30,29 +40,82 @@ CompatDB::~CompatDB() = default;
 
 enum class CompatDBPage {
     Intro = 0,
-    Selection = 1,
-    Final = 2,
+    GameBoot = 1,
+    GamePlay = 2,
+    Freeze = 3,
+    Completion = 4,
+    Graphical = 5,
+    Audio = 6,
+    Final = 7,
 };
 
 void CompatDB::Submit() {
-    QButtonGroup* compatibility = new QButtonGroup(this);
-    compatibility->addButton(ui->radioButton_Perfect, 0);
-    compatibility->addButton(ui->radioButton_Great, 1);
-    compatibility->addButton(ui->radioButton_Okay, 2);
-    compatibility->addButton(ui->radioButton_Bad, 3);
-    compatibility->addButton(ui->radioButton_IntroMenu, 4);
-    compatibility->addButton(ui->radioButton_WontBoot, 5);
+    QButtonGroup* compatibility_GameBoot = new QButtonGroup(this);
+    compatibility_GameBoot->addButton(ui->radioButton_GameBoot_Yes, 0);
+    compatibility_GameBoot->addButton(ui->radioButton_GameBoot_No, 1);
+
+    QButtonGroup* compatibility_Gameplay = new QButtonGroup(this);
+    compatibility_Gameplay->addButton(ui->radioButton_Gameplay_Yes, 0);
+    compatibility_Gameplay->addButton(ui->radioButton_Gameplay_No, 1);
+
+    QButtonGroup* compatibility_NoFreeze = new QButtonGroup(this);
+    compatibility_NoFreeze->addButton(ui->radioButton_NoFreeze_Yes, 0);
+    compatibility_NoFreeze->addButton(ui->radioButton_NoFreeze_No, 1);
+
+    QButtonGroup* compatibility_Complete = new QButtonGroup(this);
+    compatibility_Complete->addButton(ui->radioButton_Complete_Yes, 0);
+    compatibility_Complete->addButton(ui->radioButton_Complete_No, 1);
+
+    QButtonGroup* compatibility_Graphical = new QButtonGroup(this);
+    compatibility_Graphical->addButton(ui->radioButton_Graphical_Major, 0);
+    compatibility_Graphical->addButton(ui->radioButton_Graphical_Minor, 1);
+    compatibility_Graphical->addButton(ui->radioButton_Graphical_No, 2);
+
+    QButtonGroup* compatibility_Audio = new QButtonGroup(this);
+    compatibility_Audio->addButton(ui->radioButton_Audio_Major, 0);
+    compatibility_Graphical->addButton(ui->radioButton_Audio_Minor, 1);
+    compatibility_Audio->addButton(ui->radioButton_Audio_No, 2);
+
+    const int compatiblity = static_cast<int>(CalculateCompatibility());
+
     switch ((static_cast<CompatDBPage>(currentId()))) {
-    case CompatDBPage::Selection:
-        if (compatibility->checkedId() == -1) {
+    case CompatDBPage::Intro:
+        break;
+    case CompatDBPage::GameBoot:
+        if (compatibility_GameBoot->checkedId() == -1) {
+            button(NextButton)->setEnabled(false);
+        }
+        break;
+    case CompatDBPage::GamePlay:
+        if (compatibility_Gameplay->checkedId() == -1) {
+            button(NextButton)->setEnabled(false);
+        }
+        break;
+    case CompatDBPage::Freeze:
+        if (compatibility_NoFreeze->checkedId() == -1) {
+            button(NextButton)->setEnabled(false);
+        }
+        break;
+    case CompatDBPage::Completion:
+        if (compatibility_Complete->checkedId() == -1) {
+            button(NextButton)->setEnabled(false);
+        }
+        break;
+    case CompatDBPage::Graphical:
+        if (compatibility_Graphical->checkedId() == -1) {
+            button(NextButton)->setEnabled(false);
+        }
+        break;
+    case CompatDBPage::Audio:
+        if (compatibility_Audio->checkedId() == -1) {
             button(NextButton)->setEnabled(false);
         }
         break;
     case CompatDBPage::Final:
         back();
-        LOG_DEBUG(Frontend, "Compatibility Rating: {}", compatibility->checkedId());
+        LOG_INFO(Frontend, "Compatibility Rating: {}", compatiblity);
         telemetry_session.AddField(Common::Telemetry::FieldType::UserFeedback, "Compatibility",
-                                   compatibility->checkedId());
+                                   compatiblity);
 
         button(NextButton)->setEnabled(false);
         button(NextButton)->setText(tr("Submitting"));
@@ -64,6 +127,66 @@ void CompatDB::Submit() {
     default:
         LOG_ERROR(Frontend, "Unexpected page: {}", currentId());
     }
+}
+
+int CompatDB::nextId() const {
+    switch ((static_cast<CompatDBPage>(currentId()))) {
+    case CompatDBPage::Intro:
+        return static_cast<int>(CompatDBPage::GameBoot);
+    case CompatDBPage::GameBoot:
+        if (ui->radioButton_GameBoot_No->isChecked()) {
+            return static_cast<int>(CompatDBPage::Final);
+        }
+        return static_cast<int>(CompatDBPage::GamePlay);
+    case CompatDBPage::GamePlay:
+        if (ui->radioButton_Gameplay_No->isChecked()) {
+            return static_cast<int>(CompatDBPage::Final);
+        }
+        return static_cast<int>(CompatDBPage::Freeze);
+    case CompatDBPage::Freeze:
+        if (ui->radioButton_NoFreeze_No->isChecked()) {
+            return static_cast<int>(CompatDBPage::Final);
+        }
+        return static_cast<int>(CompatDBPage::Completion);
+    case CompatDBPage::Completion:
+        if (ui->radioButton_Complete_No->isChecked()) {
+            return static_cast<int>(CompatDBPage::Final);
+        }
+        return static_cast<int>(CompatDBPage::Graphical);
+    case CompatDBPage::Graphical:
+        return static_cast<int>(CompatDBPage::Audio);
+    case CompatDBPage::Audio:
+        return static_cast<int>(CompatDBPage::Final);
+    case CompatDBPage::Final:
+        return -1;
+    default:
+        LOG_ERROR(Frontend, "Unexpected page: {}", currentId());
+        return static_cast<int>(CompatDBPage::Intro);
+    }
+}
+
+CompatibilityStatus CompatDB::CalculateCompatibility() const {
+    if (ui->radioButton_GameBoot_No->isChecked()) {
+        return CompatibilityStatus::WontBoot;
+    }
+
+    if (ui->radioButton_Gameplay_No->isChecked()) {
+        return CompatibilityStatus::IntroMenu;
+    }
+
+    if (ui->radioButton_NoFreeze_No->isChecked() || ui->radioButton_Complete_No->isChecked()) {
+        return CompatibilityStatus::Ingame;
+    }
+
+    if (ui->radioButton_Graphical_Major->isChecked() || ui->radioButton_Audio_Major->isChecked()) {
+        return CompatibilityStatus::Ingame;
+    }
+
+    if (ui->radioButton_Graphical_Minor->isChecked() || ui->radioButton_Audio_Minor->isChecked()) {
+        return CompatibilityStatus::Playable;
+    }
+
+    return CompatibilityStatus::Perfect;
 }
 
 void CompatDB::OnTestcaseSubmitted() {

--- a/src/yuzu/compatdb.h
+++ b/src/yuzu/compatdb.h
@@ -12,12 +12,22 @@ namespace Ui {
 class CompatDB;
 }
 
+enum class CompatibilityStatus {
+    Perfect = 0,
+    Playable = 1,
+    // Unused: Okay = 2,
+    Ingame = 3,
+    IntroMenu = 4,
+    WontBoot = 5,
+};
+
 class CompatDB : public QWizard {
     Q_OBJECT
 
 public:
     explicit CompatDB(Core::TelemetrySession& telemetry_session_, QWidget* parent = nullptr);
     ~CompatDB();
+    int nextId() const override;
 
 private:
     QFutureWatcher<bool> testcase_watcher;
@@ -25,6 +35,7 @@ private:
     std::unique_ptr<Ui::CompatDB> ui;
 
     void Submit();
+    CompatibilityStatus CalculateCompatibility() const;
     void OnTestcaseSubmitted();
     void EnableNext();
 

--- a/src/yuzu/compatdb.ui
+++ b/src/yuzu/compatdb.ui
@@ -58,128 +58,23 @@
     </item>
    </layout>
   </widget>
-  <widget class="QWizardPage" name="wizard_Report">
+  <widget class="QWizardPage" name="wizard_GameBoot">
    <property name="title">
     <string>Report Game Compatibility</string>
    </property>
    <attribute name="pageId">
     <string notr="true">1</string>
    </attribute>
-   <layout class="QFormLayout" name="formLayout">
-    <item row="2" column="0">
-     <widget class="QRadioButton" name="radioButton_Perfect">
-      <property name="text">
-       <string>Perfect</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1">
-     <widget class="QLabel" name="lbl_Perfect">
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="0">
-     <widget class="QRadioButton" name="radioButton_Great">
-      <property name="text">
-       <string>Great</string>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
-     <widget class="QLabel" name="lbl_Great">
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="0">
-     <widget class="QRadioButton" name="radioButton_Okay">
-      <property name="text">
-       <string>Okay</string>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="1">
-     <widget class="QLabel" name="lbl_Okay">
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="0">
-     <widget class="QRadioButton" name="radioButton_Bad">
-      <property name="text">
-       <string>Bad</string>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="1">
-     <widget class="QLabel" name="lbl_Bad">
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="0">
-     <widget class="QRadioButton" name="radioButton_IntroMenu">
-      <property name="text">
-       <string>Intro/Menu</string>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="1">
-     <widget class="QLabel" name="lbl_IntroMenu">
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="0">
-     <widget class="QRadioButton" name="radioButton_WontBoot">
-      <property name="text">
-       <string>Won't Boot</string>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="1">
-     <widget class="QLabel" name="lbl_WontBoot">
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-     </widget>
-    </item>
+   <layout class="QFormLayout" name="formLayout1">
     <item row="0" column="0" colspan="2">
-     <widget class="QLabel" name="lbl_Independent">
+     <widget class="QLabel" name="lbl_Independent1">
       <property name="font">
        <font>
         <pointsize>10</pointsize>
        </font>
       </property>
       <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of yuzu?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Does the game boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -187,7 +82,295 @@
      </widget>
     </item>
     <item row="1" column="0" colspan="2">
-     <spacer name="verticalSpacer">
+     <spacer name="verticalSpacer1">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>0</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="radioButton_GameBoot_Yes">
+      <property name="text">
+       <string>Yes   The game starts to output video or audio</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QRadioButton" name="radioButton_GameBoot_No">
+      <property name="text">
+       <string>No    The game doesn't get past the &quot;Launching...&quot; screen</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="wizard_GamePlay">
+   <property name="title">
+    <string>Report Game Compatibility</string>
+   </property>
+   <attribute name="pageId">
+    <string notr="true">2</string>
+   </attribute>
+   <layout class="QFormLayout" name="formLayout2">
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="radioButton_Gameplay_Yes">
+      <property name="text">
+       <string>Yes   The game gets past the intro/menu and into gameplay</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QRadioButton" name="radioButton_Gameplay_No">
+      <property name="text">
+       <string>No    The game crashes or freezes while loading or using the menu</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0" colspan="2">
+     <widget class="QLabel" name="lbl_Independent2">
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Does the game reach gameplay?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <spacer name="verticalSpacer2">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>0</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="wizard_NoFreeze">
+   <property name="title">
+    <string>Report Game Compatibility</string>
+   </property>
+   <attribute name="pageId">
+    <string notr="true">3</string>
+   </attribute>
+   <layout class="QFormLayout" name="formLayout3">
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="radioButton_NoFreeze_Yes">
+      <property name="text">
+       <string>Yes   The game works without crashes</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QRadioButton" name="radioButton_NoFreeze_No">
+      <property name="text">
+       <string>No    The game crashes or freezes during gameplay</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0" colspan="2">
+     <widget class="QLabel" name="lbl_Independent3">
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Does the game work without crashing, freezing or locking up during gameplay?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <spacer name="verticalSpacer3">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>0</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="wizard_Complete">
+   <property name="title">
+    <string>Report Game Compatibility</string>
+   </property>
+   <attribute name="pageId">
+    <string notr="true">4</string>
+   </attribute>
+   <layout class="QFormLayout" name="formLayout4">
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="radioButton_Complete_Yes">
+      <property name="text">
+       <string>Yes   The game can be finished without any workarounds</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QRadioButton" name="radioButton_Complete_No">
+      <property name="text">
+       <string>No    The game can't progress past a certain area</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0" colspan="2">
+     <widget class="QLabel" name="lbl_Independent4">
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is the game completely playable from start to finish?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <spacer name="verticalSpacer4">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>0</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="wizard_Graphical">
+   <property name="title">
+    <string>Report Game Compatibility</string>
+   </property>
+   <attribute name="pageId">
+    <string notr="true">5</string>
+   </attribute>
+   <layout class="QFormLayout" name="formLayout5">
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="radioButton_Graphical_Major">
+      <property name="text">
+       <string>Major   The game has major graphical errors</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QRadioButton" name="radioButton_Graphical_Minor">
+      <property name="text">
+       <string>Minor   The game has minor graphical errors</string>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="0">
+     <widget class="QRadioButton" name="radioButton_Graphical_No">
+      <property name="text">
+       <string>None     Everything is rendered as it looks on the Nintendo Switch</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0" colspan="2">
+     <widget class="QLabel" name="lbl_Independent5">
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Does the game have any graphical glitches?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <spacer name="verticalSpacer5">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>0</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="wizard_Audio">
+   <property name="title">
+    <string>Report Game Compatibility</string>
+   </property>
+   <attribute name="pageId">
+    <string notr="true">6</string>
+   </attribute>
+   <layout class="QFormLayout" name="formLayout6">
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="radioButton_Audio_Major">
+      <property name="text">
+       <string>Major   The game has major audio errors</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QRadioButton" name="radioButton_Audio_Minor">
+      <property name="text">
+       <string>Minor   The game has minor audio errors</string>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="0">
+     <widget class="QRadioButton" name="radioButton_Audio_No">
+      <property name="text">
+       <string>None     Audio is played perfectly</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0" colspan="2">
+     <widget class="QLabel" name="lbl_Independent6">
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Does the game have any audio glitches / missing effects?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <spacer name="verticalSpacer6">
       <property name="orientation">
        <enum>Qt::Vertical</enum>
       </property>
@@ -206,7 +389,7 @@
     <string>Thank you for your submission!</string>
    </property>
    <attribute name="pageId">
-    <string notr="true">2</string>
+    <string notr="true">7</string>
    </attribute>
   </widget>
  </widget>

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -145,12 +145,14 @@ public:
             const char* tooltip;
         };
         // clang-format off
+        const auto ingame_status =
+                       CompatStatus{QStringLiteral("#f2d624"), QT_TR_NOOP("Ingame"),     QT_TR_NOOP("Game starts, but crashes or major glitches prevent it from being completed.")};
         static const std::map<QString, CompatStatus> status_data = {
-            {QStringLiteral("0"),  {QStringLiteral("#5c93ed"), QT_TR_NOOP("Perfect"),    QT_TR_NOOP("Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without\nany workarounds needed.")}},
-            {QStringLiteral("1"),  {QStringLiteral("#47d35c"), QT_TR_NOOP("Great"),      QT_TR_NOOP("Game functions with minor graphical or audio glitches and is playable from start to finish. May require some\nworkarounds.")}},
-            {QStringLiteral("2"),  {QStringLiteral("#94b242"), QT_TR_NOOP("Okay"),       QT_TR_NOOP("Game functions with major graphical or audio glitches, but game is playable from start to finish with\nworkarounds.")}},
-            {QStringLiteral("3"),  {QStringLiteral("#f2d624"), QT_TR_NOOP("Bad"),        QT_TR_NOOP("Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches\neven with workarounds.")}},
-            {QStringLiteral("4"),  {QStringLiteral("#FF0000"), QT_TR_NOOP("Intro/Menu"), QT_TR_NOOP("Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start\nScreen.")}},
+            {QStringLiteral("0"),  {QStringLiteral("#5c93ed"), QT_TR_NOOP("Perfect"),    QT_TR_NOOP("Game can be played without issues.")}},
+            {QStringLiteral("1"),  {QStringLiteral("#47d35c"), QT_TR_NOOP("Playable"),   QT_TR_NOOP("Game functions with minor graphical or audio glitches and is playable from start to finish.")}},
+            {QStringLiteral("2"),  ingame_status},
+            {QStringLiteral("3"),  ingame_status}, // Fallback for the removed "Okay" category
+            {QStringLiteral("4"),  {QStringLiteral("#FF0000"), QT_TR_NOOP("Intro/Menu"), QT_TR_NOOP("Game loads, but is unable to progress past the Start Screen.")}},
             {QStringLiteral("5"),  {QStringLiteral("#828282"), QT_TR_NOOP("Won't Boot"), QT_TR_NOOP("The game crashes when attempting to startup.")}},
             {QStringLiteral("99"), {QStringLiteral("#000000"), QT_TR_NOOP("Not Tested"), QT_TR_NOOP("The game has not yet been tested.")}},
         };

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2807,7 +2807,7 @@ void GMainWindow::OnMenuReportCompatibility() {
     const bool has_fma = caps.fma || caps.fma4;
     const auto processor_count = std::thread::hardware_concurrency();
     const bool has_4threads = processor_count == 0 || processor_count >= 4;
-    const bool has_8gb_ram = Common::GetMemInfo().TotalPhysicalMemory >= 8000000000;
+    const bool has_8gb_ram = Common::GetMemInfo().TotalPhysicalMemory >= 8_GiB;
     const bool has_broken_vulkan = UISettings::values.has_broken_vulkan;
 
     if (!has_fma || !has_4threads || !has_8gb_ram || has_broken_vulkan) {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2803,6 +2803,20 @@ void GMainWindow::ErrorDisplayDisplayError(QString error_code, QString error_tex
 }
 
 void GMainWindow::OnMenuReportCompatibility() {
+    const auto& caps = Common::GetCPUCaps();
+    const bool has_fma = caps.fma || caps.fma4;
+    const auto processor_count = std::thread::hardware_concurrency();
+    const bool has_4threads = processor_count == 0 || processor_count >= 4;
+    const bool has_8gb_ram = Common::GetMemInfo().TotalPhysicalMemory >= 8000000000;
+    const bool has_broken_vulkan = UISettings::values.has_broken_vulkan;
+
+    if (!has_fma || !has_4threads || !has_8gb_ram || has_broken_vulkan) {
+        QMessageBox::critical(this, tr("Hardware requirements not met"),
+                              tr("Your system does not meet the recommended hardware requirements. "
+                                 "Compatibility reporting has been disabled."));
+        return;
+    }
+
     if (!Settings::values.yuzu_token.GetValue().empty() &&
         !Settings::values.yuzu_username.GetValue().empty()) {
         CompatDB compatdb{system->TelemetrySession(), this};


### PR DESCRIPTION
This PR brings several improvements to the compatibility submission system, aimed at improving the quality of user reports:

 - Only users that match our recommended system requirements are able to submit reports
 - The submission form is now multi-page and asks specific questions from which it determines the compatibility status
 - The compatibility categories and their descriptions have been renamed to be more clear and the "Okay" category has been removed

Thanks to @german77 for providing an initial implementation of this concept.

Feedback on these changes is highly appreciated.
