### PR TITLE
yuzu-cmd: Fix input callback crash on close

### DIFF
--- a/src/core/hid/emulated_devices.cpp
+++ b/src/core/hid/emulated_devices.cpp
@@ -145,6 +145,7 @@ void EmulatedDevices::UnloadInput() {
     for (auto& button : keyboard_modifier_devices) {
         button.reset();
     }
+    ring_analog_device.reset();
 }
 
 void EmulatedDevices::EnableConfiguration() {

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -138,6 +138,16 @@ struct InputSubsystem::Impl {
         Common::Input::UnregisterFactory<Common::Input::OutputDevice>(tas_input->GetEngineName());
         tas_input.reset();
 
+        Common::Input::UnregisterFactory<Common::Input::InputDevice>(camera->GetEngineName());
+        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(camera->GetEngineName());
+        camera.reset();
+
+        Common::Input::UnregisterFactory<Common::Input::InputDevice>(
+            virtual_amiibo->GetEngineName());
+        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(
+            virtual_amiibo->GetEngineName());
+        virtual_amiibo.reset();
+
 #ifdef HAVE_SDL2
         Common::Input::UnregisterFactory<Common::Input::InputDevice>(sdl->GetEngineName());
         Common::Input::UnregisterFactory<Common::Input::OutputDevice>(sdl->GetEngineName());

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -7,6 +7,7 @@
 #include "common/scm_rev.h"
 #include "common/settings.h"
 #include "core/core.h"
+#include "core/hid/hid_core.h"
 #include "core/perf_stats.h"
 #include "input_common/drivers/keyboard.h"
 #include "input_common/drivers/mouse.h"
@@ -26,6 +27,7 @@ EmuWindow_SDL2::EmuWindow_SDL2(InputCommon::InputSubsystem* input_subsystem_, Co
 }
 
 EmuWindow_SDL2::~EmuWindow_SDL2() {
+    system.HIDCore().UnloadInputDevices();
     input_subsystem->Shutdown();
     SDL_Quit();
 }


### PR DESCRIPTION
Yuzu wasn't releasing properly the input callbacks. This PR solves that issue.