### PR TITLE
Use execlp instead of execl to avoid failure

### DIFF
--- a/src/yuzu/startup_checks.cpp
+++ b/src/yuzu/startup_checks.cpp
@@ -186,7 +186,7 @@ pid_t SpawnChild(const char* arg0) {
         return pid;
     } else if (pid == 0) {
         // child
-        execl(arg0, arg0, nullptr);
+        execlp(arg0, arg0, nullptr);
         const int err = errno;
         fmt::print(stderr, "execl failed with error {}\n", err);
         _exit(0);


### PR DESCRIPTION
When Yuzu is invoked through command line, its `argv[0]` is `yuzu`, not the full path of its executable, so `execl` fails because it's unable to find a file named `yuzu`. `execlp` solve this problem, looking for the executable in `$PATH` if the name is specified instead of its full path.