### PR TITLE
camera: Use pre-allocated vector for camera data

### DIFF
--- a/src/input_common/drivers/camera.cpp
+++ b/src/input_common/drivers/camera.cpp
@@ -17,7 +17,7 @@ Camera::Camera(std::string input_engine_) : InputEngine(std::move(input_engine_)
     PreSetController(identifier);
 }
 
-void Camera::SetCameraData(std::size_t width, std::size_t height, std::vector<u32> data) {
+void Camera::SetCameraData(std::size_t width, std::size_t height, std::span<const u32> data) {
     const std::size_t desired_width = getImageWidth();
     const std::size_t desired_height = getImageHeight();
     status.data.resize(desired_width * desired_height);

--- a/src/input_common/drivers/camera.h
+++ b/src/input_common/drivers/camera.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <span>
+
 #include "input_common/input_engine.h"
 
 namespace InputCommon {
@@ -15,7 +17,7 @@ class Camera final : public InputEngine {
 public:
     explicit Camera(std::string input_engine_);
 
-    void SetCameraData(std::size_t width, std::size_t height, std::vector<u32> data);
+    void SetCameraData(std::size_t width, std::size_t height, std::span<const u32> data);
 
     std::size_t getImageWidth() const;
     std::size_t getImageHeight() const;

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -752,6 +752,7 @@ void GRenderWindow::InitializeCamera() {
         return;
     }
 
+    camera_data.resize(CAMERA_WIDTH * CAMERA_HEIGHT);
     camera_capture->setCaptureDestination(QCameraImageCapture::CaptureDestination::CaptureToBuffer);
     connect(camera_capture.get(), &QCameraImageCapture::imageCaptured, this,
             &GRenderWindow::OnCameraCapture);
@@ -807,16 +808,13 @@ void GRenderWindow::RequestCameraCapture() {
 }
 
 void GRenderWindow::OnCameraCapture(int requestId, const QImage& img) {
-    constexpr std::size_t camera_width = 320;
-    constexpr std::size_t camera_height = 240;
+    // TODO: Capture directly in the format and resolution needed
     const auto converted =
-        img.scaled(camera_width, camera_height, Qt::AspectRatioMode::IgnoreAspectRatio,
+        img.scaled(CAMERA_WIDTH, CAMERA_HEIGHT, Qt::AspectRatioMode::IgnoreAspectRatio,
                    Qt::TransformationMode::SmoothTransformation)
             .mirrored(false, true);
-    std::vector<u32> camera_data{};
-    camera_data.resize(camera_width * camera_height);
-    std::memcpy(camera_data.data(), converted.bits(), camera_width * camera_height * sizeof(u32));
-    input_subsystem->GetCamera()->SetCameraData(camera_width, camera_height, camera_data);
+    std::memcpy(camera_data.data(), converted.bits(), CAMERA_WIDTH * CAMERA_HEIGHT * sizeof(u32));
+    input_subsystem->GetCamera()->SetCameraData(CAMERA_WIDTH, CAMERA_HEIGHT, camera_data);
     pending_camera_snapshots = 0;
 }
 

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -246,6 +246,9 @@ private:
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0)) && YUZU_USE_QT_MULTIMEDIA
     std::unique_ptr<QCamera> camera;
     std::unique_ptr<QCameraImageCapture> camera_capture;
+    static constexpr std::size_t CAMERA_WIDTH = 320;
+    static constexpr std::size_t CAMERA_HEIGHT = 240;
+    std::vector<u32> camera_data;
 #endif
     std::unique_ptr<QTimer> camera_timer;
 


### PR DESCRIPTION
Since the size of the payload is known at compile time, we can use a stack allocated array and avoid unneeded heap memory allocations.

Also avoids an unnecessary copy by using std::span when passing the data