### PR TITLE
TAS: Increase accuracy of Stick inputs

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -210,6 +210,13 @@ void EmulatedController::LoadTASParams() {
     tas_stick_params[Settings::NativeAnalog::LStick].Set("axis_y", 1);
     tas_stick_params[Settings::NativeAnalog::RStick].Set("axis_x", 2);
     tas_stick_params[Settings::NativeAnalog::RStick].Set("axis_y", 3);
+
+    // set to optimal stick to avoid sanitizing the stick and tweaking the coordinates
+    // making sure they play back in the game as originally written down in the script file
+    tas_stick_params[Settings::NativeAnalog::LStick].Set("deadzone", 0.0f);
+    tas_stick_params[Settings::NativeAnalog::LStick].Set("range", 1.0f);
+    tas_stick_params[Settings::NativeAnalog::RStick].Set("deadzone", 0.0f);
+    tas_stick_params[Settings::NativeAnalog::RStick].Set("range", 1.0f);
 }
 
 void EmulatedController::LoadVirtualGamepadParams() {


### PR DESCRIPTION
As TAS-scripts provide raw inputs for the system, they should not be sanitized by Yuzu. As the function responsible for doing that (https://github.com/yuzu-emu/yuzu/blob/bbb963a31a141979b27615b9c28bcc72be50468e/src/core/hid/input_converter.cpp#L347) cannot be worked around, the simplest way to fix the current inaccuracies is by just hardcoding the range and deadzone to full and none, meaning the sanitization will not actually perform any changes on the data.