### PR TITLE
consumer_base: Pass std::shared_ptr by const reference

### DIFF
--- a/src/core/hle/service/nvflinger/buffer_item_consumer.cpp
+++ b/src/core/hle/service/nvflinger/buffer_item_consumer.cpp
@@ -39,7 +39,7 @@ Status BufferItemConsumer::AcquireBuffer(BufferItem* item, std::chrono::nanoseco
     return Status::NoError;
 }
 
-Status BufferItemConsumer::ReleaseBuffer(const BufferItem& item, Fence& release_fence) {
+Status BufferItemConsumer::ReleaseBuffer(const BufferItem& item, const Fence& release_fence) {
     std::scoped_lock lock{mutex};
 
     if (const auto status = AddReleaseFenceLocked(item.buf, item.graphic_buffer, release_fence);

--- a/src/core/hle/service/nvflinger/buffer_item_consumer.h
+++ b/src/core/hle/service/nvflinger/buffer_item_consumer.h
@@ -22,7 +22,7 @@ public:
     explicit BufferItemConsumer(std::unique_ptr<BufferQueueConsumer> consumer);
     Status AcquireBuffer(BufferItem* item, std::chrono::nanoseconds present_when,
                          bool wait_for_fence = true);
-    Status ReleaseBuffer(const BufferItem& item, Fence& release_fence);
+    Status ReleaseBuffer(const BufferItem& item, const Fence& release_fence);
 };
 
 } // namespace Service::android

--- a/src/core/hle/service/nvflinger/buffer_queue_consumer.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue_consumer.cpp
@@ -169,7 +169,7 @@ Status BufferQueueConsumer::Connect(std::shared_ptr<IConsumerListener> consumer_
         return Status::NoInit;
     }
 
-    core->consumer_listener = consumer_listener;
+    core->consumer_listener = std::move(consumer_listener);
     core->consumer_controlled_by_app = controlled_by_app;
 
     return Status::NoError;

--- a/src/core/hle/service/nvflinger/consumer_base.cpp
+++ b/src/core/hle/service/nvflinger/consumer_base.cpp
@@ -83,7 +83,7 @@ Status ConsumerBase::AcquireBufferLocked(BufferItem* item, std::chrono::nanoseco
 }
 
 Status ConsumerBase::AddReleaseFenceLocked(s32 slot,
-                                           const std::shared_ptr<GraphicBuffer> graphic_buffer,
+                                           const std::shared_ptr<GraphicBuffer>& graphic_buffer,
                                            const Fence& fence) {
     LOG_DEBUG(Service_NVFlinger, "slot={}", slot);
 
@@ -100,7 +100,7 @@ Status ConsumerBase::AddReleaseFenceLocked(s32 slot,
 }
 
 Status ConsumerBase::ReleaseBufferLocked(s32 slot,
-                                         const std::shared_ptr<GraphicBuffer> graphic_buffer) {
+                                         const std::shared_ptr<GraphicBuffer>& graphic_buffer) {
     // If consumer no longer tracks this graphic_buffer (we received a new
     // buffer on the same slot), the buffer producer is definitely no longer
     // tracking it.
@@ -121,7 +121,7 @@ Status ConsumerBase::ReleaseBufferLocked(s32 slot,
 }
 
 bool ConsumerBase::StillTracking(s32 slot,
-                                 const std::shared_ptr<GraphicBuffer> graphic_buffer) const {
+                                 const std::shared_ptr<GraphicBuffer>& graphic_buffer) const {
     if (slot < 0 || slot >= BufferQueueDefs::NUM_BUFFER_SLOTS) {
         return false;
     }

--- a/src/core/hle/service/nvflinger/consumer_base.h
+++ b/src/core/hle/service/nvflinger/consumer_base.h
@@ -27,12 +27,12 @@ public:
 
 protected:
     explicit ConsumerBase(std::unique_ptr<BufferQueueConsumer> consumer_);
-    virtual ~ConsumerBase();
+    ~ConsumerBase() override;
 
-    virtual void OnFrameAvailable(const BufferItem& item) override;
-    virtual void OnFrameReplaced(const BufferItem& item) override;
-    virtual void OnBuffersReleased() override;
-    virtual void OnSidebandStreamChanged() override;
+    void OnFrameAvailable(const BufferItem& item) override;
+    void OnFrameReplaced(const BufferItem& item) override;
+    void OnBuffersReleased() override;
+    void OnSidebandStreamChanged() override;
 
     void FreeBufferLocked(s32 slot_index);
     Status AcquireBufferLocked(BufferItem* item, std::chrono::nanoseconds present_when);

--- a/src/core/hle/service/nvflinger/consumer_base.h
+++ b/src/core/hle/service/nvflinger/consumer_base.h
@@ -36,9 +36,9 @@ protected:
 
     void FreeBufferLocked(s32 slot_index);
     Status AcquireBufferLocked(BufferItem* item, std::chrono::nanoseconds present_when);
-    Status ReleaseBufferLocked(s32 slot, const std::shared_ptr<GraphicBuffer> graphic_buffer);
-    bool StillTracking(s32 slot, const std::shared_ptr<GraphicBuffer> graphic_buffer) const;
-    Status AddReleaseFenceLocked(s32 slot, const std::shared_ptr<GraphicBuffer> graphic_buffer,
+    Status ReleaseBufferLocked(s32 slot, const std::shared_ptr<GraphicBuffer>& graphic_buffer);
+    bool StillTracking(s32 slot, const std::shared_ptr<GraphicBuffer>& graphic_buffer) const;
+    Status AddReleaseFenceLocked(s32 slot, const std::shared_ptr<GraphicBuffer>& graphic_buffer,
                                  const Fence& fence);
 
     struct Slot final {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -307,8 +307,7 @@ void NVFlinger::Compose() {
 
         swap_interval = buffer.swap_interval;
 
-        auto fence = android::Fence::NoFence();
-        layer.GetConsumer().ReleaseBuffer(buffer, fence);
+        layer.GetConsumer().ReleaseBuffer(buffer, android::Fence::NoFence());
     }
 }
 


### PR DESCRIPTION
Avoids churning atomic reference count increments and decrements. Also given they were marked const in the header means that was likely what they were supposed to be.

Also makes a few minor related changes in the surrounding area.