### PR TITLE
common: fiber: Use Win32 impl. for fibers.

### DIFF
--- a/src/common/fiber.h
+++ b/src/common/fiber.h
@@ -6,9 +6,11 @@
 #include <functional>
 #include <memory>
 
+#if !defined(_WIN32) && !defined(WIN32)
 namespace boost::context::detail {
 struct transfer_t;
 }
+#endif
 
 namespace Common {
 
@@ -40,7 +42,7 @@ public:
 
     /// Yields control from Fiber 'from' to Fiber 'to'
     /// Fiber 'from' must be the currently running fiber.
-    static void YieldTo(std::weak_ptr<Fiber> weak_from, Fiber& to);
+    static void YieldTo(std::shared_ptr<Fiber> from, std::shared_ptr<Fiber> to);
     [[nodiscard]] static std::shared_ptr<Fiber> ThreadToFiber();
 
     void SetRewindPoint(std::function<void()>&& rewind_func);
@@ -50,13 +52,23 @@ public:
     /// Only call from main thread's fiber
     void Exit();
 
+    /// Changes the start parameter of the fiber. Has no effect if the fiber already started
+    void SetStartParameter(void* new_parameter);
+
 private:
     Fiber();
 
+#if defined(_WIN32) || defined(WIN32)
+    void OnRewind();
+    void Start();
+    static void FiberStartFunc(void* fiber_parameter);
+    static void RewindStartFunc(void* fiber_parameter);
+#else
     void OnRewind(boost::context::detail::transfer_t& transfer);
     void Start(boost::context::detail::transfer_t& transfer);
     static void FiberStartFunc(boost::context::detail::transfer_t transfer);
     static void RewindStartFunc(boost::context::detail::transfer_t transfer);
+#endif
 
     struct FiberImpl;
     std::unique_ptr<FiberImpl> impl;

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -180,7 +180,7 @@ void CpuManager::ShutdownThread() {
     auto* thread = kernel.GetCurrentEmuThread();
     auto core = is_multicore ? kernel.CurrentPhysicalCoreIndex() : 0;
 
-    Common::Fiber::YieldTo(thread->GetHostContext(), *core_data[core].host_context);
+    Common::Fiber::YieldTo(thread->GetHostContext(), core_data[core].host_context);
     UNREACHABLE();
 }
 
@@ -217,7 +217,7 @@ void CpuManager::RunThread(std::size_t core) {
     auto* thread = scheduler.GetSchedulerCurrentThread();
     Kernel::SetCurrentThread(kernel, thread);
 
-    Common::Fiber::YieldTo(data.host_context, *thread->GetHostContext());
+    Common::Fiber::YieldTo(data.host_context, thread->GetHostContext());
 }
 
 } // namespace Core

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -116,7 +116,7 @@ void KScheduler::PreemptSingleCore() {
     auto& previous_scheduler = kernel.Scheduler(thread->GetCurrentCore());
     previous_scheduler.Unload(thread);
 
-    Common::Fiber::YieldTo(thread->GetHostContext(), *m_switch_fiber);
+    Common::Fiber::YieldTo(thread->GetHostContext(), m_switch_fiber);
 
     GetCurrentThread(kernel).EnableDispatch();
 }
@@ -411,7 +411,7 @@ void KScheduler::ScheduleImpl() {
     m_switch_cur_thread = cur_thread;
     m_switch_highest_priority_thread = highest_priority_thread;
     m_switch_from_schedule = true;
-    Common::Fiber::YieldTo(cur_thread->host_context, *m_switch_fiber);
+    Common::Fiber::YieldTo(cur_thread->host_context, m_switch_fiber);
 
     // Returning from ScheduleImpl occurs after this thread has been scheduled again.
 }
@@ -489,7 +489,7 @@ void KScheduler::ScheduleImplFiber() {
     Reload(highest_priority_thread);
 
     // Reload the host thread.
-    Common::Fiber::YieldTo(m_switch_fiber, *highest_priority_thread->host_context);
+    Common::Fiber::YieldTo(m_switch_fiber, highest_priority_thread->host_context);
 }
 
 void KScheduler::Unload(KThread* thread) {

--- a/src/tests/common/fibers.cpp
+++ b/src/tests/common/fibers.cpp
@@ -50,7 +50,7 @@ public:
             value++;
         }
         results[id] = value;
-        Fiber::YieldTo(work_fibers[id], *thread_fibers[id]);
+        Fiber::YieldTo(work_fibers[id], thread_fibers[id]);
     }
 
     void ExecuteThread(u32 id);
@@ -68,7 +68,7 @@ void TestControl1::ExecuteThread(u32 id) {
     thread_fibers[id] = thread_fiber;
     work_fibers[id] = std::make_shared<Fiber>([this] { DoWork(); });
     items[id] = rand() % 256;
-    Fiber::YieldTo(thread_fibers[id], *work_fibers[id]);
+    Fiber::YieldTo(thread_fibers[id], work_fibers[id]);
     thread_fibers[id]->Exit();
 }
 
@@ -105,11 +105,11 @@ public:
         for (u32 i = 0; i < 12000; i++) {
             value1 += i;
         }
-        Fiber::YieldTo(fiber1, *fiber3);
+        Fiber::YieldTo(fiber1, fiber3);
         const u32 id = thread_ids.Get();
         assert1 = id == 1;
         value2 += 5000;
-        Fiber::YieldTo(fiber1, *thread_fibers[id]);
+        Fiber::YieldTo(fiber1, thread_fibers[id]);
     }
 
     void DoWork2() {
@@ -117,7 +117,7 @@ public:
             ;
         value2 = 2000;
         trap = false;
-        Fiber::YieldTo(fiber2, *fiber1);
+        Fiber::YieldTo(fiber2, fiber1);
         assert3 = false;
     }
 
@@ -125,19 +125,19 @@ public:
         const u32 id = thread_ids.Get();
         assert2 = id == 0;
         value1 += 1000;
-        Fiber::YieldTo(fiber3, *thread_fibers[id]);
+        Fiber::YieldTo(fiber3, thread_fibers[id]);
     }
 
     void ExecuteThread(u32 id);
 
     void CallFiber1() {
         const u32 id = thread_ids.Get();
-        Fiber::YieldTo(thread_fibers[id], *fiber1);
+        Fiber::YieldTo(thread_fibers[id], fiber1);
     }
 
     void CallFiber2() {
         const u32 id = thread_ids.Get();
-        Fiber::YieldTo(thread_fibers[id], *fiber2);
+        Fiber::YieldTo(thread_fibers[id], fiber2);
     }
 
     void Exit();
@@ -207,23 +207,23 @@ public:
 
     void DoWork1() {
         value1 += 1;
-        Fiber::YieldTo(fiber1, *fiber2);
+        Fiber::YieldTo(fiber1, fiber2);
         const u32 id = thread_ids.Get();
         value3 += 1;
-        Fiber::YieldTo(fiber1, *thread_fibers[id]);
+        Fiber::YieldTo(fiber1, thread_fibers[id]);
     }
 
     void DoWork2() {
         value2 += 1;
         const u32 id = thread_ids.Get();
-        Fiber::YieldTo(fiber2, *thread_fibers[id]);
+        Fiber::YieldTo(fiber2, thread_fibers[id]);
     }
 
     void ExecuteThread(u32 id);
 
     void CallFiber1() {
         const u32 id = thread_ids.Get();
-        Fiber::YieldTo(thread_fibers[id], *fiber1);
+        Fiber::YieldTo(thread_fibers[id], fiber1);
     }
 
     void Exit();
@@ -283,7 +283,7 @@ public:
 
     void Execute() {
         thread_fiber = Fiber::ThreadToFiber();
-        Fiber::YieldTo(thread_fiber, *fiber1);
+        Fiber::YieldTo(thread_fiber, fiber1);
         thread_fiber->Exit();
     }
 
@@ -291,7 +291,7 @@ public:
         fiber1->SetRewindPoint([this] { DoWork(); });
         if (rewinded) {
             goal_reached = true;
-            Fiber::YieldTo(fiber1, *thread_fiber);
+            Fiber::YieldTo(fiber1, thread_fiber);
         }
         rewinded = true;
         fiber1->Rewind();


### PR DESCRIPTION
Older implementation of fibers that uses Win32 implementation. Improves stability here -- tagging for broader testing.