### PR TITLE
CMake: make more features optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_SDL2 "Download bundled SDL2 binaries" ON
 # On Linux system SDL2 is likely to be lacking HIDAPI support which have drawbacks but is needed for SDL motion
 CMAKE_DEPENDENT_OPTION(YUZU_USE_EXTERNAL_SDL2 "Compile external SDL2" ON "ENABLE_SDL2;NOT MSVC" OFF)
 
+option(ENABLE_LIBUSB "Enable the use of LibUSB" ON)
+
 option(ENABLE_OPENGL "Enable OpenGL" ON)
 mark_as_advanced(FORCE ENABLE_OPENGL)
 option(ENABLE_QT "Enable the Qt frontend" ON)
@@ -206,13 +208,16 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 find_package(enet 1.3)
 find_package(fmt 9 REQUIRED)
 find_package(inih)
-find_package(libusb 1.0.24)
 find_package(lz4 REQUIRED)
 find_package(nlohmann_json 3.8 REQUIRED)
 find_package(Opus 1.3)
 find_package(Vulkan 1.3.238)
 find_package(ZLIB 1.2 REQUIRED)
 find_package(zstd 1.5 REQUIRED)
+
+if (ENABLE_LIBUSB)
+    find_package(libusb 1.0.24)
+endif()
 
 if (ARCHITECTURE_x86 OR ARCHITECTURE_x86_64)
     find_package(xbyak 6 QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ option(YUZU_TESTS "Compile tests" ON)
 
 option(YUZU_USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 
+option(YUZU_ROOM "Compile LDN room server" ON)
+
 CMAKE_DEPENDENT_OPTION(YUZU_CRASH_DUMPS "Compile Windows crash dump (Minidump) support" OFF "WIN32" OFF)
 
 option(YUZU_USE_BUNDLED_VCPKG "Use vcpkg for yuzu dependencies" "${MSVC}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,24 +215,24 @@ find_package(ZLIB 1.2 REQUIRED)
 find_package(zstd 1.5 REQUIRED)
 
 if (ARCHITECTURE_x86 OR ARCHITECTURE_x86_64)
-    find_package(xbyak 6)
+    find_package(xbyak 6 QUIET)
 endif()
 
 if (ARCHITECTURE_x86_64 OR ARCHITECTURE_arm64)
-    find_package(dynarmic 6.4.0)
+    find_package(dynarmic 6.4.0 QUIET)
 endif()
 
 if (ENABLE_CUBEB)
-    find_package(cubeb)
+    find_package(cubeb QUIET)
 endif()
 
 if (USE_DISCORD_PRESENCE)
-    find_package(DiscordRPC)
+    find_package(DiscordRPC QUIET)
 endif()
 
 if (ENABLE_WEB_SERVICE)
-    find_package(cpp-jwt 1.4)
-    find_package(httplib 0.11)
+    find_package(cpp-jwt 1.4 QUIET)
+    find_package(httplib 0.11 QUIET)
 endif()
 
 if (YUZU_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ option(ENABLE_WEB_SERVICE "Enable web services (telemetry, etc.)" ON)
 
 option(YUZU_USE_BUNDLED_FFMPEG "Download/Build bundled FFmpeg" "${WIN32}")
 
+option(YUZU_USE_EXTERNAL_VULKAN_HEADERS "Use Vulkan-Headers from externals" ON)
+
 option(YUZU_USE_QT_MULTIMEDIA "Use QtMultimedia for Camera" OFF)
 
 option(YUZU_USE_QT_WEB_ENGINE "Use QtWebEngine for web applet implementation" OFF)
@@ -211,9 +213,12 @@ find_package(inih)
 find_package(lz4 REQUIRED)
 find_package(nlohmann_json 3.8 REQUIRED)
 find_package(Opus 1.3)
-find_package(Vulkan 1.3.238)
 find_package(ZLIB 1.2 REQUIRED)
 find_package(zstd 1.5 REQUIRED)
+
+if (NOT YUZU_USE_EXTERNAL_VULKAN_HEADERS)
+    find_package(Vulkan 1.3.238)
+endif()
 
 if (ENABLE_LIBUSB)
     find_package(libusb 1.0.24)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -152,6 +152,6 @@ if (YUZU_USE_BUNDLED_FFMPEG)
 endif()
 
 # Vulkan-Headers
-if (NOT TARGET Vulkan::Headers)
+if (YUZU_USE_EXTERNAL_VULKAN_HEADERS)
     add_subdirectory(Vulkan-Headers EXCLUDE_FROM_ALL)
 endif()

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -45,7 +45,7 @@ if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12" AND CMAKE_CXX_COMPILER
 endif()
 
 # libusb
-if (NOT TARGET libusb::usb)
+if (ENABLE_LIBUSB AND NOT TARGET libusb::usb)
     add_subdirectory(libusb EXCLUDE_FROM_ALL)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,7 +161,10 @@ add_subdirectory(video_core)
 add_subdirectory(network)
 add_subdirectory(input_common)
 add_subdirectory(shader_recompiler)
-add_subdirectory(dedicated_room)
+
+if (YUZU_ROOM)
+     add_subdirectory(dedicated_room)
+endif()
 
 if (YUZU_TESTS)
     add_subdirectory(tests)

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -187,11 +187,7 @@ add_library(audio_core STATIC
     renderer/voice/voice_info.cpp
     renderer/voice/voice_info.h
     renderer/voice/voice_state.h
-    sink/cubeb_sink.cpp
-    sink/cubeb_sink.h
     sink/null_sink.h
-    sink/sdl2_sink.cpp
-    sink/sdl2_sink.h
     sink/sink.h
     sink/sink_details.cpp
     sink/sink_details.h
@@ -222,11 +218,22 @@ if (ARCHITECTURE_x86_64 OR ARCHITECTURE_arm64)
     target_link_libraries(audio_core PRIVATE dynarmic::dynarmic)
 endif()
 
-if(ENABLE_CUBEB)
+if (ENABLE_CUBEB)
+    target_sources(audio_core PRIVATE
+        sink/cubeb_sink.cpp
+        sink/cubeb_sink.h
+    )
+
     target_link_libraries(audio_core PRIVATE cubeb::cubeb)
     target_compile_definitions(audio_core PRIVATE -DHAVE_CUBEB=1)
 endif()
-if(ENABLE_SDL2)
+
+if (ENABLE_SDL2)
+    target_sources(audio_core PRIVATE
+        sink/sdl2_sink.cpp
+        sink/sdl2_sink.h
+    )
+
     target_link_libraries(audio_core PRIVATE SDL2::SDL2)
     target_compile_definitions(audio_core PRIVATE HAVE_SDL2)
 endif()

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -4,14 +4,10 @@
 add_library(input_common STATIC
     drivers/camera.cpp
     drivers/camera.h
-    drivers/gc_adapter.cpp
-    drivers/gc_adapter.h
     drivers/keyboard.cpp
     drivers/keyboard.h
     drivers/mouse.cpp
     drivers/mouse.h
-    drivers/sdl_driver.cpp
-    drivers/sdl_driver.h
     drivers/tas_input.cpp
     drivers/tas_input.h
     drivers/touch_screen.cpp
@@ -62,8 +58,17 @@ if (ENABLE_SDL2)
     target_compile_definitions(input_common PRIVATE HAVE_SDL2)
 endif()
 
+if (ENABLE_LIBUSB)
+    target_sources(input_common PRIVATE
+        drivers/gc_adapter.cpp
+        drivers/gc_adapter.h
+    )
+    target_link_libraries(input_common PRIVATE libusb::usb)
+    target_compile_definitions(input_common PRIVATE HAVE_LIBUSB)
+endif()
+
 create_target_directory_groups(input_common)
-target_link_libraries(input_common PUBLIC core PRIVATE common Boost::boost libusb::usb)
+target_link_libraries(input_common PUBLIC core PRIVATE common Boost::boost)
 
 if (YUZU_USE_PRECOMPILED_HEADERS)
     target_precompile_headers(input_common PRIVATE precompiled_headers.h)

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -5,7 +5,6 @@
 #include "common/input.h"
 #include "common/param_package.h"
 #include "input_common/drivers/camera.h"
-#include "input_common/drivers/gc_adapter.h"
 #include "input_common/drivers/keyboard.h"
 #include "input_common/drivers/mouse.h"
 #include "input_common/drivers/tas_input.h"
@@ -19,6 +18,10 @@
 #include "input_common/input_mapping.h"
 #include "input_common/input_poller.h"
 #include "input_common/main.h"
+
+#ifdef HAVE_LIBUSB
+#include "input_common/drivers/gc_adapter.h"
+#endif
 #ifdef HAVE_SDL2
 #include "input_common/drivers/sdl_driver.h"
 #endif
@@ -45,7 +48,9 @@ struct InputSubsystem::Impl {
         RegisterEngine("keyboard", keyboard);
         RegisterEngine("mouse", mouse);
         RegisterEngine("touch", touch_screen);
+#ifdef HAVE_LIBUSB
         RegisterEngine("gcpad", gcadapter);
+#endif
         RegisterEngine("cemuhookudp", udp_client);
         RegisterEngine("tas", tas_input);
         RegisterEngine("camera", camera);
@@ -72,7 +77,9 @@ struct InputSubsystem::Impl {
         UnregisterEngine(keyboard);
         UnregisterEngine(mouse);
         UnregisterEngine(touch_screen);
+#ifdef HAVE_LIBUSB
         UnregisterEngine(gcadapter);
+#endif
         UnregisterEngine(udp_client);
         UnregisterEngine(tas_input);
         UnregisterEngine(camera);
@@ -95,8 +102,10 @@ struct InputSubsystem::Impl {
         devices.insert(devices.end(), keyboard_devices.begin(), keyboard_devices.end());
         auto mouse_devices = mouse->GetInputDevices();
         devices.insert(devices.end(), mouse_devices.begin(), mouse_devices.end());
+#ifdef HAVE_LIBUSB
         auto gcadapter_devices = gcadapter->GetInputDevices();
         devices.insert(devices.end(), gcadapter_devices.begin(), gcadapter_devices.end());
+#endif
         auto udp_devices = udp_client->GetInputDevices();
         devices.insert(devices.end(), udp_devices.begin(), udp_devices.end());
 #ifdef HAVE_SDL2
@@ -119,9 +128,11 @@ struct InputSubsystem::Impl {
         if (engine == mouse->GetEngineName()) {
             return mouse;
         }
+#ifdef HAVE_LIBUSB
         if (engine == gcadapter->GetEngineName()) {
             return gcadapter;
         }
+#endif
         if (engine == udp_client->GetEngineName()) {
             return udp_client;
         }
@@ -194,9 +205,11 @@ struct InputSubsystem::Impl {
         if (engine == mouse->GetEngineName()) {
             return true;
         }
+#ifdef HAVE_LIBUSB
         if (engine == gcadapter->GetEngineName()) {
             return true;
         }
+#endif
         if (engine == udp_client->GetEngineName()) {
             return true;
         }
@@ -217,7 +230,9 @@ struct InputSubsystem::Impl {
     void BeginConfiguration() {
         keyboard->BeginConfiguration();
         mouse->BeginConfiguration();
+#ifdef HAVE_LIBUSB
         gcadapter->BeginConfiguration();
+#endif
         udp_client->BeginConfiguration();
 #ifdef HAVE_SDL2
         sdl->BeginConfiguration();
@@ -227,7 +242,9 @@ struct InputSubsystem::Impl {
     void EndConfiguration() {
         keyboard->EndConfiguration();
         mouse->EndConfiguration();
+#ifdef HAVE_LIBUSB
         gcadapter->EndConfiguration();
+#endif
         udp_client->EndConfiguration();
 #ifdef HAVE_SDL2
         sdl->EndConfiguration();
@@ -248,13 +265,16 @@ struct InputSubsystem::Impl {
 
     std::shared_ptr<Keyboard> keyboard;
     std::shared_ptr<Mouse> mouse;
-    std::shared_ptr<GCAdapter> gcadapter;
     std::shared_ptr<TouchScreen> touch_screen;
     std::shared_ptr<TasInput::Tas> tas_input;
     std::shared_ptr<CemuhookUDP::UDPClient> udp_client;
     std::shared_ptr<Camera> camera;
     std::shared_ptr<VirtualAmiibo> virtual_amiibo;
     std::shared_ptr<VirtualGamepad> virtual_gamepad;
+
+#ifdef HAVE_LIBUSB
+    std::shared_ptr<GCAdapter> gcadapter;
+#endif
 
 #ifdef HAVE_SDL2
     std::shared_ptr<SDLDriver> sdl;


### PR DESCRIPTION
With this, yuzu-room, libusb, sdl2, and cubeb are independently made optional.