### PR TITLE
core: hle: service: acc: Fix ListOpenContextStoredUsers/StoreOpenContext.

### DIFF
--- a/src/core/hle/service/acc/acc.h
+++ b/src/core/hle/service/acc/acc.h
@@ -35,7 +35,6 @@ public:
         void InitializeApplicationInfoV2(Kernel::HLERequestContext& ctx);
         void GetProfileEditor(Kernel::HLERequestContext& ctx);
         void ListQualifiedUsers(Kernel::HLERequestContext& ctx);
-        void LoadOpenContext(Kernel::HLERequestContext& ctx);
         void ListOpenContextStoredUsers(Kernel::HLERequestContext& ctx);
         void StoreSaveDataThumbnailApplication(Kernel::HLERequestContext& ctx);
         void StoreSaveDataThumbnailSystem(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/acc/acc_u0.cpp
+++ b/src/core/hle/service/acc/acc_u0.cpp
@@ -28,7 +28,7 @@ ACC_U0::ACC_U0(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> 
         {110, &ACC_U0::StoreSaveDataThumbnailApplication, "StoreSaveDataThumbnail"},
         {111, nullptr, "ClearSaveDataThumbnail"},
         {120, nullptr, "CreateGuestLoginRequest"},
-        {130, &ACC_U0::LoadOpenContext, "LoadOpenContext"}, // 5.0.0+
+        {130, nullptr, "LoadOpenContext"}, // 5.0.0+
         {131, &ACC_U0::ListOpenContextStoredUsers, "ListOpenContextStoredUsers"}, // 6.0.0+
         {140, &ACC_U0::InitializeApplicationInfoRestricted, "InitializeApplicationInfoRestricted"}, // 6.0.0+
         {141, &ACC_U0::ListQualifiedUsers, "ListQualifiedUsers"}, // 6.0.0+

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -86,6 +86,8 @@ public:
     UserIDArray GetOpenUsers() const;
     UserIDArray GetAllUsers() const;
     Common::UUID GetLastOpenedUser() const;
+    UserIDArray GetStoredOpenedUsers() const;
+    void StoreOpenedUsers();
 
     bool CanSystemRegisterUser() const;
 
@@ -101,6 +103,7 @@ private:
     bool RemoveProfileAtIndex(std::size_t index);
 
     std::array<ProfileInfo, MAX_USERS> profiles{};
+    std::array<ProfileInfo, MAX_USERS> stored_opened_profiles{};
     std::size_t user_count{};
     Common::UUID last_opened_user{};
 };


### PR DESCRIPTION
- These APIs are used to capture the opened users and allow that state to be persisted across processes.
- They are not intended to just return the system opened users, that is what ListOpenUsers is for.
- Fixes the launch hang with Bayonetta 3.