### PR TITLE
video_core: Fine tuning the index drawing judgment logic

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -3182,6 +3182,7 @@ private:
     std::vector<u32> deferred_draw_method;
     enum class DrawMode : u32 { General = 0, Instance, InlineIndex };
     DrawMode draw_mode{DrawMode::General};
+    bool draw_indexed{};
 };
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \


### PR DESCRIPTION
Previously, we would set vertex(index)_count to 0 after each draw, because we needed to determine if it was an index draw based on the value. 
But now it turns out that macro will initiate some draw calls that rely on the previous value of vertex(index)_count, so we have modified the current logic.

Fixed particle in xc3, but some particles were still found to be faulty.