### PR TITLE
Debugger improvements

### DIFF
--- a/src/core/debugger/gdbstub.h
+++ b/src/core/debugger/gdbstub.h
@@ -32,6 +32,7 @@ private:
     void ExecuteCommand(std::string_view packet, std::vector<DebuggerAction>& actions);
     void HandleVCont(std::string_view command, std::vector<DebuggerAction>& actions);
     void HandleQuery(std::string_view command);
+    void HandleRcmd(const std::vector<u8>& command);
     void HandleBreakpointInsert(std::string_view command);
     void HandleBreakpointRemove(std::string_view command);
     std::vector<char>::const_iterator CommandEnd() const;

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -320,6 +320,9 @@ public:
     constexpr VAddr GetAliasCodeRegionStart() const {
         return m_alias_code_region_start;
     }
+    constexpr VAddr GetAliasCodeRegionEnd() const {
+        return m_alias_code_region_end;
+    }
     constexpr VAddr GetAliasCodeRegionSize() const {
         return m_alias_code_region_end - m_alias_code_region_start;
     }


### PR DESCRIPTION
Fixes some issues with the debugger:
- yuzu would continue to accept connections after the debugger had already connected, but would never respond to them. This led to confusing gdb behavior if connection had to be re-attempted. Now connections can be re-attempted any number of times, and the previous connection will be closed.
- The `monitor` commands supported by ams dmnt.gen2, which provide printouts of various process information, including memory regions, were not implemented. This implements basic support.