### PR TITLE
common/cache_management: Amend header includes

### DIFF
--- a/src/common/cache_management.cpp
+++ b/src/common/cache_management.cpp
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <cstdint>
 #include <cstring>
 
-#include "alignment.h"
-#include "cache_management.h"
-#include "common_types.h"
+#include "common/cache_management.h"
 
 namespace Common {
 

--- a/src/common/cache_management.h
+++ b/src/common/cache_management.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "stdlib.h"
+#include <cstddef>
 
 namespace Common {
 


### PR DESCRIPTION
Narrows the include in the header to `<cstddef>`, since that's what houses size_t's definition, meanwhile the `<cstdint>` include can be moved into the cpp file.

Also nothing from our alignment header is used, so that can be removed