### PR TITLE
audio_core: sink: Disable stalling for science.

### DIFF
--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -265,20 +265,8 @@ void SinkStream::ProcessAudioOutAndRender(std::span<s16> output_buffer, std::siz
     }
 }
 
-void SinkStream::Stall() {
-    if (stalled) {
-        return;
-    }
-    stalled = true;
-    system.StallProcesses();
-}
+void SinkStream::Stall() {}
 
-void SinkStream::Unstall() {
-    if (!stalled) {
-        return;
-    }
-    system.UnstallProcesses();
-    stalled = false;
-}
+void SinkStream::Unstall() {}
 
 } // namespace AudioCore::Sink


### PR DESCRIPTION
Prevents error spam/potential crashes on Pokemon Scarlet/Violet. Marked as do-not-merge until we fully root cause the issue.