### PR TITLE
configure_input: Use unique pointers for player_controllers array

### DIFF
--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -68,7 +68,7 @@ private:
 
     std::unique_ptr<InputProfiles> profiles;
 
-    std::array<ConfigureInputPlayer*, 8> player_controllers;
+    std::array<std::unique_ptr<ConfigureInputPlayer>, 8> player_controllers;
     std::array<QWidget*, 8> player_tabs;
     std::array<QCheckBox*, 8> player_connected;
     ConfigureInputAdvanced* advanced;


### PR DESCRIPTION
Avoids a potential memory leak since these objects never seem to be deleted