### PR TITLE
[video_core] Fix a couple regs regressions

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -249,6 +249,11 @@ void Maxwell3D::ProcessMethodCall(u32 method, u32 argument, u32 nonshadow_argume
         return;
     case MAXWELL3D_REG_INDEX(fragment_barrier):
         return rasterizer->FragmentBarrier();
+    case MAXWELL3D_REG_INDEX(invalidate_texture_data_cache):
+        rasterizer->InvalidateGPUCache();
+        return rasterizer->WaitForIdle();
+    case MAXWELL3D_REG_INDEX(tiled_cache_barrier):
+        return rasterizer->TiledCacheBarrier();
     }
 }
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -707,7 +707,7 @@ public:
                 case Size::Size_A2_B10_G10_R10:
                     return "2_10_10_10";
                 case Size::Size_B10_G11_R11:
-                    return "10_11_12";
+                    return "10_11_11";
                 default:
                     ASSERT(false);
                     return {};
@@ -2639,7 +2639,7 @@ public:
                 L2CacheControl l2_cache_control;                                       ///< 0x0218
                 InvalidateShaderCache invalidate_shader_cache;                         ///< 0x021C
                 INSERT_PADDING_BYTES_NOINIT(0xA8);
-                SyncInfo sync_info; ///< 0x02C8
+                SyncInfo sync_info;                                                    ///< 0x02C8
                 INSERT_PADDING_BYTES_NOINIT(0x4);
                 u32 prim_circular_buffer_throttle;                                     ///< 0x02D0
                 u32 flush_invalidate_rop_mini_cache;                                   ///< 0x02D4
@@ -2731,7 +2731,11 @@ public:
                 s32 stencil_back_ref;                                                  ///< 0x0F54
                 u32 stencil_back_mask;                                                 ///< 0x0F58
                 u32 stencil_back_func_mask;                                            ///< 0x0F5C
-                INSERT_PADDING_BYTES_NOINIT(0x24);
+                INSERT_PADDING_BYTES_NOINIT(0x14);
+                u32 invalidate_texture_data_cache;                                     ///< 0x0F74 Assumed - Not in official docs.
+                INSERT_PADDING_BYTES_NOINIT(0x4);
+                u32 tiled_cache_barrier;                                               ///< 0x0F7C Assumed - Not in official docs.
+                INSERT_PADDING_BYTES_NOINIT(0x4);
                 VertexStreamSubstitute vertex_stream_substitute;                       ///< 0x0F84
                 u32 line_mode_clip_generated_edge_do_not_draw;                         ///< 0x0F8C
                 u32 color_mask_common;                                                 ///< 0x0F90
@@ -2791,7 +2795,8 @@ public:
                 FillViaTriangleMode fill_via_triangle_mode;                            ///< 0x113C
                 u32 blend_per_format_snorm8_unorm16_snorm16_enabled;                   ///< 0x1140
                 u32 flush_pending_writes_sm_gloal_store;                               ///< 0x1144
-                INSERT_PADDING_BYTES_NOINIT(0x18);
+                u32 conservative_raster_enable;                                        ///< 0x1148 Assumed - Not in official docs.
+                INSERT_PADDING_BYTES_NOINIT(0x14);
                 std::array<VertexAttribute, NumVertexAttributes> vertex_attrib_format; ///< 0x1160
                 std::array<MsaaSampleLocation, 4> multisample_sample_locations;        ///< 0x11E0
                 u32 offset_render_target_index_by_viewport_index;                      ///< 0x11F0
@@ -3287,6 +3292,8 @@ ASSERT_REG_POSITION(const_color_rendering, 0x0F40);
 ASSERT_REG_POSITION(stencil_back_ref, 0x0F54);
 ASSERT_REG_POSITION(stencil_back_mask, 0x0F58);
 ASSERT_REG_POSITION(stencil_back_func_mask, 0x0F5C);
+ASSERT_REG_POSITION(invalidate_texture_data_cache, 0x0F74);
+ASSERT_REG_POSITION(tiled_cache_barrier, 0x0F7C);
 ASSERT_REG_POSITION(vertex_stream_substitute, 0x0F84);
 ASSERT_REG_POSITION(line_mode_clip_generated_edge_do_not_draw, 0x0F8C);
 ASSERT_REG_POSITION(color_mask_common, 0x0F90);
@@ -3343,6 +3350,7 @@ ASSERT_REG_POSITION(post_ps_use_pre_ps_coverage, 0x1138);
 ASSERT_REG_POSITION(fill_via_triangle_mode, 0x113C);
 ASSERT_REG_POSITION(blend_per_format_snorm8_unorm16_snorm16_enabled, 0x1140);
 ASSERT_REG_POSITION(flush_pending_writes_sm_gloal_store, 0x1144);
+ASSERT_REG_POSITION(conservative_raster_enable, 0x1148);
 ASSERT_REG_POSITION(vertex_attrib_format, 0x1160);
 ASSERT_REG_POSITION(multisample_sample_locations, 0x11E0);
 ASSERT_REG_POSITION(offset_render_target_index_by_viewport_index, 0x11F0);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -770,7 +770,7 @@ void RasterizerOpenGL::SyncStencilTestState() {
 
     if (regs.stencil_two_side_enable) {
         glStencilFuncSeparate(GL_BACK, MaxwellToGL::ComparisonOp(regs.stencil_back_op.func),
-                              regs.stencil_back_ref, regs.stencil_back_mask);
+                              regs.stencil_back_ref, regs.stencil_back_func_mask);
         glStencilOpSeparate(GL_BACK, MaxwellToGL::StencilOp(regs.stencil_back_op.fail),
                             MaxwellToGL::StencilOp(regs.stencil_back_op.zfail),
                             MaxwellToGL::StencilOp(regs.stencil_back_op.zpass));

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -90,6 +90,7 @@ void FixedPipelineState::Refresh(Tegra::Engines::Maxwell3D& maxwell3d,
     depth_format.Assign(static_cast<u32>(regs.zeta.format));
     y_negate.Assign(regs.window_origin.mode != Maxwell::WindowOrigin::Mode::UpperLeft ? 1 : 0);
     provoking_vertex_last.Assign(regs.provoking_vertex == Maxwell::ProvokingVertex::Last ? 1 : 0);
+    conservative_raster_enable.Assign(regs.conservative_raster_enable != 0 ? 1 : 0);
     smooth_lines.Assign(regs.line_anti_alias_enable != 0 ? 1 : 0);
 
     for (size_t i = 0; i < regs.rt.size(); ++i) {

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -193,6 +193,7 @@ struct FixedPipelineState {
         BitField<6, 5, u32> depth_format;
         BitField<11, 1, u32> y_negate;
         BitField<12, 1, u32> provoking_vertex_last;
+        BitField<13, 1, u32> conservative_raster_enable;
         BitField<14, 1, u32> smooth_lines;
     };
     std::array<u8, Maxwell::NumRenderTargets> color_formats;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -680,6 +680,15 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
         .lineStippleFactor = 0,
         .lineStipplePattern = 0,
     };
+    VkPipelineRasterizationConservativeStateCreateInfoEXT conservative_raster{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT,
+        .pNext = nullptr,
+        .flags = 0,
+        .conservativeRasterizationMode = key.state.conservative_raster_enable != 0
+                                             ? VK_CONSERVATIVE_RASTERIZATION_MODE_OVERESTIMATE_EXT
+                                             : VK_CONSERVATIVE_RASTERIZATION_MODE_DISABLED_EXT,
+        .extraPrimitiveOverestimationSize = 0.0f,
+    };
     VkPipelineRasterizationProvokingVertexStateCreateInfoEXT provoking_vertex{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT,
         .pNext = nullptr,
@@ -689,6 +698,9 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
     };
     if (IsLine(input_assembly_topology) && device.IsExtLineRasterizationSupported()) {
         line_state.pNext = std::exchange(rasterization_ci.pNext, &line_state);
+    }
+    if (device.IsExtConservativeRasterizationSupported()) {
+        conservative_raster.pNext = std::exchange(rasterization_ci.pNext, &conservative_raster);
     }
     if (device.IsExtProvokingVertexSupported()) {
         provoking_vertex.pNext = std::exchange(rasterization_ci.pNext, &provoking_vertex);


### PR DESCRIPTION
In my regs PR I removed regs which weren't listed in nVidia's official docs, but that caused regressions in some games due to losing the `invalidate_texture_data_cache` register. I don't know if this reg is correct or not, but we know there are regs which were redacted from the docs, and it seems we do need something to trigger GPU cache invalidation, so I've added it back.

I also added back conservative raster for Vulkan, not sure if the reg is correct or if conservative raster affects any games. Also fixes a mistake with two-sided stencils on OpenGL.

This PR fixes the weird blocky patterns in XC3, and likely helps other games.