### PR TITLE
Port over several shader-compiler fixes from skyline

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -321,8 +321,11 @@ Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, Id vertex) {
     case IR::Attribute::PositionY:
     case IR::Attribute::PositionZ:
     case IR::Attribute::PositionW:
-        return ctx.OpLoad(ctx.F32[1], AttrPointer(ctx, ctx.input_f32, vertex, ctx.input_position,
-                                                  ctx.Const(element)));
+        return ctx.OpLoad(ctx.F32[1], ctx.need_input_position_indirect ?
+                                      AttrPointer(ctx, ctx.input_f32, vertex, ctx.input_position,
+                                                  ctx.u32_zero_value, ctx.Const(element))
+                                      : AttrPointer(ctx, ctx.input_f32, vertex, ctx.input_position,
+                                                    ctx.Const(element)));
     case IR::Attribute::InstanceId:
         if (ctx.profile.support_vertex_instance_id) {
             return ctx.OpBitcast(ctx.F32[1], ctx.OpLoad(ctx.U32[1], ctx.instance_id));

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -321,11 +321,12 @@ Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, Id vertex) {
     case IR::Attribute::PositionY:
     case IR::Attribute::PositionZ:
     case IR::Attribute::PositionW:
-        return ctx.OpLoad(ctx.F32[1], ctx.need_input_position_indirect ?
-                                      AttrPointer(ctx, ctx.input_f32, vertex, ctx.input_position,
-                                                  ctx.u32_zero_value, ctx.Const(element))
-                                      : AttrPointer(ctx, ctx.input_f32, vertex, ctx.input_position,
-                                                    ctx.Const(element)));
+        return ctx.OpLoad(
+            ctx.F32[1],
+            ctx.need_input_position_indirect
+                ? AttrPointer(ctx, ctx.input_f32, vertex, ctx.input_position, ctx.u32_zero_value,
+                              ctx.Const(element))
+                : AttrPointer(ctx, ctx.input_f32, vertex, ctx.input_position, ctx.Const(element)));
     case IR::Attribute::InstanceId:
         if (ctx.profile.support_vertex_instance_id) {
             return ctx.OpBitcast(ctx.F32[1], ctx.OpLoad(ctx.U32[1], ctx.instance_id));

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -729,7 +729,7 @@ void EmitContext::DefineAttributeMemAccess(const Info& info) {
                     else
                         return OpAccessChain(input_f32, input_position, u32_zero_value,
                                              masked_index);
-                }  else {
+                } else {
                     if (is_array)
                         return OpAccessChain(input_f32, input_position, vertex, masked_index);
                     else
@@ -1390,7 +1390,8 @@ void EmitContext::DefineInputs(const IR::Program& program) {
                            static_cast<unsigned>(spv::BuiltIn::Position));
             Decorate(input_position_struct, spv::Decoration::Block);
         } else {
-            const spv::BuiltIn built_in{is_fragment ? spv::BuiltIn::FragCoord : spv::BuiltIn::Position};
+            const spv::BuiltIn built_in{is_fragment ? spv::BuiltIn::FragCoord
+                                                    : spv::BuiltIn::Position};
             input_position = DefineInput(*this, F32[4], true, built_in);
 
             if (profile.support_geometry_shader_passthrough) {

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -721,9 +721,21 @@ void EmitContext::DefineAttributeMemAccess(const Info& info) {
         size_t label_index{0};
         if (info.loads.AnyComponent(IR::Attribute::PositionX)) {
             AddLabel(labels[label_index]);
-            const Id pointer{is_array
-                                 ? OpAccessChain(input_f32, input_position, vertex, masked_index)
-                                 : OpAccessChain(input_f32, input_position, masked_index)};
+            const Id pointer{[&]() {
+                if (need_input_position_indirect) {
+                    if (is_array)
+                        return OpAccessChain(input_f32, input_position, vertex, u32_zero_value,
+                                             masked_index);
+                    else
+                        return OpAccessChain(input_f32, input_position, u32_zero_value,
+                                             masked_index);
+                }  else {
+                    if (is_array)
+                        return OpAccessChain(input_f32, input_position, vertex, masked_index);
+                    else
+                        return OpAccessChain(input_f32, input_position, masked_index);
+                }
+            }()};
             const Id result{OpLoad(F32[1], pointer)};
             OpReturnValue(result);
             ++label_index;
@@ -1367,12 +1379,24 @@ void EmitContext::DefineInputs(const IR::Program& program) {
         Decorate(layer, spv::Decoration::Flat);
     }
     if (loads.AnyComponent(IR::Attribute::PositionX)) {
-        const bool is_fragment{stage != Stage::Fragment};
-        const spv::BuiltIn built_in{is_fragment ? spv::BuiltIn::Position : spv::BuiltIn::FragCoord};
-        input_position = DefineInput(*this, F32[4], true, built_in);
-        if (profile.support_geometry_shader_passthrough) {
-            if (info.passthrough.AnyComponent(IR::Attribute::PositionX)) {
-                Decorate(input_position, spv::Decoration::PassthroughNV);
+        const bool is_fragment{stage == Stage::Fragment};
+        if (!is_fragment && profile.has_broken_spirv_position_input) {
+            need_input_position_indirect = true;
+
+            const Id input_position_struct = TypeStruct(F32[4]);
+            input_position = DefineInput(*this, input_position_struct, true);
+
+            MemberDecorate(input_position_struct, 0, spv::Decoration::BuiltIn,
+                           static_cast<unsigned>(spv::BuiltIn::Position));
+            Decorate(input_position_struct, spv::Decoration::Block);
+        } else {
+            const spv::BuiltIn built_in{is_fragment ? spv::BuiltIn::FragCoord : spv::BuiltIn::Position};
+            input_position = DefineInput(*this, F32[4], true, built_in);
+
+            if (profile.support_geometry_shader_passthrough) {
+                if (info.passthrough.AnyComponent(IR::Attribute::PositionX)) {
+                    Decorate(input_position, spv::Decoration::PassthroughNV);
+                }
             }
         }
     }

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -544,7 +544,7 @@ void EmitContext::DefineCommonTypes(const Info& info) {
         U16 = Name(TypeInt(16, false), "u16");
         S16 = Name(TypeInt(16, true), "s16");
     }
-    if (info.uses_int64) {
+    if (info.uses_int64 && profile.support_int64) {
         AddCapability(spv::Capability::Int64);
         U64 = Name(TypeInt(64, false), "u64");
     }

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -280,6 +280,7 @@ public:
     Id write_global_func_u32x2{};
     Id write_global_func_u32x4{};
 
+    bool need_input_position_indirect{};
     Id input_position{};
     std::array<Id, 32> input_generics{};
 

--- a/src/shader_recompiler/frontend/maxwell/translate_program.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate_program.cpp
@@ -171,6 +171,64 @@ std::map<IR::Attribute, IR::Attribute> GenerateLegacyToGenericMappings(
     }
     return mapping;
 }
+
+void EmitGeometryPassthrough(IR::IREmitter& ir, const IR::Program& program, const Shader::VaryingState &passthrough_mask, bool passthrough_position, std::optional<IR::Attribute> passthrough_layer_attr) {
+    for (u32 i = 0; i < program.output_vertices; i++) {
+        // Assign generics from input
+        for (u32 j = 0; j < 32; j++) {
+            if (!passthrough_mask.Generic(j)) {
+                continue;
+            }
+
+            const IR::Attribute attr = IR::Attribute::Generic0X + (j * 4);
+            ir.SetAttribute(attr + 0, ir.GetAttribute(attr + 0, ir.Imm32(i)), ir.Imm32(0));
+            ir.SetAttribute(attr + 1, ir.GetAttribute(attr + 1, ir.Imm32(i)), ir.Imm32(0));
+            ir.SetAttribute(attr + 2, ir.GetAttribute(attr + 2, ir.Imm32(i)), ir.Imm32(0));
+            ir.SetAttribute(attr + 3, ir.GetAttribute(attr + 3, ir.Imm32(i)), ir.Imm32(0));
+        }
+
+        if (passthrough_position) {
+            // Assign position from input
+            const IR::Attribute attr = IR::Attribute::PositionX;
+            ir.SetAttribute(attr + 0, ir.GetAttribute(attr + 0, ir.Imm32(i)), ir.Imm32(0));
+            ir.SetAttribute(attr + 1, ir.GetAttribute(attr + 1, ir.Imm32(i)), ir.Imm32(0));
+            ir.SetAttribute(attr + 2, ir.GetAttribute(attr + 2, ir.Imm32(i)), ir.Imm32(0));
+            ir.SetAttribute(attr + 3, ir.GetAttribute(attr + 3, ir.Imm32(i)), ir.Imm32(0));
+        }
+
+        if (passthrough_layer_attr) {
+            // Assign layer
+            ir.SetAttribute(IR::Attribute::Layer, ir.GetAttribute(*passthrough_layer_attr), ir.Imm32(0));
+        }
+
+        // Emit vertex
+        ir.EmitVertex(ir.Imm32(0));
+    }
+    ir.EndPrimitive(ir.Imm32(0));
+}
+
+u32 GetOutputTopologyVertices(OutputTopology output_topology) {
+    switch (output_topology) {
+        case OutputTopology::PointList:
+            return 1;
+        case OutputTopology::LineStrip:
+            return 2;
+        default:
+            return 3;
+    }
+}
+
+void LowerGeometryPassthrough(const IR::Program& program, const HostTranslateInfo& host_info) {
+    for (IR::Block *const block : program.blocks) {
+        for (IR::Inst &inst : block->Instructions()) {
+            if (inst.GetOpcode() == IR::Opcode::Epilogue) {
+                IR::IREmitter ir{*block, IR::Block::InstructionList::s_iterator_to(inst)};
+                EmitGeometryPassthrough(ir, program, program.info.passthrough, program.info.passthrough.AnyComponent(IR::Attribute::PositionX), {});
+            }
+        }
+    }
+}
+
 } // Anonymous namespace
 
 IR::Program TranslateProgram(ObjectPool<IR::Inst>& inst_pool, ObjectPool<IR::Block>& block_pool,
@@ -197,6 +255,11 @@ IR::Program TranslateProgram(ObjectPool<IR::Inst>& inst_pool, ObjectPool<IR::Blo
             const auto& mask{env.GpPassthroughMask()};
             for (size_t i = 0; i < program.info.passthrough.mask.size(); ++i) {
                 program.info.passthrough.mask[i] = ((mask[i / 32] >> (i % 32)) & 1) == 0;
+            }
+
+            if (!host_info.support_geometry_shader_passthrough) {
+                program.output_vertices = GetOutputTopologyVertices(program.output_topology);
+                LowerGeometryPassthrough(program, host_info);
             }
         }
         break;
@@ -342,17 +405,8 @@ IR::Program GenerateGeometryPassthrough(ObjectPool<IR::Inst>& inst_pool,
     IR::Program program;
     program.stage = Stage::Geometry;
     program.output_topology = output_topology;
-    switch (output_topology) {
-    case OutputTopology::PointList:
-        program.output_vertices = 1;
-        break;
-    case OutputTopology::LineStrip:
-        program.output_vertices = 2;
-        break;
-    default:
-        program.output_vertices = 3;
-        break;
-    }
+    program.output_vertices = GetOutputTopologyVertices(output_topology);
+
 
     program.is_geometry_passthrough = false;
     program.info.loads.mask = source_program.info.stores.mask;
@@ -366,35 +420,7 @@ IR::Program GenerateGeometryPassthrough(ObjectPool<IR::Inst>& inst_pool,
     node.data.block = current_block;
 
     IR::IREmitter ir{*current_block};
-    for (u32 i = 0; i < program.output_vertices; i++) {
-        // Assign generics from input
-        for (u32 j = 0; j < 32; j++) {
-            if (!program.info.stores.Generic(j)) {
-                continue;
-            }
-
-            const IR::Attribute attr = IR::Attribute::Generic0X + (j * 4);
-            ir.SetAttribute(attr + 0, ir.GetAttribute(attr + 0, ir.Imm32(i)), ir.Imm32(0));
-            ir.SetAttribute(attr + 1, ir.GetAttribute(attr + 1, ir.Imm32(i)), ir.Imm32(0));
-            ir.SetAttribute(attr + 2, ir.GetAttribute(attr + 2, ir.Imm32(i)), ir.Imm32(0));
-            ir.SetAttribute(attr + 3, ir.GetAttribute(attr + 3, ir.Imm32(i)), ir.Imm32(0));
-        }
-
-        // Assign position from input
-        const IR::Attribute attr = IR::Attribute::PositionX;
-        ir.SetAttribute(attr + 0, ir.GetAttribute(attr + 0, ir.Imm32(i)), ir.Imm32(0));
-        ir.SetAttribute(attr + 1, ir.GetAttribute(attr + 1, ir.Imm32(i)), ir.Imm32(0));
-        ir.SetAttribute(attr + 2, ir.GetAttribute(attr + 2, ir.Imm32(i)), ir.Imm32(0));
-        ir.SetAttribute(attr + 3, ir.GetAttribute(attr + 3, ir.Imm32(i)), ir.Imm32(0));
-
-        // Assign layer
-        ir.SetAttribute(IR::Attribute::Layer, ir.GetAttribute(source_program.info.emulated_layer),
-                        ir.Imm32(0));
-
-        // Emit vertex
-        ir.EmitVertex(ir.Imm32(0));
-    }
-    ir.EndPrimitive(ir.Imm32(0));
+    EmitGeometryPassthrough(ir, program, program.info.stores, true, source_program.info.emulated_layer);
 
     IR::Block* return_block{block_pool.Create(inst_pool)};
     IR::IREmitter{*return_block}.Epilogue();

--- a/src/shader_recompiler/frontend/maxwell/translate_program.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate_program.cpp
@@ -172,7 +172,10 @@ std::map<IR::Attribute, IR::Attribute> GenerateLegacyToGenericMappings(
     return mapping;
 }
 
-void EmitGeometryPassthrough(IR::IREmitter& ir, const IR::Program& program, const Shader::VaryingState &passthrough_mask, bool passthrough_position, std::optional<IR::Attribute> passthrough_layer_attr) {
+void EmitGeometryPassthrough(IR::IREmitter& ir, const IR::Program& program,
+                             const Shader::VaryingState& passthrough_mask,
+                             bool passthrough_position,
+                             std::optional<IR::Attribute> passthrough_layer_attr) {
     for (u32 i = 0; i < program.output_vertices; i++) {
         // Assign generics from input
         for (u32 j = 0; j < 32; j++) {
@@ -198,7 +201,8 @@ void EmitGeometryPassthrough(IR::IREmitter& ir, const IR::Program& program, cons
 
         if (passthrough_layer_attr) {
             // Assign layer
-            ir.SetAttribute(IR::Attribute::Layer, ir.GetAttribute(*passthrough_layer_attr), ir.Imm32(0));
+            ir.SetAttribute(IR::Attribute::Layer, ir.GetAttribute(*passthrough_layer_attr),
+                            ir.Imm32(0));
         }
 
         // Emit vertex
@@ -209,21 +213,23 @@ void EmitGeometryPassthrough(IR::IREmitter& ir, const IR::Program& program, cons
 
 u32 GetOutputTopologyVertices(OutputTopology output_topology) {
     switch (output_topology) {
-        case OutputTopology::PointList:
-            return 1;
-        case OutputTopology::LineStrip:
-            return 2;
-        default:
-            return 3;
+    case OutputTopology::PointList:
+        return 1;
+    case OutputTopology::LineStrip:
+        return 2;
+    default:
+        return 3;
     }
 }
 
 void LowerGeometryPassthrough(const IR::Program& program, const HostTranslateInfo& host_info) {
-    for (IR::Block *const block : program.blocks) {
-        for (IR::Inst &inst : block->Instructions()) {
+    for (IR::Block* const block : program.blocks) {
+        for (IR::Inst& inst : block->Instructions()) {
             if (inst.GetOpcode() == IR::Opcode::Epilogue) {
                 IR::IREmitter ir{*block, IR::Block::InstructionList::s_iterator_to(inst)};
-                EmitGeometryPassthrough(ir, program, program.info.passthrough, program.info.passthrough.AnyComponent(IR::Attribute::PositionX), {});
+                EmitGeometryPassthrough(
+                    ir, program, program.info.passthrough,
+                    program.info.passthrough.AnyComponent(IR::Attribute::PositionX), {});
             }
         }
     }
@@ -407,7 +413,6 @@ IR::Program GenerateGeometryPassthrough(ObjectPool<IR::Inst>& inst_pool,
     program.output_topology = output_topology;
     program.output_vertices = GetOutputTopologyVertices(output_topology);
 
-
     program.is_geometry_passthrough = false;
     program.info.loads.mask = source_program.info.stores.mask;
     program.info.stores.mask = source_program.info.stores.mask;
@@ -420,7 +425,8 @@ IR::Program GenerateGeometryPassthrough(ObjectPool<IR::Inst>& inst_pool,
     node.data.block = current_block;
 
     IR::IREmitter ir{*current_block};
-    EmitGeometryPassthrough(ir, program, program.info.stores, true, source_program.info.emulated_layer);
+    EmitGeometryPassthrough(ir, program, program.info.stores, true,
+                            source_program.info.emulated_layer);
 
     IR::Block* return_block{block_pool.Create(inst_pool)};
     IR::IREmitter{*return_block}.Epilogue();

--- a/src/shader_recompiler/frontend/maxwell/translate_program.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate_program.cpp
@@ -223,7 +223,7 @@ IR::Program TranslateProgram(ObjectPool<IR::Inst>& inst_pool, ObjectPool<IR::Blo
 
     Optimization::PositionPass(env, program);
 
-    Optimization::GlobalMemoryToStorageBufferPass(program);
+    Optimization::GlobalMemoryToStorageBufferPass(program, host_info);
     Optimization::TexturePass(env, program, host_info);
 
     if (Settings::values.resolution_info.active) {

--- a/src/shader_recompiler/host_translate_info.h
+++ b/src/shader_recompiler/host_translate_info.h
@@ -15,6 +15,7 @@ struct HostTranslateInfo {
     bool needs_demote_reorder{}; ///< True when the device needs DemoteToHelperInvocation reordered
     bool support_snorm_render_buffer{};  ///< True when the device supports SNORM render buffers
     bool support_viewport_index_layer{}; ///< True when the device supports gl_Layer in VS
+    u32 min_ssbo_alignment{};  ///< Minimum alignment supported by the device for SSBOs
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/host_translate_info.h
+++ b/src/shader_recompiler/host_translate_info.h
@@ -15,8 +15,9 @@ struct HostTranslateInfo {
     bool needs_demote_reorder{}; ///< True when the device needs DemoteToHelperInvocation reordered
     bool support_snorm_render_buffer{};  ///< True when the device supports SNORM render buffers
     bool support_viewport_index_layer{}; ///< True when the device supports gl_Layer in VS
-    u32 min_ssbo_alignment{};  ///< Minimum alignment supported by the device for SSBOs
-    bool support_geometry_shader_passthrough{}; ///< True when the device supports geometry passthrough shaders
+    u32 min_ssbo_alignment{};            ///< Minimum alignment supported by the device for SSBOs
+    bool support_geometry_shader_passthrough{}; ///< True when the device supports geometry
+                                                ///< passthrough shaders
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/host_translate_info.h
+++ b/src/shader_recompiler/host_translate_info.h
@@ -16,6 +16,7 @@ struct HostTranslateInfo {
     bool support_snorm_render_buffer{};  ///< True when the device supports SNORM render buffers
     bool support_viewport_index_layer{}; ///< True when the device supports gl_Layer in VS
     u32 min_ssbo_alignment{};  ///< Minimum alignment supported by the device for SSBOs
+    bool support_geometry_shader_passthrough{}; ///< True when the device supports geometry passthrough shaders
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/ir_opt/global_memory_to_storage_buffer_pass.cpp
+++ b/src/shader_recompiler/ir_opt/global_memory_to_storage_buffer_pass.cpp
@@ -538,7 +538,8 @@ void GlobalMemoryToStorageBufferPass(IR::Program& program, const HostTranslateIn
         const IR::U32 index{IR::Value{static_cast<u32>(info.set.index_of(it))}};
         IR::Block* const block{storage_inst.block};
         IR::Inst* const inst{storage_inst.inst};
-        const IR::U32 offset{StorageOffset(*block, *inst, storage_buffer, host_info.min_ssbo_alignment)};
+        const IR::U32 offset{
+            StorageOffset(*block, *inst, storage_buffer, host_info.min_ssbo_alignment)};
         Replace(*block, *inst, index, offset);
     }
 }

--- a/src/shader_recompiler/ir_opt/global_memory_to_storage_buffer_pass.cpp
+++ b/src/shader_recompiler/ir_opt/global_memory_to_storage_buffer_pass.cpp
@@ -11,6 +11,7 @@
 #include "shader_recompiler/frontend/ir/breadth_first_search.h"
 #include "shader_recompiler/frontend/ir/ir_emitter.h"
 #include "shader_recompiler/frontend/ir/value.h"
+#include "shader_recompiler/host_translate_info.h"
 #include "shader_recompiler/ir_opt/passes.h"
 
 namespace Shader::Optimization {
@@ -402,7 +403,7 @@ void CollectStorageBuffers(IR::Block& block, IR::Inst& inst, StorageInfo& info) 
 }
 
 /// Returns the offset in indices (not bytes) for an equivalent storage instruction
-IR::U32 StorageOffset(IR::Block& block, IR::Inst& inst, StorageBufferAddr buffer) {
+IR::U32 StorageOffset(IR::Block& block, IR::Inst& inst, StorageBufferAddr buffer, u32 alignment) {
     IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
     IR::U32 offset;
     if (const std::optional<LowAddrInfo> low_addr{TrackLowAddress(&inst)}) {
@@ -415,7 +416,10 @@ IR::U32 StorageOffset(IR::Block& block, IR::Inst& inst, StorageBufferAddr buffer
     }
     // Subtract the least significant 32 bits from the guest offset. The result is the storage
     // buffer offset in bytes.
-    const IR::U32 low_cbuf{ir.GetCbuf(ir.Imm32(buffer.index), ir.Imm32(buffer.offset))};
+    IR::U32 low_cbuf{ir.GetCbuf(ir.Imm32(buffer.index), ir.Imm32(buffer.offset))};
+
+    // Align the offset base to match the host alignment requirements
+    low_cbuf = ir.BitwiseAnd(low_cbuf, ir.Imm32(~(alignment - 1U)));
     return ir.ISub(offset, low_cbuf);
 }
 
@@ -510,7 +514,7 @@ void Replace(IR::Block& block, IR::Inst& inst, const IR::U32& storage_index,
 }
 } // Anonymous namespace
 
-void GlobalMemoryToStorageBufferPass(IR::Program& program) {
+void GlobalMemoryToStorageBufferPass(IR::Program& program, const HostTranslateInfo& host_info) {
     StorageInfo info;
     for (IR::Block* const block : program.post_order_blocks) {
         for (IR::Inst& inst : block->Instructions()) {
@@ -534,7 +538,7 @@ void GlobalMemoryToStorageBufferPass(IR::Program& program) {
         const IR::U32 index{IR::Value{static_cast<u32>(info.set.index_of(it))}};
         IR::Block* const block{storage_inst.block};
         IR::Inst* const inst{storage_inst.inst};
-        const IR::U32 offset{StorageOffset(*block, *inst, storage_buffer)};
+        const IR::U32 offset{StorageOffset(*block, *inst, storage_buffer, host_info.min_ssbo_alignment)};
         Replace(*block, *inst, index, offset);
     }
 }

--- a/src/shader_recompiler/ir_opt/passes.h
+++ b/src/shader_recompiler/ir_opt/passes.h
@@ -15,7 +15,7 @@ namespace Shader::Optimization {
 void CollectShaderInfoPass(Environment& env, IR::Program& program);
 void ConstantPropagationPass(Environment& env, IR::Program& program);
 void DeadCodeEliminationPass(IR::Program& program);
-void GlobalMemoryToStorageBufferPass(IR::Program& program);
+void GlobalMemoryToStorageBufferPass(IR::Program& program, const HostTranslateInfo& host_info);
 void IdentityRemovalPass(IR::Program& program);
 void LowerFp16ToFp32(IR::Program& program);
 void LowerInt64ToInt32(IR::Program& program);

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -55,6 +55,8 @@ struct Profile {
 
     /// OpFClamp is broken and OpFMax + OpFMin should be used instead
     bool has_broken_spirv_clamp{};
+    /// The Position builtin needs to be wrapped in a struct when used as an input
+    bool has_broken_spirv_position_input{};
     /// Offset image operands with an unsigned type do not work
     bool has_broken_unsigned_image_offsets{};
     /// Signed instructions with unsigned data types are misinterpreted

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -65,6 +65,8 @@ enum class Interpolation {
 struct ConstantBufferDescriptor {
     u32 index;
     u32 count;
+
+    auto operator<=>(const ConstantBufferDescriptor&) const = default;
 };
 
 struct StorageBufferDescriptor {
@@ -72,6 +74,8 @@ struct StorageBufferDescriptor {
     u32 cbuf_offset;
     u32 count;
     bool is_written;
+
+    auto operator<=>(const StorageBufferDescriptor&) const = default;
 };
 
 struct TextureBufferDescriptor {
@@ -84,6 +88,8 @@ struct TextureBufferDescriptor {
     u32 secondary_shift_left;
     u32 count;
     u32 size_shift;
+
+    auto operator<=>(const TextureBufferDescriptor&) const = default;
 };
 using TextureBufferDescriptors = boost::container::small_vector<TextureBufferDescriptor, 6>;
 
@@ -95,6 +101,8 @@ struct ImageBufferDescriptor {
     u32 cbuf_offset;
     u32 count;
     u32 size_shift;
+
+    auto operator<=>(const ImageBufferDescriptor&) const = default;
 };
 using ImageBufferDescriptors = boost::container::small_vector<ImageBufferDescriptor, 2>;
 
@@ -110,6 +118,8 @@ struct TextureDescriptor {
     u32 secondary_shift_left;
     u32 count;
     u32 size_shift;
+
+    auto operator<=>(const TextureDescriptor&) const = default;
 };
 using TextureDescriptors = boost::container::small_vector<TextureDescriptor, 12>;
 
@@ -122,6 +132,8 @@ struct ImageDescriptor {
     u32 cbuf_offset;
     u32 count;
     u32 size_shift;
+
+    auto operator<=>(const ImageDescriptor&) const = default;
 };
 using ImageDescriptors = boost::container::small_vector<ImageDescriptor, 4>;
 

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1941,7 +1941,8 @@ typename BufferCache<P>::Binding BufferCache<P>::StorageBufferBinding(GPUVAddr s
     const u32 alignment = runtime.GetStorageBufferAlignment();
 
     const GPUVAddr aligned_gpu_addr = Common::AlignDown(gpu_addr, alignment);
-    const u32 aligned_size = Common::AlignUp(static_cast<u32>(gpu_addr - aligned_gpu_addr) + size, alignment);
+    const u32 aligned_size =
+        Common::AlignUp(static_cast<u32>(gpu_addr - aligned_gpu_addr) + size, alignment);
 
     const std::optional<VAddr> cpu_addr = gpu_memory->GpuToCpuAddress(aligned_gpu_addr);
     if (!cpu_addr || size == 0) {

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1938,14 +1938,20 @@ typename BufferCache<P>::Binding BufferCache<P>::StorageBufferBinding(GPUVAddr s
                                                                       bool is_written) const {
     const GPUVAddr gpu_addr = gpu_memory->Read<u64>(ssbo_addr);
     const u32 size = gpu_memory->Read<u32>(ssbo_addr + 8);
-    const std::optional<VAddr> cpu_addr = gpu_memory->GpuToCpuAddress(gpu_addr);
+    const u32 alignment = runtime.GetStorageBufferAlignment();
+
+    const GPUVAddr aligned_gpu_addr = Common::AlignDown(gpu_addr, alignment);
+    const u32 aligned_size = Common::AlignUp(static_cast<u32>(gpu_addr - aligned_gpu_addr) + size, alignment);
+
+    const std::optional<VAddr> cpu_addr = gpu_memory->GpuToCpuAddress(aligned_gpu_addr);
     if (!cpu_addr || size == 0) {
         return NULL_BINDING;
     }
-    const VAddr cpu_end = Common::AlignUp(*cpu_addr + size, Core::Memory::YUZU_PAGESIZE);
+
+    const VAddr cpu_end = Common::AlignUp(*cpu_addr + aligned_size, Core::Memory::YUZU_PAGESIZE);
     const Binding binding{
         .cpu_addr = *cpu_addr,
-        .size = is_written ? size : static_cast<u32>(cpu_end - *cpu_addr),
+        .size = is_written ? aligned_size : static_cast<u32>(cpu_end - *cpu_addr),
         .buffer_id = BufferId{},
     };
     return binding;

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -160,6 +160,10 @@ public:
         return device.CanReportMemoryUsage();
     }
 
+    u32 GetStorageBufferAlignment() const {
+        return static_cast<u32>(device.GetShaderStorageBufferAlignment());
+    }
+
 private:
     static constexpr std::array PABO_LUT{
         GL_VERTEX_PROGRAM_PARAMETER_BUFFER_NV,          GL_TESS_CONTROL_PROGRAM_PARAMETER_BUFFER_NV,

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -237,6 +237,7 @@ ShaderCache::ShaderCache(RasterizerOpenGL& rasterizer_, Core::Frontend::EmuWindo
           .support_snorm_render_buffer = false,
           .support_viewport_index_layer = device.HasVertexViewportLayer(),
           .min_ssbo_alignment = static_cast<u32>(device.GetShaderStorageBufferAlignment()),
+          .support_geometry_shader_passthrough = device.HasGeometryShaderPassthrough(),
       } {
     if (use_asynchronous_shaders) {
         workers = CreateWorkers();

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -236,6 +236,7 @@ ShaderCache::ShaderCache(RasterizerOpenGL& rasterizer_, Core::Frontend::EmuWindo
           .needs_demote_reorder = device.IsAmd(),
           .support_snorm_render_buffer = false,
           .support_viewport_index_layer = device.HasVertexViewportLayer(),
+          .min_ssbo_alignment = static_cast<u32>(device.GetShaderStorageBufferAlignment()),
       } {
     if (use_asynchronous_shaders) {
         workers = CreateWorkers();

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -330,6 +330,10 @@ bool BufferCacheRuntime::CanReportMemoryUsage() const {
     return device.CanReportMemoryUsage();
 }
 
+u32 BufferCacheRuntime::GetStorageBufferAlignment() const {
+    return static_cast<u32>(device.GetStorageBufferAlignment());
+}
+
 void BufferCacheRuntime::Finish() {
     scheduler.Finish();
 }

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -73,6 +73,8 @@ public:
 
     bool CanReportMemoryUsage() const;
 
+    u32 GetStorageBufferAlignment() const;
+
     [[nodiscard]] StagingBufferRef UploadStagingBuffer(size_t size);
 
     [[nodiscard]] StagingBufferRef DownloadStagingBuffer(size_t size);

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -345,6 +345,7 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .support_snorm_render_buffer = true,
         .support_viewport_index_layer = device.IsExtShaderViewportIndexLayerSupported(),
         .min_ssbo_alignment = static_cast<u32>(device.GetStorageBufferAlignment()),
+        .support_geometry_shader_passthrough = device.IsNvGeometryShaderPassthroughSupported(),
     };
 
     if (device.GetMaxVertexInputAttributes() < Maxwell::NumVertexAttributes) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -344,6 +344,7 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
             driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE,
         .support_snorm_render_buffer = true,
         .support_viewport_index_layer = device.IsExtShaderViewportIndexLayerSupported(),
+        .min_ssbo_alignment = static_cast<u32>(device.GetStorageBufferAlignment()),
     };
 
     if (device.GetMaxVertexInputAttributes() < Maxwell::NumVertexAttributes) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -331,6 +331,7 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .need_declared_frag_colors = false,
 
         .has_broken_spirv_clamp = driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS,
+        .has_broken_spirv_position_input = driver_id == VK_DRIVER_ID_QUALCOMM_PROPRIETARY,
         .has_broken_unsigned_image_offsets = false,
         .has_broken_signed_operations = false,
         .has_broken_fp16_float_controls = driver_id == VK_DRIVER_ID_NVIDIA_PROPRIETARY,


### PR DESCRIPTION
PRing this mainly for geometry passthrough emulation, which should fix nier, MUA3 and #9351 on AMD/Intel GPUs. I've also included an SSBO alignment change which might fix some games using on intel iGPUs and a change that alters the behaviour of `ShuffleUp`  but that needs further HW testing. (NV docs are contradictory)