### PR TITLE
core: hid: emulated_console: Avoid a crash if frontend does not configure touch_from_button_maps.

### DIFF
--- a/src/core/hid/emulated_console.cpp
+++ b/src/core/hid/emulated_console.cpp
@@ -40,6 +40,11 @@ void EmulatedConsole::SetTouchParams() {
         touch_params[index++] = std::move(touchscreen_param);
     }
 
+    if (Settings::values.touch_from_button_maps.empty()) {
+        LOG_WARNING(Input, "touch_from_button_maps is unset by frontend config");
+        return;
+    }
+
     const auto button_index =
         static_cast<u64>(Settings::values.touch_from_button_map_index.GetValue());
     const auto& touch_buttons = Settings::values.touch_from_button_maps[button_index].buttons;


### PR DESCRIPTION
Avoids a crash if frontend does not configure touch_from_button_maps. Core should gracefully handle this with logging rather than hard crash the emulator.