### PR TITLE
audio_in/out_system: Pass Initialize members by value where applicable

### DIFF
--- a/src/audio_core/in/audio_in_system.cpp
+++ b/src/audio_core/in/audio_in_system.cpp
@@ -56,7 +56,7 @@ Result System::IsConfigValid(const std::string_view device_name,
     return ResultSuccess;
 }
 
-Result System::Initialize(std::string& device_name, const AudioInParameter& in_params,
+Result System::Initialize(std::string device_name, const AudioInParameter& in_params,
                           const u32 handle_, const u64 applet_resource_user_id_) {
     auto result{IsConfigValid(device_name, in_params)};
     if (result.IsError()) {

--- a/src/audio_core/in/audio_in_system.h
+++ b/src/audio_core/in/audio_in_system.h
@@ -97,7 +97,7 @@ public:
      * @param applet_resource_user_id - Unused.
      * @return Result code.
      */
-    Result Initialize(std::string& device_name, const AudioInParameter& in_params, u32 handle,
+    Result Initialize(std::string device_name, const AudioInParameter& in_params, u32 handle,
                       u64 applet_resource_user_id);
 
     /**

--- a/src/audio_core/out/audio_out_system.cpp
+++ b/src/audio_core/out/audio_out_system.cpp
@@ -49,8 +49,8 @@ Result System::IsConfigValid(std::string_view device_name,
     return Service::Audio::ERR_INVALID_CHANNEL_COUNT;
 }
 
-Result System::Initialize(std::string& device_name, const AudioOutParameter& in_params, u32 handle_,
-                          u64& applet_resource_user_id_) {
+Result System::Initialize(std::string device_name, const AudioOutParameter& in_params, u32 handle_,
+                          u64 applet_resource_user_id_) {
     auto result = IsConfigValid(device_name, in_params);
     if (result.IsError()) {
         return result;

--- a/src/audio_core/out/audio_out_system.h
+++ b/src/audio_core/out/audio_out_system.h
@@ -88,8 +88,8 @@ public:
      * @param applet_resource_user_id - Unused.
      * @return Result code.
      */
-    Result Initialize(std::string& device_name, const AudioOutParameter& in_params, u32 handle,
-                      u64& applet_resource_user_id);
+    Result Initialize(std::string device_name, const AudioOutParameter& in_params, u32 handle,
+                      u64 applet_resource_user_id);
 
     /**
      * Start this system.

--- a/src/core/hle/service/audio/audin_u.cpp
+++ b/src/core/hle/service/audio/audin_u.cpp
@@ -17,7 +17,7 @@ using namespace AudioCore::AudioIn;
 class IAudioIn final : public ServiceFramework<IAudioIn> {
 public:
     explicit IAudioIn(Core::System& system_, Manager& manager, size_t session_id,
-                      std::string& device_name, const AudioInParameter& in_params, u32 handle,
+                      const std::string& device_name, const AudioInParameter& in_params, u32 handle,
                       u64 applet_resource_user_id)
         : ServiceFramework{system_, "IAudioIn"},
           service_context{system_, "IAudioIn"}, event{service_context.CreateEvent("AudioInEvent")},

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -24,7 +24,7 @@ using namespace AudioCore::AudioOut;
 class IAudioOut final : public ServiceFramework<IAudioOut> {
 public:
     explicit IAudioOut(Core::System& system_, AudioCore::AudioOut::Manager& manager,
-                       size_t session_id, std::string& device_name,
+                       size_t session_id, const std::string& device_name,
                        const AudioOutParameter& in_params, u32 handle, u64 applet_resource_user_id)
         : ServiceFramework{system_, "IAudioOut", ServiceThreadType::CreateNew},
           service_context{system_, "IAudioOut"}, event{service_context.CreateEvent(


### PR DESCRIPTION
applet_resource_user_id isn't actually modified and is just assigned to a member variable, so this doesn't need to be a mutable reference.

Similarly, the device name itself isn't modified and is only moved. We pass by value here, since we can still perform the move, but eliminate a sneaky set of calls that can unintentionally destroy the original string. Given how nested the calls are, it's good to get rid of this potential vector for a use-after-move bug.