### PR TITLE
ci: Allow setting clang-format binary

### DIFF
--- a/.ci/scripts/format/script.sh
+++ b/.ci/scripts/format/script.sh
@@ -10,7 +10,7 @@ if grep -nrI '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .ci* dis
 fi
 
 # Default clang-format points to default 3.5 version one
-CLANG_FORMAT=clang-format-12
+CLANG_FORMAT=${CLANG_FORMAT:-clang-format-12}
 $CLANG_FORMAT --version
 
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then


### PR DESCRIPTION
This branch changes the permissions on the ci clang-format script to be executable and allows the clang-format binary to be set.

This allows me to lint my changes with:
```sh
TRAVIS_EVENT_TYPE=pull_request CLANG_FORMAT=clang-format ./.ci/scripts/format/script.sh
```