### PR TITLE
yuzu: Fix compile and setting errors

### DIFF
--- a/src/input_common/drivers/camera.h
+++ b/src/input_common/drivers/camera.h
@@ -25,6 +25,7 @@ public:
     Common::Input::CameraError SetCameraFormat(const PadIdentifier& identifier_,
                                                Common::Input::CameraFormat camera_format) override;
 
+private:
     Common::Input::CameraStatus status{};
 };
 

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -764,7 +764,9 @@ void GRenderWindow::InitializeCamera() {
         return;
     }
 
-    camera_data.resize(CAMERA_WIDTH * CAMERA_HEIGHT);
+    const auto camera_width = input_subsystem->GetCamera()->getImageWidth();
+    const auto camera_height = input_subsystem->GetCamera()->getImageHeight();
+    camera_data.resize(camera_width * camera_height);
     camera_capture->setCaptureDestination(QCameraImageCapture::CaptureDestination::CaptureToBuffer);
     connect(camera_capture.get(), &QCameraImageCapture::imageCaptured, this,
             &GRenderWindow::OnCameraCapture);
@@ -822,12 +824,18 @@ void GRenderWindow::RequestCameraCapture() {
 void GRenderWindow::OnCameraCapture(int requestId, const QImage& img) {
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0)) && YUZU_USE_QT_MULTIMEDIA
     // TODO: Capture directly in the format and resolution needed
+    const auto camera_width = input_subsystem->GetCamera()->getImageWidth();
+    const auto camera_height = input_subsystem->GetCamera()->getImageHeight();
     const auto converted =
-        img.scaled(CAMERA_WIDTH, CAMERA_HEIGHT, Qt::AspectRatioMode::IgnoreAspectRatio,
+        img.scaled(static_cast<int>(camera_width), static_cast<int>(camera_height),
+                   Qt::AspectRatioMode::IgnoreAspectRatio,
                    Qt::TransformationMode::SmoothTransformation)
             .mirrored(false, true);
-    std::memcpy(camera_data.data(), converted.bits(), CAMERA_WIDTH * CAMERA_HEIGHT * sizeof(u32));
-    input_subsystem->GetCamera()->SetCameraData(CAMERA_WIDTH, CAMERA_HEIGHT, camera_data);
+    if (camera_data.size() != camera_width * camera_height) {
+        camera_data.resize(camera_width * camera_height);
+    }
+    std::memcpy(camera_data.data(), converted.bits(), camera_width * camera_height * sizeof(u32));
+    input_subsystem->GetCamera()->SetCameraData(camera_width, camera_height, camera_data);
     pending_camera_snapshots = 0;
 #endif
 }

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -820,6 +820,7 @@ void GRenderWindow::RequestCameraCapture() {
 }
 
 void GRenderWindow::OnCameraCapture(int requestId, const QImage& img) {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0)) && YUZU_USE_QT_MULTIMEDIA
     // TODO: Capture directly in the format and resolution needed
     const auto converted =
         img.scaled(CAMERA_WIDTH, CAMERA_HEIGHT, Qt::AspectRatioMode::IgnoreAspectRatio,
@@ -828,6 +829,7 @@ void GRenderWindow::OnCameraCapture(int requestId, const QImage& img) {
     std::memcpy(camera_data.data(), converted.bits(), CAMERA_WIDTH * CAMERA_HEIGHT * sizeof(u32));
     input_subsystem->GetCamera()->SetCameraData(CAMERA_WIDTH, CAMERA_HEIGHT, camera_data);
     pending_camera_snapshots = 0;
+#endif
 }
 
 bool GRenderWindow::event(QEvent* event) {

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -243,8 +243,6 @@ private:
     InputCommon::TasInput::TasState last_tas_state;
 
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0)) && YUZU_USE_QT_MULTIMEDIA
-    static constexpr std::size_t CAMERA_WIDTH = 320;
-    static constexpr std::size_t CAMERA_HEIGHT = 240;
     bool is_virtual_camera;
     int pending_camera_snapshots;
     std::vector<u32> camera_data;

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -242,16 +242,16 @@ private:
     bool first_frame = false;
     InputCommon::TasInput::TasState last_tas_state;
 
-    bool is_virtual_camera;
-    int pending_camera_snapshots;
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0)) && YUZU_USE_QT_MULTIMEDIA
-    std::unique_ptr<QCamera> camera;
-    std::unique_ptr<QCameraImageCapture> camera_capture;
     static constexpr std::size_t CAMERA_WIDTH = 320;
     static constexpr std::size_t CAMERA_HEIGHT = 240;
+    bool is_virtual_camera;
+    int pending_camera_snapshots;
     std::vector<u32> camera_data;
-#endif
+    std::unique_ptr<QCamera> camera;
+    std::unique_ptr<QCameraImageCapture> camera_capture;
     std::unique_ptr<QTimer> camera_timer;
+#endif
 
     Core::System& system;
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -783,8 +783,6 @@ void Config::ReadSystemValues() {
         }
     }
 
-    ReadBasicSetting(Settings::values.device_name);
-
     if (global) {
         ReadBasicSetting(Settings::values.current_user);
         Settings::values.current_user = std::clamp<int>(Settings::values.current_user.GetValue(), 0,
@@ -797,6 +795,7 @@ void Config::ReadSystemValues() {
         } else {
             Settings::values.custom_rtc = std::nullopt;
         }
+        ReadBasicSetting(Settings::values.device_name);
     }
 
     ReadGlobalSetting(Settings::values.sound_index);
@@ -1407,7 +1406,6 @@ void Config::SaveSystemValues() {
                  Settings::values.rng_seed.UsingGlobal());
     WriteSetting(QStringLiteral("rng_seed"), Settings::values.rng_seed.GetValue(global).value_or(0),
                  0, Settings::values.rng_seed.UsingGlobal());
-    WriteBasicSetting(Settings::values.device_name);
 
     if (global) {
         WriteBasicSetting(Settings::values.current_user);
@@ -1416,6 +1414,7 @@ void Config::SaveSystemValues() {
                      false);
         WriteSetting(QStringLiteral("custom_rtc"),
                      QVariant::fromValue<long long>(Settings::values.custom_rtc.value_or(0)), 0);
+        WriteBasicSetting(Settings::values.device_name);
     }
 
     WriteGlobalSetting(Settings::values.sound_index);


### PR DESCRIPTION
Avoids resetting device name with per game config and solves the build error on Qt6. Uses the correct resolution for camera captures to avoid coping more data than necessary.

Fixes #9465
Fixes #9464