### PR TITLE
Fix compilation error

### DIFF
--- a/src/video_core/engines/draw_manager.cpp
+++ b/src/video_core/engines/draw_manager.cpp
@@ -180,7 +180,7 @@ void DrawManager::ProcessTopologyOverride() {
 }
 
 void DrawManager::ProcessDraw(bool draw_indexed, u32 instance_count) {
-    LOG_TRACE(HW_GPU, "called, topology={}, count={}", draw_state.topology.Value(),
+    LOG_TRACE(HW_GPU, "called, topology={}, count={}", draw_state.topology,
               draw_indexed ? draw_state.index_buffer.count : draw_state.vertex_buffer.count);
 
     ProcessTopologyOverride();


### PR DESCRIPTION
`Maxwell3D::Regs::PrimitiveTopology` is an enum so calling functions on it fails to compile. Likely didn't get caught in CI because `LOG_TRACE` gets expanded away, it might make sense to consider this for the CI in the future.