### PR TITLE
CMake: Use precompiled headers to improve compile times

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ option(YUZU_USE_BUNDLED_OPUS "Compile bundled opus" ON)
 
 option(YUZU_TESTS "Compile tests" ON)
 
+option(YUZU_USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
+
 CMAKE_DEPENDENT_OPTION(YUZU_CRASH_DUMPS "Compile Windows crash dump (Minidump) support" OFF "WIN32" OFF)
 
 option(YUZU_USE_BUNDLED_VCPKG "Use vcpkg for yuzu dependencies" "${MSVC}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,20 @@ elseif(NOT "$ENV{VCPKG_TOOLCHAIN_FILE}" STREQUAL "")
     include("$ENV{VCPKG_TOOLCHAIN_FILE}")
 endif()
 
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    if (MSVC AND CCACHE)
+        # buildcache does not properly cache PCH files, leading to compilation errors.
+        # See https://github.com/mbitsnbites/buildcache/discussions/230
+        message(WARNING "buildcache does not properly support Precompiled Headers. Disabling PCH")
+        set(YUZU_USE_PRECOMPILED_HEADERS OFF)
+    endif()
+endif()
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    message(STATUS "Using Precompiled Headers.")
+    set(CMAKE_PCH_INSTANTIATE_TEMPLATES ON)
+endif()
+
+
 # Default to a Release build
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if (NOT IS_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,8 +82,9 @@ if (MSVC)
         /wd4324 # 'struct_name': structure was padded due to __declspec(align())
     )
 
-    if (USE_CCACHE)
+    if (USE_CCACHE OR YUZU_USE_PRECOMPILED_HEADERS)
     # when caching, we need to use /Z7 to downgrade debug info to use an older but more cachable format
+    # Precompiled headers are deleted if not using /Z7. See https://github.com/nanoant/CMakePCHCompiler/issues/21
         add_compile_options(/Z7)
     else()
         add_compile_options(/Zi)
@@ -149,6 +150,10 @@ else()
         set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
         set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
     endif()
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    set(CMAKE_PCH_INSTANTIATE_TEMPLATES ON)
 endif()
 
 add_subdirectory(common)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,10 +152,6 @@ else()
     endif()
 endif()
 
-if (YUZU_USE_PRECOMPILED_HEADERS)
-    set(CMAKE_PCH_INSTANTIATE_TEMPLATES ON)
-endif()
-
 add_subdirectory(common)
 add_subdirectory(core)
 add_subdirectory(audio_core)

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(audio_core STATIC
     out/audio_out.h
     out/audio_out_system.cpp
     out/audio_out_system.h
+    precompiled_headers.h
     renderer/adsp/adsp.cpp
     renderer/adsp/adsp.h
     renderer/adsp/audio_renderer.cpp
@@ -228,4 +229,8 @@ endif()
 if(ENABLE_SDL2)
     target_link_libraries(audio_core PRIVATE SDL2)
     target_compile_definitions(audio_core PRIVATE HAVE_SDL2)
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(audio_core PRIVATE precompiled_headers.h)
 endif()

--- a/src/audio_core/precompiled_headers.h
+++ b/src/audio_core/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/audio_core/precompiled_headers.h
+++ b/src/audio_core/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(common STATIC
     cache_management.cpp
     cache_management.h
     common_funcs.h
+    common_precompiled_headers.h
     common_types.h
     concepts.h
     div_ceil.h
@@ -187,5 +188,4 @@ endif()
 
 if (YUZU_USE_PRECOMPILED_HEADERS)
     target_precompile_headers(common PRIVATE precompiled_headers.h)
-    set(CMAKE_PCH_INSTANTIATE_TEMPLATES ON)
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -95,6 +95,7 @@ add_library(common STATIC
     param_package.h
     parent_of_member.h
     point.h
+    precompiled_headers.h
     quaternion.h
     reader_writer_queue.h
     ring_buffer.h
@@ -182,4 +183,9 @@ if (TARGET zstd::zstd)
 else()
   target_link_libraries(common PRIVATE
     $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(common PRIVATE precompiled_headers.h)
+    set(CMAKE_PCH_INSTANTIATE_TEMPLATES ON)
 endif()

--- a/src/common/common_precompiled_headers.h
+++ b/src/common/common_precompiled_headers.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"
+#include "common/common_types.h"

--- a/src/common/precompiled_headers.h
+++ b/src/common/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/common/precompiled_headers.h
+++ b/src/common/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -141,7 +141,7 @@ static std::wstring CPToUTF16(u32 code_page, const std::string& input) {
         MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), nullptr, 0);
 
     if (size == 0) {
-        return L"";
+        return {};
     }
 
     std::wstring output(size, L'\0');
@@ -158,7 +158,7 @@ std::string UTF16ToUTF8(const std::wstring& input) {
     const auto size = WideCharToMultiByte(CP_UTF8, 0, input.data(), static_cast<int>(input.size()),
                                           nullptr, 0, nullptr, nullptr);
     if (size == 0) {
-        return "";
+        return {};
     }
 
     std::string output(size, '\0');

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -771,6 +771,7 @@ add_library(core STATIC
     memory.h
     perf_stats.cpp
     perf_stats.h
+    precompiled_headers.h
     reporter.cpp
     reporter.h
     telemetry_session.cpp
@@ -824,4 +825,8 @@ if (ARCHITECTURE_x86_64 OR ARCHITECTURE_arm64)
         hle/service/jit/jit.h
     )
     target_link_libraries(core PRIVATE dynarmic)
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(core PRIVATE precompiled_headers.h)
 endif()

--- a/src/core/precompiled_headers.h
+++ b/src/core/precompiled_headers.h
@@ -3,12 +3,9 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
 #include <boost/container/flat_map.hpp> // used by service.h which is heavily included
 #include <boost/intrusive/rbtree.hpp>   // used by k_auto_object.h which is heavily included
-#include <fmt/format.h>
 
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"
+
+#include "core/hle/kernel/k_process.h"

--- a/src/core/precompiled_headers.h
+++ b/src/core/precompiled_headers.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <boost/container/flat_map.hpp> // used by service.h which is heavily included
+#include <boost/intrusive/rbtree.hpp>   // used by k_auto_object.h which is heavily included
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/dedicated_room/CMakeLists.txt
+++ b/src/dedicated_room/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 
 add_executable(yuzu-room
+    precompiled_headers.h
     yuzu_room.cpp
     yuzu_room.rc
 )
@@ -24,4 +25,8 @@ target_link_libraries(yuzu-room PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if(UNIX AND NOT APPLE)
     install(TARGETS yuzu-room)
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(yuzu-room PRIVATE precompiled_headers.h)
 endif()

--- a/src/dedicated_room/precompiled_headers.h
+++ b/src/dedicated_room/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/dedicated_room/precompiled_headers.h
+++ b/src/dedicated_room/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(input_common STATIC
     input_poller.h
     main.cpp
     main.h
+    precompiled_headers.h
 )
 
 if (MSVC)
@@ -63,3 +64,7 @@ target_link_libraries(input_common PRIVATE usb)
 
 create_target_directory_groups(input_common)
 target_link_libraries(input_common PUBLIC core PRIVATE common Boost::boost)
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(input_common PRIVATE precompiled_headers.h)
+endif()

--- a/src/input_common/precompiled_headers.h
+++ b/src/input_common/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/input_common/precompiled_headers.h
+++ b/src/input_common/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(network STATIC
     network.h
     packet.cpp
     packet.h
+    precompiled_headers.h
     room.cpp
     room.h
     room_member.cpp
@@ -22,4 +23,8 @@ target_link_libraries(network PRIVATE common enet Boost::boost)
 if (ENABLE_WEB_SERVICE)
     target_compile_definitions(network PRIVATE -DENABLE_WEB_SERVICE)
     target_link_libraries(network PRIVATE web_service)
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(network PRIVATE precompiled_headers.h)
 endif()

--- a/src/network/precompiled_headers.h
+++ b/src/network/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/network/precompiled_headers.h
+++ b/src/network/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/shader_recompiler/CMakeLists.txt
+++ b/src/shader_recompiler/CMakeLists.txt
@@ -230,6 +230,7 @@ add_library(shader_recompiler STATIC
     ir_opt/texture_pass.cpp
     ir_opt/verification_pass.cpp
     object_pool.h
+    precompiled_headers.h
     profile.h
     program_header.h
     runtime_info.h
@@ -258,3 +259,7 @@ else()
 endif()
 
 create_target_directory_groups(shader_recompiler)
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(shader_recompiler PRIVATE precompiled_headers.h)
+endif()

--- a/src/shader_recompiler/frontend/ir/value.h
+++ b/src/shader_recompiler/frontend/ir/value.h
@@ -23,7 +23,6 @@
 #include "shader_recompiler/frontend/ir/pred.h"
 #include "shader_recompiler/frontend/ir/reg.h"
 #include "shader_recompiler/frontend/ir/type.h"
-#include "shader_recompiler/frontend/ir/value.h"
 
 namespace Shader::IR {
 

--- a/src/shader_recompiler/precompiled_headers.h
+++ b/src/shader_recompiler/precompiled_headers.h
@@ -3,11 +3,5 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"
 #include "frontend/maxwell/translate/impl/impl.h"

--- a/src/shader_recompiler/precompiled_headers.h
+++ b/src/shader_recompiler/precompiled_headers.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"
+#include "frontend/maxwell/translate/impl/impl.h"

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(tests
     common/unique_function.cpp
     core/core_timing.cpp
     core/internal_network/network.cpp
+    precompiled_headers.h
     tests.cpp
     video_core/buffer_base.cpp
     input_common/calibration_configuration_job.cpp
@@ -22,3 +23,7 @@ target_link_libraries(tests PRIVATE common core input_common)
 target_link_libraries(tests PRIVATE ${PLATFORM_LIBRARIES} Catch2::Catch2 Threads::Threads)
 
 add_test(NAME tests COMMAND tests)
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(tests PRIVATE precompiled_headers.h)
+endif()

--- a/src/tests/precompiled_headers.h
+++ b/src/tests/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/tests/precompiled_headers.h
+++ b/src/tests/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(video_core STATIC
     gpu_thread.h
     memory_manager.cpp
     memory_manager.h
+    precompiled_headers.h
     pte_kind.h
     query_cache.h
     rasterizer_accelerated.cpp
@@ -299,4 +300,8 @@ endif()
 
 if (ARCHITECTURE_x86_64 OR ARCHITECTURE_arm64)
     target_link_libraries(video_core PRIVATE dynarmic)
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(video_core PRIVATE precompiled_headers.h)
 endif()

--- a/src/video_core/precompiled_headers.h
+++ b/src/video_core/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/video_core/precompiled_headers.h
+++ b/src/video_core/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/web_service/CMakeLists.txt
+++ b/src/web_service/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_library(web_service STATIC
     announce_room_json.cpp
     announce_room_json.h
+    precompiled_headers.h
     telemetry_json.cpp
     telemetry_json.h
     verify_login.cpp
@@ -17,3 +18,7 @@ add_library(web_service STATIC
 
 create_target_directory_groups(web_service)
 target_link_libraries(web_service PRIVATE common network nlohmann_json::nlohmann_json httplib cpp-jwt)
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(web_service PRIVATE precompiled_headers.h)
+endif()

--- a/src/web_service/precompiled_headers.h
+++ b/src/web_service/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/web_service/precompiled_headers.h
+++ b/src/web_service/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -186,6 +186,7 @@ add_executable(yuzu
     multiplayer/state.cpp
     multiplayer/state.h
     multiplayer/validation.h
+    precompiled_headers.h
     startup_checks.cpp
     startup_checks.h
     uisettings.cpp
@@ -404,4 +405,8 @@ endif()
 
 if (ARCHITECTURE_x86_64 OR ARCHITECTURE_arm64)
     target_link_libraries(yuzu PRIVATE dynarmic)
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(yuzu PRIVATE precompiled_headers.h)
 endif()

--- a/src/yuzu/precompiled_headers.h
+++ b/src/yuzu/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/yuzu/precompiled_headers.h
+++ b/src/yuzu/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"

--- a/src/yuzu_cmd/CMakeLists.txt
+++ b/src/yuzu_cmd/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(yuzu-cmd
     emu_window/emu_window_sdl2_gl.h
     emu_window/emu_window_sdl2_vk.cpp
     emu_window/emu_window_sdl2_vk.h
+    precompiled_headers.h
     yuzu.cpp
     yuzu.rc
 )
@@ -54,4 +55,8 @@ endif()
 if (MSVC)
     include(CopyYuzuSDLDeps)
     copy_yuzu_SDL_deps(yuzu-cmd)
+endif()
+
+if (YUZU_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(yuzu-cmd PRIVATE precompiled_headers.h)
 endif()

--- a/src/yuzu_cmd/precompiled_headers.h
+++ b/src/yuzu_cmd/precompiled_headers.h
@@ -3,10 +3,4 @@
 
 #pragma once
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-
-#include <fmt/format.h>
-
-#include "common/assert.h"
+#include "common/common_precompiled_headers.h"

--- a/src/yuzu_cmd/precompiled_headers.h
+++ b/src/yuzu_cmd/precompiled_headers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "common/assert.h"


### PR DESCRIPTION
This change introduces Precompiled Headers (PCH) for some of the more commonly included headers which take the longest to compile.

Each project/CMake target defines its own PCH in its `precompiled_headers.h` file. 
This leads to repetitive includes and recompilation of the same headers in multiple projects, but this is needed since many compilers require that PCH are compiled with same compiler flags as the source files including them. 
This also adds the flexibility of adding/removing headers in the PCH as needed for each project.

On MSVC I saw a ~50% build time reduction. Other compilers may fare better or worse.

PCH is disabled on MSVC when using buildcache for now due to compilation errors.