### PR TITLE
kernel: more complete fix for KPort reference counting

### DIFF
--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -149,9 +149,10 @@ ResultVal<Kernel::KClientSession*> SM::GetServiceImpl(Kernel::HLERequestContext&
         return port_result.Code();
     }
     auto& port = port_result.Unwrap();
-    SCOPE_EXIT({ port->GetClientPort().Close(); });
-
-    kernel.RegisterServerObject(&port->GetServerPort());
+    SCOPE_EXIT({
+        port->GetClientPort().Close();
+        port->GetServerPort().Close();
+    });
 
     // Create a new session.
     Kernel::KClientSession* session{};


### PR DESCRIPTION
Follow up to #9148

Since the current code intends for the port to be closed immediately, it should be closed immediately. This prevents the KPort slab heap from running out of space. Furthermore, the port cannot be referenced when cloning the object, since it will have been closed at that point, so the implementation of CreateSession should be used instead.

Fixes crashes in Pokemon: Let's Go (Pikachu/Eevee) and Sword, and probably other games.