### PR TITLE
spirv_emit_context: add missing flat decoration

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1362,6 +1362,7 @@ void EmitContext::DefineInputs(const IR::Program& program) {
     if (loads[IR::Attribute::Layer]) {
         AddCapability(spv::Capability::Geometry);
         layer = DefineInput(*this, U32[1], false, spv::BuiltIn::Layer);
+        Decorate(layer, spv::Decoration::Flat);
     }
     if (loads.AnyComponent(IR::Attribute::PositionX)) {
         const bool is_fragment{stage != Stage::Fragment};


### PR DESCRIPTION
Places Scarlet in its proper setting of Paldea instead of Mexico

|Before|After|
|-|-|
|![0100a3d008c5c000_2022-11-18_22-10-08-942](https://user-images.githubusercontent.com/9658600/202831425-eaf823f8-ba69-42d3-93bf-3aa6919b7f4c.png)|![0100a3d008c5c000_2022-11-18_22-07-33-286](https://user-images.githubusercontent.com/9658600/202831347-3cd5d943-cffa-4148-a2f4-22a1760b0a02.png)|

Note: AMD users should clear their shader cache for Scarlet/Violet for this to take effect