### PR TITLE
TAS: Record sanitized instead of raw stick inputs

### DIFF
--- a/src/yuzu/debugger/controller.cpp
+++ b/src/yuzu/debugger/controller.cpp
@@ -93,7 +93,7 @@ void ControllerDialog::ControllerUpdate(Core::HID::ControllerTriggerType type) {
     case Core::HID::ControllerTriggerType::Button:
     case Core::HID::ControllerTriggerType::Stick: {
         const auto buttons_values = controller->GetButtonsValues();
-        const auto stick_values = controller->GetSticksValues();
+        const auto stick_values = controller->GetSticks();
         u64 buttons = 0;
         std::size_t index = 0;
         for (const auto& button : buttons_values) {
@@ -101,12 +101,12 @@ void ControllerDialog::ControllerUpdate(Core::HID::ControllerTriggerType type) {
             index++;
         }
         const InputCommon::TasInput::TasAnalog left_axis = {
-            .x = stick_values[Settings::NativeAnalog::LStick].x.value,
-            .y = stick_values[Settings::NativeAnalog::LStick].y.value,
+            .x = stick_values.left.x / 32767.f,
+            .y = stick_values.left.y / 32767.f,
         };
         const InputCommon::TasInput::TasAnalog right_axis = {
-            .x = stick_values[Settings::NativeAnalog::RStick].x.value,
-            .y = stick_values[Settings::NativeAnalog::RStick].y.value,
+            .x = stick_values.right.x / 32767.f,
+            .y = stick_values.right.y / 32767.f,
         };
         input_subsystem->GetTas()->RecordInput(buttons, left_axis, right_axis);
         break;


### PR DESCRIPTION
Co-Authored-By: Narr the Reg <5944268+german77@users.noreply.github.com>

This will make sure that the sanitized (deadzone/range-adjusted) stick input will be written to the file instead of the raw inputs, as the playback will not run the sanitization again. This means that the file will contain all the stick values that are actually received by the game instead of the ones issued by the user, making sure that playback also syncs with different playback methods.