### PR TITLE
kernel: workaround static shared memory initialization

### DIFF
--- a/src/core/hle/kernel/k_shared_memory.cpp
+++ b/src/core/hle/kernel/k_shared_memory.cpp
@@ -6,6 +6,7 @@
 #include "core/hle/kernel/k_page_table.h"
 #include "core/hle/kernel/k_scoped_resource_reservation.h"
 #include "core/hle/kernel/k_shared_memory.h"
+#include "core/hle/kernel/k_system_resource.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/svc_results.h"
 
@@ -18,18 +19,18 @@ KSharedMemory::~KSharedMemory() {
 }
 
 Result KSharedMemory::Initialize(Core::DeviceMemory& device_memory_, KProcess* owner_process_,
-                                 KPageGroup&& page_list_, Svc::MemoryPermission owner_permission_,
-                                 Svc::MemoryPermission user_permission_, PAddr physical_address_,
-                                 std::size_t size_, std::string name_) {
+                                 Svc::MemoryPermission owner_permission_,
+                                 Svc::MemoryPermission user_permission_, std::size_t size_,
+                                 std::string name_) {
     // Set members.
     owner_process = owner_process_;
     device_memory = &device_memory_;
-    page_list = std::move(page_list_);
     owner_permission = owner_permission_;
     user_permission = user_permission_;
-    physical_address = physical_address_;
-    size = size_;
+    size = Common::AlignUp(size_, PageSize);
     name = std::move(name_);
+
+    const size_t num_pages = Common::DivideUp(size, PageSize);
 
     // Get the resource limit.
     KResourceLimit* reslimit = kernel.GetSystemResourceLimit();
@@ -38,6 +39,17 @@ Result KSharedMemory::Initialize(Core::DeviceMemory& device_memory_, KProcess* o
     KScopedResourceReservation memory_reservation(reslimit, LimitableResource::PhysicalMemoryMax,
                                                   size_);
     R_UNLESS(memory_reservation.Succeeded(), ResultLimitReached);
+
+    // Allocate the memory.
+
+    //! HACK: Open continuous mapping from sysmodule pool.
+    auto option = KMemoryManager::EncodeOption(KMemoryManager::Pool::Secure,
+                                               KMemoryManager::Direction::FromBack);
+    physical_address = kernel.MemoryManager().AllocateAndOpenContinuous(num_pages, 1, option);
+    R_UNLESS(physical_address != 0, ResultOutOfMemory);
+
+    //! Insert the result into our page group.
+    page_group.emplace(physical_address, num_pages);
 
     // Commit our reservation.
     memory_reservation.Commit();
@@ -50,12 +62,23 @@ Result KSharedMemory::Initialize(Core::DeviceMemory& device_memory_, KProcess* o
     is_initialized = true;
 
     // Clear all pages in the memory.
-    std::memset(device_memory_.GetPointer<void>(physical_address_), 0, size_);
+    for (const auto& block : page_group->Nodes()) {
+        std::memset(device_memory_.GetPointer<void>(block.GetAddress()), 0, block.GetSize());
+    }
 
     return ResultSuccess;
 }
 
 void KSharedMemory::Finalize() {
+    // Close and finalize the page group.
+    // page_group->Close();
+    // page_group->Finalize();
+
+    //! HACK: Manually close.
+    for (const auto& block : page_group->Nodes()) {
+        kernel.MemoryManager().Close(block.GetAddress(), block.GetNumPages());
+    }
+
     // Release the memory reservation.
     resource_limit->Release(LimitableResource::PhysicalMemoryMax, size);
     resource_limit->Close();
@@ -65,32 +88,28 @@ void KSharedMemory::Finalize() {
 }
 
 Result KSharedMemory::Map(KProcess& target_process, VAddr address, std::size_t map_size,
-                          Svc::MemoryPermission permissions) {
-    const u64 page_count{(map_size + PageSize - 1) / PageSize};
+                          Svc::MemoryPermission map_perm) {
+    // Validate the size.
+    R_UNLESS(size == map_size, ResultInvalidSize);
 
-    if (page_list.GetNumPages() != page_count) {
-        UNIMPLEMENTED_MSG("Page count does not match");
-    }
-
-    const Svc::MemoryPermission expected =
+    // Validate the permission.
+    const Svc::MemoryPermission test_perm =
         &target_process == owner_process ? owner_permission : user_permission;
-
-    if (permissions != expected) {
-        UNIMPLEMENTED_MSG("Permission does not match");
+    if (test_perm == Svc::MemoryPermission::DontCare) {
+        ASSERT(map_perm == Svc::MemoryPermission::Read || map_perm == Svc::MemoryPermission::Write);
+    } else {
+        R_UNLESS(map_perm == test_perm, ResultInvalidNewMemoryPermission);
     }
 
-    return target_process.PageTable().MapPages(address, page_list, KMemoryState::Shared,
-                                               ConvertToKMemoryPermission(permissions));
+    return target_process.PageTable().MapPages(address, *page_group, KMemoryState::Shared,
+                                               ConvertToKMemoryPermission(map_perm));
 }
 
 Result KSharedMemory::Unmap(KProcess& target_process, VAddr address, std::size_t unmap_size) {
-    const u64 page_count{(unmap_size + PageSize - 1) / PageSize};
+    // Validate the size.
+    R_UNLESS(size == unmap_size, ResultInvalidSize);
 
-    if (page_list.GetNumPages() != page_count) {
-        UNIMPLEMENTED_MSG("Page count does not match");
-    }
-
-    return target_process.PageTable().UnmapPages(address, page_list, KMemoryState::Shared);
+    return target_process.PageTable().UnmapPages(address, *page_group, KMemoryState::Shared);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_shared_memory.h
+++ b/src/core/hle/kernel/k_shared_memory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "common/common_types.h"
@@ -26,9 +27,8 @@ public:
     ~KSharedMemory() override;
 
     Result Initialize(Core::DeviceMemory& device_memory_, KProcess* owner_process_,
-                      KPageGroup&& page_list_, Svc::MemoryPermission owner_permission_,
-                      Svc::MemoryPermission user_permission_, PAddr physical_address_,
-                      std::size_t size_, std::string name_);
+                      Svc::MemoryPermission owner_permission_,
+                      Svc::MemoryPermission user_permission_, std::size_t size_, std::string name_);
 
     /**
      * Maps a shared memory block to an address in the target process' address space
@@ -76,7 +76,7 @@ public:
 private:
     Core::DeviceMemory* device_memory{};
     KProcess* owner_process{};
-    KPageGroup page_list;
+    std::optional<KPageGroup> page_group{};
     Svc::MemoryPermission owner_permission{};
     Svc::MemoryPermission user_permission{};
     PAddr physical_address{};


### PR DESCRIPTION
I observed that when looping hbmenu on a 5 second timer, memory blocks used for shared memory regions would sometimes collide with TLS pages, get overwritten with random data, and cause libnx to abort. After tracking down the location of the writes, I found that yuzu wasn't actually allocating those regions, just using them without allocating first.

This is a hack until we get rid of the horrid kernel-managed shared memory objects, but it will probably fix a bunch of randomly-occurring startup crashes in games.