### PR TITLE
memory: remove DEBUG_ASSERT pointer test

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -195,13 +195,11 @@ struct Memory::Impl {
                 break;
             }
             case Common::PageType::Memory: {
-                DEBUG_ASSERT(pointer);
                 u8* mem_ptr = pointer + page_offset + (page_index << YUZU_PAGEBITS);
                 on_memory(copy_amount, mem_ptr);
                 break;
             }
             case Common::PageType::DebugMemory: {
-                DEBUG_ASSERT(pointer);
                 u8* const mem_ptr{GetPointerFromDebugMemory(current_vaddr)};
                 on_memory(copy_amount, mem_ptr);
                 break;


### PR DESCRIPTION
`pointer` is a structured binding in this context and isn't captured into the function test for asserts that was introduced in #8439. MSVC accepts this, but clang and gcc don't (it is forbidden by the language). Since we never hit this assert, there's not really any need to keep it around, even in debug mode.