### PR TITLE
nvnflinger: fix lost wakeup

### DIFF
--- a/src/core/hle/service/nvflinger/buffer_queue_core.h
+++ b/src/core/hle/service/nvflinger/buffer_queue_core.h
@@ -38,7 +38,7 @@ public:
 
 private:
     void SignalDequeueCondition();
-    bool WaitForDequeueCondition();
+    bool WaitForDequeueCondition(std::unique_lock<std::mutex>& lk);
 
     s32 GetMinUndequeuedBufferCountLocked(bool async) const;
     s32 GetMinMaxBufferCountLocked(bool async) const;
@@ -60,7 +60,8 @@ private:
     BufferQueueDefs::SlotsType slots{};
     std::vector<BufferItem> queue;
     s32 override_max_buffer_count{};
-    mutable std::condition_variable_any dequeue_condition;
+    std::condition_variable dequeue_condition;
+    std::atomic<bool> dequeue_possible{};
     const bool use_async_buffer{}; // This is always disabled on HOS
     bool dequeue_buffer_cannot_block{};
     PixelFormat default_buffer_format{PixelFormat::Rgba8888};

--- a/src/core/hle/service/nvflinger/buffer_queue_producer.h
+++ b/src/core/hle/service/nvflinger/buffer_queue_producer.h
@@ -70,7 +70,8 @@ public:
 private:
     BufferQueueProducer(const BufferQueueProducer&) = delete;
 
-    Status WaitForFreeSlotThenRelock(bool async, s32* found, Status* return_flags) const;
+    Status WaitForFreeSlotThenRelock(bool async, s32* found, Status* return_flags,
+                                     std::unique_lock<std::mutex>& lk) const;
 
     Kernel::KEvent* buffer_wait_event{};
     Service::KernelHelpers::ServiceContext& service_context;


### PR DESCRIPTION
When a program produces frames very slowly at startup, a hang due to a lost wakeup on the dequeue condition is almost guaranteed to happen. This prevents it from hanging.

I verified that SignalDequeueCondition is only ever called from locked context, though it might be worthwhile to also make that explicit by passing a parameter.