### PR TITLE
ir/texture_pass: Use host_info instead of querying Settings::values

### DIFF
--- a/src/shader_recompiler/frontend/maxwell/translate_program.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate_program.cpp
@@ -223,7 +223,7 @@ IR::Program TranslateProgram(ObjectPool<IR::Inst>& inst_pool, ObjectPool<IR::Blo
     Optimization::PositionPass(env, program);
 
     Optimization::GlobalMemoryToStorageBufferPass(program);
-    Optimization::TexturePass(env, program);
+    Optimization::TexturePass(env, program, host_info);
 
     if (Settings::values.resolution_info.active) {
         Optimization::RescalingPass(program);

--- a/src/shader_recompiler/host_translate_info.h
+++ b/src/shader_recompiler/host_translate_info.h
@@ -13,6 +13,7 @@ struct HostTranslateInfo {
     bool support_float16{};      ///< True when the device supports 16-bit floats
     bool support_int64{};        ///< True when the device supports 64-bit integers
     bool needs_demote_reorder{}; ///< True when the device needs DemoteToHelperInvocation reordered
+    bool support_snorm_render_buffer{}; ///< True when the device supports SNORM render buffers
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/ir_opt/passes.h
+++ b/src/shader_recompiler/ir_opt/passes.h
@@ -6,6 +6,10 @@
 #include "shader_recompiler/environment.h"
 #include "shader_recompiler/frontend/ir/program.h"
 
+namespace Shader {
+struct HostTranslateInfo;
+}
+
 namespace Shader::Optimization {
 
 void CollectShaderInfoPass(Environment& env, IR::Program& program);
@@ -18,7 +22,7 @@ void LowerInt64ToInt32(IR::Program& program);
 void RescalingPass(IR::Program& program);
 void SsaRewritePass(IR::Program& program);
 void PositionPass(Environment& env, IR::Program& program);
-void TexturePass(Environment& env, IR::Program& program);
+void TexturePass(Environment& env, IR::Program& program, const HostTranslateInfo& host_info);
 void VerificationPass(const IR::Program& program);
 
 // Dual Vertex

--- a/src/shader_recompiler/ir_opt/texture_pass.cpp
+++ b/src/shader_recompiler/ir_opt/texture_pass.cpp
@@ -7,11 +7,11 @@
 
 #include <boost/container/small_vector.hpp>
 
-#include "common/settings.h"
 #include "shader_recompiler/environment.h"
 #include "shader_recompiler/frontend/ir/basic_block.h"
 #include "shader_recompiler/frontend/ir/breadth_first_search.h"
 #include "shader_recompiler/frontend/ir/ir_emitter.h"
+#include "shader_recompiler/host_translate_info.h"
 #include "shader_recompiler/ir_opt/passes.h"
 #include "shader_recompiler/shader_info.h"
 
@@ -494,7 +494,7 @@ void PathTexelFetch(IR::Block& block, IR::Inst& inst, TexturePixelFormat pixel_f
 }
 } // Anonymous namespace
 
-void TexturePass(Environment& env, IR::Program& program) {
+void TexturePass(Environment& env, IR::Program& program, const HostTranslateInfo& host_info) {
     TextureInstVector to_replace;
     for (IR::Block* const block : program.post_order_blocks) {
         for (IR::Inst& inst : block->Instructions()) {
@@ -639,8 +639,8 @@ void TexturePass(Environment& env, IR::Program& program) {
             inst->SetArg(0, IR::Value{});
         }
 
-        if (Settings::values.renderer_backend.GetValue() == Settings::RendererBackend::OpenGL &&
-            inst->GetOpcode() == IR::Opcode::ImageFetch && flags.type == TextureType::Buffer) {
+        if (!host_info.support_snorm_render_buffer && inst->GetOpcode() == IR::Opcode::ImageFetch &&
+            flags.type == TextureType::Buffer) {
             const auto pixel_format = ReadTexturePixelFormat(env, cbuf);
             if (pixel_format != TexturePixelFormat::OTHER) {
                 PathTexelFetch(*texture_inst.block, *texture_inst.inst, pixel_format);

--- a/src/shader_recompiler/ir_opt/texture_pass.cpp
+++ b/src/shader_recompiler/ir_opt/texture_pass.cpp
@@ -461,7 +461,7 @@ void PatchImageSampleImplicitLod(IR::Block& block, IR::Inst& inst) {
                         ir.FPRecip(ir.ConvertUToF(32, 32, ir.CompositeExtract(texture_size, 1))))));
 }
 
-void PathTexelFetch(IR::Block& block, IR::Inst& inst, TexturePixelFormat pixel_format) {
+void PatchTexelFetch(IR::Block& block, IR::Inst& inst, TexturePixelFormat pixel_format) {
     const auto it{IR::Block::InstructionList::s_iterator_to(inst)};
     IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
     auto get_max_value = [pixel_format]() -> float {
@@ -643,7 +643,7 @@ void TexturePass(Environment& env, IR::Program& program, const HostTranslateInfo
             flags.type == TextureType::Buffer) {
             const auto pixel_format = ReadTexturePixelFormat(env, cbuf);
             if (pixel_format != TexturePixelFormat::OTHER) {
-                PathTexelFetch(*texture_inst.block, *texture_inst.inst, pixel_format);
+                PatchTexelFetch(*texture_inst.block, *texture_inst.inst, pixel_format);
             }
         }
     }

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -2970,7 +2970,7 @@ public:
                 CullFace gl_cull_face;                                                 ///< 0x1920
                 Viewport::PixelCenter viewport_pixel_center;                           ///< 0x1924
                 INSERT_PADDING_BYTES_NOINIT(0x4);
-                u32 viewport_scale_offset_enbled;                                      ///< 0x192C
+                u32 viewport_scale_offset_enabled;                                     ///< 0x192C
                 INSERT_PADDING_BYTES_NOINIT(0xC);
                 ViewportClipControl viewport_clip_control;                             ///< 0x193C
                 UserClip::Op user_clip_op;                                             ///< 0x1940
@@ -3482,7 +3482,7 @@ ASSERT_REG_POSITION(gl_cull_test_enabled, 0x1918);
 ASSERT_REG_POSITION(gl_front_face, 0x191C);
 ASSERT_REG_POSITION(gl_cull_face, 0x1920);
 ASSERT_REG_POSITION(viewport_pixel_center, 0x1924);
-ASSERT_REG_POSITION(viewport_scale_offset_enbled, 0x192C);
+ASSERT_REG_POSITION(viewport_scale_offset_enabled, 0x192C);
 ASSERT_REG_POSITION(viewport_clip_control, 0x193C);
 ASSERT_REG_POSITION(user_clip_op, 0x1940);
 ASSERT_REG_POSITION(render_enable_override, 0x1944);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -618,7 +618,7 @@ void RasterizerOpenGL::SyncViewport() {
             }
             flags[Dirty::Viewport0 + index] = false;
 
-            if (!regs.viewport_scale_offset_enbled) {
+            if (!regs.viewport_scale_offset_enabled) {
                 const auto x = static_cast<GLfloat>(regs.surface_clip.x);
                 const auto y = static_cast<GLfloat>(regs.surface_clip.y);
                 const auto width = static_cast<GLfloat>(regs.surface_clip.width);

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -218,6 +218,7 @@ ShaderCache::ShaderCache(RasterizerOpenGL& rasterizer_, Core::Frontend::EmuWindo
           .support_float16 = false,
           .support_int64 = device.HasShaderInt64(),
           .needs_demote_reorder = device.IsAmd(),
+          .support_snorm_render_buffer = false,
       } {
     if (use_asynchronous_shaders) {
         workers = CreateWorkers();

--- a/src/video_core/renderer_opengl/gl_state_tracker.cpp
+++ b/src/video_core/renderer_opengl/gl_state_tracker.cpp
@@ -70,8 +70,8 @@ void SetupDirtyViewports(Tables& tables) {
     FillBlock(tables[1], OFF(viewport_transform), NUM(viewport_transform), Viewports);
     FillBlock(tables[1], OFF(viewports), NUM(viewports), Viewports);
 
-    tables[0][OFF(viewport_scale_offset_enbled)] = ViewportTransform;
-    tables[1][OFF(viewport_scale_offset_enbled)] = Viewports;
+    tables[0][OFF(viewport_scale_offset_enabled)] = ViewportTransform;
+    tables[1][OFF(viewport_scale_offset_enabled)] = Viewports;
 }
 
 void SetupDirtyScissors(Tables& tables) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -325,6 +325,7 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .support_int64 = device.IsShaderInt64Supported(),
         .needs_demote_reorder = driver_id == VK_DRIVER_ID_AMD_PROPRIETARY_KHR ||
                                 driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR,
+        .support_snorm_render_buffer = true,
     };
 }
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -683,7 +683,7 @@ void RasterizerVulkan::UpdateViewportsState(Tegra::Engines::Maxwell3D::Regs& reg
     if (!state_tracker.TouchViewports()) {
         return;
     }
-    if (!regs.viewport_scale_offset_enbled) {
+    if (!regs.viewport_scale_offset_enabled) {
         const auto x = static_cast<float>(regs.surface_clip.x);
         const auto y = static_cast<float>(regs.surface_clip.y);
         const auto width = static_cast<float>(regs.surface_clip.width);

--- a/src/video_core/renderer_vulkan/vk_state_tracker.cpp
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.cpp
@@ -51,7 +51,7 @@ Flags MakeInvalidationFlags() {
 void SetupDirtyViewports(Tables& tables) {
     FillBlock(tables[0], OFF(viewport_transform), NUM(viewport_transform), Viewports);
     FillBlock(tables[0], OFF(viewports), NUM(viewports), Viewports);
-    tables[0][OFF(viewport_scale_offset_enbled)] = Viewports;
+    tables[0][OFF(viewport_scale_offset_enabled)] = Viewports;
     tables[1][OFF(window_origin)] = Viewports;
 }
 

--- a/src/video_core/shader_environment.cpp
+++ b/src/video_core/shader_environment.cpp
@@ -352,7 +352,7 @@ Shader::TexturePixelFormat GraphicsEnvironment::ReadTexturePixelFormat(u32 handl
 
 u32 GraphicsEnvironment::ReadViewportTransformState() {
     const auto& regs{maxwell3d->regs};
-    viewport_transform_state = regs.viewport_scale_offset_enbled;
+    viewport_transform_state = regs.viewport_scale_offset_enabled;
     return viewport_transform_state;
 }
 


### PR DESCRIPTION
Adds a new entry `support_snorm_render_buffer` to determine whether the host device supports rendering to SNORM render buffers.