### PR TITLE
 Configuration: Add per-game input profiles 

### DIFF
--- a/src/common/settings_input.h
+++ b/src/common/settings_input.h
@@ -391,6 +391,7 @@ struct PlayerInput {
     u32 body_color_right;
     u32 button_color_left;
     u32 button_color_right;
+    std::string profile_name;
 };
 
 struct TouchscreenInput {

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -107,10 +107,9 @@ void EmulatedController::ReloadFromSettings() {
         original_npad_type = npad_type;
     }
 
+    Disconnect();
     if (player.connected) {
         Connect();
-    } else {
-        Disconnect();
     }
 
     ReloadInput();

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -85,6 +85,9 @@ add_executable(yuzu
     configuration/configure_input_advanced.cpp
     configuration/configure_input_advanced.h
     configuration/configure_input_advanced.ui
+    configuration/configure_input_per_game.cpp
+    configuration/configure_input_per_game.h
+    configuration/configure_input_per_game.ui
     configuration/configure_input_player.cpp
     configuration/configure_input_player.h
     configuration/configure_input_player.ui

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -34,6 +34,7 @@ public:
 
     void ReadControlPlayerValue(std::size_t player_index);
     void SaveControlPlayerValue(std::size_t player_index);
+    void ClearControlPlayerValues();
 
     const std::string& GetConfigFilePath() const;
 
@@ -58,6 +59,7 @@ public:
 
 private:
     void Initialize(const std::string& config_name);
+    bool IsCustomConfig();
 
     void ReadValues();
     void ReadPlayerValue(std::size_t player_index);

--- a/src/yuzu/configuration/configure_input_per_game.cpp
+++ b/src/yuzu/configuration/configure_input_per_game.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/settings.h"
+#include "core/core.h"
+#include "core/hid/emulated_controller.h"
+#include "core/hid/hid_core.h"
+#include "ui_configure_input_per_game.h"
+#include "yuzu/configuration/configure_input_per_game.h"
+#include "yuzu/configuration/input_profiles.h"
+
+ConfigureInputPerGame::ConfigureInputPerGame(Core::System& system_, QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInputPerGame>()),
+      profiles(std::make_unique<InputProfiles>()), system{system_} {
+    ui->setupUi(this);
+
+    Settings::values.players.SetGlobal(false);
+    const auto previous_profile = Settings::values.players.GetValue()[0].profile_name;
+
+    const auto& profile_names = profiles->GetInputProfileNames();
+
+    ui->profile_player_1->addItem(QString::fromStdString("Use global configuration"));
+    for (size_t index = 0; index < profile_names.size(); ++index) {
+        const auto& profile_name = profile_names[index];
+        ui->profile_player_1->addItem(QString::fromStdString(profile_name));
+        if (profile_name == previous_profile) {
+            // offset by 1 since the first element is the global config
+            ui->profile_player_1->setCurrentIndex(static_cast<int>(index + 1));
+        }
+    }
+    LoadConfiguration();
+}
+
+void ConfigureInputPerGame::ApplyConfiguration() {
+    LoadConfiguration();
+
+    auto& hid_core = system.HIDCore();
+    auto* emulated_controller = hid_core.GetEmulatedControllerByIndex(0);
+
+    const auto selection_index = ui->profile_player_1->currentIndex();
+    if (selection_index == 0) {
+        Settings::values.players.SetGlobal(true);
+        emulated_controller->ReloadFromSettings();
+        return;
+    } else {
+        Settings::values.players.SetGlobal(false);
+    }
+    const QString profile_name = ui->profile_player_1->itemText(selection_index);
+    if (profile_name.isEmpty()) {
+        return;
+    }
+    profiles->SaveProfile(Settings::values.players.GetValue()[0].profile_name, 0);
+    emulated_controller->ReloadFromSettings();
+}
+
+void ConfigureInputPerGame::LoadConfiguration() {
+    auto& hid_core = system.HIDCore();
+    auto* emulated_controller = hid_core.GetEmulatedControllerByIndex(0);
+
+    Settings::values.players.SetGlobal(false);
+
+    const auto selection_index = ui->profile_player_1->currentIndex();
+    if (selection_index == 0) {
+        Settings::values.players.GetValue()[0].profile_name = "";
+        Settings::values.players.SetGlobal(true);
+        emulated_controller->ReloadFromSettings();
+        return;
+    }
+    const QString profile_name = ui->profile_player_1->itemText(selection_index);
+    if (profile_name.isEmpty()) {
+        return;
+    }
+    profiles->LoadProfile(profile_name.toStdString(), 0);
+    Settings::values.players.GetValue()[0].profile_name = profile_name.toStdString();
+    emulated_controller->ReloadFromSettings();
+}

--- a/src/yuzu/configuration/configure_input_per_game.cpp
+++ b/src/yuzu/configuration/configure_input_per_game.cpp
@@ -6,12 +6,14 @@
 #include "core/hid/emulated_controller.h"
 #include "core/hid/hid_core.h"
 #include "ui_configure_input_per_game.h"
+#include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_input_per_game.h"
 #include "yuzu/configuration/input_profiles.h"
 
-ConfigureInputPerGame::ConfigureInputPerGame(Core::System& system_, QWidget* parent)
+ConfigureInputPerGame::ConfigureInputPerGame(Core::System& system_, Config* config_,
+                                             QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigureInputPerGame>()),
-      profiles(std::make_unique<InputProfiles>()), system{system_} {
+      profiles(std::make_unique<InputProfiles>()), system{system_}, config{config_} {
     ui->setupUi(this);
     const std::array labels = {
         ui->label_player_1, ui->label_player_2, ui->label_player_3, ui->label_player_4,
@@ -22,6 +24,8 @@ ConfigureInputPerGame::ConfigureInputPerGame(Core::System& system_, QWidget* par
         ui->profile_player_5, ui->profile_player_6, ui->profile_player_7, ui->profile_player_8,
     };
 
+    Settings::values.players.SetGlobal(false);
+
     const auto& profile_names = profiles->GetInputProfileNames();
     const auto populate_profiles = [this, &profile_names](size_t player_index) {
         const auto previous_profile =
@@ -29,6 +33,7 @@ ConfigureInputPerGame::ConfigureInputPerGame(Core::System& system_, QWidget* par
 
         auto* const player_combobox = profile_comboboxes[player_index];
         player_combobox->addItem(tr("Use global input configuration"));
+
         for (size_t index = 0; index < profile_names.size(); ++index) {
             const auto& profile_name = profile_names[index];
             player_combobox->addItem(QString::fromStdString(profile_name));
@@ -38,7 +43,6 @@ ConfigureInputPerGame::ConfigureInputPerGame(Core::System& system_, QWidget* par
             }
         }
     };
-
     for (size_t index = 0; index < profile_comboboxes.size(); ++index) {
         labels[index]->setText(tr("Player %1 profile").arg(index + 1));
         populate_profiles(index);
@@ -53,8 +57,10 @@ void ConfigureInputPerGame::ApplyConfiguration() {
 }
 
 void ConfigureInputPerGame::LoadConfiguration() {
+    static constexpr size_t HANDHELD_INDEX = 8;
+
     auto& hid_core = system.HIDCore();
-    const auto load_player_profile = [this, &hid_core](size_t player_index) {
+    for (size_t player_index = 0; player_index < profile_comboboxes.size(); ++player_index) {
         Settings::values.players.SetGlobal(false);
 
         auto* emulated_controller = hid_core.GetEmulatedControllerByIndex(player_index);
@@ -63,40 +69,47 @@ void ConfigureInputPerGame::LoadConfiguration() {
         const auto selection_index = player_combobox->currentIndex();
         if (selection_index == 0) {
             Settings::values.players.GetValue()[player_index].profile_name = "";
+            if (player_index == 0) {
+                Settings::values.players.GetValue()[HANDHELD_INDEX] = {};
+            }
             Settings::values.players.SetGlobal(true);
             emulated_controller->ReloadFromSettings();
-            return;
+            continue;
         }
         const auto profile_name = player_combobox->itemText(selection_index).toStdString();
         if (profile_name.empty()) {
-            return;
+            continue;
         }
+        auto& player = Settings::values.players.GetValue()[player_index];
+        player.profile_name = profile_name;
+        // Read from the profile into the custom player settings
         profiles->LoadProfile(profile_name, player_index);
-        Settings::values.players.GetValue()[player_index].profile_name = profile_name;
-        emulated_controller->ReloadFromSettings();
-    };
+        // Make sure the controller is connected
+        player.connected = true;
 
-    for (size_t index = 0; index < profile_comboboxes.size(); ++index) {
-        load_player_profile(index);
+        emulated_controller->ReloadFromSettings();
+
+        if (player_index > 0) {
+            continue;
+        }
+        // Handle Handheld cases
+        auto& handheld_player = Settings::values.players.GetValue()[HANDHELD_INDEX];
+        auto* handheld_controller = hid_core.GetEmulatedController(Core::HID::NpadIdType::Handheld);
+        if (player.controller_type == Settings::ControllerType::Handheld) {
+            handheld_player = player;
+        } else {
+            handheld_player = {};
+        }
+        handheld_controller->ReloadFromSettings();
     }
 }
 
 void ConfigureInputPerGame::SaveConfiguration() {
     Settings::values.players.SetGlobal(false);
 
-    auto& hid_core = system.HIDCore();
-    const auto save_player_profile = [this, &hid_core](size_t player_index) {
-        const auto selection_index = profile_comboboxes[player_index]->currentIndex();
-        if (selection_index == 0) {
-            return;
-        }
-        auto* emulated_controller = hid_core.GetEmulatedControllerByIndex(player_index);
-        profiles->SaveProfile(Settings::values.players.GetValue()[player_index].profile_name,
-                              player_index);
-        emulated_controller->ReloadFromSettings();
-    };
-
-    for (size_t index = 0; index < profile_comboboxes.size(); ++index) {
-        save_player_profile(index);
+    // Clear all controls from the config in case the user reverted back to globals
+    config->ClearControlPlayerValues();
+    for (size_t index = 0; index < Settings::values.players.GetValue().size(); ++index) {
+        config->SaveControlPlayerValue(index);
     }
 }

--- a/src/yuzu/configuration/configure_input_per_game.cpp
+++ b/src/yuzu/configuration/configure_input_per_game.cpp
@@ -13,64 +13,90 @@ ConfigureInputPerGame::ConfigureInputPerGame(Core::System& system_, QWidget* par
     : QWidget(parent), ui(std::make_unique<Ui::ConfigureInputPerGame>()),
       profiles(std::make_unique<InputProfiles>()), system{system_} {
     ui->setupUi(this);
-
-    Settings::values.players.SetGlobal(false);
-    const auto previous_profile = Settings::values.players.GetValue()[0].profile_name;
+    const std::array labels = {
+        ui->label_player_1, ui->label_player_2, ui->label_player_3, ui->label_player_4,
+        ui->label_player_5, ui->label_player_6, ui->label_player_7, ui->label_player_8,
+    };
+    profile_comboboxes = {
+        ui->profile_player_1, ui->profile_player_2, ui->profile_player_3, ui->profile_player_4,
+        ui->profile_player_5, ui->profile_player_6, ui->profile_player_7, ui->profile_player_8,
+    };
 
     const auto& profile_names = profiles->GetInputProfileNames();
+    const auto populate_profiles = [this, &profile_names](size_t player_index) {
+        const auto previous_profile =
+            Settings::values.players.GetValue()[player_index].profile_name;
 
-    ui->profile_player_1->addItem(QString::fromStdString("Use global configuration"));
-    for (size_t index = 0; index < profile_names.size(); ++index) {
-        const auto& profile_name = profile_names[index];
-        ui->profile_player_1->addItem(QString::fromStdString(profile_name));
-        if (profile_name == previous_profile) {
-            // offset by 1 since the first element is the global config
-            ui->profile_player_1->setCurrentIndex(static_cast<int>(index + 1));
+        auto* const player_combobox = profile_comboboxes[player_index];
+        player_combobox->addItem(tr("Use global input configuration"));
+        for (size_t index = 0; index < profile_names.size(); ++index) {
+            const auto& profile_name = profile_names[index];
+            player_combobox->addItem(QString::fromStdString(profile_name));
+            if (profile_name == previous_profile) {
+                // offset by 1 since the first element is the global config
+                player_combobox->setCurrentIndex(static_cast<int>(index + 1));
+            }
         }
+    };
+
+    for (size_t index = 0; index < profile_comboboxes.size(); ++index) {
+        labels[index]->setText(tr("Player %1 profile").arg(index + 1));
+        populate_profiles(index);
     }
+
     LoadConfiguration();
 }
 
 void ConfigureInputPerGame::ApplyConfiguration() {
     LoadConfiguration();
-
-    auto& hid_core = system.HIDCore();
-    auto* emulated_controller = hid_core.GetEmulatedControllerByIndex(0);
-
-    const auto selection_index = ui->profile_player_1->currentIndex();
-    if (selection_index == 0) {
-        Settings::values.players.SetGlobal(true);
-        emulated_controller->ReloadFromSettings();
-        return;
-    } else {
-        Settings::values.players.SetGlobal(false);
-    }
-    const QString profile_name = ui->profile_player_1->itemText(selection_index);
-    if (profile_name.isEmpty()) {
-        return;
-    }
-    profiles->SaveProfile(Settings::values.players.GetValue()[0].profile_name, 0);
-    emulated_controller->ReloadFromSettings();
+    SaveConfiguration();
 }
 
 void ConfigureInputPerGame::LoadConfiguration() {
     auto& hid_core = system.HIDCore();
-    auto* emulated_controller = hid_core.GetEmulatedControllerByIndex(0);
+    const auto load_player_profile = [this, &hid_core](size_t player_index) {
+        Settings::values.players.SetGlobal(false);
 
+        auto* emulated_controller = hid_core.GetEmulatedControllerByIndex(player_index);
+        auto* const player_combobox = profile_comboboxes[player_index];
+
+        const auto selection_index = player_combobox->currentIndex();
+        if (selection_index == 0) {
+            Settings::values.players.GetValue()[player_index].profile_name = "";
+            Settings::values.players.SetGlobal(true);
+            emulated_controller->ReloadFromSettings();
+            return;
+        }
+        const auto profile_name = player_combobox->itemText(selection_index).toStdString();
+        if (profile_name.empty()) {
+            return;
+        }
+        profiles->LoadProfile(profile_name, player_index);
+        Settings::values.players.GetValue()[player_index].profile_name = profile_name;
+        emulated_controller->ReloadFromSettings();
+    };
+
+    for (size_t index = 0; index < profile_comboboxes.size(); ++index) {
+        load_player_profile(index);
+    }
+}
+
+void ConfigureInputPerGame::SaveConfiguration() {
     Settings::values.players.SetGlobal(false);
 
-    const auto selection_index = ui->profile_player_1->currentIndex();
-    if (selection_index == 0) {
-        Settings::values.players.GetValue()[0].profile_name = "";
-        Settings::values.players.SetGlobal(true);
+    auto& hid_core = system.HIDCore();
+    const auto save_player_profile = [this, &hid_core](size_t player_index) {
+        const auto selection_index = profile_comboboxes[player_index]->currentIndex();
+        if (selection_index == 0) {
+            return;
+        }
+        auto* emulated_controller = hid_core.GetEmulatedControllerByIndex(player_index);
+        profiles->SaveProfile(Settings::values.players.GetValue()[player_index].profile_name,
+                              player_index);
         emulated_controller->ReloadFromSettings();
-        return;
+    };
+
+    for (size_t index = 0; index < profile_comboboxes.size(); ++index) {
+        save_player_profile(index);
     }
-    const QString profile_name = ui->profile_player_1->itemText(selection_index);
-    if (profile_name.isEmpty()) {
-        return;
-    }
-    profiles->LoadProfile(profile_name.toStdString(), 0);
-    Settings::values.players.GetValue()[0].profile_name = profile_name.toStdString();
-    emulated_controller->ReloadFromSettings();
 }

--- a/src/yuzu/configuration/configure_input_per_game.h
+++ b/src/yuzu/configuration/configure_input_per_game.h
@@ -11,10 +11,6 @@ namespace Core {
 class System;
 }
 
-namespace InputCommon {
-class InputSubsystem;
-}
-
 namespace Ui {
 class ConfigureInputPerGame;
 }
@@ -27,18 +23,20 @@ class ConfigureInputPerGame : public QWidget {
 public:
     explicit ConfigureInputPerGame(Core::System& system_, QWidget* parent = nullptr);
 
-    /// Initializes the input dialog with the given input subsystem.
-    // void Initialize(InputCommon::InputSubsystem* input_subsystem_, std::size_t max_players = 8);
-
-    /// Save configurations to settings file.
+    /// Load and Save configurations to settings file.
     void ApplyConfiguration();
 
 private:
     /// Load configuration from settings file.
     void LoadConfiguration();
 
+    /// Save configuration to settings file.
+    void SaveConfiguration();
+
     std::unique_ptr<Ui::ConfigureInputPerGame> ui;
     std::unique_ptr<InputProfiles> profiles;
+
+    std::array<QComboBox*, 8> profile_comboboxes;
 
     Core::System& system;
 };

--- a/src/yuzu/configuration/configure_input_per_game.h
+++ b/src/yuzu/configuration/configure_input_per_game.h
@@ -7,21 +7,23 @@
 
 #include <QWidget>
 
+#include "ui_configure_input_per_game.h"
+#include "yuzu/configuration/input_profiles.h"
+
+class QComboBox;
+
 namespace Core {
 class System;
-}
+} // namespace Core
 
-namespace Ui {
-class ConfigureInputPerGame;
-}
-
-class InputProfiles;
+class Config;
 
 class ConfigureInputPerGame : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ConfigureInputPerGame(Core::System& system_, QWidget* parent = nullptr);
+    explicit ConfigureInputPerGame(Core::System& system_, Config* config_,
+                                   QWidget* parent = nullptr);
 
     /// Load and Save configurations to settings file.
     void ApplyConfiguration();
@@ -39,4 +41,5 @@ private:
     std::array<QComboBox*, 8> profile_comboboxes;
 
     Core::System& system;
+    Config* config;
 };

--- a/src/yuzu/configuration/configure_input_per_game.h
+++ b/src/yuzu/configuration/configure_input_per_game.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <memory>
+
+#include <QWidget>
+
+namespace Core {
+class System;
+}
+
+namespace InputCommon {
+class InputSubsystem;
+}
+
+namespace Ui {
+class ConfigureInputPerGame;
+}
+
+class InputProfiles;
+
+class ConfigureInputPerGame : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ConfigureInputPerGame(Core::System& system_, QWidget* parent = nullptr);
+
+    /// Initializes the input dialog with the given input subsystem.
+    // void Initialize(InputCommon::InputSubsystem* input_subsystem_, std::size_t max_players = 8);
+
+    /// Save configurations to settings file.
+    void ApplyConfiguration();
+
+private:
+    /// Load configuration from settings file.
+    void LoadConfiguration();
+
+    std::unique_ptr<Ui::ConfigureInputPerGame> ui;
+    std::unique_ptr<InputProfiles> profiles;
+
+    Core::System& system;
+};

--- a/src/yuzu/configuration/configure_input_per_game.ui
+++ b/src/yuzu/configuration/configure_input_per_game.ui
@@ -30,7 +30,7 @@
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
          <widget class="QWidget" name="player_1" native="true">
-          <layout class="QHBoxLayout" name="input_profile_layout">
+          <layout class="QHBoxLayout" name="input_profile_layout_1">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -64,8 +64,43 @@
          </widget>
         </item>
         <item>
+         <widget class="QWidget" name="player_2" native="true">
+          <layout class="QHBoxLayout" name="input_profile_layout_2">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_player_2">
+             <property name="text">
+              <string>Player 2 Profile</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="profile_player_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QWidget" name="player_3" native="true">
-          <layout class="QHBoxLayout" name="input_profile_layout">
+          <layout class="QHBoxLayout" name="input_profile_layout_3">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -100,7 +135,7 @@
         </item>
         <item>
          <widget class="QWidget" name="player_4" native="true">
-          <layout class="QHBoxLayout" name="input_profile_layout">
+          <layout class="QHBoxLayout" name="input_profile_layout_4">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -135,7 +170,7 @@
         </item>
         <item>
          <widget class="QWidget" name="player_5" native="true">
-          <layout class="QHBoxLayout" name="input_profile_layout">
+          <layout class="QHBoxLayout" name="input_profile_layout_5">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -170,7 +205,7 @@
         </item>
         <item>
          <widget class="QWidget" name="player_6" native="true">
-          <layout class="QHBoxLayout" name="input_profile_layout">
+          <layout class="QHBoxLayout" name="input_profile_layout_6">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -205,7 +240,7 @@
         </item>
         <item>
          <widget class="QWidget" name="player_7" native="true">
-          <layout class="QHBoxLayout" name="input_profile_layout">
+          <layout class="QHBoxLayout" name="input_profile_layout_7">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -240,7 +275,7 @@
         </item>
         <item>
          <widget class="QWidget" name="player_8" native="true">
-          <layout class="QHBoxLayout" name="input_profile_layout">
+          <layout class="QHBoxLayout" name="input_profile_layout_8">
            <property name="leftMargin">
             <number>0</number>
            </property>

--- a/src/yuzu/configuration/configure_input_per_game.ui
+++ b/src/yuzu/configuration/configure_input_per_game.ui
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureInputPerGame</class>
+ <widget class="QWidget" name="PerGameInput">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>541</width>
+    <height>759</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="accessibleName">
+   <string>Graphics</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_1">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Input Profiles</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <widget class="QWidget" name="player_1" native="true">
+          <layout class="QHBoxLayout" name="input_profile_layout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_player_1">
+             <property name="text">
+              <string>Player 1 Profile</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="profile_player_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="player_3" native="true">
+          <layout class="QHBoxLayout" name="input_profile_layout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_player_3">
+             <property name="text">
+              <string>Player 3 Profile</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="profile_player_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="player_4" native="true">
+          <layout class="QHBoxLayout" name="input_profile_layout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_player_4">
+             <property name="text">
+              <string>Player 4 Profile</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="profile_player_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="player_5" native="true">
+          <layout class="QHBoxLayout" name="input_profile_layout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_player_5">
+             <property name="text">
+              <string>Player 5 Profile</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="profile_player_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="player_6" native="true">
+          <layout class="QHBoxLayout" name="input_profile_layout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_player_6">
+             <property name="text">
+              <string>Player 6 Profile</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="profile_player_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="player_7" native="true">
+          <layout class="QHBoxLayout" name="input_profile_layout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_player_7">
+             <property name="text">
+              <string>Player 7 Profile</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="profile_player_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="player_8" native="true">
+          <layout class="QHBoxLayout" name="input_profile_layout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_player_8">
+             <property name="text">
+              <string>Player 8 Profile</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="profile_player_8">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -1553,6 +1553,7 @@ void ConfigureInputPlayer::LoadProfile() {
 }
 
 void ConfigureInputPlayer::SaveProfile() {
+    static constexpr size_t HANDHELD_INDEX = 8;
     const QString profile_name = ui->comboProfiles->itemText(ui->comboProfiles->currentIndex());
 
     if (profile_name.isEmpty()) {
@@ -1561,7 +1562,12 @@ void ConfigureInputPlayer::SaveProfile() {
 
     ApplyConfiguration();
 
-    if (!profiles->SaveProfile(profile_name.toStdString(), player_index)) {
+    // When we're in handheld mode, only the handheld emulated controller bindings are updated
+    const bool is_handheld = player_index == 0 && emulated_controller->GetNpadIdType() ==
+                                                      Core::HID::NpadIdType::Handheld;
+    const auto profile_player_index = is_handheld ? HANDHELD_INDEX : player_index;
+
+    if (!profiles->SaveProfile(profile_name.toStdString(), profile_player_index)) {
         QMessageBox::critical(this, tr("Save Input Profile"),
                               tr("Failed to save the input profile \"%1\"").arg(profile_name));
         UpdateInputProfiles();

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -38,7 +38,7 @@ enum class InputType;
 
 namespace Ui {
 class ConfigureInputPlayer;
-}
+} // namespace Ui
 
 namespace Core::HID {
 class HIDCore;

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -28,7 +28,7 @@
 #include "yuzu/configuration/configure_general.h"
 #include "yuzu/configuration/configure_graphics.h"
 #include "yuzu/configuration/configure_graphics_advanced.h"
-#include "yuzu/configuration/configure_input.h"
+#include "yuzu/configuration/configure_input_per_game.h"
 #include "yuzu/configuration/configure_per_game.h"
 #include "yuzu/configuration/configure_per_game_addons.h"
 #include "yuzu/configuration/configure_system.h"
@@ -50,6 +50,7 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::st
     general_tab = std::make_unique<ConfigureGeneral>(system_, this);
     graphics_tab = std::make_unique<ConfigureGraphics>(system_, this);
     graphics_advanced_tab = std::make_unique<ConfigureGraphicsAdvanced>(system_, this);
+    input_tab = std::make_unique<ConfigureInputPerGame>(system_, this);
     system_tab = std::make_unique<ConfigureSystem>(system_, this);
 
     ui->setupUi(this);
@@ -61,6 +62,7 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::st
     ui->tabWidget->addTab(graphics_tab.get(), tr("Graphics"));
     ui->tabWidget->addTab(graphics_advanced_tab.get(), tr("Adv. Graphics"));
     ui->tabWidget->addTab(audio_tab.get(), tr("Audio"));
+    ui->tabWidget->addTab(input_tab.get(), tr("Input Profiles"));
 
     setFocusPolicy(Qt::ClickFocus);
     setWindowTitle(tr("Properties"));
@@ -91,6 +93,7 @@ void ConfigurePerGame::ApplyConfiguration() {
     graphics_tab->ApplyConfiguration();
     graphics_advanced_tab->ApplyConfiguration();
     audio_tab->ApplyConfiguration();
+    input_tab->ApplyConfiguration();
 
     system.ApplySettings();
     Settings::LogSettings();

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -50,7 +50,7 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::st
     general_tab = std::make_unique<ConfigureGeneral>(system_, this);
     graphics_tab = std::make_unique<ConfigureGraphics>(system_, this);
     graphics_advanced_tab = std::make_unique<ConfigureGraphicsAdvanced>(system_, this);
-    input_tab = std::make_unique<ConfigureInputPerGame>(system_, this);
+    input_tab = std::make_unique<ConfigureInputPerGame>(system_, game_config.get(), this);
     system_tab = std::make_unique<ConfigureSystem>(system_, this);
 
     ui->setupUi(this);

--- a/src/yuzu/configuration/configure_per_game.h
+++ b/src/yuzu/configuration/configure_per_game.h
@@ -16,12 +16,17 @@ namespace Core {
 class System;
 }
 
+namespace InputCommon {
+class InputSubsystem;
+}
+
 class ConfigurePerGameAddons;
 class ConfigureAudio;
 class ConfigureCpu;
 class ConfigureGeneral;
 class ConfigureGraphics;
 class ConfigureGraphicsAdvanced;
+class ConfigureInputPerGame;
 class ConfigureSystem;
 
 class QGraphicsScene;
@@ -72,5 +77,6 @@ private:
     std::unique_ptr<ConfigureGeneral> general_tab;
     std::unique_ptr<ConfigureGraphics> graphics_tab;
     std::unique_ptr<ConfigureGraphicsAdvanced> graphics_advanced_tab;
+    std::unique_ptr<ConfigureInputPerGame> input_tab;
     std::unique_ptr<ConfigureSystem> system_tab;
 };

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -124,6 +124,7 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #include "yuzu/compatibility_list.h"
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_dialog.h"
+#include "yuzu/configuration/configure_input_per_game.h"
 #include "yuzu/debugger/console.h"
 #include "yuzu/debugger/controller.h"
 #include "yuzu/debugger/profiler.h"
@@ -1647,6 +1648,11 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
     LOG_INFO(Frontend, "yuzu starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
 
+    // Save configurations
+    UpdateUISettings();
+    game_list->SaveInterfaceLayout();
+    config->Save();
+
     u64 title_id{0};
 
     last_filename_booted = filename;
@@ -1665,11 +1671,6 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
         Config per_game_config(config_file_name, Config::ConfigType::PerGameConfig);
         system->ApplySettings();
     }
-
-    // Save configurations
-    UpdateUISettings();
-    game_list->SaveInterfaceLayout();
-    config->Save();
 
     Settings::LogSettings();
 
@@ -2790,6 +2791,7 @@ void GMainWindow::OnStopGame() {
     ShutdownGame();
 
     Settings::RestoreGlobalState(system->IsPoweredOn());
+    system->HIDCore().ReloadInputDevices();
     UpdateStatusButtons();
 }
 
@@ -3250,6 +3252,7 @@ void GMainWindow::OpenPerGameConfiguration(u64 title_id, const std::string& file
     // Do not cause the global config to write local settings into the config file
     const bool is_powered_on = system->IsPoweredOn();
     Settings::RestoreGlobalState(is_powered_on);
+    system->HIDCore().ReloadInputDevices();
 
     UISettings::values.configuration_applied = false;
 
@@ -3709,6 +3712,7 @@ void GMainWindow::OnCoreError(Core::SystemResultStatus result, std::string detai
             ShutdownGame();
 
             Settings::RestoreGlobalState(system->IsPoweredOn());
+            system->HIDCore().ReloadInputDevices();
             UpdateStatusButtons();
         }
     } else {
@@ -3860,18 +3864,19 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
     // Unload controllers early
     controller_dialog->UnloadController();
     game_list->UnloadController();
-    system->HIDCore().UnloadInputDevices();
 
     // Shutdown session if the emu thread is active...
     if (emu_thread != nullptr) {
         ShutdownGame();
 
         Settings::RestoreGlobalState(system->IsPoweredOn());
+        system->HIDCore().ReloadInputDevices();
         UpdateStatusButtons();
     }
 
     render_window->close();
     multiplayer_state->Close();
+    system->HIDCore().UnloadInputDevices();
     system->GetRoomNetwork().Shutdown();
 
     QWidget::closeEvent(event);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1669,6 +1669,7 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
                                           ? Common::FS::PathToUTF8String(file_path.filename())
                                           : fmt::format("{:016X}", title_id);
         Config per_game_config(config_file_name, Config::ConfigType::PerGameConfig);
+        system->HIDCore().ReloadInputDevices();
         system->ApplySettings();
     }
 


### PR DESCRIPTION
This enables setting custom input profiles per-game. 

Per-game profiles also apply the controller type (i.e. Pro Controller, Handheld, GameCube) that was selected when the profile was saved.

This acts as a temporary compromise until proper Per-Game Input configurations are implemented.

![image](https://user-images.githubusercontent.com/52414509/202871502-f7df1104-3043-4c1b-845d-8c24510162d1.png)
