### PR TITLE
service: nfc: Implement mifare service

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -528,6 +528,8 @@ add_library(core STATIC
     hle/service/mnpp/mnpp_app.h
     hle/service/ncm/ncm.cpp
     hle/service/ncm/ncm.h
+    hle/service/nfc/mifare_user.cpp
+    hle/service/nfc/mifare_user.h
     hle/service/nfc/nfc.cpp
     hle/service/nfc/nfc.h
     hle/service/nfc/nfc_device.cpp

--- a/src/core/hle/service/nfc/mifare_user.cpp
+++ b/src/core/hle/service/nfc/mifare_user.cpp
@@ -1,0 +1,400 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/logging/log.h"
+#include "core/core.h"
+#include "core/hid/hid_types.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/nfc/mifare_user.h"
+#include "core/hle/service/nfc/nfc_device.h"
+#include "core/hle/service/nfc/nfc_result.h"
+
+namespace Service::NFC {
+
+MFIUser::MFIUser(Core::System& system_)
+    : ServiceFramework{system_, "NFC::MFIUser"}, service_context{system_, service_name} {
+    static const FunctionInfo functions[] = {
+        {0, &MFIUser::Initialize, "Initialize"},
+        {1, &MFIUser::Finalize, "Finalize"},
+        {2, &MFIUser::ListDevices, "ListDevices"},
+        {3, &MFIUser::StartDetection, "StartDetection"},
+        {4, &MFIUser::StopDetection, "StopDetection"},
+        {5, &MFIUser::Read, "Read"},
+        {6, &MFIUser::Write, "Write"},
+        {7, &MFIUser::GetTagInfo, "GetTagInfo"},
+        {8, &MFIUser::GetActivateEventHandle, "GetActivateEventHandle"},
+        {9, &MFIUser::GetDeactivateEventHandle, "GetDeactivateEventHandle"},
+        {10, &MFIUser::GetState, "GetState"},
+        {11, &MFIUser::GetDeviceState, "GetDeviceState"},
+        {12, &MFIUser::GetNpadId, "GetNpadId"},
+        {13, &MFIUser::GetAvailabilityChangeEventHandle, "GetAvailabilityChangeEventHandle"},
+    };
+    RegisterHandlers(functions);
+
+    availability_change_event = service_context.CreateEvent("MFIUser:AvailabilityChangeEvent");
+
+    for (u32 device_index = 0; device_index < 10; device_index++) {
+        devices[device_index] =
+            std::make_shared<NfcDevice>(Core::HID::IndexToNpadIdType(device_index), system,
+                                        service_context, availability_change_event);
+    }
+}
+
+MFIUser ::~MFIUser() {
+    availability_change_event->Close();
+}
+
+void MFIUser::Initialize(Kernel::HLERequestContext& ctx) {
+    LOG_INFO(Service_NFC, "called");
+
+    state = State::Initialized;
+
+    for (auto& device : devices) {
+        device->Initialize();
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2, 0};
+    rb.Push(ResultSuccess);
+}
+
+void MFIUser::Finalize(Kernel::HLERequestContext& ctx) {
+    LOG_INFO(Service_NFC, "called");
+
+    state = State::NonInitialized;
+
+    for (auto& device : devices) {
+        device->Finalize();
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(ResultSuccess);
+}
+
+void MFIUser::ListDevices(Kernel::HLERequestContext& ctx) {
+    LOG_DEBUG(Service_NFC, "called");
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    if (!ctx.CanWriteBuffer()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareInvalidArgument);
+        return;
+    }
+
+    if (ctx.GetWriteBufferSize() == 0) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareInvalidArgument);
+        return;
+    }
+
+    std::vector<u64> nfp_devices;
+    const std::size_t max_allowed_devices = ctx.GetWriteBufferNumElements<u64>();
+
+    for (const auto& device : devices) {
+        if (nfp_devices.size() >= max_allowed_devices) {
+            continue;
+        }
+        if (device->GetCurrentState() != NFP::DeviceState::Unavailable) {
+            nfp_devices.push_back(device->GetHandle());
+        }
+    }
+
+    if (nfp_devices.empty()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    ctx.WriteBuffer(nfp_devices);
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push(static_cast<s32>(nfp_devices.size()));
+}
+
+void MFIUser::StartDetection(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    LOG_INFO(Service_NFC, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    const auto result = device.value()->StartDetection(NFP::TagProtocol::All);
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(result);
+}
+
+void MFIUser::StopDetection(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    LOG_INFO(Service_NFC, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    const auto result = device.value()->StopDetection();
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(result);
+}
+
+void MFIUser::Read(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    const auto buffer{ctx.ReadBuffer()};
+    const auto number_of_commands{ctx.GetReadBufferNumElements<NFP::MifareReadBlockParameter>()};
+    std::vector<NFP::MifareReadBlockParameter> read_commands(number_of_commands);
+
+    memcpy(read_commands.data(), buffer.data(),
+           number_of_commands * sizeof(NFP::MifareReadBlockParameter));
+
+    LOG_INFO(Service_NFC, "(STUBBED) called, device_handle={}, read_commands_size={}",
+             device_handle, number_of_commands);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    Result result = ResultSuccess;
+    std::vector<NFP::MifareReadBlockData> out_data(number_of_commands);
+    for (std::size_t i = 0; i < number_of_commands; i++) {
+        result = device.value()->MifareRead(read_commands[i], out_data[i]);
+        if (result.IsError()) {
+            break;
+        }
+    }
+
+    ctx.WriteBuffer(out_data);
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(result);
+}
+
+void MFIUser::Write(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    const auto buffer{ctx.ReadBuffer()};
+    const auto number_of_commands{ctx.GetReadBufferNumElements<NFP::MifareWriteBlockParameter>()};
+    std::vector<NFP::MifareWriteBlockParameter> write_commands(number_of_commands);
+
+    memcpy(write_commands.data(), buffer.data(),
+           number_of_commands * sizeof(NFP::MifareWriteBlockParameter));
+
+    LOG_INFO(Service_NFC, "(STUBBED) called, device_handle={}, write_commands_size={}",
+             device_handle, number_of_commands);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    Result result = ResultSuccess;
+    std::vector<NFP::MifareReadBlockData> out_data(number_of_commands);
+    for (std::size_t i = 0; i < number_of_commands; i++) {
+        result = device.value()->MifareWrite(write_commands[i]);
+        if (result.IsError()) {
+            break;
+        }
+    }
+
+    if (result.IsSuccess()) {
+        result = device.value()->Flush();
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(result);
+}
+
+void MFIUser::GetTagInfo(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    LOG_INFO(Service_NFC, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    NFP::TagInfo tag_info{};
+    const auto result = device.value()->GetTagInfo(tag_info, true);
+    ctx.WriteBuffer(tag_info);
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(result);
+}
+
+void MFIUser::GetActivateEventHandle(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    LOG_DEBUG(Service_NFC, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2, 1};
+    rb.Push(ResultSuccess);
+    rb.PushCopyObjects(device.value()->GetActivateEvent());
+}
+
+void MFIUser::GetDeactivateEventHandle(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    LOG_DEBUG(Service_NFC, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2, 1};
+    rb.Push(ResultSuccess);
+    rb.PushCopyObjects(device.value()->GetDeactivateEvent());
+}
+
+void MFIUser::GetState(Kernel::HLERequestContext& ctx) {
+    LOG_DEBUG(Service_NFC, "called");
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.PushEnum(state);
+}
+
+void MFIUser::GetDeviceState(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    LOG_DEBUG(Service_NFC, "called, device_handle={}", device_handle);
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.PushEnum(device.value()->GetCurrentState());
+}
+
+void MFIUser::GetNpadId(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto device_handle{rp.Pop<u64>()};
+    LOG_DEBUG(Service_NFC, "called, device_handle={}", device_handle);
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    auto device = GetNfcDevice(device_handle);
+
+    if (!device.has_value()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareDeviceNotFound);
+        return;
+    }
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.PushEnum(device.value()->GetNpadId());
+}
+
+void MFIUser::GetAvailabilityChangeEventHandle(Kernel::HLERequestContext& ctx) {
+    LOG_INFO(Service_NFC, "called");
+
+    if (state == State::NonInitialized) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(MifareNfcDisabled);
+        return;
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2, 1};
+    rb.Push(ResultSuccess);
+    rb.PushCopyObjects(availability_change_event->GetReadableEvent());
+}
+
+std::optional<std::shared_ptr<NfcDevice>> MFIUser::GetNfcDevice(u64 handle) {
+    for (auto& device : devices) {
+        if (device->GetHandle() == handle) {
+            return device;
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace Service::NFC

--- a/src/core/hle/service/nfc/mifare_user.h
+++ b/src/core/hle/service/nfc/mifare_user.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <optional>
+
+#include "core/hle/service/kernel_helpers.h"
+#include "core/hle/service/service.h"
+
+namespace Service::NFC {
+class NfcDevice;
+
+class MFIUser final : public ServiceFramework<MFIUser> {
+public:
+    explicit MFIUser(Core::System& system_);
+    ~MFIUser();
+
+private:
+    enum class State : u32 {
+        NonInitialized,
+        Initialized,
+    };
+
+    void Initialize(Kernel::HLERequestContext& ctx);
+    void Finalize(Kernel::HLERequestContext& ctx);
+    void ListDevices(Kernel::HLERequestContext& ctx);
+    void StartDetection(Kernel::HLERequestContext& ctx);
+    void StopDetection(Kernel::HLERequestContext& ctx);
+    void Read(Kernel::HLERequestContext& ctx);
+    void Write(Kernel::HLERequestContext& ctx);
+    void GetTagInfo(Kernel::HLERequestContext& ctx);
+    void GetActivateEventHandle(Kernel::HLERequestContext& ctx);
+    void GetDeactivateEventHandle(Kernel::HLERequestContext& ctx);
+    void GetState(Kernel::HLERequestContext& ctx);
+    void GetDeviceState(Kernel::HLERequestContext& ctx);
+    void GetNpadId(Kernel::HLERequestContext& ctx);
+    void GetAvailabilityChangeEventHandle(Kernel::HLERequestContext& ctx);
+
+    std::optional<std::shared_ptr<NfcDevice>> GetNfcDevice(u64 handle);
+
+    KernelHelpers::ServiceContext service_context;
+
+    std::array<std::shared_ptr<NfcDevice>, 10> devices{};
+
+    State state{State::NonInitialized};
+    Kernel::KEvent* availability_change_event;
+};
+
+} // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -6,6 +6,7 @@
 #include "common/logging/log.h"
 #include "common/settings.h"
 #include "core/hle/ipc_helpers.h"
+#include "core/hle/service/nfc/mifare_user.h"
 #include "core/hle/service/nfc/nfc.h"
 #include "core/hle/service/nfc/nfc_user.h"
 #include "core/hle/service/service.h"
@@ -47,32 +48,6 @@ private:
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IAm>(system);
-    }
-};
-
-class MFIUser final : public ServiceFramework<MFIUser> {
-public:
-    explicit MFIUser(Core::System& system_) : ServiceFramework{system_, "NFC::MFIUser"} {
-        // clang-format off
-        static const FunctionInfo functions[] = {
-            {0, nullptr, "Initialize"},
-            {1, nullptr, "Finalize"},
-            {2, nullptr, "ListDevices"},
-            {3, nullptr, "StartDetection"},
-            {4, nullptr, "StopDetection"},
-            {5, nullptr, "Read"},
-            {6, nullptr, "Write"},
-            {7, nullptr, "GetTagInfo"},
-            {8, nullptr, "GetActivateEventHandle"},
-            {9, nullptr, "GetDeactivateEventHandle"},
-            {10, nullptr, "GetState"},
-            {11, nullptr, "GetDeviceState"},
-            {12, nullptr, "GetNpadId"},
-            {13, nullptr, "GetAvailabilityChangeEventHandle"},
-        };
-        // clang-format on
-
-        RegisterHandlers(functions);
     }
 };
 

--- a/src/core/hle/service/nfc/nfc_device.h
+++ b/src/core/hle/service/nfc/nfc_device.h
@@ -34,10 +34,16 @@ public:
     void Initialize();
     void Finalize();
 
-    Result StartDetection(s32 protocol_);
+    Result StartDetection(NFP::TagProtocol allowed_protocol);
     Result StopDetection();
+    Result Flush();
 
-    Result GetTagInfo(NFP::TagInfo& tag_info) const;
+    Result GetTagInfo(NFP::TagInfo& tag_info, bool is_mifare) const;
+
+    Result MifareRead(const NFP::MifareReadBlockParameter& parameter,
+                      NFP::MifareReadBlockData& read_block_data);
+
+    Result MifareWrite(const NFP::MifareWriteBlockParameter& parameter);
 
     u64 GetHandle() const;
     NFP::DeviceState GetCurrentState() const;
@@ -61,10 +67,11 @@ private:
     Kernel::KEvent* deactivate_event = nullptr;
     Kernel::KEvent* availability_change_event = nullptr;
 
-    s32 protocol{};
+    NFP::TagProtocol allowed_protocols{};
     NFP::DeviceState device_state{NFP::DeviceState::Unavailable};
 
     NFP::EncryptedNTAG215File encrypted_tag_data{};
+    std::vector<u8> tag_data{};
 };
 
 } // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc_result.h
+++ b/src/core/hle/service/nfc/nfc_result.h
@@ -12,6 +12,12 @@ constexpr Result InvalidArgument(ErrorModule::NFC, 65);
 constexpr Result WrongDeviceState(ErrorModule::NFC, 73);
 constexpr Result NfcDisabled(ErrorModule::NFC, 80);
 constexpr Result TagRemoved(ErrorModule::NFC, 97);
-constexpr Result CorruptedData(ErrorModule::NFC, 144);
+
+constexpr Result MifareDeviceNotFound(ErrorModule::NFCMifare, 64);
+constexpr Result MifareInvalidArgument(ErrorModule::NFCMifare, 65);
+constexpr Result MifareWrongDeviceState(ErrorModule::NFCMifare, 73);
+constexpr Result MifareNfcDisabled(ErrorModule::NFCMifare, 80);
+constexpr Result MifareTagRemoved(ErrorModule::NFCMifare, 97);
+constexpr Result MifareReadError(ErrorModule::NFCMifare, 288);
 
 } // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc_user.cpp
+++ b/src/core/hle/service/nfc/nfc_user.cpp
@@ -201,7 +201,7 @@ void IUser::AttachAvailabilityChangeEvent(Kernel::HLERequestContext& ctx) {
 void IUser::StartDetection(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
-    const auto nfp_protocol{rp.Pop<s32>()};
+    const auto nfp_protocol{rp.PopEnum<NFP::TagProtocol>()};
     LOG_INFO(Service_NFC, "called, device_handle={}, nfp_protocol={}", device_handle, nfp_protocol);
 
     if (state == State::NonInitialized) {
@@ -267,7 +267,7 @@ void IUser::GetTagInfo(Kernel::HLERequestContext& ctx) {
     }
 
     NFP::TagInfo tag_info{};
-    const auto result = device.value()->GetTagInfo(tag_info);
+    const auto result = device.value()->GetTagInfo(tag_info, false);
     ctx.WriteBuffer(tag_info);
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(result);

--- a/src/core/hle/service/nfp/nfp_types.h
+++ b/src/core/hle/service/nfp/nfp_types.h
@@ -106,11 +106,24 @@ enum class CabinetMode : u8 {
     StartFormatter,
 };
 
+enum class MifareCmd : u8 {
+    AuthA = 0x60,
+    AuthB = 0x61,
+    Read = 0x30,
+    Write = 0xA0,
+    Transfer = 0xB0,
+    Decrement = 0xC0,
+    Increment = 0xC1,
+    Store = 0xC2
+};
+
 using UniqueSerialNumber = std::array<u8, 7>;
 using LockBytes = std::array<u8, 2>;
 using HashData = std::array<u8, 0x20>;
 using ApplicationArea = std::array<u8, 0xD8>;
 using AmiiboName = std::array<char, (amiibo_name_length * 4) + 1>;
+using DataBlock = std::array<u8, 0x10>;
+using KeyData = std::array<u8, 0x6>;
 
 struct TagUuid {
     UniqueSerialNumber uid;
@@ -322,5 +335,38 @@ struct RegisterInfo {
     INSERT_PADDING_BYTES(0x7A);
 };
 static_assert(sizeof(RegisterInfo) == 0x100, "RegisterInfo is an invalid size");
+
+struct SectorKey {
+    MifareCmd command;
+    u8 unknown; // Usually 1
+    INSERT_PADDING_BYTES(0x6);
+    KeyData sector_key;
+    INSERT_PADDING_BYTES(0x2);
+};
+static_assert(sizeof(SectorKey) == 0x10, "SectorKey is an invalid size");
+
+struct MifareReadBlockParameter {
+    u8 sector_number;
+    INSERT_PADDING_BYTES(0x7);
+    SectorKey sector_key;
+};
+static_assert(sizeof(MifareReadBlockParameter) == 0x18,
+              "MifareReadBlockParameter is an invalid size");
+
+struct MifareReadBlockData {
+    DataBlock data;
+    u8 sector_number;
+    INSERT_PADDING_BYTES(0x7);
+};
+static_assert(sizeof(MifareReadBlockData) == 0x18, "MifareReadBlockData is an invalid size");
+
+struct MifareWriteBlockParameter {
+    DataBlock data;
+    u8 sector_number;
+    INSERT_PADDING_BYTES(0x7);
+    SectorKey sector_key;
+};
+static_assert(sizeof(MifareWriteBlockParameter) == 0x28,
+              "MifareWriteBlockParameter is an invalid size");
 
 } // namespace Service::NFP

--- a/src/input_common/drivers/virtual_amiibo.h
+++ b/src/input_common/drivers/virtual_amiibo.h
@@ -53,12 +53,13 @@ public:
     std::string GetLastFilePath() const;
 
 private:
-    static constexpr std::size_t amiibo_size = 0x21C;
-    static constexpr std::size_t amiibo_size_without_password = amiibo_size - 0x8;
+    static constexpr std::size_t AmiiboSize = 0x21C;
+    static constexpr std::size_t AmiiboSizeWithoutPassword = AmiiboSize - 0x8;
+    static constexpr std::size_t MifareSize = 0x400;
 
     std::string file_path{};
     State state{State::Initialized};
-    std::vector<u8> amiibo_data;
+    std::vector<u8> nfc_data;
     Common::Input::PollingMode polling_mode{Common::Input::PollingMode::Pasive};
 };
 } // namespace InputCommon


### PR DESCRIPTION
This PR allows to read/write plain mifare tags. Mostly used by `Skylanders Imaginators`. While encryption is not supported, plain dumps are fully functional. This completes the trilogy of NFC support. 

What's next? Besides adding encryption support I need to combine nfp and nfc as an unique file. Since both do exactly the same. For now I will keep them separated since it makes easier to identify and fix issues.