### PR TITLE
audio_core: remove explicitly defaulted and implicitly deleted constructors

### DIFF
--- a/src/audio_core/renderer/performance/detail_aspect.h
+++ b/src/audio_core/renderer/performance/detail_aspect.h
@@ -16,7 +16,6 @@ class CommandGenerator;
  */
 class DetailAspect {
 public:
-    DetailAspect() = default;
     DetailAspect(CommandGenerator& command_generator, PerformanceEntryType entry_type, s32 node_id,
                  PerformanceDetailType detail_type);
 

--- a/src/audio_core/renderer/performance/entry_aspect.h
+++ b/src/audio_core/renderer/performance/entry_aspect.h
@@ -16,7 +16,6 @@ class CommandGenerator;
  */
 class EntryAspect {
 public:
-    EntryAspect() = default;
     EntryAspect(CommandGenerator& command_generator, PerformanceEntryType type, s32 node_id);
 
     /// Command generator the command will be generated into


### PR DESCRIPTION
These classes contain a `CommandGenerator&`, which can't be defaulted.