### PR TITLE
tests: add missing header

### DIFF
--- a/src/tests/common/scratch_buffer.cpp
+++ b/src/tests/common/scratch_buffer.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <span>
 #include <catch2/catch.hpp>
 #include "common/common_types.h"


### PR DESCRIPTION
The header `<cstring>` is needed for `std::memcpy`.