### PR TITLE
vulkan_common: promote extension usages to core when possible

### DIFF
--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -58,7 +58,7 @@ VkSamplerAddressMode WrapMode(const Device& device, Tegra::Texture::WrapMode wra
     case Tegra::Texture::WrapMode::Border:
         return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
     case Tegra::Texture::WrapMode::Clamp:
-        if (device.GetDriverID() == VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR) {
+        if (device.GetDriverID() == VK_DRIVER_ID_NVIDIA_PROPRIETARY) {
             // Nvidia's Vulkan driver defaults to GL_CLAMP on invalid enumerations, we can hack this
             // by sending an invalid enumeration.
             return static_cast<VkSamplerAddressMode>(0xcafe);

--- a/src/video_core/renderer_vulkan/pipeline_helper.h
+++ b/src/video_core/renderer_vulkan/pipeline_helper.h
@@ -129,7 +129,7 @@ private:
     const Device* device{};
     bool is_compute{};
     boost::container::small_vector<VkDescriptorSetLayoutBinding, 32> bindings;
-    boost::container::small_vector<VkDescriptorUpdateTemplateEntryKHR, 32> entries;
+    boost::container::small_vector<VkDescriptorUpdateTemplateEntry, 32> entries;
     u32 binding{};
     u32 num_descriptors{};
     size_t offset{};

--- a/src/video_core/renderer_vulkan/pipeline_helper.h
+++ b/src/video_core/renderer_vulkan/pipeline_helper.h
@@ -44,17 +44,17 @@ public:
         });
     }
 
-    vk::DescriptorUpdateTemplateKHR CreateTemplate(VkDescriptorSetLayout descriptor_set_layout,
-                                                   VkPipelineLayout pipeline_layout,
-                                                   bool use_push_descriptor) const {
+    vk::DescriptorUpdateTemplate CreateTemplate(VkDescriptorSetLayout descriptor_set_layout,
+                                                VkPipelineLayout pipeline_layout,
+                                                bool use_push_descriptor) const {
         if (entries.empty()) {
             return nullptr;
         }
         const VkDescriptorUpdateTemplateType type =
             use_push_descriptor ? VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR
-                                : VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR;
-        return device->GetLogical().CreateDescriptorUpdateTemplateKHR({
-            .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR,
+                                : VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET;
+        return device->GetLogical().CreateDescriptorUpdateTemplate({
+            .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO,
             .pNext = nullptr,
             .flags = 0,
             .descriptorUpdateEntryCount = static_cast<u32>(entries.size()),

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -45,14 +45,14 @@ std::string GetDriverVersion(const Device& device) {
     // https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/5dddea46ea1120b0df14eef8f15ff8e318e35462/functions.php#L308-L314
     const u32 version = device.GetDriverVersion();
 
-    if (device.GetDriverID() == VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR) {
+    if (device.GetDriverID() == VK_DRIVER_ID_NVIDIA_PROPRIETARY) {
         const u32 major = (version >> 22) & 0x3ff;
         const u32 minor = (version >> 14) & 0x0ff;
         const u32 secondary = (version >> 6) & 0x0ff;
         const u32 tertiary = version & 0x003f;
         return fmt::format("{}.{}.{}.{}", major, minor, secondary, tertiary);
     }
-    if (device.GetDriverID() == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR) {
+    if (device.GetDriverID() == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS) {
         const u32 major = version >> 14;
         const u32 minor = version & 0x3fff;
         return fmt::format("{}.{}", major, minor);

--- a/src/video_core/renderer_vulkan/vk_compute_pass.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.cpp
@@ -93,7 +93,7 @@ constexpr DescriptorBankInfo ASTC_BANK_INFO{
     .score = 2,
 };
 
-constexpr VkDescriptorUpdateTemplateEntryKHR INPUT_OUTPUT_DESCRIPTOR_UPDATE_TEMPLATE{
+constexpr VkDescriptorUpdateTemplateEntry INPUT_OUTPUT_DESCRIPTOR_UPDATE_TEMPLATE{
     .dstBinding = 0,
     .dstArrayElement = 0,
     .descriptorCount = 2,
@@ -102,7 +102,7 @@ constexpr VkDescriptorUpdateTemplateEntryKHR INPUT_OUTPUT_DESCRIPTOR_UPDATE_TEMP
     .stride = sizeof(DescriptorUpdateEntry),
 };
 
-constexpr std::array<VkDescriptorUpdateTemplateEntryKHR, ASTC_NUM_BINDINGS>
+constexpr std::array<VkDescriptorUpdateTemplateEntry, ASTC_NUM_BINDINGS>
     ASTC_PASS_DESCRIPTOR_UPDATE_TEMPLATE_ENTRY{{
         {
             .dstBinding = ASTC_BINDING_INPUT_BUFFER,
@@ -134,7 +134,7 @@ struct AstcPushConstants {
 
 ComputePass::ComputePass(const Device& device_, DescriptorPool& descriptor_pool,
                          vk::Span<VkDescriptorSetLayoutBinding> bindings,
-                         vk::Span<VkDescriptorUpdateTemplateEntryKHR> templates,
+                         vk::Span<VkDescriptorUpdateTemplateEntry> templates,
                          const DescriptorBankInfo& bank_info,
                          vk::Span<VkPushConstantRange> push_constants, std::span<const u32> code)
     : device{device_} {
@@ -155,13 +155,13 @@ ComputePass::ComputePass(const Device& device_, DescriptorPool& descriptor_pool,
         .pPushConstantRanges = push_constants.data(),
     });
     if (!templates.empty()) {
-        descriptor_template = device.GetLogical().CreateDescriptorUpdateTemplateKHR({
-            .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR,
+        descriptor_template = device.GetLogical().CreateDescriptorUpdateTemplate({
+            .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO,
             .pNext = nullptr,
             .flags = 0,
             .descriptorUpdateEntryCount = templates.size(),
             .pDescriptorUpdateEntries = templates.data(),
-            .templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR,
+            .templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET,
             .descriptorSetLayout = *descriptor_set_layout,
             .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
             .pipelineLayout = *layout,

--- a/src/video_core/renderer_vulkan/vk_compute_pass.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.h
@@ -29,14 +29,14 @@ class ComputePass {
 public:
     explicit ComputePass(const Device& device, DescriptorPool& descriptor_pool,
                          vk::Span<VkDescriptorSetLayoutBinding> bindings,
-                         vk::Span<VkDescriptorUpdateTemplateEntryKHR> templates,
+                         vk::Span<VkDescriptorUpdateTemplateEntry> templates,
                          const DescriptorBankInfo& bank_info,
                          vk::Span<VkPushConstantRange> push_constants, std::span<const u32> code);
     ~ComputePass();
 
 protected:
     const Device& device;
-    vk::DescriptorUpdateTemplateKHR descriptor_template;
+    vk::DescriptorUpdateTemplate descriptor_template;
     vk::PipelineLayout layout;
     vk::Pipeline pipeline;
     vk::DescriptorSetLayout descriptor_set_layout;

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -53,7 +53,7 @@ ComputePipeline::ComputePipeline(const Device& device_, DescriptorPool& descript
             .requiredSubgroupSize = GuestWarpSize,
         };
         VkPipelineCreateFlags flags{};
-        if (device.IsKhrPipelineEexecutablePropertiesEnabled()) {
+        if (device.IsKhrPipelineExecutablePropertiesEnabled()) {
             flags |= VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR;
         }
         pipeline = device.GetLogical().CreateComputePipeline({

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.h
@@ -55,7 +55,7 @@ private:
     vk::DescriptorSetLayout descriptor_set_layout;
     DescriptorAllocator descriptor_allocator;
     vk::PipelineLayout pipeline_layout;
-    vk::DescriptorUpdateTemplateKHR descriptor_update_template;
+    vk::DescriptorUpdateTemplate descriptor_update_template;
     vk::Pipeline pipeline;
 
     std::condition_variable build_condvar;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -830,7 +830,7 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
         */
     }
     VkPipelineCreateFlags flags{};
-    if (device.IsKhrPipelineEexecutablePropertiesEnabled()) {
+    if (device.IsKhrPipelineExecutablePropertiesEnabled()) {
         flags |= VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR;
     }
     pipeline = device.GetLogical().CreateGraphicsPipeline({

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -151,7 +151,7 @@ private:
     vk::DescriptorSetLayout descriptor_set_layout;
     DescriptorAllocator descriptor_allocator;
     vk::PipelineLayout pipeline_layout;
-    vk::DescriptorUpdateTemplateKHR descriptor_update_template;
+    vk::DescriptorUpdateTemplate descriptor_update_template;
     vk::Pipeline pipeline;
 
     std::condition_variable build_condvar;

--- a/src/video_core/renderer_vulkan/vk_master_semaphore.cpp
+++ b/src/video_core/renderer_vulkan/vk_master_semaphore.cpp
@@ -11,10 +11,10 @@
 namespace Vulkan {
 
 MasterSemaphore::MasterSemaphore(const Device& device) {
-    static constexpr VkSemaphoreTypeCreateInfoKHR semaphore_type_ci{
-        .sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO_KHR,
+    static constexpr VkSemaphoreTypeCreateInfo semaphore_type_ci{
+        .sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO,
         .pNext = nullptr,
-        .semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR,
+        .semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE,
         .initialValue = 0,
     };
     static constexpr VkSemaphoreCreateInfo semaphore_ci{
@@ -28,7 +28,7 @@ MasterSemaphore::MasterSemaphore(const Device& device) {
         return;
     }
     // Validation layers have a bug where they fail to track resource usage when using timeline
-    // semaphores and synchronizing with GetSemaphoreCounterValueKHR. To workaround this issue, have
+    // semaphores and synchronizing with GetSemaphoreCounterValue. To workaround this issue, have
     // a separate thread waiting for each timeline semaphore value.
     debug_thread = std::jthread([this](std::stop_token stop_token) {
         u64 counter = 0;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -287,7 +287,7 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
       workers(std::max(std::thread::hardware_concurrency(), 2U) - 1, "VkPipelineBuilder"),
       serialization_thread(1, "VkPipelineSerialization") {
     const auto& float_control{device.FloatControlProperties()};
-    const VkDriverIdKHR driver_id{device.GetDriverID()};
+    const VkDriverId driver_id{device.GetDriverID()};
     profile = Shader::Profile{
         .supported_spirv = device.SupportedSpirvVersion(),
         .unified_descriptor_binding = true,
@@ -297,10 +297,10 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .support_int64 = device.IsShaderInt64Supported(),
         .support_vertex_instance_id = false,
         .support_float_controls = true,
-        .support_separate_denorm_behavior = float_control.denormBehaviorIndependence ==
-                                            VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR,
+        .support_separate_denorm_behavior =
+            float_control.denormBehaviorIndependence == VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL,
         .support_separate_rounding_mode =
-            float_control.roundingModeIndependence == VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR,
+            float_control.roundingModeIndependence == VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL,
         .support_fp16_denorm_preserve = float_control.shaderDenormPreserveFloat16 != VK_FALSE,
         .support_fp32_denorm_preserve = float_control.shaderDenormPreserveFloat32 != VK_FALSE,
         .support_fp16_denorm_flush = float_control.shaderDenormFlushToZeroFloat16 != VK_FALSE,
@@ -327,17 +327,17 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .lower_left_origin_mode = false,
         .need_declared_frag_colors = false,
 
-        .has_broken_spirv_clamp = driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR,
+        .has_broken_spirv_clamp = driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS,
         .has_broken_unsigned_image_offsets = false,
         .has_broken_signed_operations = false,
-        .has_broken_fp16_float_controls = driver_id == VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR,
+        .has_broken_fp16_float_controls = driver_id == VK_DRIVER_ID_NVIDIA_PROPRIETARY,
         .ignore_nan_fp_comparisons = false,
     };
     host_info = Shader::HostTranslateInfo{
         .support_float16 = device.IsFloat16Supported(),
         .support_int64 = device.IsShaderInt64Supported(),
-        .needs_demote_reorder = driver_id == VK_DRIVER_ID_AMD_PROPRIETARY_KHR ||
-                                driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR,
+        .needs_demote_reorder =
+            driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE,
         .support_snorm_render_buffer = true,
         .support_viewport_index_layer = device.IsExtShaderViewportIndexLayerSupported(),
     };
@@ -408,7 +408,7 @@ void PipelineCache::LoadDiskResources(u64 title_id, std::stop_token stop_loading
         std::unique_ptr<PipelineStatistics> statistics;
     } state;
 
-    if (device.IsKhrPipelineEexecutablePropertiesEnabled()) {
+    if (device.IsKhrPipelineExecutablePropertiesEnabled()) {
         state.statistics = std::make_unique<PipelineStatistics>(device);
     }
     const auto load_compute{[&](std::ifstream& file, FileEnvironment env) {

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -98,7 +98,7 @@ HostCounter::HostCounter(QueryCache& cache_, std::shared_ptr<HostCounter> depend
       query{cache_.AllocateQuery(type_)}, tick{cache_.GetScheduler().CurrentTick()} {
     const vk::Device* logical = &cache.GetDevice().GetLogical();
     cache.GetScheduler().Record([logical, query = query](vk::CommandBuffer cmdbuf) {
-        logical->ResetQueryPoolEXT(query.first, query.second, 1);
+        logical->ResetQueryPool(query.first, query.second, 1);
         cmdbuf.BeginQuery(query.first, query.second, VK_QUERY_CONTROL_PRECISE_BIT);
     });
 }

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -194,8 +194,8 @@ void Scheduler::SubmitExecution(VkSemaphore signal_semaphore, VkSemaphore wait_s
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
         };
 
-        const VkTimelineSemaphoreSubmitInfoKHR timeline_si{
-            .sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,
+        const VkTimelineSemaphoreSubmitInfo timeline_si{
+            .sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
             .pNext = nullptr,
             .waitSemaphoreValueCount = num_wait_semaphores,
             .pWaitSemaphoreValues = wait_values.data(),

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -456,6 +456,13 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     };
     SetNext(next, demote);
 
+    VkPhysicalDeviceShaderDrawParametersFeatures draw_parameters{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES,
+        .pNext = nullptr,
+        .shaderDrawParameters = true,
+    };
+    SetNext(next, draw_parameters);
+
     VkPhysicalDeviceShaderFloat16Int8Features float16_int8;
     if (is_int8_supported || is_float16_supported) {
         float16_int8 = {
@@ -989,9 +996,13 @@ void Device::CheckSuitability(bool requires_swapchain) const {
     host_query_reset.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES;
     host_query_reset.pNext = &bit8_storage;
 
+    VkPhysicalDeviceShaderDrawParametersFeatures draw_parameters{};
+    draw_parameters.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES;
+    draw_parameters.pNext = &host_query_reset;
+
     VkPhysicalDeviceFeatures2 features2{};
     features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    features2.pNext = &host_query_reset;
+    features2.pNext = &draw_parameters;
 
     physical.GetFeatures2(features2);
 
@@ -1034,6 +1045,7 @@ void Device::CheckSuitability(bool requires_swapchain) const {
         std::make_pair(bit8_storage.uniformAndStorageBuffer8BitAccess,
                        "uniformAndStorageBuffer8BitAccess"),
         std::make_pair(host_query_reset.hostQueryReset, "hostQueryReset"),
+        std::make_pair(draw_parameters.shaderDrawParameters, "shaderDrawParameters"),
     };
 
     bool has_all_required_features = true;

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -973,9 +973,25 @@ void Device::CheckSuitability(bool requires_swapchain) const {
     robustness2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
     robustness2.pNext = &variable_pointers;
 
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore{};
+    timeline_semaphore.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+    timeline_semaphore.pNext = &robustness2;
+
+    VkPhysicalDevice16BitStorageFeatures bit16_storage{};
+    bit16_storage.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES;
+    bit16_storage.pNext = &timeline_semaphore;
+
+    VkPhysicalDevice8BitStorageFeatures bit8_storage{};
+    bit8_storage.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES;
+    bit8_storage.pNext = &bit16_storage;
+
+    VkPhysicalDeviceHostQueryResetFeatures host_query_reset{};
+    host_query_reset.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES;
+    host_query_reset.pNext = &bit8_storage;
+
     VkPhysicalDeviceFeatures2KHR features2{};
     features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    features2.pNext = &robustness2;
+    features2.pNext = &host_query_reset;
 
     physical.GetFeatures2KHR(features2);
 
@@ -1011,6 +1027,13 @@ void Device::CheckSuitability(bool requires_swapchain) const {
         std::make_pair(robustness2.robustImageAccess2, "robustImageAccess2"),
         std::make_pair(robustness2.nullDescriptor, "nullDescriptor"),
         std::make_pair(demote.shaderDemoteToHelperInvocation, "shaderDemoteToHelperInvocation"),
+        std::make_pair(timeline_semaphore.timelineSemaphore, "timelineSemaphore"),
+        std::make_pair(bit16_storage.storageBuffer16BitAccess, "storageBuffer16BitAccess"),
+        std::make_pair(bit16_storage.uniformAndStorageBuffer16BitAccess,
+                       "uniformAndStorageBuffer16BitAccess"),
+        std::make_pair(bit8_storage.uniformAndStorageBuffer8BitAccess,
+                       "uniformAndStorageBuffer8BitAccess"),
+        std::make_pair(host_query_reset.hostQueryReset, "hostQueryReset"),
     };
 
     bool has_all_required_features = true;

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -77,10 +77,6 @@ enum class NvidiaArchitecture {
 constexpr std::array REQUIRED_EXTENSIONS{
     VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,
     VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,
-
-    // Core in 1.2, but required due to use of extension methods,
-    // and well-supported by drivers
-    VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
 #ifdef _WIN32
     VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
 #endif
@@ -438,8 +434,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     };
     SetNext(next, robustness2);
 
-    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset{
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT,
+    VkPhysicalDeviceHostQueryResetFeatures host_query_reset{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES,
         .pNext = nullptr,
         .hostQueryReset = true,
     };

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -980,7 +980,7 @@ void Device::CheckSuitability(bool requires_swapchain) const {
     physical.GetFeatures2KHR(features2);
 
     const VkPhysicalDeviceFeatures& features{features2.features};
-    std::vector feature_report{
+    std::array feature_report{
         std::make_pair(features.robustBufferAccess, "robustBufferAccess"),
         std::make_pair(features.vertexPipelineStoresAndAtomics, "vertexPipelineStoresAndAtomics"),
         std::make_pair(features.imageCubeArray, "imageCubeArray"),
@@ -996,6 +996,7 @@ void Device::CheckSuitability(bool requires_swapchain) const {
         std::make_pair(features.tessellationShader, "tessellationShader"),
         std::make_pair(features.sampleRateShading, "sampleRateShading"),
         std::make_pair(features.dualSrcBlend, "dualSrcBlend"),
+        std::make_pair(features.logicOp, "logicOp"),
         std::make_pair(features.occlusionQueryPrecise, "occlusionQueryPrecise"),
         std::make_pair(features.fragmentStoresAndAtomics, "fragmentStoresAndAtomics"),
         std::make_pair(features.shaderImageGatherExtended, "shaderImageGatherExtended"),

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -80,7 +80,6 @@ constexpr std::array REQUIRED_EXTENSIONS{
 
     // Core in 1.2, but required due to use of extension methods,
     // and well-supported by drivers
-    VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
     VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME,
     VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
 #ifdef _WIN32

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -80,7 +80,6 @@ constexpr std::array REQUIRED_EXTENSIONS{
 
     // Core in 1.2, but required due to use of extension methods,
     // and well-supported by drivers
-    VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME,
     VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
 #ifdef _WIN32
     VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -406,8 +406,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     };
     SetNext(next, timeline_semaphore);
 
-    VkPhysicalDevice16BitStorageFeaturesKHR bit16_storage{
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR,
+    VkPhysicalDevice16BitStorageFeatures bit16_storage{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES,
         .pNext = nullptr,
         .storageBuffer16BitAccess = true,
         .uniformAndStorageBuffer16BitAccess = true,

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -399,8 +399,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     const void* first_next = &features2;
     void** next = &features2.pNext;
 
-    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore{
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR,
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES,
         .pNext = nullptr,
         .timelineSemaphore = true,
     };

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -305,10 +305,10 @@ NvidiaArchitecture GetNvidiaArchitecture(vk::PhysicalDevice physical,
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR shading_rate_props{};
         shading_rate_props.sType =
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR;
-        VkPhysicalDeviceProperties2KHR physical_properties{};
-        physical_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+        VkPhysicalDeviceProperties2 physical_properties{};
+        physical_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
         physical_properties.pNext = &shading_rate_props;
-        physical.GetProperties2KHR(physical_properties);
+        physical.GetProperties2(physical_properties);
         if (shading_rate_props.primitiveFragmentShadingRateWithMultipleViewports) {
             // Only Ampere and newer support this feature
             return NvidiaArchitecture::AmpereOrNewer;
@@ -416,8 +416,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     };
     SetNext(next, bit16_storage);
 
-    VkPhysicalDevice8BitStorageFeaturesKHR bit8_storage{
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR,
+    VkPhysicalDevice8BitStorageFeatures bit8_storage{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES,
         .pNext = nullptr,
         .storageBuffer8BitAccess = false,
         .uniformAndStorageBuffer8BitAccess = true,
@@ -441,8 +441,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     };
     SetNext(next, host_query_reset);
 
-    VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers{
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR,
+    VkPhysicalDeviceVariablePointerFeatures variable_pointers{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES,
         .pNext = nullptr,
         .variablePointersStorageBuffer = VK_TRUE,
         .variablePointers = VK_TRUE,
@@ -456,10 +456,10 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     };
     SetNext(next, demote);
 
-    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8;
+    VkPhysicalDeviceShaderFloat16Int8Features float16_int8;
     if (is_int8_supported || is_float16_supported) {
         float16_int8 = {
-            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR,
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES,
             .pNext = nullptr,
             .shaderFloat16 = is_float16_supported,
             .shaderInt8 = is_int8_supported,
@@ -485,10 +485,10 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         LOG_INFO(Render_Vulkan, "Device doesn't support passthrough geometry shaders");
     }
 
-    VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR std430_layout;
+    VkPhysicalDeviceUniformBufferStandardLayoutFeatures std430_layout;
     if (khr_uniform_buffer_standard_layout) {
         std430_layout = {
-            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR,
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES,
             .pNext = nullptr,
             .uniformBufferStandardLayout = true,
         };
@@ -606,10 +606,10 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         LOG_INFO(Render_Vulkan, "Device doesn't support vertex input dynamic state");
     }
 
-    VkPhysicalDeviceShaderAtomicInt64FeaturesKHR atomic_int64;
+    VkPhysicalDeviceShaderAtomicInt64Features atomic_int64;
     if (ext_shader_atomic_int64) {
         atomic_int64 = {
-            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR,
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES,
             .pNext = nullptr,
             .shaderBufferInt64Atomics = VK_TRUE,
             .shaderSharedInt64Atomics = VK_TRUE,
@@ -965,8 +965,8 @@ void Device::CheckSuitability(bool requires_swapchain) const {
     demote.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES;
     demote.pNext = nullptr;
 
-    VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers{};
-    variable_pointers.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR;
+    VkPhysicalDeviceVariablePointerFeatures variable_pointers{};
+    variable_pointers.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES;
     variable_pointers.pNext = &demote;
 
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2{};
@@ -989,11 +989,11 @@ void Device::CheckSuitability(bool requires_swapchain) const {
     host_query_reset.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES;
     host_query_reset.pNext = &bit8_storage;
 
-    VkPhysicalDeviceFeatures2KHR features2{};
+    VkPhysicalDeviceFeatures2 features2{};
     features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     features2.pNext = &host_query_reset;
 
-    physical.GetFeatures2KHR(features2);
+    physical.GetFeatures2(features2);
 
     const VkPhysicalDeviceFeatures& features{features2.features};
     std::array feature_report{
@@ -1126,37 +1126,37 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
                  VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME, false);
         }
     }
-    VkPhysicalDeviceFeatures2KHR features{};
-    features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
+    VkPhysicalDeviceFeatures2 features{};
+    features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 
-    VkPhysicalDeviceProperties2KHR physical_properties{};
-    physical_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+    VkPhysicalDeviceProperties2 physical_properties{};
+    physical_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
 
     if (has_khr_shader_float16_int8) {
-        VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8_features;
-        float16_int8_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR;
+        VkPhysicalDeviceShaderFloat16Int8Features float16_int8_features;
+        float16_int8_features.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
         float16_int8_features.pNext = nullptr;
         features.pNext = &float16_int8_features;
 
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
         is_float16_supported = float16_int8_features.shaderFloat16;
         is_int8_supported = float16_int8_features.shaderInt8;
         extensions.push_back(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     }
     if (has_ext_subgroup_size_control) {
-        VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_features;
-        subgroup_features.sType =
-            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT;
+        VkPhysicalDeviceSubgroupSizeControlFeatures subgroup_features;
+        subgroup_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES;
         subgroup_features.pNext = nullptr;
         features.pNext = &subgroup_features;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
-        VkPhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_properties;
+        VkPhysicalDeviceSubgroupSizeControlProperties subgroup_properties;
         subgroup_properties.sType =
-            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT;
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES;
         subgroup_properties.pNext = nullptr;
         physical_properties.pNext = &subgroup_properties;
-        physical.GetProperties2KHR(physical_properties);
+        physical.GetProperties2(physical_properties);
 
         is_warp_potentially_bigger = subgroup_properties.maxSubgroupSize > GuestWarpSize;
 
@@ -1175,7 +1175,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         provoking_vertex.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT;
         provoking_vertex.pNext = nullptr;
         features.pNext = &provoking_vertex;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         if (provoking_vertex.provokingVertexLast &&
             provoking_vertex.transformFeedbackPreservesProvokingVertex) {
@@ -1189,7 +1189,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT;
         vertex_input.pNext = nullptr;
         features.pNext = &vertex_input;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         if (vertex_input.vertexInputDynamicState) {
             extensions.push_back(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
@@ -1201,7 +1201,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         atomic_int64.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
         atomic_int64.pNext = nullptr;
         features.pNext = &atomic_int64;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         if (atomic_int64.shaderBufferInt64Atomics && atomic_int64.shaderSharedInt64Atomics) {
             extensions.push_back(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
@@ -1213,13 +1213,13 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         tfb_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
         tfb_features.pNext = nullptr;
         features.pNext = &tfb_features;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         VkPhysicalDeviceTransformFeedbackPropertiesEXT tfb_properties;
         tfb_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT;
         tfb_properties.pNext = nullptr;
         physical_properties.pNext = &tfb_properties;
-        physical.GetProperties2KHR(physical_properties);
+        physical.GetProperties2(physical_properties);
 
         if (tfb_features.transformFeedback && tfb_features.geometryStreams &&
             tfb_properties.maxTransformFeedbackStreams >= 4 &&
@@ -1234,7 +1234,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         border_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
         border_features.pNext = nullptr;
         features.pNext = &border_features;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         if (border_features.customBorderColors && border_features.customBorderColorWithoutFormat) {
             extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
@@ -1247,7 +1247,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT;
         extended_dynamic_state.pNext = nullptr;
         features.pNext = &extended_dynamic_state;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         if (extended_dynamic_state.extendedDynamicState) {
             extensions.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
@@ -1259,7 +1259,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         line_raster.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT;
         line_raster.pNext = nullptr;
         features.pNext = &line_raster;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
         if (line_raster.rectangularLines && line_raster.smoothLines) {
             extensions.push_back(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME);
             ext_line_rasterization = true;
@@ -1271,7 +1271,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR;
         layout.pNext = nullptr;
         features.pNext = &layout;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         if (layout.workgroupMemoryExplicitLayout &&
             layout.workgroupMemoryExplicitLayout8BitAccess &&
@@ -1287,7 +1287,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR;
         executable_properties.pNext = nullptr;
         features.pNext = &executable_properties;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         if (executable_properties.pipelineExecutableInfo) {
             extensions.push_back(VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME);
@@ -1300,7 +1300,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT;
         primitive_topology_list_restart.pNext = nullptr;
         features.pNext = &primitive_topology_list_restart;
-        physical.GetFeatures2KHR(features);
+        physical.GetFeatures2(features);
 
         is_topology_list_restart_supported =
             primitive_topology_list_restart.primitiveTopologyListRestart;
@@ -1318,7 +1318,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         push_descriptor.pNext = nullptr;
 
         physical_properties.pNext = &push_descriptor;
-        physical.GetProperties2KHR(physical_properties);
+        physical.GetProperties2(physical_properties);
 
         max_push_descriptors = push_descriptor.maxPushDescriptors;
     }
@@ -1369,18 +1369,18 @@ void Device::SetupFeatures() {
 }
 
 void Device::SetupProperties() {
-    float_controls.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR;
+    float_controls.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES;
 
     VkPhysicalDeviceProperties2KHR properties2{};
-    properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+    properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
     properties2.pNext = &float_controls;
 
-    physical.GetProperties2KHR(properties2);
+    physical.GetProperties2(properties2);
 }
 
 void Device::CollectTelemetryParameters() {
-    VkPhysicalDeviceDriverPropertiesKHR driver{
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR,
+    VkPhysicalDeviceDriverProperties driver{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES,
         .pNext = nullptr,
         .driverID = {},
         .driverName = {},
@@ -1388,12 +1388,12 @@ void Device::CollectTelemetryParameters() {
         .conformanceVersion = {},
     };
 
-    VkPhysicalDeviceProperties2KHR device_properties{
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR,
+    VkPhysicalDeviceProperties2 device_properties{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
         .pNext = &driver,
         .properties = {},
     };
-    physical.GetProperties2KHR(device_properties);
+    physical.GetProperties2(device_properties);
 
     driver_id = driver.driverID;
     vendor_name = driver.driverName;
@@ -1449,23 +1449,10 @@ void Device::CollectToolingInfo() {
     if (!ext_tooling_info) {
         return;
     }
-    const auto vkGetPhysicalDeviceToolPropertiesEXT =
-        reinterpret_cast<PFN_vkGetPhysicalDeviceToolPropertiesEXT>(
-            dld.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceToolPropertiesEXT"));
-    if (!vkGetPhysicalDeviceToolPropertiesEXT) {
-        return;
-    }
-    u32 tool_count = 0;
-    if (vkGetPhysicalDeviceToolPropertiesEXT(physical, &tool_count, nullptr) != VK_SUCCESS) {
-        return;
-    }
-    std::vector<VkPhysicalDeviceToolPropertiesEXT> tools(tool_count);
-    if (vkGetPhysicalDeviceToolPropertiesEXT(physical, &tool_count, tools.data()) != VK_SUCCESS) {
-        return;
-    }
-    for (const VkPhysicalDeviceToolPropertiesEXT& tool : tools) {
+    auto tools{physical.GetPhysicalDeviceToolProperties()};
+    for (const VkPhysicalDeviceToolProperties& tool : tools) {
         const std::string_view name = tool.name;
-        LOG_INFO(Render_Vulkan, "{}", name);
+        LOG_INFO(Render_Vulkan, "Attached debugging tool: {}", name);
         has_renderdoc = has_renderdoc || name == "RenderDoc";
         has_nsight_graphics = has_nsight_graphics || name == "NVIDIA Nsight Graphics";
     }

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -217,7 +217,7 @@ public:
     }
 
     /// Returns true if VK_KHR_pipeline_executable_properties is enabled.
-    bool IsKhrPipelineEexecutablePropertiesEnabled() const {
+    bool IsKhrPipelineExecutablePropertiesEnabled() const {
         return khr_pipeline_executable_properties;
     }
 

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -130,7 +130,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
     X(vkCreateComputePipelines);
     X(vkCreateDescriptorPool);
     X(vkCreateDescriptorSetLayout);
-    X(vkCreateDescriptorUpdateTemplateKHR);
+    X(vkCreateDescriptorUpdateTemplate);
     X(vkCreateEvent);
     X(vkCreateFence);
     X(vkCreateFramebuffer);
@@ -149,7 +149,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
     X(vkDestroyCommandPool);
     X(vkDestroyDescriptorPool);
     X(vkDestroyDescriptorSetLayout);
-    X(vkDestroyDescriptorUpdateTemplateKHR);
+    X(vkDestroyDescriptorUpdateTemplate);
     X(vkDestroyEvent);
     X(vkDestroyFence);
     X(vkDestroyFramebuffer);
@@ -188,7 +188,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
     X(vkSetDebugUtilsObjectNameEXT);
     X(vkSetDebugUtilsObjectTagEXT);
     X(vkUnmapMemory);
-    X(vkUpdateDescriptorSetWithTemplateKHR);
+    X(vkUpdateDescriptorSetWithTemplate);
     X(vkUpdateDescriptorSets);
     X(vkWaitForFences);
     X(vkWaitSemaphores);
@@ -366,9 +366,9 @@ void Destroy(VkDevice device, VkDescriptorSetLayout handle, const DeviceDispatch
     dld.vkDestroyDescriptorSetLayout(device, handle, nullptr);
 }
 
-void Destroy(VkDevice device, VkDescriptorUpdateTemplateKHR handle,
+void Destroy(VkDevice device, VkDescriptorUpdateTemplate handle,
              const DeviceDispatch& dld) noexcept {
-    dld.vkDestroyDescriptorUpdateTemplateKHR(device, handle, nullptr);
+    dld.vkDestroyDescriptorUpdateTemplate(device, handle, nullptr);
 }
 
 void Destroy(VkDevice device, VkDeviceMemory handle, const DeviceDispatch& dld) noexcept {
@@ -744,11 +744,11 @@ CommandPool Device::CreateCommandPool(const VkCommandPoolCreateInfo& ci) const {
     return CommandPool(object, handle, *dld);
 }
 
-DescriptorUpdateTemplateKHR Device::CreateDescriptorUpdateTemplateKHR(
-    const VkDescriptorUpdateTemplateCreateInfoKHR& ci) const {
-    VkDescriptorUpdateTemplateKHR object;
-    Check(dld->vkCreateDescriptorUpdateTemplateKHR(handle, &ci, nullptr, &object));
-    return DescriptorUpdateTemplateKHR(object, handle, *dld);
+DescriptorUpdateTemplate Device::CreateDescriptorUpdateTemplate(
+    const VkDescriptorUpdateTemplateCreateInfo& ci) const {
+    VkDescriptorUpdateTemplate object;
+    Check(dld->vkCreateDescriptorUpdateTemplate(handle, &ci, nullptr, &object));
+    return DescriptorUpdateTemplate(object, handle, *dld);
 }
 
 QueryPool Device::CreateQueryPool(const VkQueryPoolCreateInfo& ci) const {

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -184,7 +184,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
     X(vkMapMemory);
     X(vkQueueSubmit);
     X(vkResetFences);
-    X(vkResetQueryPoolEXT);
+    X(vkResetQueryPool);
     X(vkSetDebugUtilsObjectNameEXT);
     X(vkSetDebugUtilsObjectTagEXT);
     X(vkUnmapMemory);
@@ -198,6 +198,11 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
         Proc(dld.vkGetSemaphoreCounterValue, dld, "vkGetSemaphoreCounterValue", device);
         Proc(dld.vkWaitForFences, dld, "vkWaitForFencesKHR", device);
         Proc(dld.vkWaitSemaphores, dld, "vkWaitSemaphoresKHR", device);
+    }
+
+    // Support for host query reset is mandatory in Vulkan 1.2
+    if (!dld.vkResetQueryPool) {
+        Proc(dld.vkResetQueryPool, dld, "vkResetQueryPoolEXT", device);
     }
 #undef X
 }

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -180,7 +180,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
     X(vkGetQueryPoolResults);
     X(vkGetPipelineExecutablePropertiesKHR);
     X(vkGetPipelineExecutableStatisticsKHR);
-    X(vkGetSemaphoreCounterValueKHR);
+    X(vkGetSemaphoreCounterValue);
     X(vkMapMemory);
     X(vkQueueSubmit);
     X(vkResetFences);
@@ -191,7 +191,14 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
     X(vkUpdateDescriptorSetWithTemplateKHR);
     X(vkUpdateDescriptorSets);
     X(vkWaitForFences);
-    X(vkWaitSemaphoresKHR);
+    X(vkWaitSemaphores);
+
+    // Support for timeline semaphores is mandatory in Vulkan 1.2
+    if (!dld.vkGetSemaphoreCounterValue) {
+        Proc(dld.vkGetSemaphoreCounterValue, dld, "vkGetSemaphoreCounterValue", device);
+        Proc(dld.vkWaitForFences, dld, "vkWaitForFencesKHR", device);
+        Proc(dld.vkWaitSemaphores, dld, "vkWaitSemaphoresKHR", device);
+    }
 #undef X
 }
 

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -235,12 +235,13 @@ bool Load(VkInstance instance, InstanceDispatch& dld) noexcept {
     X(vkCreateDebugUtilsMessengerEXT);
     X(vkDestroyDebugUtilsMessengerEXT);
     X(vkDestroySurfaceKHR);
-    X(vkGetPhysicalDeviceFeatures2KHR);
-    X(vkGetPhysicalDeviceProperties2KHR);
+    X(vkGetPhysicalDeviceFeatures2);
+    X(vkGetPhysicalDeviceProperties2);
     X(vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
     X(vkGetPhysicalDeviceSurfaceFormatsKHR);
     X(vkGetPhysicalDeviceSurfacePresentModesKHR);
     X(vkGetPhysicalDeviceSurfaceSupportKHR);
+    X(vkGetPhysicalDeviceToolProperties);
     X(vkGetSwapchainImagesKHR);
     X(vkQueuePresentKHR);
 
@@ -868,20 +869,20 @@ VkPhysicalDeviceProperties PhysicalDevice::GetProperties() const noexcept {
     return properties;
 }
 
-void PhysicalDevice::GetProperties2KHR(VkPhysicalDeviceProperties2KHR& properties) const noexcept {
-    dld->vkGetPhysicalDeviceProperties2KHR(physical_device, &properties);
+void PhysicalDevice::GetProperties2(VkPhysicalDeviceProperties2& properties) const noexcept {
+    dld->vkGetPhysicalDeviceProperties2(physical_device, &properties);
 }
 
 VkPhysicalDeviceFeatures PhysicalDevice::GetFeatures() const noexcept {
-    VkPhysicalDeviceFeatures2KHR features2;
-    features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
+    VkPhysicalDeviceFeatures2 features2;
+    features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     features2.pNext = nullptr;
-    dld->vkGetPhysicalDeviceFeatures2KHR(physical_device, &features2);
+    dld->vkGetPhysicalDeviceFeatures2(physical_device, &features2);
     return features2.features;
 }
 
-void PhysicalDevice::GetFeatures2KHR(VkPhysicalDeviceFeatures2KHR& features) const noexcept {
-    dld->vkGetPhysicalDeviceFeatures2KHR(physical_device, &features);
+void PhysicalDevice::GetFeatures2(VkPhysicalDeviceFeatures2& features) const noexcept {
+    dld->vkGetPhysicalDeviceFeatures2(physical_device, &features);
 }
 
 VkFormatProperties PhysicalDevice::GetFormatProperties(VkFormat format) const noexcept {
@@ -903,6 +904,18 @@ std::vector<VkQueueFamilyProperties> PhysicalDevice::GetQueueFamilyProperties() 
     dld->vkGetPhysicalDeviceQueueFamilyProperties(physical_device, &num, nullptr);
     std::vector<VkQueueFamilyProperties> properties(num);
     dld->vkGetPhysicalDeviceQueueFamilyProperties(physical_device, &num, properties.data());
+    return properties;
+}
+
+std::vector<VkPhysicalDeviceToolProperties> PhysicalDevice::GetPhysicalDeviceToolProperties()
+    const {
+    u32 num = 0;
+    if (!dld->vkGetPhysicalDeviceToolProperties) {
+        return {};
+    }
+    dld->vkGetPhysicalDeviceToolProperties(physical_device, &num, nullptr);
+    std::vector<VkPhysicalDeviceToolProperties> properties(num);
+    dld->vkGetPhysicalDeviceToolProperties(physical_device, &num, properties.data());
     return properties;
 }
 

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -195,8 +195,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
 
     // Support for timeline semaphores is mandatory in Vulkan 1.2
     if (!dld.vkGetSemaphoreCounterValue) {
-        Proc(dld.vkGetSemaphoreCounterValue, dld, "vkGetSemaphoreCounterValue", device);
-        Proc(dld.vkWaitForFences, dld, "vkWaitForFencesKHR", device);
+        Proc(dld.vkGetSemaphoreCounterValue, dld, "vkGetSemaphoreCounterValueKHR", device);
         Proc(dld.vkWaitSemaphores, dld, "vkWaitSemaphoresKHR", device);
     }
 

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -301,7 +301,7 @@ struct DeviceDispatch : InstanceDispatch {
     PFN_vkMapMemory vkMapMemory{};
     PFN_vkQueueSubmit vkQueueSubmit{};
     PFN_vkResetFences vkResetFences{};
-    PFN_vkResetQueryPoolEXT vkResetQueryPoolEXT{};
+    PFN_vkResetQueryPool vkResetQueryPool{};
     PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT{};
     PFN_vkSetDebugUtilsObjectTagEXT vkSetDebugUtilsObjectTagEXT{};
     PFN_vkUnmapMemory vkUnmapMemory{};
@@ -884,8 +884,8 @@ public:
         return dld->vkDeviceWaitIdle(handle);
     }
 
-    void ResetQueryPoolEXT(VkQueryPool query_pool, u32 first, u32 count) const noexcept {
-        dld->vkResetQueryPoolEXT(handle, query_pool, first, count);
+    void ResetQueryPool(VkQueryPool query_pool, u32 first, u32 count) const noexcept {
+        dld->vkResetQueryPool(handle, query_pool, first, count);
     }
 
     VkResult GetQueryResults(VkQueryPool query_pool, u32 first, u32 count, std::size_t data_size,

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -297,7 +297,7 @@ struct DeviceDispatch : InstanceDispatch {
     PFN_vkGetPipelineExecutablePropertiesKHR vkGetPipelineExecutablePropertiesKHR{};
     PFN_vkGetPipelineExecutableStatisticsKHR vkGetPipelineExecutableStatisticsKHR{};
     PFN_vkGetQueryPoolResults vkGetQueryPoolResults{};
-    PFN_vkGetSemaphoreCounterValueKHR vkGetSemaphoreCounterValueKHR{};
+    PFN_vkGetSemaphoreCounterValue vkGetSemaphoreCounterValue{};
     PFN_vkMapMemory vkMapMemory{};
     PFN_vkQueueSubmit vkQueueSubmit{};
     PFN_vkResetFences vkResetFences{};
@@ -308,7 +308,7 @@ struct DeviceDispatch : InstanceDispatch {
     PFN_vkUpdateDescriptorSetWithTemplateKHR vkUpdateDescriptorSetWithTemplateKHR{};
     PFN_vkUpdateDescriptorSets vkUpdateDescriptorSets{};
     PFN_vkWaitForFences vkWaitForFences{};
-    PFN_vkWaitSemaphoresKHR vkWaitSemaphoresKHR{};
+    PFN_vkWaitSemaphores vkWaitSemaphores{};
 };
 
 /// Loads instance agnostic function pointers.
@@ -766,7 +766,7 @@ public:
 
     [[nodiscard]] u64 GetCounter() const {
         u64 value;
-        Check(dld->vkGetSemaphoreCounterValueKHR(owner, handle, &value));
+        Check(dld->vkGetSemaphoreCounterValue(owner, handle, &value));
         return value;
     }
 
@@ -778,15 +778,15 @@ public:
      * @return        True on successful wait, false on timeout
      */
     bool Wait(u64 value, u64 timeout = std::numeric_limits<u64>::max()) const {
-        const VkSemaphoreWaitInfoKHR wait_info{
-            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO_KHR,
+        const VkSemaphoreWaitInfo wait_info{
+            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO,
             .pNext = nullptr,
             .flags = 0,
             .semaphoreCount = 1,
             .pSemaphores = &handle,
             .pValues = &value,
         };
-        const VkResult result = dld->vkWaitSemaphoresKHR(owner, &wait_info, timeout);
+        const VkResult result = dld->vkWaitSemaphores(owner, &wait_info, timeout);
         switch (result) {
         case VK_SUCCESS:
             return true;

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -247,7 +247,7 @@ struct DeviceDispatch : InstanceDispatch {
     PFN_vkCreateComputePipelines vkCreateComputePipelines{};
     PFN_vkCreateDescriptorPool vkCreateDescriptorPool{};
     PFN_vkCreateDescriptorSetLayout vkCreateDescriptorSetLayout{};
-    PFN_vkCreateDescriptorUpdateTemplateKHR vkCreateDescriptorUpdateTemplateKHR{};
+    PFN_vkCreateDescriptorUpdateTemplate vkCreateDescriptorUpdateTemplate{};
     PFN_vkCreateEvent vkCreateEvent{};
     PFN_vkCreateFence vkCreateFence{};
     PFN_vkCreateFramebuffer vkCreateFramebuffer{};
@@ -266,7 +266,7 @@ struct DeviceDispatch : InstanceDispatch {
     PFN_vkDestroyCommandPool vkDestroyCommandPool{};
     PFN_vkDestroyDescriptorPool vkDestroyDescriptorPool{};
     PFN_vkDestroyDescriptorSetLayout vkDestroyDescriptorSetLayout{};
-    PFN_vkDestroyDescriptorUpdateTemplateKHR vkDestroyDescriptorUpdateTemplateKHR{};
+    PFN_vkDestroyDescriptorUpdateTemplate vkDestroyDescriptorUpdateTemplate{};
     PFN_vkDestroyEvent vkDestroyEvent{};
     PFN_vkDestroyFence vkDestroyFence{};
     PFN_vkDestroyFramebuffer vkDestroyFramebuffer{};
@@ -305,7 +305,7 @@ struct DeviceDispatch : InstanceDispatch {
     PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT{};
     PFN_vkSetDebugUtilsObjectTagEXT vkSetDebugUtilsObjectTagEXT{};
     PFN_vkUnmapMemory vkUnmapMemory{};
-    PFN_vkUpdateDescriptorSetWithTemplateKHR vkUpdateDescriptorSetWithTemplateKHR{};
+    PFN_vkUpdateDescriptorSetWithTemplate vkUpdateDescriptorSetWithTemplate{};
     PFN_vkUpdateDescriptorSets vkUpdateDescriptorSets{};
     PFN_vkWaitForFences vkWaitForFences{};
     PFN_vkWaitSemaphores vkWaitSemaphores{};
@@ -327,7 +327,7 @@ void Destroy(VkDevice, VkBufferView, const DeviceDispatch&) noexcept;
 void Destroy(VkDevice, VkCommandPool, const DeviceDispatch&) noexcept;
 void Destroy(VkDevice, VkDescriptorPool, const DeviceDispatch&) noexcept;
 void Destroy(VkDevice, VkDescriptorSetLayout, const DeviceDispatch&) noexcept;
-void Destroy(VkDevice, VkDescriptorUpdateTemplateKHR, const DeviceDispatch&) noexcept;
+void Destroy(VkDevice, VkDescriptorUpdateTemplate, const DeviceDispatch&) noexcept;
 void Destroy(VkDevice, VkDeviceMemory, const DeviceDispatch&) noexcept;
 void Destroy(VkDevice, VkEvent, const DeviceDispatch&) noexcept;
 void Destroy(VkDevice, VkFence, const DeviceDispatch&) noexcept;
@@ -559,7 +559,7 @@ private:
 
 using DebugUtilsMessenger = Handle<VkDebugUtilsMessengerEXT, VkInstance, InstanceDispatch>;
 using DescriptorSetLayout = Handle<VkDescriptorSetLayout, VkDevice, DeviceDispatch>;
-using DescriptorUpdateTemplateKHR = Handle<VkDescriptorUpdateTemplateKHR, VkDevice, DeviceDispatch>;
+using DescriptorUpdateTemplate = Handle<VkDescriptorUpdateTemplate, VkDevice, DeviceDispatch>;
 using Pipeline = Handle<VkPipeline, VkDevice, DeviceDispatch>;
 using PipelineLayout = Handle<VkPipelineLayout, VkDevice, DeviceDispatch>;
 using QueryPool = Handle<VkQueryPool, VkDevice, DeviceDispatch>;
@@ -840,8 +840,8 @@ public:
 
     CommandPool CreateCommandPool(const VkCommandPoolCreateInfo& ci) const;
 
-    DescriptorUpdateTemplateKHR CreateDescriptorUpdateTemplateKHR(
-        const VkDescriptorUpdateTemplateCreateInfoKHR& ci) const;
+    DescriptorUpdateTemplate CreateDescriptorUpdateTemplate(
+        const VkDescriptorUpdateTemplateCreateInfo& ci) const;
 
     QueryPool CreateQueryPool(const VkQueryPoolCreateInfo& ci) const;
 
@@ -869,9 +869,9 @@ public:
     void UpdateDescriptorSets(Span<VkWriteDescriptorSet> writes,
                               Span<VkCopyDescriptorSet> copies) const noexcept;
 
-    void UpdateDescriptorSet(VkDescriptorSet set, VkDescriptorUpdateTemplateKHR update_template,
+    void UpdateDescriptorSet(VkDescriptorSet set, VkDescriptorUpdateTemplate update_template,
                              const void* data) const noexcept {
-        dld->vkUpdateDescriptorSetWithTemplateKHR(handle, set, update_template, data);
+        dld->vkUpdateDescriptorSetWithTemplate(handle, set, update_template, data);
     }
 
     VkResult AcquireNextImageKHR(VkSwapchainKHR swapchain, u64 timeout, VkSemaphore semaphore,
@@ -980,7 +980,7 @@ public:
                                      dynamic_offsets.size(), dynamic_offsets.data());
     }
 
-    void PushDescriptorSetWithTemplateKHR(VkDescriptorUpdateTemplateKHR update_template,
+    void PushDescriptorSetWithTemplateKHR(VkDescriptorUpdateTemplate update_template,
                                           VkPipelineLayout layout, u32 set,
                                           const void* data) const noexcept {
         dld->vkCmdPushDescriptorSetWithTemplateKHR(handle, update_template, layout, set, data);

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -168,12 +168,13 @@ struct InstanceDispatch {
     PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties{};
     PFN_vkEnumeratePhysicalDevices vkEnumeratePhysicalDevices{};
     PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr{};
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR{};
+    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2{};
     PFN_vkGetPhysicalDeviceFormatProperties vkGetPhysicalDeviceFormatProperties{};
     PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties{};
     PFN_vkGetPhysicalDeviceMemoryProperties2 vkGetPhysicalDeviceMemoryProperties2{};
     PFN_vkGetPhysicalDeviceProperties vkGetPhysicalDeviceProperties{};
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR{};
+    PFN_vkGetPhysicalDeviceProperties2 vkGetPhysicalDeviceProperties2{};
+    PFN_vkGetPhysicalDeviceToolProperties vkGetPhysicalDeviceToolProperties{};
     PFN_vkGetPhysicalDeviceQueueFamilyProperties vkGetPhysicalDeviceQueueFamilyProperties{};
     PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR vkGetPhysicalDeviceSurfaceCapabilitiesKHR{};
     PFN_vkGetPhysicalDeviceSurfaceFormatsKHR vkGetPhysicalDeviceSurfaceFormatsKHR{};
@@ -910,17 +911,19 @@ public:
 
     VkPhysicalDeviceProperties GetProperties() const noexcept;
 
-    void GetProperties2KHR(VkPhysicalDeviceProperties2KHR&) const noexcept;
+    void GetProperties2(VkPhysicalDeviceProperties2&) const noexcept;
 
     VkPhysicalDeviceFeatures GetFeatures() const noexcept;
 
-    void GetFeatures2KHR(VkPhysicalDeviceFeatures2KHR&) const noexcept;
+    void GetFeatures2(VkPhysicalDeviceFeatures2&) const noexcept;
 
     VkFormatProperties GetFormatProperties(VkFormat) const noexcept;
 
     std::vector<VkExtensionProperties> EnumerateDeviceExtensionProperties() const;
 
     std::vector<VkQueueFamilyProperties> GetQueueFamilyProperties() const;
+
+    std::vector<VkPhysicalDeviceToolProperties> GetPhysicalDeviceToolProperties() const;
 
     bool GetSurfaceSupportKHR(u32 queue_family_index, VkSurfaceKHR) const;
 


### PR DESCRIPTION
See individual commits for details. We take the KHR/EXT version when the core method is not available. Descriptor update templates are mandatory in 1.1 and we already have 1.1 as a minimum, so the extension method was removed entirely for this case.