### PR TITLE
Vulkan: update initialization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
     url = https://github.com/KhronosGroup/Vulkan-Headers.git
 [submodule "sirit"]
     path = externals/sirit
-    url = https://github.com/ReinUsesLisp/sirit
+    url = https://github.com/yuzu-emu/sirit
 [submodule "mbedtls"]
     path = externals/mbedtls
     url = https://github.com/yuzu-emu/mbedtls

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -17,6 +17,8 @@ enum class WindowSystemType {
     Windows,
     X11,
     Wayland,
+    Cocoa,
+    Android,
 };
 
 /**

--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -402,8 +402,10 @@ void SetupCapabilities(const Profile& profile, const Info& info, EmitContext& ct
         ctx.AddCapability(spv::Capability::SparseResidency);
     }
     if (info.uses_demote_to_helper_invocation && profile.support_demote_to_helper_invocation) {
-        ctx.AddExtension("SPV_EXT_demote_to_helper_invocation");
-        ctx.AddCapability(spv::Capability::DemoteToHelperInvocationEXT);
+        if (profile.supported_spirv < 0x00010600) {
+            ctx.AddExtension("SPV_EXT_demote_to_helper_invocation");
+        }
+        ctx.AddCapability(spv::Capability::DemoteToHelperInvocation);
     }
     if (info.stores[IR::Attribute::ViewportIndex]) {
         ctx.AddCapability(spv::Capability::MultiViewport);
@@ -426,12 +428,11 @@ void SetupCapabilities(const Profile& profile, const Info& info, EmitContext& ct
     if ((info.uses_subgroup_vote || info.uses_subgroup_invocation_id ||
          info.uses_subgroup_shuffles) &&
         profile.support_vote) {
-        ctx.AddExtension("SPV_KHR_shader_ballot");
-        ctx.AddCapability(spv::Capability::SubgroupBallotKHR);
+        ctx.AddCapability(spv::Capability::GroupNonUniformBallot);
+        ctx.AddCapability(spv::Capability::GroupNonUniformShuffle);
         if (!profile.warp_size_potentially_larger_than_guest) {
             // vote ops are only used when not taking the long path
-            ctx.AddExtension("SPV_KHR_subgroup_vote");
-            ctx.AddCapability(spv::Capability::SubgroupVoteKHR);
+            ctx.AddCapability(spv::Capability::GroupNonUniformVote);
         }
     }
     if (info.uses_int64_bit_atomics && profile.support_int64_atomics) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_control_flow.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_control_flow.cpp
@@ -12,7 +12,7 @@ void EmitJoin(EmitContext&) {
 
 void EmitDemoteToHelperInvocation(EmitContext& ctx) {
     if (ctx.profile.support_demote_to_helper_invocation) {
-        ctx.OpDemoteToHelperInvocationEXT();
+        ctx.OpDemoteToHelperInvocation();
     } else {
         const Id kill_label{ctx.OpLabel()};
         const Id impossible_label{ctx.OpLabel()};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -53,7 +53,7 @@ using VideoCommon::FileEnvironment;
 using VideoCommon::GenericEnvironment;
 using VideoCommon::GraphicsEnvironment;
 
-constexpr u32 CACHE_VERSION = 7;
+constexpr u32 CACHE_VERSION = 8;
 
 template <typename Container>
 auto MakeSpan(Container& container) {
@@ -277,7 +277,7 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
     const auto& float_control{device.FloatControlProperties()};
     const VkDriverIdKHR driver_id{device.GetDriverID()};
     profile = Shader::Profile{
-        .supported_spirv = device.IsKhrSpirv1_4Supported() ? 0x00010400U : 0x00010000U,
+        .supported_spirv = device.SupportedSpirvVersion(),
         .unified_descriptor_binding = true,
         .support_descriptor_aliasing = true,
         .support_int8 = device.IsInt8Supported(),

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -211,11 +211,6 @@ public:
         return khr_uniform_buffer_standard_layout;
     }
 
-    /// Returns true if the device supports VK_KHR_spirv_1_4.
-    bool IsKhrSpirv1_4Supported() const {
-        return khr_spirv_1_4;
-    }
-
     /// Returns true if the device supports VK_KHR_push_descriptor.
     bool IsKhrPushDescriptorSupported() const {
         return khr_push_descriptor;
@@ -314,6 +309,17 @@ public:
     /// Returns true if the device supports VK_KHR_shader_atomic_int64.
     bool IsExtShaderAtomicInt64Supported() const {
         return ext_shader_atomic_int64;
+    }
+
+    /// Returns the minimum supported version of SPIR-V.
+    u32 SupportedSpirvVersion() const {
+        if (instance_version >= VK_API_VERSION_1_3) {
+            return 0x00010600U;
+        }
+        if (khr_spirv_1_4) {
+            return 0x00010400U;
+        }
+        return 0x00010000U;
     }
 
     /// Returns true when a known debugging tool is attached.

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -265,6 +265,10 @@ static Core::Frontend::WindowSystemType GetWindowSystemType() {
         return Core::Frontend::WindowSystemType::X11;
     else if (platform_name == QStringLiteral("wayland"))
         return Core::Frontend::WindowSystemType::Wayland;
+    else if (platform_name == QStringLiteral("cocoa"))
+        return Core::Frontend::WindowSystemType::Cocoa;
+    else if (platform_name == QStringLiteral("android"))
+        return Core::Frontend::WindowSystemType::Android;
 
     LOG_CRITICAL(Frontend, "Unknown Qt platform!");
     return Core::Frontend::WindowSystemType::Windows;

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -331,7 +331,7 @@ void ConfigureGraphics::RetrieveVulkanDevices() try {
 
     vk::InstanceDispatch dld;
     const Common::DynamicLibrary library = OpenLibrary();
-    const vk::Instance instance = CreateInstance(library, dld, VK_API_VERSION_1_0);
+    const vk::Instance instance = CreateInstance(library, dld, VK_API_VERSION_1_1);
     const std::vector<VkPhysicalDevice> physical_devices = instance.EnumeratePhysicalDevices();
 
     vulkan_devices.clear();

--- a/src/yuzu/startup_checks.cpp
+++ b/src/yuzu/startup_checks.cpp
@@ -24,7 +24,7 @@ void CheckVulkan() {
         Vulkan::vk::InstanceDispatch dld;
         const Common::DynamicLibrary library = Vulkan::OpenLibrary();
         const Vulkan::vk::Instance instance =
-            Vulkan::CreateInstance(library, dld, VK_API_VERSION_1_0);
+            Vulkan::CreateInstance(library, dld, VK_API_VERSION_1_1);
 
     } catch (const Vulkan::vk::Exception& exception) {
         std::fprintf(stderr, "Failed to initialize Vulkan: %s\n", exception.what());

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
@@ -51,22 +51,12 @@ EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsyste
         window_info.type = Core::Frontend::WindowSystemType::Windows;
         window_info.render_surface = reinterpret_cast<void*>(wm.info.win.window);
         break;
-#else
-    case SDL_SYSWM_TYPE::SDL_SYSWM_WINDOWS:
-        LOG_CRITICAL(Frontend, "Window manager subsystem Windows not compiled");
-        std::exit(EXIT_FAILURE);
-        break;
 #endif
 #ifdef SDL_VIDEO_DRIVER_X11
     case SDL_SYSWM_TYPE::SDL_SYSWM_X11:
         window_info.type = Core::Frontend::WindowSystemType::X11;
         window_info.display_connection = wm.info.x11.display;
         window_info.render_surface = reinterpret_cast<void*>(wm.info.x11.window);
-        break;
-#else
-    case SDL_SYSWM_TYPE::SDL_SYSWM_X11:
-        LOG_CRITICAL(Frontend, "Window manager subsystem X11 not compiled");
-        std::exit(EXIT_FAILURE);
         break;
 #endif
 #ifdef SDL_VIDEO_DRIVER_WAYLAND
@@ -75,14 +65,21 @@ EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsyste
         window_info.display_connection = wm.info.wl.display;
         window_info.render_surface = wm.info.wl.surface;
         break;
-#else
-    case SDL_SYSWM_TYPE::SDL_SYSWM_WAYLAND:
-        LOG_CRITICAL(Frontend, "Window manager subsystem Wayland not compiled");
-        std::exit(EXIT_FAILURE);
+#endif
+#ifdef SDL_VIDEO_DRIVER_COCOA
+    case SDL_SYSWM_TYPE::SDL_SYSWM_COCOA:
+        window_info.type = Core::Frontend::WindowSystemType::Cocoa;
+        window_info.render_surface = SDL_Metal_CreateView(render_window);
+        break;
+#endif
+#ifdef SDL_VIDEO_DRIVER_ANDROID
+    case SDL_SYSWM_TYPE::SDL_SYSWM_ANDROID:
+        window_info.type = Core::Frontend::WindowSystemType::Android;
+        window_info.render_surface = reinterpret_cast<void*>(wm.info.android.window);
         break;
 #endif
     default:
-        LOG_CRITICAL(Frontend, "Window manager subsystem not implemented");
+        LOG_CRITICAL(Frontend, "Window manager subsystem {} not implemented", wm.subsystem);
         std::exit(EXIT_FAILURE);
         break;
     }


### PR DESCRIPTION
1. Bumps minimum version of Vulkan to 1.1 (increasing shader cache version), and removes insertion of extensions that are not necessary based on the version:
    - VK_EXT_shader_subgroup_ballot - superseded by GroupNonUniformBallot in Vulkan 1.1
    - VK_EXT_shader_subgroup_vote - superseded by GroupNonUniformVote in Vulkan 1.1
    - VK_EXT_shader_demote_to_helper_invocation - promoted to Vulkan 1.3, unsuffixed as the same operation and capability
2. Adds VK_KHR_portability_enumeration extension to Apple compile
    - Needed for MVK
3. Adds support for new platform surface init in Qt and SDL2 frontends
    - MVK surface creation tested in both Qt and SDL2