### PR TITLE
service: nfc: Silence ListDevices

### DIFF
--- a/src/core/hle/service/nfc/nfc_user.cpp
+++ b/src/core/hle/service/nfc/nfc_user.cpp
@@ -97,7 +97,7 @@ void IUser::IsNfcEnabled(Kernel::HLERequestContext& ctx) {
 }
 
 void IUser::ListDevices(Kernel::HLERequestContext& ctx) {
-    LOG_INFO(Service_NFC, "called");
+    LOG_DEBUG(Service_NFC, "called");
 
     if (state == State::NonInitialized) {
         IPC::ResponseBuilder rb{ctx, 2};

--- a/src/core/hle/service/nfp/nfp_user.cpp
+++ b/src/core/hle/service/nfp/nfp_user.cpp
@@ -83,7 +83,7 @@ void IUser::Finalize(Kernel::HLERequestContext& ctx) {
 }
 
 void IUser::ListDevices(Kernel::HLERequestContext& ctx) {
-    LOG_INFO(Service_NFP, "called");
+    LOG_DEBUG(Service_NFP, "called");
 
     if (state == State::NonInitialized) {
         IPC::ResponseBuilder rb{ctx, 2};


### PR DESCRIPTION
Some games like BoTW have top quality coding and keep spamming this function.