### PR TITLE
engines: Remove unnecessary casts

### DIFF
--- a/src/video_core/engines/engine_upload.cpp
+++ b/src/video_core/engines/engine_upload.cpp
@@ -49,10 +49,9 @@ void State::ProcessData(std::span<const u8> read_buffer) {
         if (regs.line_count == 1) {
             rasterizer->AccelerateInlineToMemory(address, copy_size, read_buffer);
         } else {
-            for (u32 line = 0; line < regs.line_count; ++line) {
-                const GPUVAddr dest_line = address + static_cast<size_t>(line) * regs.dest.pitch;
-                std::span<const u8> buffer(read_buffer.data() +
-                                               static_cast<size_t>(line) * regs.line_length_in,
+            for (size_t line = 0; line < regs.line_count; ++line) {
+                const GPUVAddr dest_line = address + line * regs.dest.pitch;
+                std::span<const u8> buffer(read_buffer.data() + line * regs.line_length_in,
                                            regs.line_length_in);
                 rasterizer->AccelerateInlineToMemory(dest_line, regs.line_length_in, buffer);
             }

--- a/src/video_core/engines/engine_upload.h
+++ b/src/video_core/engines/engine_upload.h
@@ -39,7 +39,7 @@ struct Registers {
         u32 y;
 
         GPUVAddr Address() const {
-            return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) | address_low);
+            return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
         }
 
         u32 BlockWidth() const {

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -97,7 +97,7 @@ public:
         u32 addr_lower;
 
         [[nodiscard]] constexpr GPUVAddr Address() const noexcept {
-            return (static_cast<GPUVAddr>(addr_upper) << 32) | static_cast<GPUVAddr>(addr_lower);
+            return (GPUVAddr{addr_upper} << 32) | GPUVAddr{addr_lower};
         }
     };
     static_assert(sizeof(Surface) == 0x28, "Surface has incorrect size");

--- a/src/video_core/engines/kepler_compute.cpp
+++ b/src/video_core/engines/kepler_compute.cpp
@@ -50,11 +50,11 @@ void KeplerCompute::CallMultiMethod(u32 method, const u32* base_start, u32 amoun
                                     u32 methods_pending) {
     switch (method) {
     case KEPLER_COMPUTE_REG_INDEX(data_upload):
-        upload_state.ProcessData(base_start, static_cast<size_t>(amount));
+        upload_state.ProcessData(base_start, amount);
         return;
     default:
-        for (std::size_t i = 0; i < amount; i++) {
-            CallMethod(method, base_start[i], methods_pending - static_cast<u32>(i) <= 1);
+        for (u32 i = 0; i < amount; i++) {
+            CallMethod(method, base_start[i], methods_pending - i <= 1);
         }
         break;
     }

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -68,7 +68,7 @@ public:
                 struct {
                     u32 address;
                     GPUVAddr Address() const {
-                        return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address) << 8));
+                        return GPUVAddr{address} << 8;
                     }
                 } launch_desc_loc;
 
@@ -83,8 +83,7 @@ public:
                     u32 address_low;
                     u32 limit;
                     GPUVAddr Address() const {
-                        return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                                     address_low);
+                        return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
                     }
                 } tsc;
 
@@ -95,8 +94,7 @@ public:
                     u32 address_low;
                     u32 limit;
                     GPUVAddr Address() const {
-                        return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                                     address_low);
+                        return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
                     }
                 } tic;
 
@@ -106,8 +104,7 @@ public:
                     u32 address_high;
                     u32 address_low;
                     GPUVAddr Address() const {
-                        return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                                     address_low);
+                        return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
                     }
                 } code_loc;
 
@@ -162,8 +159,7 @@ public:
                 BitField<15, 17, u32> size;
             };
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high.Value()) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high.Value()} << 32) | GPUVAddr{address_low};
             }
         };
         std::array<ConstBufferConfig, NumConstBuffers> const_buffer_config;

--- a/src/video_core/engines/kepler_memory.cpp
+++ b/src/video_core/engines/kepler_memory.cpp
@@ -42,11 +42,11 @@ void KeplerMemory::CallMultiMethod(u32 method, const u32* base_start, u32 amount
                                    u32 methods_pending) {
     switch (method) {
     case KEPLERMEMORY_REG_INDEX(data):
-        upload_state.ProcessData(base_start, static_cast<size_t>(amount));
+        upload_state.ProcessData(base_start, amount);
         return;
     default:
-        for (std::size_t i = 0; i < amount; i++) {
-            CallMethod(method, base_start[i], methods_pending - static_cast<u32>(i) <= 1);
+        for (u32 i = 0; i < amount; i++) {
+            CallMethod(method, base_start[i], methods_pending - i <= 1);
         }
         break;
     }

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -370,11 +370,11 @@ void Maxwell3D::CallMultiMethod(u32 method, const u32* base_start, u32 amount,
         ProcessCBMultiData(base_start, amount);
         break;
     case MAXWELL3D_REG_INDEX(inline_data):
-        upload_state.ProcessData(base_start, static_cast<size_t>(amount));
+        upload_state.ProcessData(base_start, amount);
         return;
     default:
-        for (std::size_t i = 0; i < amount; i++) {
-            CallMethod(method, base_start[i], methods_pending - static_cast<u32>(i) <= 1);
+        for (u32 i = 0; i < amount; i++) {
+            CallMethod(method, base_start[i], methods_pending - i <= 1);
         }
         break;
     }
@@ -652,12 +652,12 @@ void Maxwell3D::ProcessDeferredDraw() {
         return;
     }
 
-    u32 method_count = static_cast<u32>(deferred_draw_method.size());
+    const auto method_count = deferred_draw_method.size();
     u32 instance_count = 1;
     u32 vertex_buffer_count = 0;
     u32 index_buffer_count = 0;
-    for (u32 index = 0; index < method_count; ++index) {
-        u32 method = deferred_draw_method[index];
+    for (size_t index = 0; index < method_count; ++index) {
+        const u32 method = deferred_draw_method[index];
         if (method == MAXWELL3D_REG_INDEX(vertex_buffer.count)) {
             instance_count = ++vertex_buffer_count;
         } else if (method == MAXWELL3D_REG_INDEX(index_buffer.count)) {

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -96,8 +96,7 @@ public:
             u32 type;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -106,8 +105,7 @@ public:
             u32 address_low;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -124,8 +122,7 @@ public:
             Mode mode;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(offset_high) << 32) |
-                                             offset_low);
+                return (GPUVAddr{offset_high} << 32) | GPUVAddr{offset_low};
             }
         };
 
@@ -468,8 +465,7 @@ public:
                 INSERT_PADDING_BYTES_NOINIT(0xC);
 
                 GPUVAddr Address() const {
-                    return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                                 address_low);
+                    return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
                 }
             };
             static_assert(sizeof(Buffer) == 0x20);
@@ -511,12 +507,11 @@ public:
             u32 default_size_per_warp;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
 
             u64 Size() const {
-                return (static_cast<u64>(size_high) << 32) | size_low;
+                return (u64{size_high} << 32) | u64{size_low};
             }
         };
 
@@ -538,13 +533,11 @@ public:
             u32 storage_limit_address_low;
 
             GPUVAddr StorageAddress() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(storage_address_high) << 32) |
-                                             storage_address_low);
+                return (GPUVAddr{storage_address_high} << 32) | GPUVAddr{storage_address_low};
             }
             GPUVAddr StorageLimitAddress() const {
-                return static_cast<GPUVAddr>(
-                    (static_cast<GPUVAddr>(storage_limit_address_high) << 32) |
-                    storage_limit_address_low);
+                return (GPUVAddr{storage_limit_address_high} << 32) |
+                       GPUVAddr{storage_limit_address_low};
             }
         };
 
@@ -1138,8 +1131,7 @@ public:
             INSERT_PADDING_BYTES_NOINIT(0x18);
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
         static_assert(sizeof(RenderTargetConfig) == 0x40);
@@ -1482,8 +1474,7 @@ public:
             u32 address_low;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -1533,8 +1524,7 @@ public:
             u32 address_low;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -1561,8 +1551,7 @@ public:
             u32 array_pitch;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -1910,8 +1899,7 @@ public:
             Mode mode;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -1921,8 +1909,7 @@ public:
             u32 limit;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -1932,8 +1919,7 @@ public:
             u32 limit;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -1981,8 +1967,7 @@ public:
             u32 address_low;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -2027,8 +2012,7 @@ public:
             u32 address_low;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -2224,19 +2208,16 @@ public:
             }
 
             GPUVAddr StartAddress() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(start_addr_high) << 32) |
-                                             start_addr_low);
+                return (GPUVAddr{start_addr_high} << 32) | GPUVAddr{start_addr_low};
             }
 
             GPUVAddr EndAddress() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(limit_addr_high) << 32) |
-                                             limit_addr_low);
+                return (GPUVAddr{limit_addr_high} << 32) | GPUVAddr{limit_addr_low};
             }
 
             /// Adjust the index buffer offset so it points to the first desired index.
             GPUVAddr IndexStart() const {
-                return StartAddress() +
-                       static_cast<size_t>(first) * static_cast<size_t>(FormatSizeInBytes());
+                return StartAddress() + size_t{first} * size_t{FormatSizeInBytes()};
             }
         };
 
@@ -2464,8 +2445,7 @@ public:
             } query;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 
@@ -2479,8 +2459,7 @@ public:
             u32 frequency;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
 
             bool IsEnabled() const {
@@ -2494,8 +2473,7 @@ public:
             u32 address_low;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
         static_assert(sizeof(VertexStreamLimit) == 0x8);
@@ -2543,8 +2521,7 @@ public:
             std::array<u32, NumCBData> buffer;
 
             GPUVAddr Address() const {
-                return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
-                                             address_low);
+                return (GPUVAddr{address_high} << 32) | GPUVAddr{address_low};
             }
         };
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -184,7 +184,7 @@ public:
                 default:
                     // Thresholds begin at 0x10 (1 << 4)
                     // Threshold is in the range 0x1 to 0x13
-                    return 1 << (4 + threshold.Value() - 1);
+                    return 1U << (4 + threshold.Value() - 1);
                 }
             }
         };
@@ -822,11 +822,11 @@ public:
         struct CompressionThresholdSamples {
             u32 samples;
 
-            u32 Samples() {
+            u32 Samples() const {
                 if (samples == 0) {
                     return 0;
                 }
-                return 1 << (samples - 1);
+                return 1U << (samples - 1);
             }
         };
 

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -41,8 +41,8 @@ void MaxwellDMA::CallMethod(u32 method, u32 method_argument, bool is_last_call) 
 
 void MaxwellDMA::CallMultiMethod(u32 method, const u32* base_start, u32 amount,
                                  u32 methods_pending) {
-    for (size_t i = 0; i < amount; ++i) {
-        CallMethod(method, base_start[i], methods_pending - static_cast<u32>(i) <= 1);
+    for (u32 i = 0; i < amount; ++i) {
+        CallMethod(method, base_start[i], methods_pending - i <= 1);
     }
 }
 
@@ -94,14 +94,14 @@ void MaxwellDMA::Launch() {
                                             reinterpret_cast<u8*>(tmp_buffer.data()),
                                             regs.line_length_in * sizeof(u32));
         } else {
-            auto convert_linear_2_blocklinear_addr = [](u64 address) {
+            const auto convert_linear_2_blocklinear_addr = [](u64 address) {
                 return (address & ~0x1f0ULL) | ((address & 0x40) >> 2) | ((address & 0x10) << 1) |
                        ((address & 0x180) >> 1) | ((address & 0x20) << 3);
             };
-            auto src_kind = memory_manager.GetPageKind(regs.offset_in);
-            auto dst_kind = memory_manager.GetPageKind(regs.offset_out);
-            const bool is_src_pitch = IsPitchKind(static_cast<PTEKind>(src_kind));
-            const bool is_dst_pitch = IsPitchKind(static_cast<PTEKind>(dst_kind));
+            const auto src_kind = memory_manager.GetPageKind(regs.offset_in);
+            const auto dst_kind = memory_manager.GetPageKind(regs.offset_out);
+            const bool is_src_pitch = IsPitchKind(src_kind);
+            const bool is_dst_pitch = IsPitchKind(dst_kind);
             if (!is_src_pitch && is_dst_pitch) {
                 UNIMPLEMENTED_IF(regs.line_length_in % 16 != 0);
                 UNIMPLEMENTED_IF(regs.offset_in % 16 != 0);

--- a/src/video_core/engines/puller.cpp
+++ b/src/video_core/engines/puller.cpp
@@ -31,7 +31,7 @@ void Puller::ProcessBindMethod(const MethodCall& method_call) {
     LOG_DEBUG(HW_GPU, "Binding subchannel {} to engine {}", method_call.subchannel,
               method_call.argument);
     const auto engine_id = static_cast<EngineID>(method_call.argument);
-    bound_engines[method_call.subchannel] = static_cast<EngineID>(engine_id);
+    bound_engines[method_call.subchannel] = engine_id;
     switch (engine_id) {
     case EngineID::FERMI_TWOD_A:
         dma_pusher.BindSubchannel(channel_state.fermi_2d.get(), method_call.subchannel);
@@ -285,12 +285,12 @@ void Puller::CallMultiMethod(u32 method, u32 subchannel, const u32* base_start, 
     if (ExecuteMethodOnEngine(method)) {
         CallEngineMultiMethod(method, subchannel, base_start, amount, methods_pending);
     } else {
-        for (std::size_t i = 0; i < amount; i++) {
+        for (u32 i = 0; i < amount; i++) {
             CallPullerMethod(MethodCall{
                 method,
                 base_start[i],
                 subchannel,
-                methods_pending - static_cast<u32>(i),
+                methods_pending - i,
             });
         }
     }


### PR DESCRIPTION
In a few cases we have some casts that can be trivially removed.