### PR TITLE
yuzu: Make unlimited frame rate non persistent between game boots

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -697,7 +697,6 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.fsr_sharpening_slider);
     ReadGlobalSetting(Settings::values.anti_aliasing);
     ReadGlobalSetting(Settings::values.max_anisotropy);
-    ReadGlobalSetting(Settings::values.use_speed_limit);
     ReadGlobalSetting(Settings::values.speed_limit);
     ReadGlobalSetting(Settings::values.use_disk_shader_cache);
     ReadGlobalSetting(Settings::values.gpu_accuracy);
@@ -1328,7 +1327,6 @@ void Config::SaveRendererValues() {
                  static_cast<u32>(Settings::values.anti_aliasing.GetDefault()),
                  Settings::values.anti_aliasing.UsingGlobal());
     WriteGlobalSetting(Settings::values.max_anisotropy);
-    WriteGlobalSetting(Settings::values.use_speed_limit);
     WriteGlobalSetting(Settings::values.speed_limit);
     WriteGlobalSetting(Settings::values.use_disk_shader_cache);
     WriteSetting(QString::fromStdString(Settings::values.gpu_accuracy.GetLabel()),

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1790,6 +1790,9 @@ void GMainWindow::ShutdownGame() {
 
     AllowOSSleep();
 
+    // Disable unlimited frame rate
+    Settings::values.use_speed_limit.SetValue(true);
+
     system->SetShuttingDown(true);
     system->DetachDebugger();
     discord_rpc->Pause();


### PR DESCRIPTION
Unlimited frame rate was made persistent due to user request. But this setting still causes some games to crash at boot. So it was decided to make it non persistent again to favor stability.

Potentially fixes #7356