### PR TITLE
shader_recompiler: add gl_Layer translation GS for older hardware

### DIFF
--- a/src/shader_recompiler/CMakeLists.txt
+++ b/src/shader_recompiler/CMakeLists.txt
@@ -221,6 +221,7 @@ add_library(shader_recompiler STATIC
     ir_opt/dual_vertex_pass.cpp
     ir_opt/global_memory_to_storage_buffer_pass.cpp
     ir_opt/identity_removal_pass.cpp
+    ir_opt/layer_pass.cpp
     ir_opt/lower_fp16_to_fp32.cpp
     ir_opt/lower_int64_to_int32.cpp
     ir_opt/passes.h

--- a/src/shader_recompiler/frontend/maxwell/translate_program.h
+++ b/src/shader_recompiler/frontend/maxwell/translate_program.h
@@ -25,4 +25,13 @@ namespace Shader::Maxwell {
 
 void ConvertLegacyToGeneric(IR::Program& program, const RuntimeInfo& runtime_info);
 
+// Maxwell v1 and older Nvidia cards don't support setting gl_Layer from non-geometry stages.
+// This creates a workaround by setting the layer as a generic output and creating a
+// passthrough geometry shader that reads the generic and sets the layer.
+[[nodiscard]] IR::Program GenerateGeometryPassthrough(ObjectPool<IR::Inst>& inst_pool,
+                                                      ObjectPool<IR::Block>& block_pool,
+                                                      const HostTranslateInfo& host_info,
+                                                      IR::Program& source_program,
+                                                      Shader::OutputTopology output_topology);
+
 } // namespace Shader::Maxwell

--- a/src/shader_recompiler/host_translate_info.h
+++ b/src/shader_recompiler/host_translate_info.h
@@ -13,7 +13,8 @@ struct HostTranslateInfo {
     bool support_float16{};      ///< True when the device supports 16-bit floats
     bool support_int64{};        ///< True when the device supports 64-bit integers
     bool needs_demote_reorder{}; ///< True when the device needs DemoteToHelperInvocation reordered
-    bool support_snorm_render_buffer{}; ///< True when the device supports SNORM render buffers
+    bool support_snorm_render_buffer{};  ///< True when the device supports SNORM render buffers
+    bool support_viewport_index_layer{}; ///< True when the device supports gl_Layer in VS
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/ir_opt/layer_pass.cpp
+++ b/src/shader_recompiler/ir_opt/layer_pass.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <bit>
+#include <optional>
+
+#include <boost/container/small_vector.hpp>
+
+#include "shader_recompiler/environment.h"
+#include "shader_recompiler/frontend/ir/basic_block.h"
+#include "shader_recompiler/frontend/ir/breadth_first_search.h"
+#include "shader_recompiler/frontend/ir/ir_emitter.h"
+#include "shader_recompiler/host_translate_info.h"
+#include "shader_recompiler/ir_opt/passes.h"
+#include "shader_recompiler/shader_info.h"
+
+namespace Shader::Optimization {
+
+static IR::Attribute EmulatedLayerAttribute(VaryingState& stores) {
+    for (u32 i = 0; i < 32; i++) {
+        if (!stores.Generic(i)) {
+            return IR::Attribute::Generic0X + (i * 4);
+        }
+    }
+    return IR::Attribute::Layer;
+}
+
+static bool PermittedProgramStage(Stage stage) {
+    switch (stage) {
+    case Stage::VertexA:
+    case Stage::VertexB:
+    case Stage::TessellationControl:
+    case Stage::TessellationEval:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void LayerPass(IR::Program& program, const HostTranslateInfo& host_info) {
+    if (host_info.support_viewport_index_layer || !PermittedProgramStage(program.stage)) {
+        return;
+    }
+
+    const auto end{program.post_order_blocks.end()};
+    const auto layer_attribute = EmulatedLayerAttribute(program.info.stores);
+    bool requires_layer_emulation = false;
+
+    for (auto block = program.post_order_blocks.begin(); block != end; ++block) {
+        for (IR::Inst& inst : (*block)->Instructions()) {
+            if (inst.GetOpcode() == IR::Opcode::SetAttribute &&
+                inst.Arg(0).Attribute() == IR::Attribute::Layer) {
+                requires_layer_emulation = true;
+                inst.SetArg(0, IR::Value{layer_attribute});
+            }
+        }
+    }
+
+    if (requires_layer_emulation) {
+        program.info.requires_layer_emulation = true;
+        program.info.emulated_layer = layer_attribute;
+        program.info.stores.Set(IR::Attribute::Layer, false);
+        program.info.stores.Set(layer_attribute, true);
+    }
+}
+
+} // namespace Shader::Optimization

--- a/src/shader_recompiler/ir_opt/passes.h
+++ b/src/shader_recompiler/ir_opt/passes.h
@@ -23,6 +23,7 @@ void RescalingPass(IR::Program& program);
 void SsaRewritePass(IR::Program& program);
 void PositionPass(Environment& env, IR::Program& program);
 void TexturePass(Environment& env, IR::Program& program, const HostTranslateInfo& host_info);
+void LayerPass(IR::Program& program, const HostTranslateInfo& host_info);
 void VerificationPass(const IR::Program& program);
 
 // Dual Vertex

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -204,6 +204,9 @@ struct Info {
     u32 nvn_buffer_base{};
     std::bitset<16> nvn_buffer_used{};
 
+    bool requires_layer_emulation{};
+    IR::Attribute emulated_layer{};
+
     boost::container::static_vector<ConstantBufferDescriptor, MAX_CBUFS>
         constant_buffer_descriptors;
     boost::container::static_vector<StorageBufferDescriptor, MAX_SSBOS> storage_buffers_descriptors;


### PR DESCRIPTION
Should fix rendering of Pokemon Scarlet on Maxwell v1 and older Nvidia cards.

Also experimentally seems to fix it on RadeonSI (well, it displays _something_, whereas before it was just black), but RadeonSI reports support for GL_ARB_shader_viewport_layer_array even though it is broken, and I didn't bother to add another workaround for this particular case, since radv should be much better for this game anyway.