### PR TITLE
input_common: Add virtual gamepad

### DIFF
--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -385,6 +385,9 @@ private:
     /// Set the params for TAS devices
     void LoadTASParams();
 
+    /// Set the params for virtual pad devices
+    void LoadVirtualGamepadParams();
+
     /**
      * @param use_temporary_value If true tmp_npad_type will be used
      * @return true if the controller style is fullkey
@@ -499,6 +502,12 @@ private:
     StickParams tas_stick_params;
     ButtonDevices tas_button_devices;
     StickDevices tas_stick_devices;
+
+    // Virtual gamepad related variables
+    ButtonParams virtual_button_params;
+    StickParams virtual_stick_params;
+    ButtonDevices virtual_button_devices;
+    StickDevices virtual_stick_devices;
 
     mutable std::mutex mutex;
     mutable std::mutex callback_mutex;

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(input_common STATIC
     drivers/udp_client.h
     drivers/virtual_amiibo.cpp
     drivers/virtual_amiibo.h
+    drivers/virtual_gamepad.cpp
+    drivers/virtual_gamepad.h
     helpers/stick_from_buttons.cpp
     helpers/stick_from_buttons.h
     helpers/touch_from_buttons.cpp

--- a/src/input_common/drivers/virtual_gamepad.cpp
+++ b/src/input_common/drivers/virtual_gamepad.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "input_common/drivers/virtual_gamepad.h"
+
+namespace InputCommon {
+constexpr std::size_t PlayerIndexCount = 10;
+
+VirtualGamepad::VirtualGamepad(std::string input_engine_) : InputEngine(std::move(input_engine_)) {
+    for (std::size_t i = 0; i < PlayerIndexCount; i++) {
+        PreSetController(GetIdentifier(i));
+    }
+}
+
+void VirtualGamepad::SetButtonState(std::size_t player_index, int button_id, bool value) {
+    if (player_index > PlayerIndexCount) {
+        return;
+    }
+    const auto identifier = GetIdentifier(player_index);
+    SetButton(identifier, button_id, value);
+}
+
+void VirtualGamepad::SetButtonState(std::size_t player_index, VirtualButton button_id, bool value) {
+    SetButtonState(player_index, static_cast<int>(button_id), value);
+}
+
+void VirtualGamepad::SetStickPosition(std::size_t player_index, int axis_id, float x_value,
+                                      float y_value) {
+    if (player_index > PlayerIndexCount) {
+        return;
+    }
+    const auto identifier = GetIdentifier(player_index);
+    SetAxis(identifier, axis_id * 2, x_value);
+    SetAxis(identifier, (axis_id * 2) + 1, y_value);
+}
+
+void VirtualGamepad::SetStickPosition(std::size_t player_index, VirtualStick axis_id, float x_value,
+                                      float y_value) {
+    SetStickPosition(player_index, static_cast<int>(axis_id), x_value, y_value);
+}
+
+void VirtualGamepad::ResetControllers() {
+    for (std::size_t i = 0; i < PlayerIndexCount; i++) {
+        SetStickPosition(i, VirtualStick::Left, 0.0f, 0.0f);
+        SetStickPosition(i, VirtualStick::Right, 0.0f, 0.0f);
+
+        SetButtonState(i, VirtualButton::ButtonA, false);
+        SetButtonState(i, VirtualButton::ButtonB, false);
+        SetButtonState(i, VirtualButton::ButtonX, false);
+        SetButtonState(i, VirtualButton::ButtonY, false);
+        SetButtonState(i, VirtualButton::StickL, false);
+        SetButtonState(i, VirtualButton::StickR, false);
+        SetButtonState(i, VirtualButton::TriggerL, false);
+        SetButtonState(i, VirtualButton::TriggerR, false);
+        SetButtonState(i, VirtualButton::TriggerZL, false);
+        SetButtonState(i, VirtualButton::TriggerZR, false);
+        SetButtonState(i, VirtualButton::ButtonPlus, false);
+        SetButtonState(i, VirtualButton::ButtonMinus, false);
+        SetButtonState(i, VirtualButton::ButtonLeft, false);
+        SetButtonState(i, VirtualButton::ButtonUp, false);
+        SetButtonState(i, VirtualButton::ButtonRight, false);
+        SetButtonState(i, VirtualButton::ButtonDown, false);
+        SetButtonState(i, VirtualButton::ButtonSL, false);
+        SetButtonState(i, VirtualButton::ButtonSR, false);
+        SetButtonState(i, VirtualButton::ButtonHome, false);
+        SetButtonState(i, VirtualButton::ButtonCapture, false);
+    }
+}
+
+PadIdentifier VirtualGamepad::GetIdentifier(std::size_t player_index) const {
+    return {
+        .guid = Common::UUID{},
+        .port = player_index,
+        .pad = 0,
+    };
+}
+
+} // namespace InputCommon

--- a/src/input_common/drivers/virtual_gamepad.h
+++ b/src/input_common/drivers/virtual_gamepad.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "input_common/input_engine.h"
+
+namespace InputCommon {
+
+/**
+ * A virtual controller that is always assigned to the game input
+ */
+class VirtualGamepad final : public InputEngine {
+public:
+    enum class VirtualButton {
+        ButtonA,
+        ButtonB,
+        ButtonX,
+        ButtonY,
+        StickL,
+        StickR,
+        TriggerL,
+        TriggerR,
+        TriggerZL,
+        TriggerZR,
+        ButtonPlus,
+        ButtonMinus,
+        ButtonLeft,
+        ButtonUp,
+        ButtonRight,
+        ButtonDown,
+        ButtonSL,
+        ButtonSR,
+        ButtonHome,
+        ButtonCapture,
+    };
+
+    enum class VirtualStick {
+        Left = 0,
+        Right = 1,
+    };
+
+    explicit VirtualGamepad(std::string input_engine_);
+
+    /**
+     * Sets the status of all buttons bound with the key to pressed
+     * @param player_index the player number that will take this action
+     * @param button_id the id of the button
+     * @param value indicates if the button is pressed or not
+     */
+    void SetButtonState(std::size_t player_index, int button_id, bool value);
+    void SetButtonState(std::size_t player_index, VirtualButton button_id, bool value);
+
+    /**
+     * Sets the status of all buttons bound with the key to released
+     * @param player_index the player number that will take this action
+     * @param axis_id the id of the axis to move
+     * @param x_value the position of the stick in the x axis
+     * @param y_value the position of the stick in the y axis
+     */
+    void SetStickPosition(std::size_t player_index, int axis_id, float x_value, float y_value);
+    void SetStickPosition(std::size_t player_index, VirtualStick axis_id, float x_value,
+                          float y_value);
+
+    /// Restores all inputs into the neutral position
+    void ResetControllers();
+
+private:
+    /// Returns the correct identifier corresponding to the player index
+    PadIdentifier GetIdentifier(std::size_t player_index) const;
+};
+
+} // namespace InputCommon

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -34,6 +34,7 @@ class Keyboard;
 class Mouse;
 class TouchScreen;
 class VirtualAmiibo;
+class VirtualGamepad;
 struct MappingData;
 } // namespace InputCommon
 
@@ -107,6 +108,12 @@ public:
 
     /// Retrieves the underlying virtual amiibo input device.
     [[nodiscard]] const VirtualAmiibo* GetVirtualAmiibo() const;
+
+    /// Retrieves the underlying virtual gamepad input device.
+    [[nodiscard]] VirtualGamepad* GetVirtualGamepad();
+
+    /// Retrieves the underlying virtual gamepad input device.
+    [[nodiscard]] const VirtualGamepad* GetVirtualGamepad() const;
 
     /**
      * Returns all available input devices that this Factory can create a new device with.


### PR DESCRIPTION
This PR implements a virtual gamepad that can be accessed from the frontend that is mapped by default 