### PR TITLE
host1x/syncpoint_manager: Pass DeregisterAction() handle as const-ref 

### DIFF
--- a/src/video_core/host1x/syncpoint_manager.cpp
+++ b/src/video_core/host1x/syncpoint_manager.cpp
@@ -34,7 +34,7 @@ SyncpointManager::ActionHandle SyncpointManager::RegisterAction(
 }
 
 void SyncpointManager::DeregisterAction(std::list<RegisteredAction>& action_storage,
-                                        ActionHandle& handle) {
+                                        const ActionHandle& handle) {
     std::unique_lock lk(guard);
 
     // We want to ensure the iterator still exists prior to erasing it
@@ -49,11 +49,11 @@ void SyncpointManager::DeregisterAction(std::list<RegisteredAction>& action_stor
     }
 }
 
-void SyncpointManager::DeregisterGuestAction(u32 syncpoint_id, ActionHandle& handle) {
+void SyncpointManager::DeregisterGuestAction(u32 syncpoint_id, const ActionHandle& handle) {
     DeregisterAction(guest_action_storage[syncpoint_id], handle);
 }
 
-void SyncpointManager::DeregisterHostAction(u32 syncpoint_id, ActionHandle& handle) {
+void SyncpointManager::DeregisterHostAction(u32 syncpoint_id, const ActionHandle& handle) {
     DeregisterAction(host_action_storage[syncpoint_id], handle);
 }
 

--- a/src/video_core/host1x/syncpoint_manager.h
+++ b/src/video_core/host1x/syncpoint_manager.h
@@ -48,9 +48,9 @@ public:
                               expected_value, std::move(func));
     }
 
-    void DeregisterGuestAction(u32 syncpoint_id, ActionHandle& handle);
+    void DeregisterGuestAction(u32 syncpoint_id, const ActionHandle& handle);
 
-    void DeregisterHostAction(u32 syncpoint_id, ActionHandle& handle);
+    void DeregisterHostAction(u32 syncpoint_id, const ActionHandle& handle);
 
     void IncrementGuest(u32 syncpoint_id);
 
@@ -76,7 +76,7 @@ private:
                                 std::list<RegisteredAction>& action_storage, u32 expected_value,
                                 std::function<void()>&& action);
 
-    void DeregisterAction(std::list<RegisteredAction>& action_storage, ActionHandle& handle);
+    void DeregisterAction(std::list<RegisteredAction>& action_storage, const ActionHandle& handle);
 
     void Wait(std::atomic<u32>& syncpoint, std::condition_variable& wait_cv, u32 expected_value);
 

--- a/src/video_core/host1x/syncpoint_manager.h
+++ b/src/video_core/host1x/syncpoint_manager.h
@@ -36,16 +36,14 @@ public:
 
     template <typename Func>
     ActionHandle RegisterGuestAction(u32 syncpoint_id, u32 expected_value, Func&& action) {
-        std::function<void()> func(action);
         return RegisterAction(syncpoints_guest[syncpoint_id], guest_action_storage[syncpoint_id],
-                              expected_value, std::move(func));
+                              expected_value, std::move(action));
     }
 
     template <typename Func>
     ActionHandle RegisterHostAction(u32 syncpoint_id, u32 expected_value, Func&& action) {
-        std::function<void()> func(action);
         return RegisterAction(syncpoints_host[syncpoint_id], host_action_storage[syncpoint_id],
-                              expected_value, std::move(func));
+                              expected_value, std::move(action));
     }
 
     void DeregisterGuestAction(u32 syncpoint_id, const ActionHandle& handle);


### PR DESCRIPTION
The handle is only compared against and not modified in any way, so we can pass it by const reference.

This also allows us to mark the respective parameters for `DeregisterGuestAction()` and `DeregisterHostAction()` as const references
as well.

Makes it a little more explicit that the handle isn't intended to be modified from an self-documenting standpoint.