### PR TITLE
host_memory: mmap changes for virtual_base

### DIFF
--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -393,8 +393,8 @@ public:
         }
 
         // Virtual memory initialization
-        virtual_base = static_cast<u8*>(
-            mmap(nullptr, virtual_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+        virtual_base = static_cast<u8*>(mmap(nullptr, virtual_size, PROT_NONE,
+                                             MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0));
         if (virtual_base == MAP_FAILED) {
             LOG_CRITICAL(HW_Memory, "mmap failed: {}", strerror(errno));
             throw std::bad_alloc{};

--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -393,12 +393,27 @@ public:
         }
 
         // Virtual memory initialization
+#if defined(__FreeBSD__)
+        virtual_base =
+            static_cast<u8*>(mmap(nullptr, virtual_size, PROT_NONE,
+                                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_ALIGNED_SUPER, -1, 0));
+        if (virtual_base == MAP_FAILED) {
+            virtual_base = static_cast<u8*>(
+                mmap(nullptr, virtual_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+            if (virtual_base == MAP_FAILED) {
+                LOG_CRITICAL(HW_Memory, "mmap failed: {}", strerror(errno));
+                throw std::bad_alloc{};
+            }
+        }
+#else
         virtual_base = static_cast<u8*>(mmap(nullptr, virtual_size, PROT_NONE,
                                              MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0));
         if (virtual_base == MAP_FAILED) {
             LOG_CRITICAL(HW_Memory, "mmap failed: {}", strerror(errno));
             throw std::bad_alloc{};
         }
+        madvise(virtual_base, virtual_size, MADV_HUGEPAGE);
+#endif
 
         good = true;
     }


### PR DESCRIPTION
* `NORESERVE`: Specify that we do not require swap to be reserved for this address range; allow overcommitting (if it's disabled for whatever reason).
* Transparent huge pages (THP): Ensure THP is enabled for the requested region.