### PR TITLE
yuzu: Remember last selected directory

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2661,6 +2661,9 @@ void GMainWindow::OnMenuInstallToNAND() {
         return;
     }
 
+    // Save folder location of the first selected file
+    UISettings::values.roms_path = QFileInfo(filenames[0]).path();
+
     int remaining = filenames.size();
 
     // This would only overflow above 2^43 bytes (8.796 TB)


### PR DESCRIPTION
Yuzu will now remember the last install to nand directory that was opened.
Fixes: #9376