### PR TITLE
core: hid: Implement true multitouch support

### DIFF
--- a/src/core/hid/emulated_console.h
+++ b/src/core/hid/emulated_console.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 
 #include "common/common_funcs.h"
@@ -20,6 +21,8 @@
 #include "core/hid/motion_input.h"
 
 namespace Core::HID {
+static constexpr std::size_t MaxTouchDevices = 32;
+static constexpr std::size_t MaxActiveTouchInputs = 16;
 
 struct ConsoleMotionInfo {
     Common::Input::MotionStatus raw_status{};
@@ -27,13 +30,13 @@ struct ConsoleMotionInfo {
 };
 
 using ConsoleMotionDevices = std::unique_ptr<Common::Input::InputDevice>;
-using TouchDevices = std::array<std::unique_ptr<Common::Input::InputDevice>, 16>;
+using TouchDevices = std::array<std::unique_ptr<Common::Input::InputDevice>, MaxTouchDevices>;
 
 using ConsoleMotionParams = Common::ParamPackage;
-using TouchParams = std::array<Common::ParamPackage, 16>;
+using TouchParams = std::array<Common::ParamPackage, MaxTouchDevices>;
 
 using ConsoleMotionValues = ConsoleMotionInfo;
-using TouchValues = std::array<Common::Input::TouchStatus, 16>;
+using TouchValues = std::array<Common::Input::TouchStatus, MaxTouchDevices>;
 
 struct TouchFinger {
     u64 last_touch{};
@@ -55,7 +58,7 @@ struct ConsoleMotion {
     bool is_at_rest{};
 };
 
-using TouchFingerState = std::array<TouchFinger, 16>;
+using TouchFingerState = std::array<TouchFinger, MaxActiveTouchInputs>;
 
 struct ConsoleStatus {
     // Data from input_common
@@ -165,6 +168,10 @@ private:
      * @param index Finger ID to be updated
      */
     void SetTouch(const Common::Input::CallbackStatus& callback, std::size_t index);
+
+    std::optional<std::size_t> GetIndexFromFingerId(std::size_t finger_id) const;
+
+    std::optional<std::size_t> GetNextFreeIndex() const;
 
     /**
      * Triggers a callback that something has changed on the console status

--- a/src/core/hid/input_converter.cpp
+++ b/src/core/hid/input_converter.cpp
@@ -200,9 +200,6 @@ Common::Input::TouchStatus TransformToTouch(const Common::Input::CallbackStatus&
     x = std::clamp(x, 0.0f, 1.0f);
     y = std::clamp(y, 0.0f, 1.0f);
 
-    // Limit id to maximum number of fingers
-    status.id = std::clamp(status.id, 0, 16);
-
     if (status.pressed.inverted) {
         status.pressed.value = !status.pressed.value;
     }

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -71,12 +71,14 @@ private:
 
     void GetSharedMemoryHandle(Kernel::HLERequestContext& ctx);
     void UpdateControllers(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
+    void UpdateNpad(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
     void UpdateMouseKeyboard(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
     void UpdateMotion(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
 
     KernelHelpers::ServiceContext& service_context;
 
-    std::shared_ptr<Core::Timing::EventType> pad_update_event;
+    std::shared_ptr<Core::Timing::EventType> npad_update_event;
+    std::shared_ptr<Core::Timing::EventType> default_update_event;
     std::shared_ptr<Core::Timing::EventType> mouse_keyboard_update_event;
     std::shared_ptr<Core::Timing::EventType> motion_update_event;
 

--- a/src/input_common/helpers/touch_from_buttons.cpp
+++ b/src/input_common/helpers/touch_from_buttons.cpp
@@ -10,8 +10,8 @@ namespace InputCommon {
 class TouchFromButtonDevice final : public Common::Input::InputDevice {
 public:
     using Button = std::unique_ptr<Common::Input::InputDevice>;
-    TouchFromButtonDevice(Button button_, int touch_id_, float x_, float y_)
-        : button(std::move(button_)), touch_id(touch_id_), x(x_), y(y_) {
+    TouchFromButtonDevice(Button button_, float x_, float y_)
+        : button(std::move(button_)), x(x_), y(y_) {
         last_button_value = false;
         button->SetCallback({
             .on_change =
@@ -34,7 +34,6 @@ public:
             .pressed = button_status,
             .x = {},
             .y = {},
-            .id = touch_id,
         };
         status.x.properties = properties;
         status.y.properties = properties;
@@ -62,7 +61,6 @@ public:
 private:
     Button button;
     bool last_button_value;
-    const int touch_id;
     const float x;
     const float y;
     const Common::Input::AnalogProperties properties{0.0f, 1.0f, 0.5f, 0.0f, false};
@@ -73,10 +71,9 @@ std::unique_ptr<Common::Input::InputDevice> TouchFromButton::Create(
     const std::string null_engine = Common::ParamPackage{{"engine", "null"}}.Serialize();
     auto button = Common::Input::CreateDeviceFromString<Common::Input::InputDevice>(
         params.Get("button", null_engine));
-    const auto touch_id = params.Get("touch_id", 0);
     const float x = params.Get("x", 0.0f) / 1280.0f;
     const float y = params.Get("y", 0.0f) / 720.0f;
-    return std::make_unique<TouchFromButtonDevice>(std::move(button), touch_id, x, y);
+    return std::make_unique<TouchFromButtonDevice>(std::move(button), x, y);
 }
 
 } // namespace InputCommon

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -229,13 +229,12 @@ private:
 
 class InputFromTouch final : public Common::Input::InputDevice {
 public:
-    explicit InputFromTouch(PadIdentifier identifier_, int touch_id_, int button_, bool toggle_,
-                            bool inverted_, int axis_x_, int axis_y_,
-                            Common::Input::AnalogProperties properties_x_,
+    explicit InputFromTouch(PadIdentifier identifier_, int button_, bool toggle_, bool inverted_,
+                            int axis_x_, int axis_y_, Common::Input::AnalogProperties properties_x_,
                             Common::Input::AnalogProperties properties_y_,
                             InputEngine* input_engine_)
-        : identifier(identifier_), touch_id(touch_id_), button(button_), toggle(toggle_),
-          inverted(inverted_), axis_x(axis_x_), axis_y(axis_y_), properties_x(properties_x_),
+        : identifier(identifier_), button(button_), toggle(toggle_), inverted(inverted_),
+          axis_x(axis_x_), axis_y(axis_y_), properties_x(properties_x_),
           properties_y(properties_y_), input_engine(input_engine_) {
         UpdateCallback engine_callback{[this]() { OnChange(); }};
         const InputIdentifier button_input_identifier{
@@ -271,8 +270,7 @@ public:
     }
 
     Common::Input::TouchStatus GetStatus() const {
-        Common::Input::TouchStatus status;
-        status.id = touch_id;
+        Common::Input::TouchStatus status{};
         status.pressed = {
             .value = input_engine->GetButton(identifier, button),
             .inverted = inverted,
@@ -307,7 +305,6 @@ public:
 
 private:
     const PadIdentifier identifier;
-    const int touch_id;
     const int button;
     const bool toggle;
     const bool inverted;
@@ -919,7 +916,6 @@ std::unique_ptr<Common::Input::InputDevice> InputFactory::CreateTriggerDevice(
 
 std::unique_ptr<Common::Input::InputDevice> InputFactory::CreateTouchDevice(
     const Common::ParamPackage& params) {
-    const auto touch_id = params.Get("touch_id", 0);
     const auto deadzone = std::clamp(params.Get("deadzone", 0.0f), 0.0f, 1.0f);
     const auto range = std::clamp(params.Get("range", 1.0f), 0.25f, 1.50f);
     const auto threshold = std::clamp(params.Get("threshold", 0.5f), 0.0f, 1.0f);
@@ -954,8 +950,8 @@ std::unique_ptr<Common::Input::InputDevice> InputFactory::CreateTouchDevice(
     input_engine->PreSetAxis(identifier, axis_x);
     input_engine->PreSetAxis(identifier, axis_y);
     input_engine->PreSetButton(identifier, button);
-    return std::make_unique<InputFromTouch>(identifier, touch_id, button, toggle, inverted, axis_x,
-                                            axis_y, properties_x, properties_y, input_engine.get());
+    return std::make_unique<InputFromTouch>(identifier, button, toggle, inverted, axis_x, axis_y,
+                                            properties_x, properties_y, input_engine.get());
 }
 
 std::unique_ptr<Common::Input::InputDevice> InputFactory::CreateBatteryDevice(


### PR DESCRIPTION
Our previous touch implementation distributed 16 fingers between all touch engines.  This finally completes the implementation by allowing any number of touch inputs.

Additionally touch was running way too fast for games. This often resulted in missing inputs and other bugs. I set the correct update rate by just overclocking npad and leaving everything else at stock refresh rate.

This fixes `Mini Motorways` faulty inputs and lack of multitouch support.