### PR TITLE
configure_profile_manager: Use a custom dialog when deleting a profile

### DIFF
--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -115,7 +115,7 @@ ConfigureProfileManager::ConfigureProfileManager(const Core::System& system_, QW
             &ConfigureProfileManager::ConfirmDeleteUser);
     connect(ui->pm_set_image, &QPushButton::clicked, this, &ConfigureProfileManager::SetUserImage);
 
-    confirm_dialog = std::make_unique<ConfigureProfileManagerDeleteDialog>(this);
+    confirm_dialog = new ConfigureProfileManagerDeleteDialog(this);
 
     scene = new QGraphicsScene;
     ui->current_user_icon->setScene(scene);
@@ -246,7 +246,7 @@ void ConfigureProfileManager::ConfirmDeleteUser() {
     confirm_dialog->show();
 }
 
-void ConfigureProfileManager::DeleteUser(const Common::UUID uuid) {
+void ConfigureProfileManager::DeleteUser(const Common::UUID& uuid) {
     if (Settings::values.current_user.GetValue() == tree_view->currentIndex().row()) {
         Settings::values.current_user = 0;
     }
@@ -324,7 +324,7 @@ void ConfigureProfileManager::SetUserImage() {
 }
 
 ConfigureProfileManagerDeleteDialog::ConfigureProfileManagerDeleteDialog(QWidget* parent)
-    : QDialog(parent) {
+    : QDialog{parent} {
     auto dialog_vbox_layout = new QVBoxLayout(this);
     dialog_button_box =
         new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No, Qt::Horizontal, parent);
@@ -354,7 +354,7 @@ ConfigureProfileManagerDeleteDialog::ConfigureProfileManagerDeleteDialog(QWidget
 
 ConfigureProfileManagerDeleteDialog::~ConfigureProfileManagerDeleteDialog() = default;
 
-void ConfigureProfileManagerDeleteDialog::SetInfo(const QString username, const Common::UUID uuid,
+void ConfigureProfileManagerDeleteDialog::SetInfo(const QString& username, const Common::UUID& uuid,
                                                   std::function<void()> accept_callback) {
     label_info->setText(
         tr("Name: %1\nUUID: %2").arg(username, QString::fromStdString(uuid.FormattedString())));

--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <algorithm>
+#include <functional>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QFileDialog>
 #include <QGraphicsItem>
 #include <QHeaderView>
@@ -108,8 +111,11 @@ ConfigureProfileManager::ConfigureProfileManager(const Core::System& system_, QW
 
     connect(ui->pm_add, &QPushButton::clicked, this, &ConfigureProfileManager::AddUser);
     connect(ui->pm_rename, &QPushButton::clicked, this, &ConfigureProfileManager::RenameUser);
-    connect(ui->pm_remove, &QPushButton::clicked, this, &ConfigureProfileManager::DeleteUser);
+    connect(ui->pm_remove, &QPushButton::clicked, this,
+            &ConfigureProfileManager::ConfirmDeleteUser);
     connect(ui->pm_set_image, &QPushButton::clicked, this, &ConfigureProfileManager::SetUserImage);
+
+    confirm_dialog = std::make_unique<ConfigureProfileManagerDeleteDialog>(this);
 
     scene = new QGraphicsScene;
     ui->current_user_icon->setScene(scene);
@@ -230,26 +236,23 @@ void ConfigureProfileManager::RenameUser() {
     UpdateCurrentUser();
 }
 
-void ConfigureProfileManager::DeleteUser() {
+void ConfigureProfileManager::ConfirmDeleteUser() {
     const auto index = tree_view->currentIndex().row();
     const auto uuid = profile_manager->GetUser(index);
     ASSERT(uuid);
     const auto username = GetAccountUsername(*profile_manager, *uuid);
 
-    const auto confirm = QMessageBox::question(
-        this, tr("Confirm Delete"),
-        tr("You are about to delete user with name \"%1\". Are you sure?").arg(username));
+    confirm_dialog->SetInfo(username, *uuid, [this, uuid]() { DeleteUser(*uuid); });
+    confirm_dialog->show();
+}
 
-    if (confirm == QMessageBox::No) {
-        return;
-    }
-
+void ConfigureProfileManager::DeleteUser(const Common::UUID uuid) {
     if (Settings::values.current_user.GetValue() == tree_view->currentIndex().row()) {
         Settings::values.current_user = 0;
     }
     UpdateCurrentUser();
 
-    if (!profile_manager->RemoveUser(*uuid)) {
+    if (!profile_manager->RemoveUser(uuid)) {
         return;
     }
 
@@ -318,4 +321,48 @@ void ConfigureProfileManager::SetUserImage() {
     item_model->setItem(index, 0,
                         new QStandardItem{GetIcon(*uuid), FormatUserEntryText(username, *uuid)});
     UpdateCurrentUser();
+}
+
+ConfigureProfileManagerDeleteDialog::ConfigureProfileManagerDeleteDialog(QWidget* parent)
+    : QDialog(parent) {
+    auto dialog_vbox_layout = new QVBoxLayout(this);
+    dialog_button_box =
+        new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No, Qt::Horizontal, parent);
+    auto label_message =
+        new QLabel(tr("Delete this user? All of the user's save data will be deleted."), this);
+    label_info = new QLabel(this);
+    auto dialog_hbox_layout_widget = new QWidget(this);
+    auto dialog_hbox_layout = new QHBoxLayout(dialog_hbox_layout_widget);
+    icon_scene = new QGraphicsScene(0, 0, 64, 64, this);
+    auto icon_view = new QGraphicsView(icon_scene, this);
+
+    dialog_hbox_layout_widget->setLayout(dialog_hbox_layout);
+    icon_view->setMaximumSize(64, 64);
+    icon_view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    icon_view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    this->setLayout(dialog_vbox_layout);
+    this->setWindowTitle(tr("Confirm Delete"));
+    this->setSizeGripEnabled(false);
+    dialog_vbox_layout->addWidget(label_message);
+    dialog_vbox_layout->addWidget(dialog_hbox_layout_widget);
+    dialog_vbox_layout->addWidget(dialog_button_box);
+    dialog_hbox_layout->addWidget(icon_view);
+    dialog_hbox_layout->addWidget(label_info);
+
+    connect(dialog_button_box, &QDialogButtonBox::rejected, this, [this]() { close(); });
+}
+
+ConfigureProfileManagerDeleteDialog::~ConfigureProfileManagerDeleteDialog() = default;
+
+void ConfigureProfileManagerDeleteDialog::SetInfo(const QString username, const Common::UUID uuid,
+                                                  std::function<void()> accept_callback) {
+    label_info->setText(
+        tr("Name: %1\nUUID: %2").arg(username, QString::fromStdString(uuid.FormattedString())));
+    icon_scene->clear();
+    icon_scene->addPixmap(GetIcon(uuid));
+
+    connect(dialog_button_box, &QDialogButtonBox::accepted, this, [this, accept_callback]() {
+        close();
+        accept_callback();
+    });
 }

--- a/src/yuzu/configuration/configure_profile_manager.h
+++ b/src/yuzu/configuration/configure_profile_manager.h
@@ -10,7 +10,9 @@
 #include <QList>
 #include <QWidget>
 
-#include "common/uuid.h"
+namespace Common {
+struct UUID;
+}
 
 namespace Core {
 class System;
@@ -37,7 +39,7 @@ public:
     explicit ConfigureProfileManagerDeleteDialog(QWidget* parent);
     ~ConfigureProfileManagerDeleteDialog();
 
-    void SetInfo(const QString username, const Common::UUID uuid,
+    void SetInfo(const QString& username, const Common::UUID& uuid,
                  std::function<void()> accept_callback);
 
 private:
@@ -68,7 +70,7 @@ private:
     void AddUser();
     void RenameUser();
     void ConfirmDeleteUser();
-    void DeleteUser(const Common::UUID uuid);
+    void DeleteUser(const Common::UUID& uuid);
     void SetUserImage();
 
     QVBoxLayout* layout;
@@ -76,7 +78,7 @@ private:
     QStandardItemModel* item_model;
     QGraphicsScene* scene;
 
-    std::unique_ptr<ConfigureProfileManagerDeleteDialog> confirm_dialog;
+    ConfigureProfileManagerDeleteDialog* confirm_dialog;
 
     std::vector<QList<QStandardItem*>> list_items;
 

--- a/src/yuzu/configuration/configure_profile_manager.h
+++ b/src/yuzu/configuration/configure_profile_manager.h
@@ -3,16 +3,22 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 
+#include <QDialog>
 #include <QList>
 #include <QWidget>
+
+#include "common/uuid.h"
 
 namespace Core {
 class System;
 }
 
 class QGraphicsScene;
+class QDialogButtonBox;
+class QLabel;
 class QStandardItem;
 class QStandardItemModel;
 class QTreeView;
@@ -25,6 +31,20 @@ class ProfileManager;
 namespace Ui {
 class ConfigureProfileManager;
 }
+
+class ConfigureProfileManagerDeleteDialog : public QDialog {
+public:
+    explicit ConfigureProfileManagerDeleteDialog(QWidget* parent);
+    ~ConfigureProfileManagerDeleteDialog();
+
+    void SetInfo(const QString username, const Common::UUID uuid,
+                 std::function<void()> accept_callback);
+
+private:
+    QDialogButtonBox* dialog_button_box;
+    QGraphicsScene* icon_scene;
+    QLabel* label_info;
+};
 
 class ConfigureProfileManager : public QWidget {
     Q_OBJECT
@@ -47,13 +67,16 @@ private:
     void SelectUser(const QModelIndex& index);
     void AddUser();
     void RenameUser();
-    void DeleteUser();
+    void ConfirmDeleteUser();
+    void DeleteUser(const Common::UUID uuid);
     void SetUserImage();
 
     QVBoxLayout* layout;
     QTreeView* tree_view;
     QStandardItemModel* item_model;
     QGraphicsScene* scene;
+
+    std::unique_ptr<ConfigureProfileManagerDeleteDialog> confirm_dialog;
 
     std::vector<QList<QStandardItem*>> list_items;
 

--- a/src/yuzu/configuration/configure_profile_manager.ui
+++ b/src/yuzu/configuration/configure_profile_manager.ui
@@ -57,6 +57,12 @@
               <height>48</height>
              </size>
             </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
             <property name="verticalScrollBarPolicy">
              <enum>Qt::ScrollBarAlwaysOff</enum>
             </property>


### PR DESCRIPTION
I was prompted to add this after a user deleted their user profile and found out that it also deleted all the associated save data for that user.

This adds a hopefully more informative dialog that most importantly notifies the user that their saves will be deleted with the user profile. It shows the profile icon, name, and UUID in the dialog.

![Screenshot from 2022-11-15 17-41-23](https://user-images.githubusercontent.com/22451773/202042938-b98d7256-d04b-452c-b6de-0480c85170ea.png)

While I was in this segment of the configuration, I also removed the frame from the profile picture in the manager, since it caused the image to be offset by 1px and cropped by 2px.