### PR TITLE
Qt: enable recent Linux features on BSDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,11 +218,11 @@ if(ENABLE_QT)
     set(QT_VERSION 5.15)
 
     # Check for system Qt on Linux, fallback to bundled Qt
-    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    if (UNIX AND NOT APPLE)
         if (NOT YUZU_USE_BUNDLED_QT)
             find_package(Qt5 ${QT_VERSION} COMPONENTS Widgets DBus Multimedia)
         endif()
-        if (NOT Qt5_FOUND OR YUZU_USE_BUNDLED_QT)
+        if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND (NOT Qt5_FOUND OR YUZU_USE_BUNDLED_QT))
             # Check for dependencies, then enable bundled Qt download
 
             # Check that the system GLIBCXX version is compatible
@@ -323,7 +323,7 @@ if(ENABLE_QT)
 
         set(YUZU_QT_NO_CMAKE_SYSTEM_PATH "NO_CMAKE_SYSTEM_PATH")
     endif()
-    if ((${CMAKE_SYSTEM_NAME} STREQUAL "Linux") AND YUZU_USE_BUNDLED_QT)
+    if (UNIX AND NOT APPLE AND YUZU_USE_BUNDLED_QT)
         find_package(Qt5 ${QT_VERSION} REQUIRED COMPONENTS Widgets Concurrent Multimedia DBus ${QT_PREFIX_HINT} ${YUZU_QT_NO_CMAKE_SYSTEM_PATH})
     else()
         find_package(Qt5 ${QT_VERSION} REQUIRED COMPONENTS Widgets Concurrent Multimedia ${QT_PREFIX_HINT} ${YUZU_QT_NO_CMAKE_SYSTEM_PATH})

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -315,7 +315,7 @@ target_include_directories(yuzu PRIVATE ../../externals/Vulkan-Headers/include)
 if (NOT WIN32)
     target_include_directories(yuzu PRIVATE ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if (UNIX AND NOT APPLE)
     target_link_libraries(yuzu PRIVATE Qt::DBus)
 endif()
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -9,7 +9,7 @@
 #ifdef __APPLE__
 #include <unistd.h> // for chdir
 #endif
-#ifdef __linux__
+#ifdef __unix__
 #include <csignal>
 #include <sys/socket.h>
 #endif
@@ -275,7 +275,7 @@ static void OverrideWindowsFont() {
 #endif
 
 bool GMainWindow::CheckDarkMode() {
-#ifdef __linux__
+#ifdef __unix__
     const QPalette test_palette(qApp->palette());
     const QColor text_color = test_palette.color(QPalette::Active, QPalette::Text);
     const QColor window_color = test_palette.color(QPalette::Active, QPalette::Window);
@@ -283,7 +283,7 @@ bool GMainWindow::CheckDarkMode() {
 #else
     // TODO: Windows
     return false;
-#endif // __linux__
+#endif // __unix__
 }
 
 GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan)
@@ -291,7 +291,7 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
       input_subsystem{std::make_shared<InputCommon::InputSubsystem>()}, config{std::move(config_)},
       vfs{std::make_shared<FileSys::RealVfsFilesystem>()},
       provider{std::make_unique<FileSys::ManualContentProvider>()} {
-#ifdef __linux__
+#ifdef __unix__
     SetupSigInterrupts();
 #endif
     system->Initialize();
@@ -509,7 +509,7 @@ GMainWindow::~GMainWindow() {
         delete render_window;
     }
 
-#ifdef __linux__
+#ifdef __unix__
     ::close(sig_interrupt_fds[0]);
     ::close(sig_interrupt_fds[1]);
 #endif
@@ -1379,7 +1379,7 @@ void GMainWindow::OnDisplayTitleBars(bool show) {
 }
 
 void GMainWindow::SetupPrepareForSleep() {
-#ifdef __linux__
+#ifdef __unix__
     auto bus = QDBusConnection::systemBus();
     if (bus.isConnected()) {
         const bool success = bus.connect(
@@ -1393,7 +1393,7 @@ void GMainWindow::SetupPrepareForSleep() {
     } else {
         LOG_WARNING(Frontend, "QDBusConnection system bus is not connected");
     }
-#endif // __linux__
+#endif // __unix__
 }
 
 void GMainWindow::OnPrepareForSleep(bool prepare_sleep) {
@@ -1415,7 +1415,7 @@ void GMainWindow::OnPrepareForSleep(bool prepare_sleep) {
     }
 }
 
-#ifdef __linux__
+#ifdef __unix__
 static std::optional<QDBusObjectPath> HoldWakeLockLinux(u32 window_id = 0) {
     if (!QDBusConnection::sessionBus().isConnected()) {
         return {};
@@ -1500,14 +1500,14 @@ void GMainWindow::OnSigInterruptNotifierActivated() {
 
     emit SigInterrupt();
 }
-#endif // __linux__
+#endif // __unix__
 
 void GMainWindow::PreventOSSleep() {
 #ifdef _WIN32
     SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
 #elif defined(HAVE_SDL2)
     SDL_DisableScreenSaver();
-#ifdef __linux__
+#ifdef __unix__
     auto reply = HoldWakeLockLinux(winId());
     if (reply) {
         wake_lock = std::move(reply.value());
@@ -1521,7 +1521,7 @@ void GMainWindow::AllowOSSleep() {
     SetThreadExecutionState(ES_CONTINUOUS);
 #elif defined(HAVE_SDL2)
     SDL_EnableScreenSaver();
-#ifdef __linux__
+#ifdef __unix__
     if (!wake_lock.path().isEmpty()) {
         ReleaseWakeLockLinux(wake_lock);
     }
@@ -4070,7 +4070,7 @@ void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {
 }
 
 void GMainWindow::changeEvent(QEvent* event) {
-#ifdef __linux__
+#ifdef __unix__
     // PaletteChange event appears to only reach so far into the GUI, explicitly asking to
     // UpdateUITheme is a decent work around
     if (event->type() == QEvent::PaletteChange) {
@@ -4085,7 +4085,7 @@ void GMainWindow::changeEvent(QEvent* event) {
         }
         last_window_color = window_color;
     }
-#endif // __linux__
+#endif // __unix__
     QWidget::changeEvent(event);
 }
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -15,7 +15,7 @@
 #include "yuzu/compatibility_list.h"
 #include "yuzu/hotkeys.h"
 
-#ifdef __linux__
+#ifdef __unix__
 #include <QVariant>
 #include <QtDBus/QDBusInterface>
 #include <QtDBus/QtDBus>
@@ -255,7 +255,7 @@ private:
     void changeEvent(QEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
 
-#ifdef __linux__
+#ifdef __unix__
     void SetupSigInterrupts();
     static void HandleSigInterrupt(int);
     void OnSigInterruptNotifierActivated();
@@ -435,7 +435,7 @@ private:
     // True if TAS recording dialog is visible
     bool is_tas_recording_dialog_active{};
 
-#ifdef __linux__
+#ifdef __unix__
     QSocketNotifier* sig_interrupt_notifier;
     static std::array<int, 3> sig_interrupt_fds;
 


### PR DESCRIPTION
Covers #7614 ([via](https://www.freshports.org/deskutils/xdg-desktop-portal)), #8585 ([via](https://www.freshports.org/sysutils/consolekit2)), #8592, #8647 for systems like FreeBSD or Solaris. macOS is excluded (like before) due to not defining `__unix__`.

Splitting conditionals for granular commits is error-prone, so I didn't bother.
