### PR TITLE
qt: prevent reentrant shutdown

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1785,9 +1785,9 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
     OnStartGame();
 }
 
-void GMainWindow::OnShutdownBegin() {
+bool GMainWindow::OnShutdownBegin() {
     if (!emulation_running) {
-        return;
+        return false;
     }
 
     if (ui->action_Fullscreen->isChecked()) {
@@ -1798,6 +1798,10 @@ void GMainWindow::OnShutdownBegin() {
 
     // Disable unlimited frame rate
     Settings::values.use_speed_limit.SetValue(true);
+
+    if (system->IsShuttingDown()) {
+        return false;
+    }
 
     system->SetShuttingDown(true);
     discord_rpc->Pause();
@@ -1817,6 +1821,8 @@ void GMainWindow::OnShutdownBegin() {
     ui->action_Pause->setEnabled(false);
     ui->action_Restart->setEnabled(false);
     ui->action_Stop->setEnabled(false);
+
+    return true;
 }
 
 void GMainWindow::OnShutdownBeginDialog() {
@@ -3003,8 +3009,9 @@ void GMainWindow::OnStopGame() {
         return;
     }
 
-    OnShutdownBegin();
-    OnShutdownBeginDialog();
+    if (OnShutdownBegin()) {
+        OnShutdownBeginDialog();
+    }
 }
 
 void GMainWindow::OnLoadComplete() {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -336,7 +336,7 @@ private slots:
     void OnReinitializeKeys(ReinitializeKeyBehavior behavior);
     void OnLanguageChanged(const QString& locale);
     void OnMouseActivity();
-    void OnShutdownBegin();
+    bool OnShutdownBegin();
     void OnShutdownBeginDialog();
     void OnEmulationStopped();
     void OnEmulationStopTimeExpired();


### PR DESCRIPTION
Caused by the perils of programming in event loops.