### PR TITLE
qt: exit properly on guest-initiated close

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -78,7 +78,6 @@ void EmuThread::run() {
     gpu.Start();
 
     m_system.GetCpuManager().OnGpuReady();
-    m_system.RegisterExitCallback([this] { m_stop_source.request_stop(); });
 
     if (m_system.DebuggerEnabled()) {
         m_system.InitializeDebugger();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1710,6 +1710,11 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
     system->RegisterExecuteProgramCallback(
         [this](std::size_t program_index_) { render_window->ExecuteProgram(program_index_); });
 
+    system->RegisterExitCallback([this] {
+        emu_thread->ForceStop();
+        render_window->Exit();
+    });
+
     connect(render_window, &GRenderWindow::Closed, this, &GMainWindow::OnStopGame);
     connect(render_window, &GRenderWindow::MouseActivity, this, &GMainWindow::OnMouseActivity);
     // BlockingQueuedConnection is important here, it makes sure we've finished refreshing our views
@@ -4143,6 +4148,10 @@ bool GMainWindow::ConfirmForceLockedExit() {
 }
 
 void GMainWindow::RequestGameExit() {
+    if (!system->IsPoweredOn()) {
+        return;
+    }
+
     auto& sm{system->ServiceManager()};
     auto applet_oe = sm.GetService<Service::AM::AppletOE>("appletOE");
     auto applet_ae = sm.GetService<Service::AM::AppletAE>("appletAE");


### PR DESCRIPTION
Allows homebrew demos and such to avoid crashing on exit.