### PR TITLE
AudioCore: Take suspend lock when stalling the running process.

### DIFF
--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -266,19 +266,20 @@ void SinkStream::ProcessAudioOutAndRender(std::span<s16> output_buffer, std::siz
 }
 
 void SinkStream::Stall() {
-    if (stalled) {
+    std::scoped_lock lk{stall_guard};
+    if (stalled_lock) {
         return;
     }
-    stalled = true;
-    system.StallProcesses();
+    stalled_lock = system.StallProcesses();
 }
 
 void SinkStream::Unstall() {
-    if (!stalled) {
+    std::scoped_lock lk{stall_guard};
+    if (!stalled_lock) {
         return;
     }
     system.UnstallProcesses();
-    stalled = false;
+    stalled_lock.unlock();
 }
 
 } // namespace AudioCore::Sink

--- a/src/audio_core/sink/sink_stream.h
+++ b/src/audio_core/sink/sink_stream.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <span>
 #include <vector>
 
@@ -240,8 +241,8 @@ private:
     f32 system_volume{1.0f};
     /// Set via IAudioDevice service calls
     f32 device_volume{1.0f};
-    /// True if coretiming has been stalled
-    bool stalled{false};
+    std::mutex stall_guard;
+    std::unique_lock<std::mutex> stalled_lock;
 };
 
 using SinkStreamPtr = std::unique_ptr<SinkStream>;


### PR DESCRIPTION
There is a lock returned by StallProcesses() to prevent callers to Un/StallProcesses from stomping on each other. This fixes assert spam in Pokemon Scarlet/Violet where this code path tends to kick in frequently.

Moves IsPaused() to use an atomic instead of taking the suspend lock, as AudioCore calls this when it may be holding the suspend lock already. This means IsPaused may be slightly stale, but that should be acceptable for how it is used.