### PR TITLE
common/input: Add helper functions for constructing input and output devices

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -417,12 +417,12 @@ std::unique_ptr<InputDeviceType> CreateDeviceFromString(const std::string& param
 }
 
 /**
- * Create an input device from given paramters.
+ * Create an input device from given parameters.
  * @tparam InputDeviceType the type of input devices to create
- * @param A ParamPackage that contains all parameters for creating the device
+ * @param package A ParamPackage that contains all parameters for creating the device
  */
 template <typename InputDeviceType>
-std::unique_ptr<InputDeviceType> CreateDevice(const Common::ParamPackage package) {
+std::unique_ptr<InputDeviceType> CreateDevice(const ParamPackage& package) {
     const std::string engine = package.Get("engine", "null");
     const auto& factory_list = Impl::FactoryList<InputDeviceType>::list;
     const auto pair = factory_list.find(engine);

--- a/src/common/input.h
+++ b/src/common/input.h
@@ -383,6 +383,16 @@ void RegisterFactory(const std::string& name, std::shared_ptr<Factory<InputDevic
     }
 }
 
+inline void RegisterInputFactory(const std::string& name,
+                                 std::shared_ptr<Factory<InputDevice>> factory) {
+    RegisterFactory<InputDevice>(name, std::move(factory));
+}
+
+inline void RegisterOutputFactory(const std::string& name,
+                                  std::shared_ptr<Factory<OutputDevice>> factory) {
+    RegisterFactory<OutputDevice>(name, std::move(factory));
+}
+
 /**
  * Unregisters an input device factory.
  * @tparam InputDeviceType the type of input devices the factory can create
@@ -393,6 +403,14 @@ void UnregisterFactory(const std::string& name) {
     if (Impl::FactoryList<InputDeviceType>::list.erase(name) == 0) {
         LOG_ERROR(Input, "Factory '{}' not registered", name);
     }
+}
+
+inline void UnregisterInputFactory(const std::string& name) {
+    UnregisterFactory<InputDevice>(name);
+}
+
+inline void UnregisterOutputFactory(const std::string& name) {
+    UnregisterFactory<OutputDevice>(name);
 }
 
 /**
@@ -416,6 +434,14 @@ std::unique_ptr<InputDeviceType> CreateDeviceFromString(const std::string& param
     return pair->second->Create(package);
 }
 
+inline std::unique_ptr<InputDevice> CreateInputDeviceFromString(const std::string& params) {
+    return CreateDeviceFromString<InputDevice>(params);
+}
+
+inline std::unique_ptr<OutputDevice> CreateOutputDeviceFromString(const std::string& params) {
+    return CreateDeviceFromString<OutputDevice>(params);
+}
+
 /**
  * Create an input device from given parameters.
  * @tparam InputDeviceType the type of input devices to create
@@ -433,6 +459,14 @@ std::unique_ptr<InputDeviceType> CreateDevice(const ParamPackage& package) {
         return std::make_unique<InputDeviceType>();
     }
     return pair->second->Create(package);
+}
+
+inline std::unique_ptr<InputDevice> CreateInputDevice(const ParamPackage& package) {
+    return CreateDevice<InputDevice>(package);
+}
+
+inline std::unique_ptr<OutputDevice> CreateOutputDevice(const ParamPackage& package) {
+    return CreateDevice<OutputDevice>(package);
 }
 
 } // namespace Common::Input

--- a/src/core/hid/emulated_console.cpp
+++ b/src/core/hid/emulated_console.cpp
@@ -68,7 +68,7 @@ void EmulatedConsole::ReloadInput() {
     // If you load any device here add the equivalent to the UnloadInput() function
     SetTouchParams();
 
-    motion_devices = Common::Input::CreateDevice<Common::Input::InputDevice>(motion_params);
+    motion_devices = Common::Input::CreateInputDevice(motion_params);
     if (motion_devices) {
         motion_devices->SetCallback({
             .on_change =
@@ -79,7 +79,7 @@ void EmulatedConsole::ReloadInput() {
     // Unique index for identifying touch device source
     std::size_t index = 0;
     for (auto& touch_device : touch_devices) {
-        touch_device = Common::Input::CreateDevice<Common::Input::InputDevice>(touch_params[index]);
+        touch_device = Common::Input::CreateInputDevice(touch_params[index]);
         if (!touch_device) {
             continue;
         }

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -146,27 +146,27 @@ void EmulatedController::LoadDevices() {
 
     std::transform(button_params.begin() + Settings::NativeButton::BUTTON_HID_BEGIN,
                    button_params.begin() + Settings::NativeButton::BUTTON_NS_END,
-                   button_devices.begin(), Common::Input::CreateDevice<Common::Input::InputDevice>);
+                   button_devices.begin(), Common::Input::CreateInputDevice);
     std::transform(stick_params.begin() + Settings::NativeAnalog::STICK_HID_BEGIN,
                    stick_params.begin() + Settings::NativeAnalog::STICK_HID_END,
-                   stick_devices.begin(), Common::Input::CreateDevice<Common::Input::InputDevice>);
+                   stick_devices.begin(), Common::Input::CreateInputDevice);
     std::transform(motion_params.begin() + Settings::NativeMotion::MOTION_HID_BEGIN,
                    motion_params.begin() + Settings::NativeMotion::MOTION_HID_END,
-                   motion_devices.begin(), Common::Input::CreateDevice<Common::Input::InputDevice>);
+                   motion_devices.begin(), Common::Input::CreateInputDevice);
     std::transform(trigger_params.begin(), trigger_params.end(), trigger_devices.begin(),
-                   Common::Input::CreateDevice<Common::Input::InputDevice>);
+                   Common::Input::CreateInputDevice);
     std::transform(battery_params.begin(), battery_params.end(), battery_devices.begin(),
-                   Common::Input::CreateDevice<Common::Input::InputDevice>);
-    camera_devices = Common::Input::CreateDevice<Common::Input::InputDevice>(camera_params);
-    nfc_devices = Common::Input::CreateDevice<Common::Input::InputDevice>(nfc_params);
+                   Common::Input::CreateInputDevice);
+    camera_devices = Common::Input::CreateInputDevice(camera_params);
+    nfc_devices = Common::Input::CreateInputDevice(nfc_params);
     std::transform(output_params.begin(), output_params.end(), output_devices.begin(),
-                   Common::Input::CreateDevice<Common::Input::OutputDevice>);
+                   Common::Input::CreateOutputDevice);
 
     // Initialize TAS devices
     std::transform(tas_button_params.begin(), tas_button_params.end(), tas_button_devices.begin(),
-                   Common::Input::CreateDevice<Common::Input::InputDevice>);
+                   Common::Input::CreateInputDevice);
     std::transform(tas_stick_params.begin(), tas_stick_params.end(), tas_stick_devices.begin(),
-                   Common::Input::CreateDevice<Common::Input::InputDevice>);
+                   Common::Input::CreateInputDevice);
 }
 
 void EmulatedController::LoadTASParams() {

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2021 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+
 #include "common/thread.h"
 #include "core/hid/emulated_controller.h"
 #include "core/hid/input_converter.h"
@@ -144,29 +146,23 @@ void EmulatedController::LoadDevices() {
 
     LoadTASParams();
 
-    std::transform(button_params.begin() + Settings::NativeButton::BUTTON_HID_BEGIN,
-                   button_params.begin() + Settings::NativeButton::BUTTON_NS_END,
-                   button_devices.begin(), Common::Input::CreateInputDevice);
-    std::transform(stick_params.begin() + Settings::NativeAnalog::STICK_HID_BEGIN,
-                   stick_params.begin() + Settings::NativeAnalog::STICK_HID_END,
-                   stick_devices.begin(), Common::Input::CreateInputDevice);
-    std::transform(motion_params.begin() + Settings::NativeMotion::MOTION_HID_BEGIN,
-                   motion_params.begin() + Settings::NativeMotion::MOTION_HID_END,
-                   motion_devices.begin(), Common::Input::CreateInputDevice);
-    std::transform(trigger_params.begin(), trigger_params.end(), trigger_devices.begin(),
-                   Common::Input::CreateInputDevice);
-    std::transform(battery_params.begin(), battery_params.end(), battery_devices.begin(),
-                   Common::Input::CreateInputDevice);
+    std::ranges::transform(button_params, button_devices.begin(), Common::Input::CreateInputDevice);
+    std::ranges::transform(stick_params, stick_devices.begin(), Common::Input::CreateInputDevice);
+    std::ranges::transform(motion_params, motion_devices.begin(), Common::Input::CreateInputDevice);
+    std::ranges::transform(trigger_params, trigger_devices.begin(),
+                           Common::Input::CreateInputDevice);
+    std::ranges::transform(battery_params, battery_devices.begin(),
+                           Common::Input::CreateInputDevice);
     camera_devices = Common::Input::CreateInputDevice(camera_params);
     nfc_devices = Common::Input::CreateInputDevice(nfc_params);
-    std::transform(output_params.begin(), output_params.end(), output_devices.begin(),
-                   Common::Input::CreateOutputDevice);
+    std::ranges::transform(output_params, output_devices.begin(),
+                           Common::Input::CreateOutputDevice);
 
     // Initialize TAS devices
-    std::transform(tas_button_params.begin(), tas_button_params.end(), tas_button_devices.begin(),
-                   Common::Input::CreateInputDevice);
-    std::transform(tas_stick_params.begin(), tas_stick_params.end(), tas_stick_devices.begin(),
-                   Common::Input::CreateInputDevice);
+    std::ranges::transform(tas_button_params, tas_button_devices.begin(),
+                           Common::Input::CreateInputDevice);
+    std::ranges::transform(tas_stick_params, tas_stick_devices.begin(),
+                           Common::Input::CreateInputDevice);
 }
 
 void EmulatedController::LoadTASParams() {

--- a/src/core/hid/emulated_devices.cpp
+++ b/src/core/hid/emulated_devices.cpp
@@ -25,12 +25,12 @@ void EmulatedDevices::ReloadInput() {
         Common::ParamPackage mouse_params;
         mouse_params.Set("engine", "mouse");
         mouse_params.Set("button", static_cast<int>(key_index));
-        mouse_device = Common::Input::CreateDevice<Common::Input::InputDevice>(mouse_params);
+        mouse_device = Common::Input::CreateInputDevice(mouse_params);
         key_index++;
     }
 
-    mouse_stick_device = Common::Input::CreateDeviceFromString<Common::Input::InputDevice>(
-        "engine:mouse,axis_x:0,axis_y:1");
+    mouse_stick_device =
+        Common::Input::CreateInputDeviceFromString("engine:mouse,axis_x:0,axis_y:1");
 
     // First two axis are reserved for mouse position
     key_index = 2;
@@ -38,7 +38,7 @@ void EmulatedDevices::ReloadInput() {
         Common::ParamPackage mouse_params;
         mouse_params.Set("engine", "mouse");
         mouse_params.Set("axis", static_cast<int>(key_index));
-        mouse_device = Common::Input::CreateDevice<Common::Input::InputDevice>(mouse_params);
+        mouse_device = Common::Input::CreateInputDevice(mouse_params);
         key_index++;
     }
 
@@ -50,7 +50,7 @@ void EmulatedDevices::ReloadInput() {
         keyboard_params.Set("button", static_cast<int>(key_index));
         keyboard_params.Set("port", 1);
         keyboard_params.Set("pad", 0);
-        keyboard_device = Common::Input::CreateDevice<Common::Input::InputDevice>(keyboard_params);
+        keyboard_device = Common::Input::CreateInputDevice(keyboard_params);
         key_index++;
     }
 
@@ -62,11 +62,11 @@ void EmulatedDevices::ReloadInput() {
         keyboard_params.Set("button", static_cast<int>(key_index));
         keyboard_params.Set("port", 1);
         keyboard_params.Set("pad", 1);
-        keyboard_device = Common::Input::CreateDevice<Common::Input::InputDevice>(keyboard_params);
+        keyboard_device = Common::Input::CreateInputDevice(keyboard_params);
         key_index++;
     }
 
-    ring_analog_device = Common::Input::CreateDevice<Common::Input::InputDevice>(ring_params);
+    ring_analog_device = Common::Input::CreateInputDevice(ring_params);
 
     for (std::size_t index = 0; index < mouse_button_devices.size(); ++index) {
         if (!mouse_button_devices[index]) {

--- a/src/input_common/helpers/stick_from_buttons.cpp
+++ b/src/input_common/helpers/stick_from_buttons.cpp
@@ -318,16 +318,11 @@ private:
 std::unique_ptr<Common::Input::InputDevice> StickFromButton::Create(
     const Common::ParamPackage& params) {
     const std::string null_engine = Common::ParamPackage{{"engine", "null"}}.Serialize();
-    auto up = Common::Input::CreateDeviceFromString<Common::Input::InputDevice>(
-        params.Get("up", null_engine));
-    auto down = Common::Input::CreateDeviceFromString<Common::Input::InputDevice>(
-        params.Get("down", null_engine));
-    auto left = Common::Input::CreateDeviceFromString<Common::Input::InputDevice>(
-        params.Get("left", null_engine));
-    auto right = Common::Input::CreateDeviceFromString<Common::Input::InputDevice>(
-        params.Get("right", null_engine));
-    auto modifier = Common::Input::CreateDeviceFromString<Common::Input::InputDevice>(
-        params.Get("modifier", null_engine));
+    auto up = Common::Input::CreateInputDeviceFromString(params.Get("up", null_engine));
+    auto down = Common::Input::CreateInputDeviceFromString(params.Get("down", null_engine));
+    auto left = Common::Input::CreateInputDeviceFromString(params.Get("left", null_engine));
+    auto right = Common::Input::CreateInputDeviceFromString(params.Get("right", null_engine));
+    auto modifier = Common::Input::CreateInputDeviceFromString(params.Get("modifier", null_engine));
     auto modifier_scale = params.Get("modifier_scale", 0.5f);
     auto modifier_angle = params.Get("modifier_angle", 5.5f);
     return std::make_unique<Stick>(std::move(up), std::move(down), std::move(left),

--- a/src/input_common/helpers/touch_from_buttons.cpp
+++ b/src/input_common/helpers/touch_from_buttons.cpp
@@ -69,8 +69,7 @@ private:
 std::unique_ptr<Common::Input::InputDevice> TouchFromButton::Create(
     const Common::ParamPackage& params) {
     const std::string null_engine = Common::ParamPackage{{"engine", "null"}}.Serialize();
-    auto button = Common::Input::CreateDeviceFromString<Common::Input::InputDevice>(
-        params.Get("button", null_engine));
+    auto button = Common::Input::CreateInputDeviceFromString(params.Get("button", null_engine));
     const float x = params.Get("x", 0.0f) / 1280.0f;
     const float y = params.Get("y", 0.0f) / 720.0f;
     return std::make_unique<TouchFromButtonDevice>(std::move(button), x, y);

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -33,129 +33,113 @@ struct InputSubsystem::Impl {
         keyboard->SetMappingCallback(mapping_callback);
         keyboard_factory = std::make_shared<InputFactory>(keyboard);
         keyboard_output_factory = std::make_shared<OutputFactory>(keyboard);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(keyboard->GetEngineName(),
-                                                                   keyboard_factory);
-        Common::Input::RegisterFactory<Common::Input::OutputDevice>(keyboard->GetEngineName(),
-                                                                    keyboard_output_factory);
+        Common::Input::RegisterInputFactory(keyboard->GetEngineName(), keyboard_factory);
+        Common::Input::RegisterOutputFactory(keyboard->GetEngineName(), keyboard_output_factory);
 
         mouse = std::make_shared<Mouse>("mouse");
         mouse->SetMappingCallback(mapping_callback);
         mouse_factory = std::make_shared<InputFactory>(mouse);
         mouse_output_factory = std::make_shared<OutputFactory>(mouse);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(mouse->GetEngineName(),
-                                                                   mouse_factory);
-        Common::Input::RegisterFactory<Common::Input::OutputDevice>(mouse->GetEngineName(),
-                                                                    mouse_output_factory);
+        Common::Input::RegisterInputFactory(mouse->GetEngineName(), mouse_factory);
+        Common::Input::RegisterOutputFactory(mouse->GetEngineName(), mouse_output_factory);
 
         touch_screen = std::make_shared<TouchScreen>("touch");
         touch_screen_factory = std::make_shared<InputFactory>(touch_screen);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(touch_screen->GetEngineName(),
-                                                                   touch_screen_factory);
+        Common::Input::RegisterInputFactory(touch_screen->GetEngineName(), touch_screen_factory);
 
         gcadapter = std::make_shared<GCAdapter>("gcpad");
         gcadapter->SetMappingCallback(mapping_callback);
         gcadapter_input_factory = std::make_shared<InputFactory>(gcadapter);
         gcadapter_output_factory = std::make_shared<OutputFactory>(gcadapter);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(gcadapter->GetEngineName(),
-                                                                   gcadapter_input_factory);
-        Common::Input::RegisterFactory<Common::Input::OutputDevice>(gcadapter->GetEngineName(),
-                                                                    gcadapter_output_factory);
+        Common::Input::RegisterInputFactory(gcadapter->GetEngineName(), gcadapter_input_factory);
+        Common::Input::RegisterOutputFactory(gcadapter->GetEngineName(), gcadapter_output_factory);
 
         udp_client = std::make_shared<CemuhookUDP::UDPClient>("cemuhookudp");
         udp_client->SetMappingCallback(mapping_callback);
         udp_client_input_factory = std::make_shared<InputFactory>(udp_client);
         udp_client_output_factory = std::make_shared<OutputFactory>(udp_client);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(udp_client->GetEngineName(),
-                                                                   udp_client_input_factory);
-        Common::Input::RegisterFactory<Common::Input::OutputDevice>(udp_client->GetEngineName(),
-                                                                    udp_client_output_factory);
+        Common::Input::RegisterInputFactory(udp_client->GetEngineName(), udp_client_input_factory);
+        Common::Input::RegisterOutputFactory(udp_client->GetEngineName(),
+                                             udp_client_output_factory);
 
         tas_input = std::make_shared<TasInput::Tas>("tas");
         tas_input->SetMappingCallback(mapping_callback);
         tas_input_factory = std::make_shared<InputFactory>(tas_input);
         tas_output_factory = std::make_shared<OutputFactory>(tas_input);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(tas_input->GetEngineName(),
-                                                                   tas_input_factory);
-        Common::Input::RegisterFactory<Common::Input::OutputDevice>(tas_input->GetEngineName(),
-                                                                    tas_output_factory);
+        Common::Input::RegisterInputFactory(tas_input->GetEngineName(), tas_input_factory);
+        Common::Input::RegisterOutputFactory(tas_input->GetEngineName(), tas_output_factory);
 
         camera = std::make_shared<Camera>("camera");
         camera->SetMappingCallback(mapping_callback);
         camera_input_factory = std::make_shared<InputFactory>(camera);
         camera_output_factory = std::make_shared<OutputFactory>(camera);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(camera->GetEngineName(),
-                                                                   camera_input_factory);
-        Common::Input::RegisterFactory<Common::Input::OutputDevice>(camera->GetEngineName(),
-                                                                    camera_output_factory);
+        Common::Input::RegisterInputFactory(camera->GetEngineName(), camera_input_factory);
+        Common::Input::RegisterOutputFactory(camera->GetEngineName(), camera_output_factory);
 
         virtual_amiibo = std::make_shared<VirtualAmiibo>("virtual_amiibo");
         virtual_amiibo->SetMappingCallback(mapping_callback);
         virtual_amiibo_input_factory = std::make_shared<InputFactory>(virtual_amiibo);
         virtual_amiibo_output_factory = std::make_shared<OutputFactory>(virtual_amiibo);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(virtual_amiibo->GetEngineName(),
-                                                                   virtual_amiibo_input_factory);
-        Common::Input::RegisterFactory<Common::Input::OutputDevice>(virtual_amiibo->GetEngineName(),
-                                                                    virtual_amiibo_output_factory);
+        Common::Input::RegisterInputFactory(virtual_amiibo->GetEngineName(),
+                                            virtual_amiibo_input_factory);
+        Common::Input::RegisterOutputFactory(virtual_amiibo->GetEngineName(),
+                                             virtual_amiibo_output_factory);
 
 #ifdef HAVE_SDL2
         sdl = std::make_shared<SDLDriver>("sdl");
         sdl->SetMappingCallback(mapping_callback);
         sdl_input_factory = std::make_shared<InputFactory>(sdl);
         sdl_output_factory = std::make_shared<OutputFactory>(sdl);
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(sdl->GetEngineName(),
-                                                                   sdl_input_factory);
-        Common::Input::RegisterFactory<Common::Input::OutputDevice>(sdl->GetEngineName(),
-                                                                    sdl_output_factory);
+        Common::Input::RegisterInputFactory(sdl->GetEngineName(), sdl_input_factory);
+        Common::Input::RegisterOutputFactory(sdl->GetEngineName(), sdl_output_factory);
 #endif
 
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(
-            "touch_from_button", std::make_shared<TouchFromButton>());
-        Common::Input::RegisterFactory<Common::Input::InputDevice>(
-            "analog_from_button", std::make_shared<StickFromButton>());
+        Common::Input::RegisterInputFactory("touch_from_button",
+                                            std::make_shared<TouchFromButton>());
+        Common::Input::RegisterInputFactory("analog_from_button",
+                                            std::make_shared<StickFromButton>());
     }
 
     void Shutdown() {
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(keyboard->GetEngineName());
-        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(keyboard->GetEngineName());
+        Common::Input::UnregisterInputFactory(keyboard->GetEngineName());
+        Common::Input::UnregisterOutputFactory(keyboard->GetEngineName());
         keyboard.reset();
 
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(mouse->GetEngineName());
-        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(mouse->GetEngineName());
+        Common::Input::UnregisterInputFactory(mouse->GetEngineName());
+        Common::Input::UnregisterOutputFactory(mouse->GetEngineName());
         mouse.reset();
 
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(touch_screen->GetEngineName());
+        Common::Input::UnregisterInputFactory(touch_screen->GetEngineName());
         touch_screen.reset();
 
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(gcadapter->GetEngineName());
-        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(gcadapter->GetEngineName());
+        Common::Input::UnregisterInputFactory(gcadapter->GetEngineName());
+        Common::Input::UnregisterOutputFactory(gcadapter->GetEngineName());
         gcadapter.reset();
 
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(udp_client->GetEngineName());
-        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(udp_client->GetEngineName());
+        Common::Input::UnregisterInputFactory(udp_client->GetEngineName());
+        Common::Input::UnregisterOutputFactory(udp_client->GetEngineName());
         udp_client.reset();
 
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(tas_input->GetEngineName());
-        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(tas_input->GetEngineName());
+        Common::Input::UnregisterInputFactory(tas_input->GetEngineName());
+        Common::Input::UnregisterOutputFactory(tas_input->GetEngineName());
         tas_input.reset();
 
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(camera->GetEngineName());
-        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(camera->GetEngineName());
+        Common::Input::UnregisterInputFactory(camera->GetEngineName());
+        Common::Input::UnregisterOutputFactory(camera->GetEngineName());
         camera.reset();
 
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(
-            virtual_amiibo->GetEngineName());
-        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(
-            virtual_amiibo->GetEngineName());
+        Common::Input::UnregisterInputFactory(virtual_amiibo->GetEngineName());
+        Common::Input::UnregisterOutputFactory(virtual_amiibo->GetEngineName());
         virtual_amiibo.reset();
 
 #ifdef HAVE_SDL2
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>(sdl->GetEngineName());
-        Common::Input::UnregisterFactory<Common::Input::OutputDevice>(sdl->GetEngineName());
+        Common::Input::UnregisterInputFactory(sdl->GetEngineName());
+        Common::Input::UnregisterOutputFactory(sdl->GetEngineName());
         sdl.reset();
 #endif
 
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>("touch_from_button");
-        Common::Input::UnregisterFactory<Common::Input::InputDevice>("analog_from_button");
+        Common::Input::UnregisterInputFactory("touch_from_button");
+        Common::Input::UnregisterInputFactory("analog_from_button");
     }
 
     [[nodiscard]] std::vector<Common::ParamPackage> GetInputDevices() const {


### PR DESCRIPTION
Lessens the noise of creating a new device by quite a bit, since no namespaces or types need to be respecified.

Also passes the ParamPackage instance to CreateDevice by const reference, so we're not churning allocations unnecessarily