### PR TITLE
k_server_session: fix crashes

### DIFF
--- a/src/core/hle/kernel/k_server_session.h
+++ b/src/core/hle/kernel/k_server_session.h
@@ -91,7 +91,7 @@ private:
 
     /// List of threads which are pending a reply.
     boost::intrusive::list<KSessionRequest> m_request_list;
-    KSessionRequest* m_current_request;
+    KSessionRequest* m_current_request{};
 
     KLightLock m_lock;
 };

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -80,7 +80,6 @@ ResultVal<Kernel::KPort*> ServiceManager::GetServicePort(const std::string& name
     }
 
     auto* port = Kernel::KPort::Create(kernel);
-    SCOPE_EXIT({ port->Close(); });
 
     port->Initialize(ServerSessionCountMax, false, name);
     auto handler = it->second;


### PR DESCRIPTION
Fixes two issues which arose after #9078:

- KPort is intended to be owned only by the client port and server port. Therefore Close() should never be called on it except by the KClientPort and KServerPort Destroy method. The client port is closed immediately which then closed the parent. This caused the server port to later try to reference invalid memory when closing.
- m_current_request in KServerSession wasn't default-initialized, and caused CleanupRequests to sometimes reference invalid memory.