### PR TITLE
Dynarmic: Remove inaccurate NaN from Auto CPU settings.

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -348,7 +348,6 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
         if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
             config.unsafe_optimizations = true;
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
             config.fastmem_address_space_bits = 64;
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
         }


### PR DESCRIPTION
Outsourced testing has shown that disabling this option improves stability in Pokemon Scarlet. I cannot verify it myself yet, so I'll leave it as "experimental".