### PR TITLE
producer_listener: Add virtual destructor to IProducerListener

### DIFF
--- a/src/core/hle/service/nvflinger/producer_listener.h
+++ b/src/core/hle/service/nvflinger/producer_listener.h
@@ -10,6 +10,7 @@ namespace Service::android {
 
 class IProducerListener {
 public:
+    virtual ~IProducerListener() = default;
     virtual void OnBufferReleased() = 0;
 };
 


### PR DESCRIPTION
Several member variables are shared_ptr's to this base class. Even though producer listeners are still unimplemented, this ensures we always have consistent deletion behavior once this ends up being used polymorphically.