### PR TITLE
settings: warn on invalid regon/language combinations

### DIFF
--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -14,6 +14,20 @@
 #include "yuzu/configuration/configuration_shared.h"
 #include "yuzu/configuration/configure_system.h"
 
+constexpr std::array<u32, 7> LOCALE_BLOCKLIST{
+    0b100011100001100000, // Japan
+    0b000001101001100100, // Americas
+    0b100110100001000010, // Europe
+    0b100110100001000010, // Australia
+    0b000000000000000000, // China
+    0b100111100001000000, // Korea
+    0b100111100001000000, // Taiwan
+};
+
+static bool IsValidLocale(u32 region_index, u32 language_index) {
+    return ((LOCALE_BLOCKLIST[region_index] >> language_index) & 1) == 0;
+}
+
 ConfigureSystem::ConfigureSystem(Core::System& system_, QWidget* parent)
     : QWidget(parent), ui{std::make_unique<Ui::ConfigureSystem>()}, system{system_} {
     ui->setupUi(this);
@@ -33,6 +47,22 @@ ConfigureSystem::ConfigureSystem(Core::System& system_, QWidget* parent)
             ui->custom_rtc_edit->setDateTime(QDateTime::currentDateTime());
         }
     });
+
+    const auto locale_check = [this](int index) {
+        const bool valid_locale =
+            IsValidLocale(ui->combo_region->currentIndex(), ui->combo_language->currentIndex());
+        ui->label_warn_invalid_locale->setVisible(!valid_locale);
+        if (!valid_locale) {
+            ui->label_warn_invalid_locale->setText(
+                tr("Warning: \"%1\" is not a valid language for region \"%2\"")
+                    .arg(ui->combo_language->currentText())
+                    .arg(ui->combo_region->currentText()));
+        }
+    };
+
+    connect(ui->combo_language, qOverload<int>(&QComboBox::currentIndexChanged), this,
+            locale_check);
+    connect(ui->combo_region, qOverload<int>(&QComboBox::currentIndexChanged), this, locale_check);
 
     ui->label_console_id->setVisible(Settings::IsConfiguringGlobal());
     ui->button_regenerate_console_id->setVisible(Settings::IsConfiguringGlobal());

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -15,13 +15,19 @@
 #include "yuzu/configuration/configure_system.h"
 
 constexpr std::array<u32, 7> LOCALE_BLOCKLIST{
-    0b100011100001100000, // Japan
-    0b000001101001100100, // Americas
-    0b100110100001000010, // Europe
-    0b100110100001000010, // Australia
-    0b000000000000000000, // China
-    0b100111100001000000, // Korea
-    0b100111100001000000, // Taiwan
+    // pzzefezrpnkzeidfej
+    // thhsrnhutlohsternp
+    // BHH4CG          U
+    // Raa1AB          S
+    //  nn9
+    //  ts
+    0b0100011100001100000, // Japan
+    0b0000001101001100100, // Americas
+    0b0100110100001000010, // Europe
+    0b0100110100001000010, // Australia
+    0b0000000000000000000, // China
+    0b0100111100001000000, // Korea
+    0b0100111100001000000, // Taiwan
 };
 
 static bool IsValidLocale(u32 region_index, u32 language_index) {

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -25,7 +25,7 @@ constexpr std::array<u32, 7> LOCALE_BLOCKLIST{
 };
 
 static bool IsValidLocale(u32 region_index, u32 language_index) {
-    return ((LOCALE_BLOCKLIST[region_index] >> language_index) & 1) == 0;
+    return ((LOCALE_BLOCKLIST.at(region_index) >> language_index) & 1) == 0;
 }
 
 ConfigureSystem::ConfigureSystem(Core::System& system_, QWidget* parent)

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -326,7 +326,7 @@
             </item>
             <item>
              <property name="text">
-              <string>English</string>
+              <string>American English</string>
              </property>
             </item>
             <item>
@@ -544,6 +544,16 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_warn_invalid_locale">
+       <property name="text">
+        <string></string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="label_disable_info">


### PR DESCRIPTION
I was trying to figure out why the temperature indicator in BotW was in Fahrenheit.

Since British English is at index 13 it's easy to overlook.

This branch changes the "English" language option to "American English".

It also adds a warning to the settings window when the selected language isn't valid for the selected region.
This warning doesn't appear when the region is set to China, as that isn't an option on my switch.