### PR TITLE
video_core: Reimplement inline index buffer binding

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -222,8 +222,6 @@ void RasterizerOpenGL::Draw(bool is_indexed, u32 instance_count) {
     pipeline->SetEngine(maxwell3d, gpu_memory);
     pipeline->Configure(is_indexed);
 
-    BindInlineIndexBuffer();
-
     SyncState();
 
     const GLenum primitive_mode = MaxwellToGL::PrimitiveTopology(maxwell3d->regs.draw.topology);
@@ -1138,16 +1136,6 @@ void RasterizerOpenGL::ReleaseChannel(s32 channel_id) {
     }
     shader_cache.EraseChannel(channel_id);
     query_cache.EraseChannel(channel_id);
-}
-
-void RasterizerOpenGL::BindInlineIndexBuffer() {
-    if (maxwell3d->inline_index_draw_indexes.empty()) {
-        return;
-    }
-    const auto data_count = static_cast<u32>(maxwell3d->inline_index_draw_indexes.size());
-    auto buffer = Buffer(buffer_cache_runtime, *this, 0, data_count);
-    buffer.ImmediateUpload(0, maxwell3d->inline_index_draw_indexes);
-    buffer_cache_runtime.BindIndexBuffer(buffer, 0, data_count);
 }
 
 AccelerateDMA::AccelerateDMA(BufferCache& buffer_cache_) : buffer_cache{buffer_cache_} {}

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -199,8 +199,6 @@ private:
     /// End a transform feedback
     void EndTransformFeedback();
 
-    void BindInlineIndexBuffer();
-
     Tegra::GPU& gpu;
 
     const Device& device;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -191,8 +191,6 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
     pipeline->SetEngine(maxwell3d, gpu_memory);
     pipeline->Configure(is_indexed);
 
-    BindInlineIndexBuffer();
-
     BeginTransformFeedback();
 
     UpdateDynamicStates();
@@ -1027,19 +1025,6 @@ void RasterizerVulkan::ReleaseChannel(s32 channel_id) {
     }
     pipeline_cache.EraseChannel(channel_id);
     query_cache.EraseChannel(channel_id);
-}
-
-void RasterizerVulkan::BindInlineIndexBuffer() {
-    if (maxwell3d->inline_index_draw_indexes.empty()) {
-        return;
-    }
-    const auto data_count = static_cast<u32>(maxwell3d->inline_index_draw_indexes.size());
-    auto buffer = buffer_cache_runtime.UploadStagingBuffer(data_count);
-    std::memcpy(buffer.mapped_span.data(), maxwell3d->inline_index_draw_indexes.data(), data_count);
-    buffer_cache_runtime.BindIndexBuffer(
-        maxwell3d->regs.draw.topology, maxwell3d->regs.index_buffer.format,
-        maxwell3d->regs.index_buffer.first, maxwell3d->regs.index_buffer.count, buffer.buffer,
-        static_cast<u32>(buffer.offset), data_count);
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -141,8 +141,6 @@ private:
 
     void UpdateVertexInput(Tegra::Engines::Maxwell3D::Regs& regs);
 
-    void BindInlineIndexBuffer();
-
     Tegra::GPU& gpu;
 
     ScreenInfo& screen_info;


### PR DESCRIPTION
The previous implementation would cause opengl to crash in non-unified_memory mode, and the generated buffer would not be recycled.
Now we have a unified implementation of vulkan and opengl.