### PR TITLE
[audio_core] Signal buffer event on audio in/out system stop

### DIFF
--- a/src/audio_core/device/audio_buffers.h
+++ b/src/audio_core/device/audio_buffers.h
@@ -91,9 +91,10 @@ public:
      * @param core_timing - The CoreTiming instance
      * @param session     - The device session
      *
-     * @return Is the buffer was released.
+     * @return If any buffer was released.
      */
-    bool ReleaseBuffers(const Core::Timing::CoreTiming& core_timing, const DeviceSession& session) {
+    bool ReleaseBuffers(const Core::Timing::CoreTiming& core_timing, const DeviceSession& session,
+                        bool force) {
         std::scoped_lock l{lock};
         bool buffer_released{false};
         while (registered_count > 0) {
@@ -103,7 +104,8 @@ public:
             }
 
             // Check with the backend if this buffer can be released yet.
-            if (!session.IsBufferConsumed(buffers[index])) {
+            // If we're shutting down, we don't care if it's been played or not.
+            if (!force && !session.IsBufferConsumed(buffers[index])) {
                 break;
             }
 

--- a/src/audio_core/device/device_session.cpp
+++ b/src/audio_core/device/device_session.cpp
@@ -73,6 +73,12 @@ void DeviceSession::Stop() {
     }
 }
 
+void DeviceSession::ClearBuffers() {
+    if (stream) {
+        stream->ClearQueue();
+    }
+}
+
 void DeviceSession::AppendBuffers(std::span<const AudioBuffer> buffers) const {
     for (const auto& buffer : buffers) {
         Sink::SinkBuffer new_buffer{

--- a/src/audio_core/device/device_session.h
+++ b/src/audio_core/device/device_session.h
@@ -91,6 +91,11 @@ public:
     void Stop();
 
     /**
+     * Clear out the underlying audio buffers in the backend stream.
+     */
+    void ClearBuffers();
+
+    /**
      * Set this device session's volume.
      *
      * @param volume - New volume for this session.

--- a/src/audio_core/in/audio_in_system.cpp
+++ b/src/audio_core/in/audio_in_system.cpp
@@ -23,7 +23,6 @@ System::~System() {
 void System::Finalize() {
     Stop();
     session->Finalize();
-    buffer_event->Signal();
 }
 
 void System::StartSession() {
@@ -102,6 +101,10 @@ Result System::Stop() {
     if (state == State::Started) {
         session->Stop();
         session->SetVolume(0.0f);
+        session->ClearBuffers();
+        if (buffers.ReleaseBuffers(system.CoreTiming(), *session, true)) {
+            buffer_event->Signal();
+        }
         state = State::Stopped;
     }
 
@@ -138,7 +141,7 @@ void System::RegisterBuffers() {
 }
 
 void System::ReleaseBuffers() {
-    bool signal{buffers.ReleaseBuffers(system.CoreTiming(), *session)};
+    bool signal{buffers.ReleaseBuffers(system.CoreTiming(), *session, false)};
 
     if (signal) {
         // Signal if any buffer was released, or if none are registered, we need more.


### PR DESCRIPTION
Currently this event is only firing when the system is finalised, and not when it's stopped. When stopping, registered buffers are forcibly cleared, and the event is signalled if any existed.

This fixes a softlock at the start of Pokemon Brilliant Diamond 1.0.0 right after choosing your character.