### PR TITLE
Add break statement in default cases

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -151,6 +151,7 @@ void UpdateRescalingInfo() {
         ASSERT(false);
         info.up_scale = 1;
         info.down_shift = 0;
+        break;
     }
     info.up_factor = static_cast<f32>(info.up_scale) / (1U << info.down_shift);
     info.down_factor = static_cast<f32>(1U << info.down_shift) / info.up_scale;


### PR DESCRIPTION
According to the contributing page (https://github.com/yuzu-emu/yuzu/wiki/Contributing) the default cases should have a break statement

default:
        // Yes, even break for the last case
        break;