### PR TITLE
qt: fix 'Pause' menu item

### DIFF
--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -80,7 +80,7 @@ public:
      * @return True if the emulation thread is running, otherwise false
      */
     bool IsRunning() const {
-        return m_is_running.load();
+        return m_is_running.load() || m_should_run;
     }
 
     /**


### PR DESCRIPTION
GMainWindow checks for EmuThread::IsRunning() immediately after resuming the game when updating the menu. The thread is not likely to have woken up before this happens. IsRunning therefore should return true if the game is intended to resume as well.