### PR TITLE
kernel: Ensure relevant class members are always initialized on construction

### DIFF
--- a/src/core/hle/kernel/k_memory_block.h
+++ b/src/core/hle/kernel/k_memory_block.h
@@ -280,18 +280,19 @@ struct KMemoryInfo {
 
 class KMemoryBlock : public Common::IntrusiveRedBlackTreeBaseNode<KMemoryBlock> {
 private:
-    u16 m_device_disable_merge_left_count;
-    u16 m_device_disable_merge_right_count;
-    VAddr m_address;
-    size_t m_num_pages;
-    KMemoryState m_memory_state;
-    u16 m_ipc_lock_count;
-    u16 m_device_use_count;
-    u16 m_ipc_disable_merge_count;
-    KMemoryPermission m_permission;
-    KMemoryPermission m_original_permission;
-    KMemoryAttribute m_attribute;
-    KMemoryBlockDisableMergeAttribute m_disable_merge_attribute;
+    u16 m_device_disable_merge_left_count{};
+    u16 m_device_disable_merge_right_count{};
+    VAddr m_address{};
+    size_t m_num_pages{};
+    KMemoryState m_memory_state{KMemoryState::None};
+    u16 m_ipc_lock_count{};
+    u16 m_device_use_count{};
+    u16 m_ipc_disable_merge_count{};
+    KMemoryPermission m_permission{KMemoryPermission::None};
+    KMemoryPermission m_original_permission{KMemoryPermission::None};
+    KMemoryAttribute m_attribute{KMemoryAttribute::None};
+    KMemoryBlockDisableMergeAttribute m_disable_merge_attribute{
+        KMemoryBlockDisableMergeAttribute::None};
 
 public:
     static constexpr int Compare(const KMemoryBlock& lhs, const KMemoryBlock& rhs) {
@@ -367,12 +368,8 @@ public:
 
     constexpr KMemoryBlock(VAddr addr, size_t np, KMemoryState ms, KMemoryPermission p,
                            KMemoryAttribute attr)
-        : Common::IntrusiveRedBlackTreeBaseNode<KMemoryBlock>(),
-          m_device_disable_merge_left_count(), m_device_disable_merge_right_count(),
-          m_address(addr), m_num_pages(np), m_memory_state(ms), m_ipc_lock_count(0),
-          m_device_use_count(0), m_ipc_disable_merge_count(), m_permission(p),
-          m_original_permission(KMemoryPermission::None), m_attribute(attr),
-          m_disable_merge_attribute() {}
+        : Common::IntrusiveRedBlackTreeBaseNode<KMemoryBlock>(), m_address(addr), m_num_pages(np),
+          m_memory_state(ms), m_permission(p), m_attribute(attr) {}
 
     constexpr void Initialize(VAddr addr, size_t np, KMemoryState ms, KMemoryPermission p,
                               KMemoryAttribute attr) {

--- a/src/core/hle/kernel/k_memory_block_manager.h
+++ b/src/core/hle/kernel/k_memory_block_manager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <functional>
 
 #include "common/common_funcs.h"
@@ -17,9 +18,9 @@ public:
     static constexpr size_t MaxBlocks = 2;
 
 private:
-    KMemoryBlock* m_blocks[MaxBlocks];
-    size_t m_index;
-    KMemoryBlockSlabManager* m_slab_manager;
+    std::array<KMemoryBlock*, MaxBlocks> m_blocks{};
+    size_t m_index{MaxBlocks};
+    KMemoryBlockSlabManager* m_slab_manager{};
 
 private:
     Result Initialize(size_t num_blocks) {
@@ -41,7 +42,7 @@ private:
 public:
     KMemoryBlockManagerUpdateAllocator(Result* out_result, KMemoryBlockSlabManager* sm,
                                        size_t num_blocks = MaxBlocks)
-        : m_blocks(), m_index(MaxBlocks), m_slab_manager(sm) {
+        : m_slab_manager(sm) {
         *out_result = this->Initialize(num_blocks);
     }
 

--- a/src/core/hle/kernel/k_shared_memory.h
+++ b/src/core/hle/kernel/k_shared_memory.h
@@ -74,7 +74,7 @@ public:
     static void PostDestroy([[maybe_unused]] uintptr_t arg) {}
 
 private:
-    Core::DeviceMemory* device_memory;
+    Core::DeviceMemory* device_memory{};
     KProcess* owner_process{};
     KPageGroup page_list;
     Svc::MemoryPermission owner_permission{};

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -784,8 +784,8 @@ private:
     std::vector<KSynchronizationObject*> wait_objects_for_debugging;
     VAddr mutex_wait_address_for_debugging{};
     ThreadWaitReasonForDebugging wait_reason_for_debugging{};
-    uintptr_t argument;
-    VAddr stack_top;
+    uintptr_t argument{};
+    VAddr stack_top{};
 
 public:
     using ConditionVariableThreadTreeType = ConditionVariableThreadTree;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -891,7 +891,7 @@ struct KernelCore::Impl {
     Common::ThreadWorker service_threads_manager;
     Common::Barrier service_thread_barrier;
 
-    std::array<KThread*, Core::Hardware::NUM_CPU_CORES> shutdown_threads;
+    std::array<KThread*, Core::Hardware::NUM_CPU_CORES> shutdown_threads{};
     std::array<std::unique_ptr<Kernel::KScheduler>, Core::Hardware::NUM_CPU_CORES> schedulers{};
 
     bool is_multicore{};

--- a/src/core/hle/kernel/physical_core.h
+++ b/src/core/hle/kernel/physical_core.h
@@ -85,7 +85,7 @@ private:
     std::mutex guard;
     std::condition_variable on_interrupt;
     std::unique_ptr<Core::ARM_Interface> arm_interface;
-    bool is_interrupted;
+    bool is_interrupted{};
 };
 
 } // namespace Kernel


### PR DESCRIPTION
Reduces the likelihood of unintentional uninitialized reads occurring especially for members that rely on being set and read through a public interface