### PR TITLE
emulated_console/emulated_controller: std::move ParamPackage instances where applicable

### DIFF
--- a/src/core/hid/emulated_console.cpp
+++ b/src/core/hid/emulated_console.cpp
@@ -37,7 +37,7 @@ void EmulatedConsole::SetTouchParams() {
         touchscreen_param.Set("axis_x", i * 2);
         touchscreen_param.Set("axis_y", (i * 2) + 1);
         touchscreen_param.Set("button", i);
-        touch_params[index++] = touchscreen_param;
+        touch_params[index++] = std::move(touchscreen_param);
     }
 
     const auto button_index =
@@ -59,7 +59,7 @@ void EmulatedConsole::SetTouchParams() {
         touch_button_params.Set("button", params.Serialize());
         touch_button_params.Set("x", x);
         touch_button_params.Set("y", y);
-        touch_params[index] = touch_button_params;
+        touch_params[index] = std::move(touch_button_params);
         index++;
     }
 }
@@ -131,7 +131,7 @@ Common::ParamPackage EmulatedConsole::GetMotionParam() const {
 }
 
 void EmulatedConsole::SetMotionParam(Common::ParamPackage param) {
-    motion_params = param;
+    motion_params = std::move(param);
     ReloadInput();
 }
 
@@ -284,7 +284,7 @@ void EmulatedConsole::TriggerOnChange(ConsoleTriggerType type) {
 
 int EmulatedConsole::SetCallback(ConsoleUpdateCallback update_callback) {
     std::scoped_lock lock{callback_mutex};
-    callback_list.insert_or_assign(last_callback_key, update_callback);
+    callback_list.insert_or_assign(last_callback_key, std::move(update_callback));
     return last_callback_key++;
 }
 

--- a/src/core/hid/emulated_console.cpp
+++ b/src/core/hid/emulated_console.cpp
@@ -199,7 +199,7 @@ void EmulatedConsole::SetTouch(const Common::Input::CallbackStatus& callback, st
 
     if (is_new_input) {
         touch_value.pressed.value = true;
-        touch_value.id = static_cast<u32>(index);
+        touch_value.id = static_cast<int>(index);
     }
 
     touch_value.x = touch_input.x;

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -424,8 +424,7 @@ void EmulatedController::RestoreConfig() {
     ReloadFromSettings();
 }
 
-std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
-    EmulatedDeviceIndex device_index) const {
+std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices() const {
     std::vector<Common::ParamPackage> devices;
     for (const auto& param : button_params) {
         if (!param.Has("engine")) {

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -432,7 +432,7 @@ std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
             continue;
         }
         const auto devices_it = std::find_if(
-            devices.begin(), devices.end(), [param](const Common::ParamPackage param_) {
+            devices.begin(), devices.end(), [&param](const Common::ParamPackage& param_) {
                 return param.Get("engine", "") == param_.Get("engine", "") &&
                        param.Get("guid", "") == param_.Get("guid", "") &&
                        param.Get("port", 0) == param_.Get("port", 0) &&
@@ -441,12 +441,12 @@ std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
         if (devices_it != devices.end()) {
             continue;
         }
-        Common::ParamPackage device{};
+
+        auto& device = devices.emplace_back();
         device.Set("engine", param.Get("engine", ""));
         device.Set("guid", param.Get("guid", ""));
         device.Set("port", param.Get("port", 0));
         device.Set("pad", param.Get("pad", 0));
-        devices.push_back(device);
     }
 
     for (const auto& param : stick_params) {
@@ -457,7 +457,7 @@ std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
             continue;
         }
         const auto devices_it = std::find_if(
-            devices.begin(), devices.end(), [param](const Common::ParamPackage param_) {
+            devices.begin(), devices.end(), [&param](const Common::ParamPackage& param_) {
                 return param.Get("engine", "") == param_.Get("engine", "") &&
                        param.Get("guid", "") == param_.Get("guid", "") &&
                        param.Get("port", 0) == param_.Get("port", 0) &&
@@ -466,12 +466,12 @@ std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
         if (devices_it != devices.end()) {
             continue;
         }
-        Common::ParamPackage device{};
+
+        auto& device = devices.emplace_back();
         device.Set("engine", param.Get("engine", ""));
         device.Set("guid", param.Get("guid", ""));
         device.Set("port", param.Get("port", 0));
         device.Set("pad", param.Get("pad", 0));
-        devices.push_back(device);
     }
     return devices;
 }

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -244,7 +244,7 @@ public:
     void RestoreConfig();
 
     /// Returns a vector of mapped devices from the mapped button and stick parameters
-    std::vector<Common::ParamPackage> GetMappedDevices(EmulatedDeviceIndex device_index) const;
+    std::vector<Common::ParamPackage> GetMappedDevices() const;
 
     // Returns the current mapped button device
     Common::ParamPackage GetButtonParam(std::size_t index) const;

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -855,8 +855,7 @@ void ConfigureInputPlayer::UpdateInputDeviceCombobox() {
         return;
     }
 
-    const auto devices =
-        emulated_controller->GetMappedDevices(Core::HID::EmulatedDeviceIndex::AllDevices);
+    const auto devices = emulated_controller->GetMappedDevices();
     UpdateInputDevices();
 
     if (devices.empty()) {


### PR DESCRIPTION
Trivial change that just makes these functions churn a little bit less memory