### PR TITLE
kernel: assign KProcess to service threads

### DIFF
--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -263,9 +263,9 @@ Result KThread::InitializeThread(KThread* thread, KThreadFunction func, uintptr_
     R_SUCCEED();
 }
 
-Result KThread::InitializeDummyThread(KThread* thread) {
+Result KThread::InitializeDummyThread(KThread* thread, KProcess* owner) {
     // Initialize the thread.
-    R_TRY(thread->Initialize({}, {}, {}, DummyThreadPriority, 3, {}, ThreadType::Dummy));
+    R_TRY(thread->Initialize({}, {}, {}, DummyThreadPriority, 3, owner, ThreadType::Dummy));
 
     // Initialize emulation parameters.
     thread->stack_parameters.disable_count = 0;

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -415,7 +415,7 @@ public:
 
     static void PostDestroy(uintptr_t arg);
 
-    [[nodiscard]] static Result InitializeDummyThread(KThread* thread);
+    [[nodiscard]] static Result InitializeDummyThread(KThread* thread, KProcess* owner);
 
     [[nodiscard]] static Result InitializeMainThread(Core::System& system, KThread* thread,
                                                      s32 virt_core);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -236,7 +236,7 @@ public:
     void RegisterCoreThread(std::size_t core_id);
 
     /// Register the current thread as a non CPU core thread.
-    void RegisterHostThread();
+    void RegisterHostThread(KThread* existing_thread = nullptr);
 
     /// Gets the virtual memory manager for the kernel.
     KMemoryManager& MemoryManager();


### PR DESCRIPTION
This is the next step in the conversion of services to userspace. After tweaking the SVC code, many SVCs will become callable from service thread context.