### PR TITLE
k_handle_table: Remove cast to void* in GetObjectForIpc

### DIFF
--- a/src/core/hle/kernel/k_handle_table.cpp
+++ b/src/core/hle/kernel/k_handle_table.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "core/hle/kernel/k_handle_table.h"
+#include "core/hle/kernel/k_process.h"
 
 namespace Kernel {
 
@@ -80,6 +81,22 @@ Result KHandleTable::Add(Handle* out_handle, KAutoObject* obj) {
     }
 
     R_SUCCEED();
+}
+
+KScopedAutoObject<KAutoObject> KHandleTable::GetObjectForIpc(Handle handle,
+                                                             KThread* cur_thread) const {
+    // Handle pseudo-handles.
+    ASSERT(cur_thread != nullptr);
+    if (handle == Svc::PseudoHandle::CurrentProcess) {
+        auto* const cur_process = cur_thread->GetOwnerProcess();
+        ASSERT(cur_process != nullptr);
+        return cur_process;
+    }
+    if (handle == Svc::PseudoHandle::CurrentThread) {
+        return cur_thread;
+    }
+
+    return GetObjectForIpcWithoutPseudoHandle(handle);
 }
 
 Result KHandleTable::Reserve(Handle* out_handle) {

--- a/src/core/hle/kernel/k_handle_table.h
+++ b/src/core/hle/kernel/k_handle_table.h
@@ -113,21 +113,7 @@ public:
         return this->GetObjectImpl(handle);
     }
 
-    KScopedAutoObject<KAutoObject> GetObjectForIpc(Handle handle, KThread* cur_thread) const {
-        // Handle pseudo-handles.
-        ASSERT(cur_thread != nullptr);
-        if (handle == Svc::PseudoHandle::CurrentProcess) {
-            auto* const cur_process =
-                static_cast<KAutoObject*>(static_cast<void*>(cur_thread->GetOwnerProcess()));
-            ASSERT(cur_process != nullptr);
-            return cur_process;
-        }
-        if (handle == Svc::PseudoHandle::CurrentThread) {
-            return static_cast<KAutoObject*>(cur_thread);
-        }
-
-        return GetObjectForIpcWithoutPseudoHandle(handle);
-    }
+    KScopedAutoObject<KAutoObject> GetObjectForIpc(Handle handle, KThread* cur_thread) const;
 
     KScopedAutoObject<KAutoObject> GetObjectByIndex(Handle* out_handle, size_t index) const {
         KScopedDisableDispatch dd{m_kernel};


### PR DESCRIPTION
This was used to get around the KProcess class being incomplete. We can just move this to the cpp file and eliminate the cast entirely, letting the compiler do its work and still enforce type-safety