### PR TITLE
cmake: improve find_package failure messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,42 +207,43 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 # System imported libraries
 # =======================================================================
 
-find_package(enet 1.3)
+# Enforce the search mode of non-required packages for better and shorter failure messages
+find_package(enet 1.3 MODULE)
 find_package(fmt 9 REQUIRED)
-find_package(inih)
+find_package(inih MODULE)
 find_package(lz4 REQUIRED)
 find_package(nlohmann_json 3.8 REQUIRED)
-find_package(Opus 1.3)
+find_package(Opus 1.3 MODULE)
 find_package(ZLIB 1.2 REQUIRED)
 find_package(zstd 1.5 REQUIRED)
 
 if (NOT YUZU_USE_EXTERNAL_VULKAN_HEADERS)
-    find_package(Vulkan 1.3.238)
+    find_package(Vulkan 1.3.238 REQUIRED)
 endif()
 
 if (ENABLE_LIBUSB)
-    find_package(libusb 1.0.24)
+    find_package(libusb 1.0.24 MODULE)
 endif()
 
 if (ARCHITECTURE_x86 OR ARCHITECTURE_x86_64)
-    find_package(xbyak 6 QUIET)
+    find_package(xbyak 6 CONFIG)
 endif()
 
 if (ARCHITECTURE_x86_64 OR ARCHITECTURE_arm64)
-    find_package(dynarmic 6.4.0 QUIET)
+    find_package(dynarmic 6.4.0 CONFIG)
 endif()
 
 if (ENABLE_CUBEB)
-    find_package(cubeb QUIET)
+    find_package(cubeb CONFIG)
 endif()
 
 if (USE_DISCORD_PRESENCE)
-    find_package(DiscordRPC QUIET)
+    find_package(DiscordRPC MODULE)
 endif()
 
 if (ENABLE_WEB_SERVICE)
-    find_package(cpp-jwt 1.4 QUIET)
-    find_package(httplib 0.11 QUIET)
+    find_package(cpp-jwt 1.4 CONFIG)
+    find_package(httplib 0.11 MODULE)
 endif()
 
 if (YUZU_TESTS)

--- a/externals/find-modules/Findhttplib.cmake
+++ b/externals/find-modules/Findhttplib.cmake
@@ -5,7 +5,7 @@
 include(FindPackageHandleStandardArgs)
 
 find_package(httplib QUIET CONFIG)
-if (httplib_FOUND)
+if (httplib_CONSIDERED_CONFIGS)
     find_package_handle_standard_args(httplib CONFIG_MODE)
 else()
     find_package(PkgConfig QUIET)

--- a/externals/find-modules/Findlz4.cmake
+++ b/externals/find-modules/Findlz4.cmake
@@ -4,7 +4,7 @@
 include(FindPackageHandleStandardArgs)
 
 find_package(lz4 QUIET CONFIG)
-if (lz4_FOUND)
+if (lz4_CONSIDERED_CONFIGS)
     find_package_handle_standard_args(lz4 CONFIG_MODE)
 else()
     find_package(PkgConfig QUIET)

--- a/externals/find-modules/Findzstd.cmake
+++ b/externals/find-modules/Findzstd.cmake
@@ -4,7 +4,7 @@
 include(FindPackageHandleStandardArgs)
 
 find_package(zstd QUIET CONFIG)
-if (zstd_FOUND)
+if (zstd_CONSIDERED_CONFIGS)
     find_package_handle_standard_args(zstd CONFIG_MODE)
 else()
     find_package(PkgConfig QUIET)


### PR DESCRIPTION
Make failure messages less scary as discussed in https://github.com/yuzu-emu/yuzu/pull/9515.

Also don't try to find a library via `pkg-config` when a CMake config file with unsuitable version has already been found. The `pkg-config` will fail too and it makes the message better.