### PR TITLE
video_core: fix off by one in anisotropic filtering amount

### DIFF
--- a/src/video_core/textures/texture.cpp
+++ b/src/video_core/textures/texture.cpp
@@ -64,10 +64,11 @@ float TSCEntry::MaxAnisotropy() const noexcept {
         return 1.0f;
     }
     const auto anisotropic_settings = Settings::values.max_anisotropy.GetValue();
-    u32 added_anisotropic{};
+    s32 added_anisotropic{};
     if (anisotropic_settings == 0) {
         added_anisotropic = Settings::values.resolution_info.up_scale >>
                             Settings::values.resolution_info.down_shift;
+        added_anisotropic = std::max(added_anisotropic - 1, 0);
     } else {
         added_anisotropic = Settings::values.max_anisotropy.GetValue() - 1U;
     }


### PR DESCRIPTION
Fixes #8856 SMO rendering in RADV at 1x with automatic anisotropy (other scaler resolutions are still affected, this seems to be related to differing behaviors of higher anisotropy levels with sRGB textures) 
Fixes SMS water rendering in LVP at automatic anisotropy (still happens with other anisotropy values, see [here](https://wiki.dolphin-emu.org/index.php?title=Super_Mario_Sunshine#Anisotropic_Filtering))

|Before|After|
|-|-|
|![0100000000010000_2022-12-10_19-32-29-022](https://user-images.githubusercontent.com/9658600/206882881-dddb1491-9603-4bca-bd3c-670a2255e3b8.png)|![0100000000010000_2022-12-10_19-33-41-902](https://user-images.githubusercontent.com/9658600/206882882-1789b3b0-9b70-461b-b7f3-9ce4e6abb6ee.png)|
|![010049900f546002_2022-12-10_19-29-25-455](https://user-images.githubusercontent.com/9658600/206882900-6aaefe26-9ebd-46c2-adfa-632575ffdd94.png)|![010049900f546002_2022-12-10_19-27-30-336](https://user-images.githubusercontent.com/9658600/206882901-e6301396-4793-4fcb-a8b6-f960b997e591.png)|