### PR TITLE
input_common: Pump SDL events from main thread

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -361,6 +361,12 @@ void SDLDriver::CloseJoystick(SDL_Joystick* sdl_joystick) {
     }
 }
 
+void SDLDriver::PumpEvents() const {
+    if (initialized) {
+        SDL_PumpEvents();
+    }
+}
+
 void SDLDriver::HandleGameControllerEvent(const SDL_Event& event) {
     switch (event.type) {
     case SDL_JOYBUTTONUP: {
@@ -451,14 +457,6 @@ SDLDriver::SDLDriver(std::string input_engine_) : InputEngine(std::move(input_en
 
     initialized = true;
     if (start_thread) {
-        poll_thread = std::thread([this] {
-            Common::SetCurrentThreadName("SDL_MainLoop");
-            using namespace std::chrono_literals;
-            while (initialized) {
-                SDL_PumpEvents();
-                std::this_thread::sleep_for(1ms);
-            }
-        });
         vibration_thread = std::thread([this] {
             Common::SetCurrentThreadName("SDL_Vibration");
             using namespace std::chrono_literals;
@@ -481,7 +479,6 @@ SDLDriver::~SDLDriver() {
 
     initialized = false;
     if (start_thread) {
-        poll_thread.join();
         vibration_thread.join();
         SDL_QuitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER);
     }

--- a/src/input_common/drivers/sdl_driver.h
+++ b/src/input_common/drivers/sdl_driver.h
@@ -36,6 +36,8 @@ public:
     /// Unregisters SDL device factories and shut them down.
     ~SDLDriver() override;
 
+    void PumpEvents() const;
+
     /// Handle SDL_Events for joysticks from SDL_PollEvent
     void HandleGameControllerEvent(const SDL_Event& event);
 
@@ -128,7 +130,6 @@ private:
     bool start_thread = false;
     std::atomic<bool> initialized = false;
 
-    std::thread poll_thread;
     std::thread vibration_thread;
 };
 } // namespace InputCommon

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -324,6 +324,12 @@ struct InputSubsystem::Impl {
 #endif
     }
 
+    void PumpEvents() const {
+#ifdef HAVE_SDL2
+        sdl->PumpEvents();
+#endif
+    }
+
     void RegisterInput(const MappingData& data) {
         mapping_factory->RegisterInput(data);
     }
@@ -470,6 +476,10 @@ Common::ParamPackage InputSubsystem::GetNextInput() const {
 void InputSubsystem::StopMapping() const {
     impl->EndConfiguration();
     impl->mapping_factory->StopMapping();
+}
+
+void InputSubsystem::PumpEvents() const {
+    impl->PumpEvents();
 }
 
 std::string GenerateKeyboardParam(int key_code) {

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -147,6 +147,9 @@ public:
     /// Stop polling from all backends.
     void StopMapping() const;
 
+    /// Signals SDL driver for new input events
+    void PumpEvents() const;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -167,6 +167,7 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 
 constexpr int default_mouse_hide_timeout = 2500;
 constexpr int default_mouse_center_timeout = 10;
+constexpr int default_input_update_timeout = 1;
 
 /**
  * "Callouts" are one-time instructional messages shown to the user. In the config settings, there
@@ -403,6 +404,10 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
 
     mouse_center_timer.setInterval(default_mouse_center_timeout);
     connect(&mouse_center_timer, &QTimer::timeout, this, &GMainWindow::CenterMouseCursor);
+
+    update_input_timer.setInterval(default_input_update_timeout);
+    connect(&update_input_timer, &QTimer::timeout, this, &GMainWindow::UpdateInputDrivers);
+    update_input_timer.start();
 
     MigrateConfigFiles();
 
@@ -3634,6 +3639,13 @@ void GMainWindow::UpdateUISettings() {
     UISettings::values.show_filter_bar = ui->action_Show_Filter_Bar->isChecked();
     UISettings::values.show_status_bar = ui->action_Show_Status_Bar->isChecked();
     UISettings::values.first_start = false;
+}
+
+void GMainWindow::UpdateInputDrivers() {
+    if (!input_subsystem) {
+        return;
+    }
+    input_subsystem->PumpEvents();
 }
 
 void GMainWindow::HideMouseCursor() {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -353,6 +353,7 @@ private:
     void UpdateGPUAccuracyButton();
     void UpdateStatusButtons();
     void UpdateUISettings();
+    void UpdateInputDrivers();
     void HideMouseCursor();
     void ShowMouseCursor();
     void CenterMouseCursor();
@@ -404,6 +405,7 @@ private:
     bool auto_muted = false;
     QTimer mouse_hide_timer;
     QTimer mouse_center_timer;
+    QTimer update_input_timer;
 
     QString startup_icon_theme;
     bool os_dark_mode = false;


### PR DESCRIPTION
Apple doesn't allow pumping events from anything else that is not the main thread. 