### PR TITLE
kernel: implement data cache management operations

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(common STATIC
     bit_util.h
     cityhash.cpp
     cityhash.h
+    cache_management.cpp
+    cache_management.h
     common_funcs.h
     common_types.h
     concepts.h

--- a/src/common/cache_management.cpp
+++ b/src/common/cache_management.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <cstring>
+
+#include "alignment.h"
+#include "cache_management.h"
+#include "common_types.h"
+
+namespace Common {
+
+#if defined(ARCHITECTURE_x86_64)
+
+// Most cache operations are no-ops on x86
+
+void DataCacheLineCleanByVAToPoU(void* start, size_t size) {}
+void DataCacheLineCleanAndInvalidateByVAToPoC(void* start, size_t size) {}
+void DataCacheLineCleanByVAToPoC(void* start, size_t size) {}
+void DataCacheZeroByVA(void* start, size_t size) {
+    std::memset(start, 0, size);
+}
+
+#elif defined(ARCHITECTURE_arm64)
+
+// BS/DminLine is log2(cache size in words), we want size in bytes
+#define EXTRACT_DMINLINE(ctr_el0) (1 << ((((ctr_el0) >> 16) & 0xf) + 2))
+#define EXTRACT_BS(dczid_el0) (1 << (((dczid_el0)&0xf) + 2))
+
+#define DEFINE_DC_OP(op_name, function_name)                                                       \
+    void function_name(void* start, size_t size) {                                                 \
+        size_t ctr_el0;                                                                            \
+        asm volatile("mrs %[ctr_el0], ctr_el0\n\t" : [ctr_el0] "=r"(ctr_el0));                     \
+        size_t cacheline_size = EXTRACT_DMINLINE(ctr_el0);                                         \
+        uintptr_t va_start = reinterpret_cast<uintptr_t>(start);                                   \
+        uintptr_t va_end = va_start + size;                                                        \
+        for (uintptr_t va = va_start; va < va_end; va += cacheline_size) {                         \
+            asm volatile("dc " #op_name ", %[va]\n\t" : : [va] "r"(va) : "memory");                \
+        }                                                                                          \
+    }
+
+#define DEFINE_DC_OP_DCZID(op_name, function_name)                                                 \
+    void function_name(void* start, size_t size) {                                                 \
+        size_t dczid_el0;                                                                          \
+        asm volatile("mrs %[dczid_el0], dczid_el0\n\t" : [dczid_el0] "=r"(dczid_el0));             \
+        size_t cacheline_size = EXTRACT_BS(dczid_el0);                                             \
+        uintptr_t va_start = reinterpret_cast<uintptr_t>(start);                                   \
+        uintptr_t va_end = va_start + size;                                                        \
+        for (uintptr_t va = va_start; va < va_end; va += cacheline_size) {                         \
+            asm volatile("dc " #op_name ", %[va]\n\t" : : [va] "r"(va) : "memory");                \
+        }                                                                                          \
+    }
+
+DEFINE_DC_OP(cvau, DataCacheLineCleanByVAToPoU);
+DEFINE_DC_OP(civac, DataCacheLineCleanAndInvalidateByVAToPoC);
+DEFINE_DC_OP(cvac, DataCacheLineCleanByVAToPoC);
+DEFINE_DC_OP_DCZID(zva, DataCacheZeroByVA);
+
+#endif
+
+} // namespace Common

--- a/src/common/cache_management.h
+++ b/src/common/cache_management.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "stdlib.h"
+
+namespace Common {
+
+// Data cache instructions enabled at EL0 by SCTLR_EL1.UCI.
+// VA = virtual address
+// PoC = point of coherency
+// PoU = point of unification
+
+// dc cvau
+void DataCacheLineCleanByVAToPoU(void* start, size_t size);
+
+// dc civac
+void DataCacheLineCleanAndInvalidateByVAToPoC(void* start, size_t size);
+
+// dc cvac
+void DataCacheLineCleanByVAToPoC(void* start, size_t size);
+
+// dc zva
+void DataCacheZeroByVA(void* start, size_t size);
+
+} // namespace Common

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -722,4 +722,12 @@ void SvcWrap32(Core::System& system) {
     FuncReturn(system, retval);
 }
 
+// Used by Invalidate/Store/FlushProcessDataCache32
+template <Result func(Core::System&, Handle, u64, u64)>
+void SvcWrap32(Core::System& system) {
+    const u64 address = (Param(system, 3) << 32) | Param(system, 2);
+    const u64 size = (Param(system, 4) << 32) | Param(system, 1);
+    FuncReturn32(system, func(system, Param32(system, 0), address, size).raw);
+}
+
 } // namespace Kernel

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include "common/common_types.h"
+#include "core/hle/result.h"
 
 namespace Common {
 struct PageTable;
@@ -448,6 +449,39 @@ public:
      *       value 0.
      */
     void ZeroBlock(const Kernel::KProcess& process, VAddr dest_addr, std::size_t size);
+
+    /**
+     * Invalidates a range of bytes within the current process' address space at the specified
+     * virtual address.
+     *
+     * @param process   The process that will have data invalidated within its address space.
+     * @param dest_addr The destination virtual address to invalidate the data from.
+     * @param size      The size of the range to invalidate, in bytes.
+     *
+     */
+    Result InvalidateDataCache(const Kernel::KProcess& process, VAddr dest_addr, std::size_t size);
+
+    /**
+     * Stores a range of bytes within the current process' address space at the specified
+     * virtual address.
+     *
+     * @param process   The process that will have data stored within its address space.
+     * @param dest_addr The destination virtual address to store the data from.
+     * @param size      The size of the range to store, in bytes.
+     *
+     */
+    Result StoreDataCache(const Kernel::KProcess& process, VAddr dest_addr, std::size_t size);
+
+    /**
+     * Flushes a range of bytes within the current process' address space at the specified
+     * virtual address.
+     *
+     * @param process   The process that will have data flushed within its address space.
+     * @param dest_addr The destination virtual address to flush the data from.
+     * @param size      The size of the range to flush, in bytes.
+     *
+     */
+    Result FlushDataCache(const Kernel::KProcess& process, VAddr dest_addr, std::size_t size);
 
     /**
      * Marks each page within the specified address range as cached or uncached.


### PR DESCRIPTION
x86 does not need to do anything special to ensure the program data cache behaves as intended, but arm64 does.