### PR TITLE
don't revert to defaults on input type switch

### DIFF
--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -736,9 +736,6 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
         emulated_controller->SetNpadStyleIndex(type);
     });
 
-    connect(ui->comboDevices, qOverload<int>(&QComboBox::activated), this,
-            &ConfigureInputPlayer::UpdateMappingWithDefaults);
-
     ui->comboDevices->setCurrentIndex(-1);
 
     ui->buttonRefreshDevices->setIcon(QIcon::fromTheme(QStringLiteral("view-refresh")));

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -736,6 +736,9 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
         emulated_controller->SetNpadStyleIndex(type);
     });
 
+    connect(ui->comboDevices, qOverload<int>(&QComboBox::activated), this,
+            &ConfigureInputPlayer::UpdateMappingWithDefaults);
+
     ui->comboDevices->setCurrentIndex(-1);
 
     ui->buttonRefreshDevices->setIcon(QIcon::fromTheme(QStringLiteral("view-refresh")));


### PR DESCRIPTION
One of the most annoying features in Yuzu's input configuration is the resetting to defaults. Here's a typical use case:

1. Set custom controls
2. Save profile
3. Go to the next player tab
4. Load profile
5. Notice that the input device was also saved as part of the profile, meaning both players are controlled by the same controller
6. Change the input device from Foobar 0 to Foobar 1
7. All customization is reset to default

This makes it effectively impossible to use a profile with two different players/controllers at the same time. **Hence, this pull request eliminates (7) above.**

If this solution destroys too much (e.g. resetting to defaults is necessary for some other reason), another way would be to have the profile not include the input device. That would lead to this use case:

1. Set custom controls
2. Save profile
3. Go to the next player tab
4. **Choose input device**
5. Load profile
6. The input device is not overwritten, but the customization of the inputs is