### PR TITLE
vulkan_common: quiet some validation errors

### DIFF
--- a/src/video_core/vulkan_common/vulkan_debug_callback.cpp
+++ b/src/video_core/vulkan_common/vulkan_debug_callback.cpp
@@ -16,6 +16,8 @@ VkBool32 Callback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
     case 0x682a878au: // VUID-vkCmdBindVertexBuffers2EXT-pBuffers-parameter
     case 0x99fb7dfdu: // UNASSIGNED-RequiredParameter (vkCmdBindVertexBuffers2EXT pBuffers[0])
     case 0xe8616bf2u: // Bound VkDescriptorSet 0x0[] was destroyed. Likely push_descriptor related
+    case 0x1608dec0u: // Image layout in vkUpdateDescriptorSet doesn't match descriptor use
+    case 0x55362756u: // Descriptor binding and framebuffer attachment overlap
         return VK_FALSE;
     default:
         break;

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1058,7 +1058,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         test(has_ext_transform_feedback, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME, false);
         test(has_ext_custom_border_color, VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME, false);
         test(has_ext_extended_dynamic_state, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME, false);
-        test(has_ext_subgroup_size_control, VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME, false);
+        test(has_ext_subgroup_size_control, VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME, true);
         test(has_ext_provoking_vertex, VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME, false);
         test(has_ext_vertex_input_dynamic_state, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME,
              false);


### PR DESCRIPTION
- VUID-VkPipelineShaderStageCreateInfo-pNext-02755: subgroupSizeControl should be enabled when feature-tested
- VUID-vkCmdDraw-None-02699: it's normal for shaders to have image different bindings in different uses
- VUID-vkCmdDrawIndexed-None-06538: the image bound as storage isn't written to