### PR TITLE
config: Save multiplayer settings only globally

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -941,7 +941,6 @@ void Config::ReadValues() {
     ReadRendererValues();
     ReadAudioValues();
     ReadSystemValues();
-    ReadMultiplayerValues();
 }
 
 void Config::SavePlayerValue(std::size_t player_index) {
@@ -1099,7 +1098,6 @@ void Config::SaveValues() {
     SaveRendererValues();
     SaveAudioValues();
     SaveSystemValues();
-    SaveMultiplayerValues();
 }
 
 void Config::SaveAudioValues() {


### PR DESCRIPTION
Yuzu saves the remote ip and nickname in the "Direct Connect" dialog by default, which makes it way more convenient to connect to the same host.
But there is an annoying bug, that these saved settings get lost everytime you boot up a game. I don't think that this should be desirable behaviour.

The reason is that the ui settings `multiplayer_nickname`, `multiplayer_ip`, etc. were replaced by the values stored in the per-game config files, whenever a game was loaded and these settings are always default values.
It can simply be fixed by only loading and storing multiplayer settings globally. I might be wrong, but I don't see a reason multiplayer settings should be read from the game specific configs at this point.

`ReadMultiplayerValues` and `SaveMultiplayerValues` were called actually twice in `SaveValues`/`ReadValues` for the global config, because the functions are already called in `SaveUIValues`/`ReadUIValues`.