### PR TITLE
Add break for default cases

### DIFF
--- a/src/audio_core/renderer/performance/performance_manager.cpp
+++ b/src/audio_core/renderer/performance/performance_manager.cpp
@@ -26,6 +26,7 @@ void PerformanceManager::CreateImpl(const size_t version) {
         impl = std::make_unique<
             PerformanceManagerImpl<PerformanceVersion::Version1, PerformanceFrameHeaderVersion1,
                                    PerformanceEntryVersion1, PerformanceDetailVersion1>>();
+        break;
     }
 }
 

--- a/src/common/atomic_helpers.h
+++ b/src/common/atomic_helpers.h
@@ -156,6 +156,7 @@ AE_FORCEINLINE void compiler_fence(memory_order order) AE_NO_TSAN {
         break;
     default:
         assert(false);
+        break;
     }
 }
 

--- a/src/core/hle/kernel/init/init_slab_setup.cpp
+++ b/src/core/hle/kernel/init/init_slab_setup.cpp
@@ -243,6 +243,7 @@ void InitializeSlabHeaps(Core::System& system, KMemoryLayout& memory_layout) {
             // If we somehow get an invalid type, abort.
         default:
             ASSERT_MSG(false, "Unknown slab type: {}", slab_types[i]);
+            break;
         }
 
         // If we've hit the end of a gap, free it.

--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -2301,6 +2301,7 @@ Result KPageTable::SetProcessMemoryPermission(VAddr addr, size_t size,
             break;
         default:
             ASSERT(false);
+            break;
         }
     }
 
@@ -2803,6 +2804,7 @@ Result KPageTable::Operate(VAddr addr, size_t num_pages, const KPageGroup& page_
             break;
         default:
             ASSERT(false);
+            break;
         }
 
         addr += size;
@@ -2838,6 +2840,7 @@ Result KPageTable::Operate(VAddr addr, size_t num_pages, KMemoryPermission perm,
         break;
     default:
         ASSERT(false);
+        break;
     }
     R_SUCCEED();
 }

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -395,6 +395,7 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
 
     default:
         ASSERT(false);
+        break;
     }
 
     // Create TLS region

--- a/src/core/hle/service/am/applets/applet_error.cpp
+++ b/src/core/hle/service/am/applets/applet_error.cpp
@@ -144,6 +144,7 @@ void Error::Initialize() {
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented LibAppletError mode={:02X}!", mode);
+        break;
     }
 }
 

--- a/src/core/hle/service/am/applets/applet_general_backend.cpp
+++ b/src/core/hle/service/am/applets/applet_general_backend.cpp
@@ -129,6 +129,7 @@ void Auth::Execute() {
     }
     default:
         unimplemented_log();
+        break;
     }
 }
 
@@ -192,6 +193,7 @@ void PhotoViewer::Execute() {
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented PhotoViewer applet mode={:02X}!", mode);
+        break;
     }
 }
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -300,11 +300,10 @@ Kernel::KEvent* nvhost_ctrl_gpu::QueryEvent(u32 event_id) {
         return error_notifier_event;
     case 2:
         return unknown_event;
-    default: {
+    default:
         LOG_CRITICAL(Service_NVDRV, "Unknown Ctrl GPU Event {}", event_id);
+        return nullptr;
     }
-    }
-    return nullptr;
 }
 
 } // namespace Service::Nvidia::Devices

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -364,11 +364,10 @@ Kernel::KEvent* nvhost_gpu::QueryEvent(u32 event_id) {
         return sm_exception_breakpoint_pause_report_event;
     case 3:
         return error_notifier_event;
-    default: {
+    default:
         LOG_CRITICAL(Service_NVDRV, "Unknown Ctrl GPU Event {}", event_id);
+        return nullptr;
     }
-    }
-    return nullptr;
 }
 
 } // namespace Service::Nvidia::Devices

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -228,6 +228,7 @@ Result ServiceFrameworkBase::HandleSyncRequest(Kernel::KServerSession& session,
         }
 
         UNIMPLEMENTED_MSG("command_type={}", ctx.GetCommandType());
+        break;
     }
 
     // If emulation was shutdown, we are closing service threads, do not write the response back to

--- a/src/core/hle/service/time/time_zone_manager.cpp
+++ b/src/core/hle/service/time/time_zone_manager.cpp
@@ -280,6 +280,7 @@ static constexpr int TransitionTime(int year, Rule rule, int offset) {
     }
     default:
         ASSERT(false);
+        break;
     }
     return value + rule.transition_time + offset;
 }

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -311,6 +311,7 @@ void MaxwellDMA::ReleaseSemaphore() {
     }
     default:
         ASSERT_MSG(false, "Unknown semaphore type: {}", static_cast<u32>(type.Value()));
+        break;
     }
 }
 

--- a/src/video_core/engines/puller.cpp
+++ b/src/video_core/engines/puller.cpp
@@ -50,6 +50,7 @@ void Puller::ProcessBindMethod(const MethodCall& method_call) {
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented engine {:04X}", engine_id);
+        break;
     }
 }
 
@@ -65,6 +66,7 @@ void Puller::ProcessFenceActionMethod() {
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented operation {}", regs.fence_action.op.Value());
+        break;
     }
 }
 
@@ -228,6 +230,7 @@ void Puller::CallEngineMethod(const MethodCall& method_call) {
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented engine");
+        break;
     }
 }
 
@@ -254,6 +257,7 @@ void Puller::CallEngineMultiMethod(u32 method, u32 subchannel, const u32* base_s
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented engine");
+        break;
     }
 }
 

--- a/src/video_core/macro/macro_interpreter.cpp
+++ b/src/video_core/macro/macro_interpreter.cpp
@@ -201,6 +201,7 @@ bool MacroInterpreterImpl::Step(bool is_delay_slot) {
     }
     default:
         UNIMPLEMENTED_MSG("Unimplemented macro operation {}", opcode.operation.Value());
+        break;
     }
 
     // An instruction with the Exit flag will not actually
@@ -297,6 +298,7 @@ void MacroInterpreterImpl::ProcessResult(Macro::ResultOperation operation, u32 r
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented result operation {}", operation);
+        break;
     }
 }
 

--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -652,6 +652,7 @@ void MacroJITx64Impl::Compile_ProcessResult(Macro::ResultOperation operation, u3
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented macro operation {}", operation);
+        break;
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -891,6 +891,7 @@ void Image::CopyBufferToImage(const VideoCommon::BufferImageCopy& copy, size_t b
         break;
     default:
         ASSERT(false);
+        break;
     }
 }
 
@@ -927,6 +928,7 @@ void Image::CopyImageToBuffer(const VideoCommon::BufferImageCopy& copy, size_t b
         break;
     default:
         ASSERT(false);
+        break;
     }
     // Compressed formats don't have a pixel format or type
     const bool is_compressed = gl_format == GL_NONE;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -340,6 +340,7 @@ void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
         texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
         // UNIMPLEMENTED_MSG("Unknown framebuffer pixel format: {}",
         //                   static_cast<u32>(framebuffer.pixel_format));
+        break;
     }
 
     texture.resource.Release();

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -221,6 +221,7 @@ void Scheduler::SubmitExecution(VkSemaphore signal_semaphore, VkSemaphore wait_s
             [[fallthrough]];
         default:
             vk::Check(result);
+            break;
         }
     });
     chunk->MarkSubmit();

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -108,6 +108,7 @@ constexpr VkBorderColor ConvertBorderColor(const std::array<float, 4>& color) {
             break;
         default:
             ASSERT_MSG(false, "Invalid surface type");
+            break;
         }
     }
     if (info.storage) {

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -170,6 +170,7 @@ void Swizzle(std::span<u8> output, std::span<const u8> input, u32 bytes_per_pixe
 #undef BPP_CASE
     default:
         ASSERT_MSG(false, "Invalid bytes_per_pixel={}", bytes_per_pixel);
+        break;
     }
 }
 
@@ -217,6 +218,7 @@ void SwizzleSubrect(std::span<u8> output, std::span<const u8> input, u32 bytes_p
 #undef BPP_CASE
     default:
         ASSERT_MSG(false, "Invalid bytes_per_pixel={}", bytes_per_pixel);
+        break;
     }
 }
 
@@ -240,6 +242,7 @@ void UnswizzleSubrect(std::span<u8> output, std::span<const u8> input, u32 bytes
 #undef BPP_CASE
     default:
         ASSERT_MSG(false, "Invalid bytes_per_pixel={}", bytes_per_pixel);
+        break;
     }
 }
 

--- a/src/yuzu/compatdb.cpp
+++ b/src/yuzu/compatdb.cpp
@@ -63,6 +63,7 @@ void CompatDB::Submit() {
         break;
     default:
         LOG_ERROR(Frontend, "Unexpected page: {}", currentId());
+        break;
     }
 }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1953,6 +1953,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
     }
     default:
         UNIMPLEMENTED();
+        break;
     }
 
     const QString qpath = QString::fromStdString(Common::FS::PathToUTF8String(path));
@@ -3182,6 +3183,7 @@ void GMainWindow::OnToggleGpuAccuracy() {
     case Settings::GPUAccuracy::Extreme:
     default: {
         Settings::values.gpu_accuracy.SetValue(Settings::GPUAccuracy::High);
+        break;
     }
     }
 
@@ -3514,6 +3516,7 @@ void GMainWindow::UpdateGPUAccuracyButton() {
     default: {
         gpu_accuracy_button->setText(tr("GPU ERROR"));
         gpu_accuracy_button->setChecked(true);
+        break;
     }
     }
 }

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
@@ -84,6 +84,7 @@ EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsyste
     default:
         LOG_CRITICAL(Frontend, "Window manager subsystem not implemented");
         std::exit(EXIT_FAILURE);
+        break;
     }
 
     OnResize();

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -351,6 +351,7 @@ int main(int argc, char** argv) {
                          "additional help.\n\nError Code: {:04X}-{:04X}\nError Description: {}",
                          loader_id, error_id, static_cast<Loader::ResultStatus>(error_id));
         }
+        break;
     }
 
     system.TelemetrySession().AddField(Common::Telemetry::FieldType::App, "Frontend", "SDL");


### PR DESCRIPTION
Visual Studio has an option to search all files in a solution, so I did a search in there for "default:" looking for any missing break statements.

I've left out default statements that `return` something, and that `throw` something, even if via `ThrowInvalidType`


----
UNREACHABLE() also throws


Follow-up to #9217  #9228 