### PR TITLE
kernel: invert session request handling flow

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -86,13 +86,13 @@ public:
         u32 num_domain_objects{};
         const bool always_move_handles{
             (static_cast<u32>(flags) & static_cast<u32>(Flags::AlwaysMoveHandles)) != 0};
-        if (!ctx.Session()->GetSessionRequestManager()->IsDomain() || always_move_handles) {
+        if (!ctx.GetManager()->IsDomain() || always_move_handles) {
             num_handles_to_move = num_objects_to_move;
         } else {
             num_domain_objects = num_objects_to_move;
         }
 
-        if (ctx.Session()->GetSessionRequestManager()->IsDomain()) {
+        if (ctx.GetManager()->IsDomain()) {
             raw_data_size +=
                 static_cast<u32>(sizeof(DomainMessageHeader) / sizeof(u32) + num_domain_objects);
             ctx.write_size += num_domain_objects;
@@ -125,8 +125,7 @@ public:
         if (!ctx.IsTipc()) {
             AlignWithPadding();
 
-            if (ctx.Session()->GetSessionRequestManager()->IsDomain() &&
-                ctx.HasDomainMessageHeader()) {
+            if (ctx.GetManager()->IsDomain() && ctx.HasDomainMessageHeader()) {
                 IPC::DomainMessageHeader domain_header{};
                 domain_header.num_objects = num_domain_objects;
                 PushRaw(domain_header);
@@ -146,18 +145,18 @@ public:
 
     template <class T>
     void PushIpcInterface(std::shared_ptr<T> iface) {
-        if (context->Session()->GetSessionRequestManager()->IsDomain()) {
+        if (context->GetManager()->IsDomain()) {
             context->AddDomainObject(std::move(iface));
         } else {
             kernel.CurrentProcess()->GetResourceLimit()->Reserve(
                 Kernel::LimitableResource::Sessions, 1);
 
             auto* session = Kernel::KSession::Create(kernel);
-            session->Initialize(nullptr, iface->GetServiceName(),
-                                std::make_shared<Kernel::SessionRequestManager>(kernel));
+            session->Initialize(nullptr, iface->GetServiceName());
+            iface->RegisterSession(&session->GetServerSession(),
+                                   std::make_shared<Kernel::SessionRequestManager>(kernel));
 
             context->AddMoveObject(&session->GetClientSession());
-            iface->ClientConnected(&session->GetServerSession());
         }
     }
 
@@ -387,7 +386,7 @@ public:
 
     template <class T>
     std::weak_ptr<T> PopIpcInterface() {
-        ASSERT(context->Session()->GetSessionRequestManager()->IsDomain());
+        ASSERT(context->GetManager()->IsDomain());
         ASSERT(context->GetDomainMessageHeader().input_object_count > 0);
         return context->GetDomainHandler<T>(Pop<u32>() - 1);
     }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -45,11 +45,13 @@ class KAutoObject;
 class KernelCore;
 class KEvent;
 class KHandleTable;
+class KServerPort;
 class KProcess;
 class KServerSession;
 class KThread;
 class KReadableEvent;
 class KSession;
+class SessionRequestManager;
 class ServiceThread;
 
 enum class ThreadWakeupReason;
@@ -76,19 +78,9 @@ public:
     virtual Result HandleSyncRequest(Kernel::KServerSession& session,
                                      Kernel::HLERequestContext& context) = 0;
 
-    /**
-     * Signals that a client has just connected to this HLE handler and keeps the
-     * associated ServerSession alive for the duration of the connection.
-     * @param server_session Owning pointer to the ServerSession associated with the connection.
-     */
-    void ClientConnected(KServerSession* session);
-
-    /**
-     * Signals that a client has just disconnected from this HLE handler and releases the
-     * associated ServerSession.
-     * @param server_session ServerSession associated with the connection.
-     */
-    void ClientDisconnected(KServerSession* session);
+    void AcceptSession(KServerPort* server_port);
+    void RegisterSession(KServerSession* server_session,
+                         std::shared_ptr<SessionRequestManager> manager);
 
     std::weak_ptr<ServiceThread> GetServiceThread() const {
         return service_thread;
@@ -170,7 +162,6 @@ public:
 
     Result HandleDomainSyncRequest(KServerSession* server_session, HLERequestContext& context);
     Result CompleteSyncRequest(KServerSession* server_session, HLERequestContext& context);
-    Result QueueSyncRequest(KSession* parent, std::shared_ptr<HLERequestContext>&& context);
 
 private:
     bool convert_to_domain{};
@@ -350,17 +341,21 @@ public:
 
     template <typename T>
     std::shared_ptr<T> GetDomainHandler(std::size_t index) const {
-        return std::static_pointer_cast<T>(manager.lock()->DomainHandler(index).lock());
+        return std::static_pointer_cast<T>(GetManager()->DomainHandler(index).lock());
     }
 
     void SetSessionRequestManager(std::weak_ptr<SessionRequestManager> manager_) {
-        manager = std::move(manager_);
+        manager = manager_;
     }
 
     std::string Description() const;
 
     KThread& GetThread() {
         return *thread;
+    }
+
+    std::shared_ptr<SessionRequestManager> GetManager() const {
+        return manager.lock();
     }
 
 private:
@@ -396,7 +391,7 @@ private:
     u32 handles_offset{};
     u32 domain_offset{};
 
-    std::weak_ptr<SessionRequestManager> manager;
+    std::weak_ptr<SessionRequestManager> manager{};
 
     KernelCore& kernel;
     Core::Memory::Memory& memory;

--- a/src/core/hle/kernel/k_client_port.cpp
+++ b/src/core/hle/kernel/k_client_port.cpp
@@ -58,8 +58,7 @@ bool KClientPort::IsSignaled() const {
     return num_sessions < max_sessions;
 }
 
-Result KClientPort::CreateSession(KClientSession** out,
-                                  std::shared_ptr<SessionRequestManager> session_manager) {
+Result KClientPort::CreateSession(KClientSession** out) {
     // Reserve a new session from the resource limit.
     KScopedResourceReservation session_reservation(kernel.CurrentProcess()->GetResourceLimit(),
                                                    LimitableResource::Sessions);
@@ -104,7 +103,7 @@ Result KClientPort::CreateSession(KClientSession** out,
     }
 
     // Initialize the session.
-    session->Initialize(this, parent->GetName(), session_manager);
+    session->Initialize(this, parent->GetName());
 
     // Commit the session reservation.
     session_reservation.Commit();

--- a/src/core/hle/kernel/k_client_port.h
+++ b/src/core/hle/kernel/k_client_port.h
@@ -52,8 +52,7 @@ public:
     void Destroy() override;
     bool IsSignaled() const override;
 
-    Result CreateSession(KClientSession** out,
-                         std::shared_ptr<SessionRequestManager> session_manager = nullptr);
+    Result CreateSession(KClientSession** out);
 
 private:
     std::atomic<s32> num_sessions{};

--- a/src/core/hle/kernel/k_port.cpp
+++ b/src/core/hle/kernel/k_port.cpp
@@ -57,12 +57,6 @@ Result KPort::EnqueueSession(KServerSession* session) {
 
     server.EnqueueSession(session);
 
-    if (auto session_ptr = server.GetSessionRequestHandler().lock()) {
-        session_ptr->ClientConnected(server.AcceptSession());
-    } else {
-        ASSERT(false);
-    }
-
     return ResultSuccess;
 }
 

--- a/src/core/hle/kernel/k_server_port.cpp
+++ b/src/core/hle/kernel/k_server_port.cpp
@@ -19,6 +19,8 @@ void KServerPort::Initialize(KPort* parent_port_, std::string&& name_) {
     // Set member variables.
     parent = parent_port_;
     name = std::move(name_);
+
+    kernel.RegisterServerObject(this);
 }
 
 bool KServerPort::IsLight() const {
@@ -61,9 +63,6 @@ void KServerPort::Destroy() {
 
     // Close our reference to our parent.
     parent->Close();
-
-    // Release host emulation members.
-    session_handler.reset();
 
     // Ensure that the global list tracking server objects does not hold on to a reference.
     kernel.UnregisterServerObject(this);

--- a/src/core/hle/kernel/k_server_port.cpp
+++ b/src/core/hle/kernel/k_server_port.cpp
@@ -19,8 +19,6 @@ void KServerPort::Initialize(KPort* parent_port_, std::string&& name_) {
     // Set member variables.
     parent = parent_port_;
     name = std::move(name_);
-
-    kernel.RegisterServerObject(this);
 }
 
 bool KServerPort::IsLight() const {
@@ -63,9 +61,6 @@ void KServerPort::Destroy() {
 
     // Close our reference to our parent.
     parent->Close();
-
-    // Ensure that the global list tracking server objects does not hold on to a reference.
-    kernel.UnregisterServerObject(this);
 }
 
 bool KServerPort::IsSignaled() const {

--- a/src/core/hle/kernel/k_server_port.h
+++ b/src/core/hle/kernel/k_server_port.h
@@ -27,24 +27,6 @@ public:
 
     void Initialize(KPort* parent_port_, std::string&& name_);
 
-    /// Whether or not this server port has an HLE handler available.
-    bool HasSessionRequestHandler() const {
-        return !session_handler.expired();
-    }
-
-    /// Gets the HLE handler for this port.
-    SessionRequestHandlerWeakPtr GetSessionRequestHandler() const {
-        return session_handler;
-    }
-
-    /**
-     * Sets the HLE handler template for the port. ServerSessions crated by connecting to this port
-     * will inherit a reference to this handler.
-     */
-    void SetSessionHandler(SessionRequestHandlerWeakPtr&& handler) {
-        session_handler = std::move(handler);
-    }
-
     void EnqueueSession(KServerSession* pending_session);
 
     KServerSession* AcceptSession();
@@ -65,7 +47,6 @@ private:
     void CleanupSessions();
 
     SessionList session_list;
-    SessionRequestHandlerWeakPtr session_handler;
     KPort* parent{};
 };
 

--- a/src/core/hle/kernel/k_server_session.h
+++ b/src/core/hle/kernel/k_server_session.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2019 yuzu Emulator Project
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
@@ -16,21 +16,11 @@
 #include "core/hle/kernel/k_synchronization_object.h"
 #include "core/hle/result.h"
 
-namespace Core::Memory {
-class Memory;
-}
-
-namespace Core::Timing {
-class CoreTiming;
-struct EventType;
-} // namespace Core::Timing
-
 namespace Kernel {
 
 class HLERequestContext;
 class KernelCore;
 class KSession;
-class SessionRequestHandler;
 class SessionRequestManager;
 class KThread;
 
@@ -46,8 +36,7 @@ public:
 
     void Destroy() override;
 
-    void Initialize(KSession* parent_session_, std::string&& name_,
-                    std::shared_ptr<SessionRequestManager> manager_);
+    void Initialize(KSession* parent_session_, std::string&& name_);
 
     KSession* GetParent() {
         return parent;
@@ -60,31 +49,15 @@ public:
     bool IsSignaled() const override;
     void OnClientClosed();
 
-    /// Gets the session request manager, which forwards requests to the underlying service
-    std::shared_ptr<SessionRequestManager>& GetSessionRequestManager() {
-        return manager;
-    }
-
     /// TODO: flesh these out to match the real kernel
     Result OnRequest(KSessionRequest* request);
-    Result SendReply();
-    Result ReceiveRequest();
+    Result SendReply(bool is_hle = false);
+    Result ReceiveRequest(std::shared_ptr<HLERequestContext>* out_context = nullptr,
+                          std::weak_ptr<SessionRequestManager> manager = {});
 
 private:
     /// Frees up waiting client sessions when this server session is about to die
     void CleanupRequests();
-
-    /// Queues a sync request from the emulated application.
-    Result QueueSyncRequest(KThread* thread, Core::Memory::Memory& memory);
-
-    /// Completes a sync request from the emulated application.
-    Result CompleteSyncRequest(HLERequestContext& context);
-
-    /// This session's HLE request handlers; if nullptr, this is not an HLE server
-    std::shared_ptr<SessionRequestManager> manager;
-
-    /// When set to True, converts the session to a domain at the end of the command
-    bool convert_to_domain{};
 
     /// KSession that owns this KServerSession
     KSession* parent{};

--- a/src/core/hle/kernel/k_server_session.h
+++ b/src/core/hle/kernel/k_server_session.h
@@ -55,6 +55,10 @@ public:
     Result ReceiveRequest(std::shared_ptr<HLERequestContext>* out_context = nullptr,
                           std::weak_ptr<SessionRequestManager> manager = {});
 
+    Result SendReplyHLE() {
+        return SendReply(true);
+    }
+
 private:
     /// Frees up waiting client sessions when this server session is about to die
     void CleanupRequests();

--- a/src/core/hle/kernel/k_session.cpp
+++ b/src/core/hle/kernel/k_session.cpp
@@ -13,8 +13,7 @@ KSession::KSession(KernelCore& kernel_)
     : KAutoObjectWithSlabHeapAndContainer{kernel_}, server{kernel_}, client{kernel_} {}
 KSession::~KSession() = default;
 
-void KSession::Initialize(KClientPort* port_, const std::string& name_,
-                          std::shared_ptr<SessionRequestManager> manager_) {
+void KSession::Initialize(KClientPort* port_, const std::string& name_) {
     // Increment reference count.
     // Because reference count is one on creation, this will result
     // in a reference count of two. Thus, when both server and client are closed
@@ -26,7 +25,7 @@ void KSession::Initialize(KClientPort* port_, const std::string& name_,
     KAutoObject::Create(std::addressof(client));
 
     // Initialize our sub sessions.
-    server.Initialize(this, name_ + ":Server", manager_);
+    server.Initialize(this, name_ + ":Server");
     client.Initialize(this, name_ + ":Client");
 
     // Set state and name.

--- a/src/core/hle/kernel/k_session.h
+++ b/src/core/hle/kernel/k_session.h
@@ -21,8 +21,7 @@ public:
     explicit KSession(KernelCore& kernel_);
     ~KSession() override;
 
-    void Initialize(KClientPort* port_, const std::string& name_,
-                    std::shared_ptr<SessionRequestManager> manager_ = nullptr);
+    void Initialize(KClientPort* port_, const std::string& name_);
 
     void Finalize() override;
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -336,6 +336,8 @@ struct KernelCore::Impl {
         return this_id;
     }
 
+    static inline thread_local bool is_phantom_mode_for_singlecore{false};
+
     bool IsPhantomModeForSingleCore() const {
         return is_phantom_mode_for_singlecore;
     }
@@ -800,7 +802,6 @@ struct KernelCore::Impl {
 
     bool is_multicore{};
     std::atomic_bool is_shutting_down{};
-    bool is_phantom_mode_for_singlecore{};
     u32 single_core_thread_id{};
 
     std::array<u64, Core::Hardware::NUM_CPU_CORES> svc_ticks{};

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -45,6 +45,7 @@ class KPort;
 class KProcess;
 class KResourceLimit;
 class KScheduler;
+class KServerPort;
 class KServerSession;
 class KSession;
 class KSessionRequest;
@@ -62,6 +63,8 @@ class TimeManager;
 
 using ServiceInterfaceFactory =
     std::function<KClientPort&(Service::SM::ServiceManager&, Core::System&)>;
+
+using ServiceInterfaceHandlerFn = std::function<void(Service::SM::ServiceManager&, KServerPort*)>;
 
 namespace Init {
 struct KSlabResourceCounts;
@@ -192,8 +195,14 @@ public:
     /// Registers a named HLE service, passing a factory used to open a port to that service.
     void RegisterNamedService(std::string name, ServiceInterfaceFactory&& factory);
 
+    /// Registers a setup function for the named HLE service.
+    void RegisterInterfaceForNamedService(std::string name, ServiceInterfaceHandlerFn&& handler);
+
     /// Opens a port to a service previously registered with RegisterNamedService.
     KClientPort* CreateNamedServicePort(std::string name);
+
+    /// Accepts a session on a port created by CreateNamedServicePort.
+    void RegisterNamedServiceHandler(std::string name, KServerPort* server_port);
 
     /// Registers a server session or port with the gobal emulation state, to be freed on shutdown.
     /// This is necessary because we do not emulate processes for HLE sessions and ports.

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -204,14 +204,6 @@ public:
     /// Accepts a session on a port created by CreateNamedServicePort.
     void RegisterNamedServiceHandler(std::string name, KServerPort* server_port);
 
-    /// Registers a server session or port with the gobal emulation state, to be freed on shutdown.
-    /// This is necessary because we do not emulate processes for HLE sessions and ports.
-    void RegisterServerObject(KAutoObject* server_object);
-
-    /// Unregisters a server session or port previously registered with RegisterServerSession when
-    /// it was destroyed during the current emulation session.
-    void UnregisterServerObject(KAutoObject* server_object);
-
     /// Registers all kernel objects with the global emulation state, this is purely for tracking
     /// leaks after emulation has been shutdown.
     void RegisterKernelObject(KAutoObject* object);

--- a/src/core/hle/kernel/service_thread.cpp
+++ b/src/core/hle/kernel/service_thread.cpp
@@ -103,7 +103,7 @@ void ServiceThread::Impl::WaitAndProcessImpl() {
     Result service_rc = manager->CompleteSyncRequest(server_session, *context);
 
     // Reply to the client.
-    rc = server_session->SendReply(true);
+    rc = server_session->SendReplyHLE();
 
     if (rc == ResultSessionClosed || service_rc == IPC::ERR_REMOTE_PROCESS_DEAD) {
         SessionClosed(server_session, manager);

--- a/src/core/hle/kernel/service_thread.cpp
+++ b/src/core/hle/kernel/service_thread.cpp
@@ -1,15 +1,17 @@
-// SPDX-FileCopyrightText: Copyright 2020 yuzu Emulator Project
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <thread>
 #include <vector>
-#include <queue>
 
 #include "common/scope_exit.h"
 #include "common/thread.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/hle_ipc.h"
+#include "core/hle/kernel/k_event.h"
+#include "core/hle/kernel/k_scoped_resource_reservation.h"
 #include "core/hle/kernel/k_session.h"
 #include "core/hle/kernel/k_thread.h"
 #include "core/hle/kernel/kernel.h"
@@ -19,101 +21,201 @@ namespace Kernel {
 
 class ServiceThread::Impl final {
 public:
-    explicit Impl(KernelCore& kernel, std::size_t num_threads, const std::string& name);
+    explicit Impl(KernelCore& kernel, const std::string& service_name);
     ~Impl();
 
-    void QueueSyncRequest(KSession& session, std::shared_ptr<HLERequestContext>&& context);
+    void WaitAndProcessImpl();
+    void SessionClosed(KServerSession* server_session,
+                       std::shared_ptr<SessionRequestManager> manager);
+    void LoopProcess();
+
+    void RegisterServerSession(KServerSession* session,
+                               std::shared_ptr<SessionRequestManager> manager);
 
 private:
-    std::vector<std::jthread> threads;
-    std::queue<std::function<void()>> requests;
-    std::mutex queue_mutex;
-    std::condition_variable_any condition;
-    const std::string service_name;
+    KernelCore& kernel;
+
+    std::jthread m_thread;
+    std::mutex m_session_mutex;
+    std::vector<KServerSession*> m_sessions;
+    std::vector<std::shared_ptr<SessionRequestManager>> m_managers;
+    KEvent* m_wakeup_event;
+    KProcess* m_process;
+    std::atomic<bool> m_shutdown_requested;
+    const std::string m_service_name;
 };
 
-ServiceThread::Impl::Impl(KernelCore& kernel, std::size_t num_threads, const std::string& name)
-    : service_name{name} {
-    for (std::size_t i = 0; i < num_threads; ++i) {
-        threads.emplace_back([this, &kernel](std::stop_token stop_token) {
-            Common::SetCurrentThreadName(std::string{service_name}.c_str());
+void ServiceThread::Impl::WaitAndProcessImpl() {
+    // Create local list of waitable sessions.
+    std::vector<KSynchronizationObject*> objs;
+    std::vector<std::shared_ptr<SessionRequestManager>> managers;
 
-            // Wait for first request before trying to acquire a render context
-            {
-                std::unique_lock lock{queue_mutex};
-                condition.wait(lock, stop_token, [this] { return !requests.empty(); });
-            }
+    {
+        // Lock to get the list.
+        std::scoped_lock lk{m_session_mutex};
 
-            if (stop_token.stop_requested()) {
-                return;
-            }
+        // Resize to the needed quantity.
+        objs.resize(m_sessions.size() + 1);
+        managers.resize(m_managers.size());
 
-            // Allocate a dummy guest thread for this host thread.
-            kernel.RegisterHostThread();
+        // Copy to our local list.
+        std::copy(m_sessions.begin(), m_sessions.end(), objs.begin());
+        std::copy(m_managers.begin(), m_managers.end(), managers.begin());
 
-            while (true) {
-                std::function<void()> task;
+        // Insert the wakeup event at the end.
+        objs.back() = &m_wakeup_event->GetReadableEvent();
+    }
 
-                {
-                    std::unique_lock lock{queue_mutex};
-                    condition.wait(lock, stop_token, [this] { return !requests.empty(); });
+    // Wait on the list of sessions.
+    s32 index{-1};
+    Result rc = KSynchronizationObject::Wait(kernel, &index, objs.data(),
+                                             static_cast<s32>(objs.size()), -1);
+    ASSERT(!rc.IsFailure());
 
-                    if (stop_token.stop_requested()) {
-                        return;
-                    }
+    // If this was the wakeup event, clear it and finish.
+    if (index >= static_cast<s64>(objs.size() - 1)) {
+        m_wakeup_event->Clear();
+        return;
+    }
 
-                    if (requests.empty()) {
-                        continue;
-                    }
+    // This event is from a server session.
+    auto* server_session = static_cast<KServerSession*>(objs[index]);
+    auto& manager = managers[index];
 
-                    task = std::move(requests.front());
-                    requests.pop();
-                }
+    // Fetch the HLE request context.
+    std::shared_ptr<HLERequestContext> context;
+    rc = server_session->ReceiveRequest(&context, manager);
 
-                task();
-            }
-        });
+    // If the session was closed, handle that.
+    if (rc == ResultSessionClosed) {
+        SessionClosed(server_session, manager);
+
+        // Finish.
+        return;
+    }
+
+    // TODO: handle other cases
+    ASSERT(rc == ResultSuccess);
+
+    // Perform the request.
+    Result service_rc = manager->CompleteSyncRequest(server_session, *context);
+
+    // Reply to the client.
+    rc = server_session->SendReply(true);
+
+    if (rc == ResultSessionClosed || service_rc == IPC::ERR_REMOTE_PROCESS_DEAD) {
+        SessionClosed(server_session, manager);
+        return;
+    }
+
+    // TODO: handle other cases
+    ASSERT(rc == ResultSuccess);
+    ASSERT(service_rc == ResultSuccess);
+}
+
+void ServiceThread::Impl::SessionClosed(KServerSession* server_session,
+                                        std::shared_ptr<SessionRequestManager> manager) {
+    {
+        // Lock to get the list.
+        std::scoped_lock lk{m_session_mutex};
+
+        // Get the index of the session.
+        const auto index =
+            std::find(m_sessions.begin(), m_sessions.end(), server_session) - m_sessions.begin();
+        ASSERT(index < static_cast<s64>(m_sessions.size()));
+
+        // Remove the session and its manager.
+        m_sessions.erase(m_sessions.begin() + index);
+        m_managers.erase(m_managers.begin() + index);
+    }
+
+    // Close our reference to the server session.
+    server_session->Close();
+}
+
+void ServiceThread::Impl::LoopProcess() {
+    Common::SetCurrentThreadName(m_service_name.c_str());
+
+    kernel.RegisterHostThread();
+
+    while (!m_shutdown_requested.load()) {
+        WaitAndProcessImpl();
     }
 }
 
-void ServiceThread::Impl::QueueSyncRequest(KSession& session,
-                                           std::shared_ptr<HLERequestContext>&& context) {
+void ServiceThread::Impl::RegisterServerSession(KServerSession* server_session,
+                                                std::shared_ptr<SessionRequestManager> manager) {
+    // Open the server session.
+    server_session->Open();
+
     {
-        std::unique_lock lock{queue_mutex};
+        // Lock to get the list.
+        std::scoped_lock lk{m_session_mutex};
 
-        auto* server_session{&session.GetServerSession()};
-
-        // Open a reference to the session to ensure it is not closes while the service request
-        // completes asynchronously.
-        server_session->Open();
-
-        requests.emplace([server_session, context{std::move(context)}]() {
-            // Close the reference.
-            SCOPE_EXIT({ server_session->Close(); });
-
-            // Complete the service request.
-            server_session->CompleteSyncRequest(*context);
-        });
+        // Insert the session and manager.
+        m_sessions.push_back(server_session);
+        m_managers.push_back(manager);
     }
-    condition.notify_one();
+
+    // Signal the wakeup event.
+    m_wakeup_event->Signal();
 }
 
 ServiceThread::Impl::~Impl() {
-    condition.notify_all();
-    for (auto& thread : threads) {
-        thread.request_stop();
-        thread.join();
+    // Shut down the processing thread.
+    m_shutdown_requested.store(true);
+    m_wakeup_event->Signal();
+    m_thread.join();
+
+    // Lock mutex.
+    m_session_mutex.lock();
+
+    // Close all remaining sessions.
+    for (size_t i = 0; i < m_sessions.size(); i++) {
+        m_sessions[i]->Close();
     }
+
+    // Close event.
+    m_wakeup_event->GetReadableEvent().Close();
+    m_wakeup_event->Close();
+
+    // Close process.
+    m_process->Close();
 }
 
-ServiceThread::ServiceThread(KernelCore& kernel, std::size_t num_threads, const std::string& name)
-    : impl{std::make_unique<Impl>(kernel, num_threads, name)} {}
+ServiceThread::Impl::Impl(KernelCore& kernel_, const std::string& service_name)
+    : kernel{kernel_}, m_service_name{service_name} {
+    // Initialize process.
+    m_process = KProcess::Create(kernel);
+    KProcess::Initialize(m_process, kernel.System(), service_name,
+                         KProcess::ProcessType::KernelInternal, kernel.GetSystemResourceLimit());
+
+    // Reserve a new event from the process resource limit
+    KScopedResourceReservation event_reservation(m_process, LimitableResource::Events);
+    ASSERT(event_reservation.Succeeded());
+
+    // Initialize event.
+    m_wakeup_event = KEvent::Create(kernel);
+    m_wakeup_event->Initialize(m_process);
+
+    // Commit the event reservation.
+    event_reservation.Commit();
+
+    // Register the event.
+    KEvent::Register(kernel, m_wakeup_event);
+
+    // Start thread.
+    m_thread = std::jthread([this] { LoopProcess(); });
+}
+
+ServiceThread::ServiceThread(KernelCore& kernel, const std::string& name)
+    : impl{std::make_unique<Impl>(kernel, name)} {}
 
 ServiceThread::~ServiceThread() = default;
 
-void ServiceThread::QueueSyncRequest(KSession& session,
-                                     std::shared_ptr<HLERequestContext>&& context) {
-    impl->QueueSyncRequest(session, std::move(context));
+void ServiceThread::RegisterServerSession(KServerSession* session,
+                                          std::shared_ptr<SessionRequestManager> manager) {
+    impl->RegisterServerSession(session, manager);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/service_thread.h
+++ b/src/core/hle/kernel/service_thread.h
@@ -11,13 +11,15 @@ namespace Kernel {
 class HLERequestContext;
 class KernelCore;
 class KSession;
+class SessionRequestManager;
 
 class ServiceThread final {
 public:
-    explicit ServiceThread(KernelCore& kernel, std::size_t num_threads, const std::string& name);
+    explicit ServiceThread(KernelCore& kernel, const std::string& name);
     ~ServiceThread();
 
-    void QueueSyncRequest(KSession& session, std::shared_ptr<HLERequestContext>&& context);
+    void RegisterServerSession(KServerSession* session,
+                               std::shared_ptr<SessionRequestManager> manager);
 
 private:
     class Impl;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -24,6 +24,7 @@
 #include "core/hle/kernel/k_memory_block.h"
 #include "core/hle/kernel/k_memory_layout.h"
 #include "core/hle/kernel/k_page_table.h"
+#include "core/hle/kernel/k_port.h"
 #include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_readable_event.h"
 #include "core/hle/kernel/k_resource_limit.h"
@@ -382,9 +383,10 @@ static Result ConnectToNamedPort(Core::System& system, Handle* out, VAddr port_n
 
     // Create a session.
     KClientSession* session{};
-    R_TRY(port->CreateSession(std::addressof(session),
-                              std::make_shared<SessionRequestManager>(kernel)));
+    R_TRY(port->CreateSession(std::addressof(session)));
     port->Close();
+
+    kernel.RegisterNamedServiceHandler(port_name, &port->GetParent()->GetServerPort());
 
     // Register the session in the table, close the extra reference.
     handle_table.Register(*out, session);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -384,7 +384,6 @@ static Result ConnectToNamedPort(Core::System& system, Handle* out, VAddr port_n
     // Create a session.
     KClientSession* session{};
     R_TRY(port->CreateSession(std::addressof(session)));
-    port->Close();
 
     kernel.RegisterNamedServiceHandler(port_name, &port->GetParent()->GetServerPort());
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -99,6 +99,10 @@ ServiceFrameworkBase::ServiceFrameworkBase(Core::System& system_, const char* se
 ServiceFrameworkBase::~ServiceFrameworkBase() {
     // Wait for other threads to release access before destroying
     const auto guard = LockService();
+
+    if (named_port != nullptr) {
+        named_port->Close();
+    }
 }
 
 void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager) {
@@ -115,13 +119,12 @@ Kernel::KClientPort& ServiceFrameworkBase::CreatePort() {
 
     ASSERT(!service_registered);
 
-    auto* port = Kernel::KPort::Create(kernel);
-    port->Initialize(max_sessions, false, service_name);
-    port->GetServerPort().SetSessionHandler(shared_from_this());
+    named_port = Kernel::KPort::Create(kernel);
+    named_port->Initialize(max_sessions, false, service_name);
 
     service_registered = true;
 
-    return port->GetClientPort();
+    return named_port->GetClientPort();
 }
 
 void ServiceFrameworkBase::RegisterHandlersBase(const FunctionInfoBase* functions, std::size_t n) {
@@ -199,7 +202,6 @@ Result ServiceFrameworkBase::HandleSyncRequest(Kernel::KServerSession& session,
     switch (ctx.GetCommandType()) {
     case IPC::CommandType::Close:
     case IPC::CommandType::TIPC_Close: {
-        session.Close();
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultSuccess);
         result = IPC::ERR_REMOTE_PROCESS_DEAD;
@@ -244,6 +246,7 @@ Services::Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system
     system.GetFileSystemController().CreateFactories(*system.GetFilesystem(), false);
 
     system.Kernel().RegisterNamedService("sm:", SM::ServiceManager::InterfaceFactory);
+    system.Kernel().RegisterInterfaceForNamedService("sm:", SM::ServiceManager::SessionHandler);
 
     Account::InstallInterfaces(system);
     AM::InstallInterfaces(*sm, *nv_flinger, system);

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -119,12 +119,14 @@ void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager)
 Kernel::KClientPort& ServiceFrameworkBase::CreatePort() {
     const auto guard = LockService();
 
-    ASSERT(!service_registered);
+    if (named_port == nullptr) {
+        ASSERT(!service_registered);
 
-    named_port = Kernel::KPort::Create(kernel);
-    named_port->Initialize(max_sessions, false, service_name);
+        named_port = Kernel::KPort::Create(kernel);
+        named_port->Initialize(max_sessions, false, service_name);
 
-    service_registered = true;
+        service_registered = true;
+    }
 
     return named_port->GetClientPort();
 }

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -101,7 +101,9 @@ ServiceFrameworkBase::~ServiceFrameworkBase() {
     const auto guard = LockService();
 
     if (named_port != nullptr) {
-        named_port->Close();
+        named_port->GetClientPort().Close();
+        named_port->GetServerPort().Close();
+        named_port = nullptr;
     }
 }
 

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -20,6 +20,7 @@ class System;
 namespace Kernel {
 class HLERequestContext;
 class KClientPort;
+class KPort;
 class KServerSession;
 class ServiceThread;
 } // namespace Kernel
@@ -97,6 +98,9 @@ protected:
 
     /// Identifier string used to connect to the service.
     std::string service_name;
+
+    /// Port used by ManageNamedPort.
+    Kernel::KPort* named_port{};
 
 private:
     template <typename T>

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -51,6 +51,7 @@ private:
 class ServiceManager {
 public:
     static Kernel::KClientPort& InterfaceFactory(ServiceManager& self, Core::System& system);
+    static void SessionHandler(ServiceManager& self, Kernel::KServerPort* server_port);
 
     explicit ServiceManager(Kernel::KernelCore& kernel_);
     ~ServiceManager();

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -79,6 +79,7 @@ private:
 
     /// Map of registered services, retrieved using GetServicePort.
     std::unordered_map<std::string, Kernel::SessionRequestHandlerPtr> registered_services;
+    std::unordered_map<std::string, Kernel::KPort*> service_ports;
 
     /// Kernel context
     Kernel::KernelCore& kernel;

--- a/src/core/hle/service/sm/sm_controller.cpp
+++ b/src/core/hle/service/sm/sm_controller.cpp
@@ -33,16 +33,13 @@ void Controller::CloneCurrentObject(Kernel::HLERequestContext& ctx) {
     // FIXME: this is duplicated from the SVC, it should just call it instead
     // once this is a proper process
 
-    // Declare the session we're going to allocate.
-    Kernel::KSession* session;
-
     // Reserve a new session from the process resource limit.
     Kernel::KScopedResourceReservation session_reservation(&process,
                                                            Kernel::LimitableResource::Sessions);
     ASSERT(session_reservation.Succeeded());
 
     // Create the session.
-    session = Kernel::KSession::Create(system.Kernel());
+    Kernel::KSession* session = Kernel::KSession::Create(system.Kernel());
     ASSERT(session != nullptr);
 
     // Initialize the session.


### PR DESCRIPTION
This is a major refactor of how service handling works for multiprocess. This is required as the first step for properly demoting services to userspace processes (where they belong). It removes essentially all of the remaining HLE IPC logic from KServerSession and places it into the session manager.

With this, instead of pushing requests to services, service threads will wait for and pull the requests themselves. There is still much more that is blocked on the kernel and service processes not having their own emulated address spaces, but this is out of scope for these changes.