### PR TITLE
 maxwell3d: HLE multi-layer clear macro 

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -232,7 +232,7 @@ void Maxwell3D::ProcessMethodCall(u32 method, u32 argument, u32 nonshadow_argume
         use_topology_override = true;
         return;
     case MAXWELL3D_REG_INDEX(clear_surface):
-        return ProcessClearBuffers();
+        return ProcessClearBuffers(1);
     case MAXWELL3D_REG_INDEX(report_semaphore.query):
         return ProcessQueryGet();
     case MAXWELL3D_REG_INDEX(render_enable.mode):
@@ -596,8 +596,8 @@ u32 Maxwell3D::GetRegisterValue(u32 method) const {
     return regs.reg_array[method];
 }
 
-void Maxwell3D::ProcessClearBuffers() {
-    rasterizer->Clear();
+void Maxwell3D::ProcessClearBuffers(u32 layer_count) {
+    rasterizer->Clear(layer_count);
 }
 
 void Maxwell3D::ProcessDraw(u32 instance_count) {

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1129,7 +1129,6 @@ public:
             Tegra::RenderTargetFormat format;
             TileMode tile_mode;
             union {
-                u32 depth_volume;
                 BitField<0, 16, u32> depth;
                 BitField<16, 1, u32> volume;
             };
@@ -3087,6 +3086,9 @@ public:
 
     std::vector<u8> inline_index_draw_indexes;
 
+    /// Handles a write to the CLEAR_BUFFERS register.
+    void ProcessClearBuffers(u32 layer_count);
+
 private:
     void InitializeRegisterDefaults();
 
@@ -3120,9 +3122,6 @@ private:
 
     /// Handles firmware blob 4
     void ProcessFirmwareCall4();
-
-    /// Handles a write to the CLEAR_BUFFERS register.
-    void ProcessClearBuffers();
 
     /// Handles a write to the QUERY_GET register.
     void ProcessQueryGet();

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1129,6 +1129,7 @@ public:
             Tegra::RenderTargetFormat format;
             TileMode tile_mode;
             union {
+                u32 depth_volume;
                 BitField<0, 16, u32> depth;
                 BitField<16, 1, u32> volume;
             };

--- a/src/video_core/macro/macro_hle.cpp
+++ b/src/video_core/macro/macro_hle.cpp
@@ -126,11 +126,31 @@ void HLE_3F5E74B9C9A50164(Engines::Maxwell3D& maxwell3d, const std::vector<u32>&
     }
 }
 
-constexpr std::array<std::pair<u64, HLEFunction>, 4> hle_funcs{{
+// Multi-layer Clear
+void HLE_EAD26C3E2109B06B(Engines::Maxwell3D& maxwell3d, const std::vector<u32>& parameters) {
+    ASSERT(parameters.size() == 1);
+
+    Engines::Maxwell3D::Regs::ClearSurface clear_params{parameters[0]};
+
+    const u32 rt_index = clear_params.RT;
+    const u32 num_layers = maxwell3d.regs.rt[rt_index].depth_volume;
+
+    for (u32 i = 0; i < num_layers; i++) {
+        // 0x674 = regs.clear_surface
+        maxwell3d.CallMethod(0x674, clear_params.raw, true);
+        clear_params.layer.Assign(clear_params.layer + 1);
+
+        // FIXME: remove this when amdvlk can clear multiple layers without crashing
+        break;
+    }
+}
+
+constexpr std::array<std::pair<u64, HLEFunction>, 5> hle_funcs{{
     {0x771BB18C62444DA0, &HLE_771BB18C62444DA0},
     {0x0D61FC9FAAC9FCAD, &HLE_0D61FC9FAAC9FCAD},
     {0x0217920100488FF7, &HLE_0217920100488FF7},
     {0x3F5E74B9C9A50164, &HLE_3F5E74B9C9A50164},
+    {0xEAD26C3E2109B06B, &HLE_EAD26C3E2109B06B},
 }};
 
 class HLEMacroImpl final : public CachedMacro {

--- a/src/video_core/macro/macro_hle.cpp
+++ b/src/video_core/macro/macro_hle.cpp
@@ -130,19 +130,13 @@ void HLE_3F5E74B9C9A50164(Engines::Maxwell3D& maxwell3d, const std::vector<u32>&
 void HLE_EAD26C3E2109B06B(Engines::Maxwell3D& maxwell3d, const std::vector<u32>& parameters) {
     ASSERT(parameters.size() == 1);
 
-    Engines::Maxwell3D::Regs::ClearSurface clear_params{parameters[0]};
-
+    const Engines::Maxwell3D::Regs::ClearSurface clear_params{parameters[0]};
     const u32 rt_index = clear_params.RT;
-    const u32 num_layers = maxwell3d.regs.rt[rt_index].depth_volume;
+    const u32 num_layers = maxwell3d.regs.rt[rt_index].depth;
+    ASSERT(clear_params.layer == 0);
 
-    for (u32 i = 0; i < num_layers; i++) {
-        // 0x674 = regs.clear_surface
-        maxwell3d.CallMethod(0x674, clear_params.raw, true);
-        clear_params.layer.Assign(clear_params.layer + 1);
-
-        // FIXME: remove this when amdvlk can clear multiple layers without crashing
-        break;
-    }
+    maxwell3d.regs.clear_surface.raw = clear_params.raw;
+    maxwell3d.ProcessClearBuffers(num_layers);
 }
 
 constexpr std::array<std::pair<u64, HLEFunction>, 5> hle_funcs{{

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -43,7 +43,7 @@ public:
     virtual void Draw(bool is_indexed, u32 instance_count) = 0;
 
     /// Clear the current framebuffer
-    virtual void Clear() = 0;
+    virtual void Clear(u32 layer_count) = 0;
 
     /// Dispatches a compute shader invocation
     virtual void DispatchCompute() = 0;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -136,7 +136,7 @@ void RasterizerOpenGL::LoadDiskResources(u64 title_id, std::stop_token stop_load
     shader_cache.LoadDiskResources(title_id, stop_loading, callback);
 }
 
-void RasterizerOpenGL::Clear() {
+void RasterizerOpenGL::Clear(u32 layer_count) {
     MICROPROFILE_SCOPE(OpenGL_Clears);
     if (!maxwell3d->ShouldExecute()) {
         return;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -69,7 +69,7 @@ public:
     ~RasterizerOpenGL() override;
 
     void Draw(bool is_indexed, u32 instance_count) override;
-    void Clear() override;
+    void Clear(u32 layer_count) override;
     void DispatchCompute() override;
     void ResetCounter(VideoCore::QueryType type) override;
     void Query(GPUVAddr gpu_addr, VideoCore::QueryType type, std::optional<u64> timestamp) override;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -213,7 +213,7 @@ void RasterizerVulkan::Draw(bool is_indexed, u32 instance_count) {
     EndTransformFeedback();
 }
 
-void RasterizerVulkan::Clear() {
+void RasterizerVulkan::Clear(u32 layer_count) {
     MICROPROFILE_SCOPE(Vulkan_Clearing);
 
     if (!maxwell3d->ShouldExecute()) {
@@ -256,7 +256,7 @@ void RasterizerVulkan::Clear() {
         .rect = regs.clear_control.use_scissor ? GetScissorState(regs, 0, up_scale, down_shift)
                                                : default_scissor,
         .baseArrayLayer = regs.clear_surface.layer,
-        .layerCount = 1,
+        .layerCount = layer_count,
     };
     if (clear_rect.rect.extent.width == 0 || clear_rect.rect.extent.height == 0) {
         return;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -65,7 +65,7 @@ public:
     ~RasterizerVulkan() override;
 
     void Draw(bool is_indexed, u32 instance_count) override;
-    void Clear() override;
+    void Clear(u32 layer_count) override;
     void DispatchCompute() override;
     void ResetCounter(VideoCore::QueryType type) override;
     void Query(GPUVAddr gpu_addr, VideoCore::QueryType type, std::optional<u64> timestamp) override;


### PR DESCRIPTION
Adds a HLE multi-layer clear mechanism, since AMD has been dragging their feet on fixing clears of multiple layers per command queue submission in their driver. This allows Xenoblade Chronicles 3 to become playable on AMD Windows again.

Fixes #9038

TODO: is the layer index not implemented for OpenGL? I couldn't see how it was used.