### PR TITLE
Qt: assign menuRole properties for actions

### DIFF
--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -231,6 +231,9 @@
    <property name="text">
     <string>Con&amp;figure...</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
+   </property>
   </action>
   <action name="action_Display_Dock_Widget_Headers">
    <property name="checkable">
@@ -363,6 +366,9 @@
    <property name="text">
     <string>&amp;Configure TAS...</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::NoRole</enum>
+   </property>
   </action>
   <action name="action_Configure_Current_Game">
    <property name="enabled">
@@ -370,6 +376,9 @@
    </property>
    <property name="text">
     <string>Configure C&amp;urrent Game...</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="action_TAS_Start">


### PR DESCRIPTION
> Each QAction has a menuRole property which controls the special placement of application menu items; however by default the menuRole is TextHeuristicRole which mean the menu items will be auto-detected by their text.

These items were being detected incorrectly. Used by Qt on Cocoa.