### PR TITLE
Remove unimplemented geometry transform feedback log spam

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -658,8 +658,7 @@ void RasterizerVulkan::BeginTransformFeedback() {
         return;
     }
     UNIMPLEMENTED_IF(regs.IsShaderConfigEnabled(Maxwell::ShaderType::TessellationInit) ||
-                     regs.IsShaderConfigEnabled(Maxwell::ShaderType::Tessellation) ||
-                     regs.IsShaderConfigEnabled(Maxwell::ShaderType::Geometry));
+                     regs.IsShaderConfigEnabled(Maxwell::ShaderType::Tessellation));
     scheduler.Record(
         [](vk::CommandBuffer cmdbuf) { cmdbuf.BeginTransformFeedbackEXT(0, 0, nullptr, nullptr); });
 }


### PR DESCRIPTION
Transform feedback is implemented for geometry shaders and seems to work just fine, it's used in multiple games and the outputs are fine. This is mainly for Xenoblade Chronicles 3 though, the logs are unreadable with this message spamming.