### PR TITLE
service_thread: fix deletion

### DIFF
--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -82,13 +82,13 @@ public:
     void RegisterSession(KServerSession* server_session,
                          std::shared_ptr<SessionRequestManager> manager);
 
-    std::weak_ptr<ServiceThread> GetServiceThread() const {
+    ServiceThread& GetServiceThread() const {
         return service_thread;
     }
 
 protected:
     KernelCore& kernel;
-    std::weak_ptr<ServiceThread> service_thread;
+    ServiceThread& service_thread;
 };
 
 using SessionRequestHandlerWeakPtr = std::weak_ptr<SessionRequestHandler>;
@@ -154,7 +154,7 @@ public:
         session_handler = std::move(handler);
     }
 
-    std::weak_ptr<ServiceThread> GetServiceThread() const {
+    ServiceThread& GetServiceThread() const {
         return session_handler->GetServiceThread();
     }
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -309,24 +309,24 @@ public:
      * See GetDefaultServiceThread.
      * @param name String name for the ServerSession creating this thread, used for debug
      * purposes.
-     * @returns The a weak pointer newly created service thread.
+     * @returns A reference to the newly created service thread.
      */
-    std::weak_ptr<Kernel::ServiceThread> CreateServiceThread(const std::string& name);
+    Kernel::ServiceThread& CreateServiceThread(const std::string& name);
 
     /**
      * Gets the default host service thread, which executes HLE service requests. Unless service
      * requests need to block on the host, the default service thread should be used in favor of
      * creating a new service thread.
-     * @returns The a weak pointer for the default service thread.
+     * @returns A reference to the default service thread.
      */
-    std::weak_ptr<Kernel::ServiceThread> GetDefaultServiceThread() const;
+    Kernel::ServiceThread& GetDefaultServiceThread() const;
 
     /**
      * Releases a HLE service thread, instructing KernelCore to free it. This should be called when
      * the ServerSession associated with the thread is destroyed.
      * @param service_thread Service thread to release.
      */
-    void ReleaseServiceThread(std::weak_ptr<Kernel::ServiceThread> service_thread);
+    void ReleaseServiceThread(Kernel::ServiceThread& service_thread);
 
     /// Workaround for single-core mode when preempting threads while idle.
     bool IsPhantomModeForSingleCore() const;


### PR DESCRIPTION
Service threads must be deleted by a different thread than the one requesting the thread to be deleted, or a deadlock will occur. The following code raced the queuing of the service thread for removal, and if won, nothing would happen.
```cpp
SessionRequestHandler::~SessionRequestHandler() {
    kernel.ReleaseServiceThread(service_thread.lock());
}
```
However, if it lost, then the service thread would be destroyed when the shared_ptr generated from the call to `lock()` went out of scope. This would cause the service thread to try to delete itself and deadlock. This was observed to occur somewhat reliably on Asahi Linux.

To ensure this will never happen anymore, I removed all weak_ptr and shared_ptr ownership of service threads and only return direct references from KernelCore. That way, destruction will always happen inside the separate thread from KernelCore.