### PR TITLE
input_common/helpers: Mark analog property structs members as static constexpr

### DIFF
--- a/src/input_common/helpers/stick_from_buttons.cpp
+++ b/src/input_common/helpers/stick_from_buttons.cpp
@@ -294,6 +294,15 @@ public:
     }
 
 private:
+    static constexpr Common::Input::AnalogProperties properties{
+        .deadzone = 0.0f,
+        .range = 1.0f,
+        .threshold = 0.5f,
+        .offset = 0.0f,
+        .inverted = false,
+        .toggle = false,
+    };
+
     Button up;
     Button down;
     Button left;
@@ -311,7 +320,6 @@ private:
     float last_x_axis_value{};
     float last_y_axis_value{};
     Common::Input::ButtonStatus modifier_status{};
-    const Common::Input::AnalogProperties properties{0.0f, 1.0f, 0.5f, 0.0f, false};
     std::chrono::time_point<std::chrono::steady_clock> last_update;
 };
 

--- a/src/input_common/helpers/touch_from_buttons.cpp
+++ b/src/input_common/helpers/touch_from_buttons.cpp
@@ -59,11 +59,19 @@ public:
     }
 
 private:
+    static constexpr Common::Input::AnalogProperties properties{
+        .deadzone = 0.0f,
+        .range = 1.0f,
+        .threshold = 0.5f,
+        .offset = 0.0f,
+        .inverted = false,
+        .toggle = false,
+    };
+
     Button button;
     bool last_button_value;
     const float x;
     const float y;
-    const Common::Input::AnalogProperties properties{0.0f, 1.0f, 0.5f, 0.0f, false};
 };
 
 std::unique_ptr<Common::Input::InputDevice> TouchFromButton::Create(


### PR DESCRIPTION
These are const with no dependency on any other data members, so we can make these static constexpr to reduce the overall object size.