### PR TITLE
vk_scheduler: Remove recorded_counts

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -144,7 +144,6 @@ private:
             using FuncType = TypedCommand<T>;
             static_assert(sizeof(FuncType) < sizeof(data), "Lambda is too large");
 
-            recorded_counts++;
             command_offset = Common::AlignUp(command_offset, alignof(FuncType));
             if (command_offset > sizeof(data) - sizeof(FuncType)) {
                 return false;
@@ -166,7 +165,7 @@ private:
         }
 
         bool Empty() const {
-            return recorded_counts == 0;
+            return command_offset == 0;
         }
 
         bool HasSubmit() const {
@@ -177,7 +176,6 @@ private:
         Command* first = nullptr;
         Command* last = nullptr;
 
-        size_t recorded_counts = 0;
         size_t command_offset = 0;
         bool submit = false;
         alignas(std::max_align_t) std::array<u8, 0x8000> data{};


### PR DESCRIPTION
`recorded_counts` was never reset to 0 which could lead to the scheduler submitting empty chunks. It's only used to check whether the chunk is empty and we can just use the offset to do that.
