### PR TITLE
Add CPU core count to log files

### DIFF
--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string_view>
 #include "common/common_types.h"
 
@@ -73,5 +74,8 @@ struct CPUCaps {
  * @return Reference to a CPUCaps struct with the detected host CPU capabilities
  */
 const CPUCaps& GetCPUCaps();
+
+/// Detects CPU core count
+std::optional<int> GetProcessorCount();
 
 } // namespace Common

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -362,6 +362,10 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
     }
     LOG_INFO(Frontend, "Host CPU: {}", cpu_string);
 #endif
+
+    if (std::optional<int> processor_core = Common::GetProcessorCount()) {
+        LOG_INFO(Frontend, "Host CPU Cores: {}", *processor_core);
+    }
     LOG_INFO(Frontend, "Host CPU Threads: {}", processor_count);
     LOG_INFO(Frontend, "Host OS: {}", PrettyProductName().toStdString());
     LOG_INFO(Frontend, "Host RAM: {:.2f} GiB",


### PR DESCRIPTION
[GetLogicalProcessorInformation](http://msdn.microsoft.com/en-us/library/ms683194) is used for Windows, which is a chore and a half.
Linux checks for the existence of SMT, as @liamwhite suggested.