### PR TITLE
vk_blit_screen: recreate swapchain images on guest format change

### DIFF
--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -480,11 +480,15 @@ void BlitScreen::RefreshResources(const Tegra::FramebufferConfig& framebuffer) {
         fsr.reset();
     }
 
-    if (framebuffer.width == raw_width && framebuffer.height == raw_height && !raw_images.empty()) {
+    if (framebuffer.width == raw_width && framebuffer.height == raw_height &&
+        framebuffer.pixel_format == pixel_format && !raw_images.empty()) {
         return;
     }
+
     raw_width = framebuffer.width;
     raw_height = framebuffer.height;
+    pixel_format = framebuffer.pixel_format;
+
     ReleaseRawImages();
 
     CreateStagingBuffer(framebuffer);

--- a/src/video_core/renderer_vulkan/vk_blit_screen.h
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.h
@@ -28,6 +28,10 @@ namespace VideoCore {
 class RasterizerInterface;
 }
 
+namespace Service::android {
+enum class PixelFormat : u32;
+}
+
 namespace Vulkan {
 
 struct ScreenInfo;
@@ -156,6 +160,7 @@ private:
 
     u32 raw_width = 0;
     u32 raw_height = 0;
+    Service::android::PixelFormat pixel_format{};
 
     std::unique_ptr<FSR> fsr;
 };


### PR DESCRIPTION
This allows applications that don't use the RGBA8 buffer format to render correctly when launched from hbmenu, and not flicker incessantly.

|Frame|Before|After|
|-|-|-|
|Odd|![010000000000100d_2022-10-30_15-06-30-738](https://user-images.githubusercontent.com/9658600/198896966-ff5f86c8-28df-4291-bba1-211ac256e621.png)|![010000000000100d_2022-10-30_15-05-11-258](https://user-images.githubusercontent.com/9658600/198896974-3e644738-58da-4db6-9993-0859227ba023.png)|
|Even|![010000000000100d_2022-10-30_15-06-14-010](https://user-images.githubusercontent.com/9658600/198896992-b875292a-1ff9-4524-9bac-e42eb1598064.png)|![010000000000100d_2022-10-30_15-05-11-258](https://user-images.githubusercontent.com/9658600/198896974-3e644738-58da-4db6-9993-0859227ba023.png)|