### PR TITLE
UI: split up strings relating to content removal

### DIFF
--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -324,9 +324,10 @@ private slots:
     void OnMouseActivity();
 
 private:
-    void RemoveBaseContent(u64 program_id, const QString& entry_type);
-    void RemoveUpdateContent(u64 program_id, const QString& entry_type);
-    void RemoveAddOnContent(u64 program_id, const QString& entry_type);
+    QString GetGameListErrorRemoving(InstalledEntryType type) const;
+    void RemoveBaseContent(u64 program_id, InstalledEntryType type);
+    void RemoveUpdateContent(u64 program_id, InstalledEntryType type);
+    void RemoveAddOnContent(u64 program_id, InstalledEntryType type);
     void RemoveTransferableShaderCache(u64 program_id, GameListRemoveTarget target);
     void RemoveAllTransferableShaderCaches(u64 program_id);
     void RemoveCustomConfiguration(u64 program_id, const std::string& game_path);


### PR DESCRIPTION
Requested by Italian translator (Fs00 in Discord)

"Remove Installed Game %1?"
"Error Removing %1"

I didn't press for translated strings, so have a taste direct from deepl

Rimuovere il contenuto del gioco installato?
Rimuovere l'aggiornamento del gioco installato?
Rimuovere il DLC del gioco installato?


-------
UI Element in question
![image](https://user-images.githubusercontent.com/190571/199968681-b352f3d4-41fb-479f-becb-969bf293207a.png)

Request from our discord 
> Hello everyone! I've found out an issue regarding a particular translatable string in Yuzu: "Remove Installed Game %1?".
Since I wasn't able to understand what the placeholder was for, I dug into the code and discovered that the %1 can get replaced with Contents, Update or DLC (https://github.com/yuzu-emu/yuzu/blob/master/src/yuzu/main.cpp#L1999-L2016).
The problem is that the code is assuming that the part leading to the placeholder ("Remove Installed Game") won't change regardless of the placeholder, which is not the case in other languages such as Italian. In the latter language for example, I need to add an article before Contents, Update or DLC which is not the same in all cases.
So, instead of using a placeholder, I'd recommend having 3 different translatable strings for the 3 scenarios ("Remove Installed Game Contents?", "Remove Installed Game Update?", "Remove Installed Game DLC?") in order to leave more room to translators. Thank you!

Note: [Updated code link](https://github.com/yuzu-emu/yuzu/blob/9fc1bcc7b2da398d12327e8111c21e453a4af27d/src/yuzu/main.cpp#L2021-L2036)