### PR TITLE
input_common: Filter SDL GUID

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -16,6 +16,8 @@ Common::UUID GetGUID(SDL_Joystick* joystick) {
     const SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
     std::array<u8, 16> data{};
     std::memcpy(data.data(), guid.data, sizeof(data));
+    // Clear controller name crc
+    std::memset(data.data() + 2, 0, sizeof(u16));
     return Common::UUID{data};
 }
 } // Anonymous namespace


### PR DESCRIPTION
This is a quick patch to fix latest SDL update with custom GUID for every controller. It shouldn't break current input profiles.

It will take me a bit to rewrite the current SDL driver. So for now this will do with the current issues.