### PR TITLE
cmake: make OpenGL loader optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_SDL2 "Download bundled SDL2 binaries" ON
 # On Linux system SDL2 is likely to be lacking HIDAPI support which have drawbacks but is needed for SDL motion
 CMAKE_DEPENDENT_OPTION(YUZU_USE_EXTERNAL_SDL2 "Compile external SDL2" ON "ENABLE_SDL2;NOT MSVC" OFF)
 
+option(ENABLE_OPENGL "Enable OpenGL" ON)
+mark_as_advanced(FORCE ENABLE_OPENGL)
 option(ENABLE_QT "Enable the Qt frontend" ON)
 option(ENABLE_QT6 "Allow usage of Qt6 to be attempted" OFF)
 set(QT6_LOCATION "" CACHE PATH "Additional Location to search for Qt6 libraries like C:/Qt/6.3.1/msvc2019_64/")

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -402,7 +402,7 @@ if (MSVC)
     copy_yuzu_FFmpeg_deps(yuzu)
 endif()
 
-if (NOT APPLE)
+if (NOT APPLE AND ENABLE_OPENGL)
     target_compile_definitions(yuzu PRIVATE HAS_OPENGL)
 endif()
 


### PR DESCRIPTION
Used for Flatpak arm64, where Qt is compiled with GLES instead of desktop OpenGL.