### PR TITLE
tests: update catch2 to 3.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,14 @@
 
 cmake_minimum_required(VERSION 3.22)
 
+project(yuzu)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modules")
+
 include(DownloadExternals)
 include(CMakeDependentOption)
-
-project(yuzu)
+include(CTest)
 
 # Set bundled sdl2/qt as dependent options.
 # OFF by default, but if ENABLE_SDL2 and MSVC are true then ON
@@ -42,7 +44,7 @@ option(ENABLE_CUBEB "Enables the cubeb audio backend" ON)
 
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence" OFF)
 
-option(YUZU_TESTS "Compile tests" ON)
+option(YUZU_TESTS "Compile tests" "${BUILD_TESTING}")
 
 option(YUZU_USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 
@@ -606,7 +608,6 @@ if (YUZU_USE_FASTER_LD AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-enable_testing()
 add_subdirectory(externals)
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ if (ENABLE_WEB_SERVICE)
 endif()
 
 if (YUZU_TESTS)
-    find_package(Catch2 2.13.7 REQUIRED)
+    find_package(Catch2 3.0.1 REQUIRED)
 endif()
 
 find_package(Boost 1.73.0 COMPONENTS context)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -5,6 +5,9 @@
 # some of its variables, which is only possible in 3.13+
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
+# Disable tests in all externals supporting the standard option name
+set(BUILD_TESTING OFF)
+
 # xbyak
 if ((ARCHITECTURE_x86 OR ARCHITECTURE_x86_64) AND NOT TARGET xbyak::xbyak)
     add_subdirectory(xbyak EXCLUDE_FROM_ALL)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable(tests
     core/core_timing.cpp
     core/internal_network/network.cpp
     precompiled_headers.h
-    tests.cpp
     video_core/buffer_base.cpp
     input_common/calibration_configuration_job.cpp
 )
@@ -22,7 +21,7 @@ add_executable(tests
 create_target_directory_groups(tests)
 
 target_link_libraries(tests PRIVATE common core input_common)
-target_link_libraries(tests PRIVATE ${PLATFORM_LIBRARIES} Catch2::Catch2 Threads::Threads)
+target_link_libraries(tests PRIVATE ${PLATFORM_LIBRARIES} Catch2::Catch2WithMain Threads::Threads)
 
 add_test(NAME tests COMMAND tests)
 

--- a/src/tests/common/bit_field.cpp
+++ b/src/tests/common/bit_field.cpp
@@ -4,7 +4,7 @@
 #include <array>
 #include <cstring>
 #include <type_traits>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include "common/bit_field.h"
 
 TEST_CASE("BitField", "[common]") {

--- a/src/tests/common/cityhash.cpp
+++ b/src/tests/common/cityhash.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2021 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "common/cityhash.h"
 

--- a/src/tests/common/fibers.cpp
+++ b/src/tests/common/fibers.cpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "common/common_types.h"
 #include "common/fiber.h"

--- a/src/tests/common/host_memory.cpp
+++ b/src/tests/common/host_memory.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2021 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "common/host_memory.h"
 #include "common/literals.h"

--- a/src/tests/common/param_package.cpp
+++ b/src/tests/common/param_package.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2017 Citra Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <math.h>
 #include "common/logging/backend.h"
 #include "common/param_package.h"

--- a/src/tests/common/range_map.cpp
+++ b/src/tests/common/range_map.cpp
@@ -3,7 +3,7 @@
 
 #include <stdexcept>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "common/range_map.h"
 

--- a/src/tests/common/ring_buffer.cpp
+++ b/src/tests/common/ring_buffer.cpp
@@ -7,7 +7,7 @@
 #include <numeric>
 #include <thread>
 #include <vector>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include "common/ring_buffer.h"
 
 namespace Common {

--- a/src/tests/common/scratch_buffer.cpp
+++ b/src/tests/common/scratch_buffer.cpp
@@ -5,7 +5,7 @@
 #include <array>
 #include <cstring>
 #include <span>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include "common/common_types.h"
 #include "common/scratch_buffer.h"
 

--- a/src/tests/common/unique_function.cpp
+++ b/src/tests/common/unique_function.cpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "common/unique_function.h"
 

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2016 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <array>
 #include <bitset>

--- a/src/tests/core/internal_network/network.cpp
+++ b/src/tests/core/internal_network/network.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2021 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "core/internal_network/network.h"
 #include "core/internal_network/sockets.h"

--- a/src/tests/input_common/calibration_configuration_job.cpp
+++ b/src/tests/input_common/calibration_configuration_job.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 #include <boost/asio.hpp>
 #include <boost/crc.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "input_common/drivers/udp_client.h"
 #include "input_common/helpers/udp_protocol.h"

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -1,8 +1,0 @@
-// SPDX-FileCopyrightText: 2016 Citra Emulator Project
-// SPDX-License-Identifier: GPL-2.0-or-later
-
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
-// Catch provides the main function since we've given it the
-// CATCH_CONFIG_MAIN preprocessor directive.

--- a/src/tests/video_core/buffer_base.cpp
+++ b/src/tests/video_core/buffer_base.cpp
@@ -4,7 +4,7 @@
 #include <stdexcept>
 #include <unordered_map>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "common/alignment.h"
 #include "common/common_types.h"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -40,7 +40,7 @@
     "overrides": [
         {
             "name": "catch2",
-            "version": "2.13.9"
+            "version": "3.0.1"
         },
         {
             "name": "fmt",


### PR DESCRIPTION
Also support the standard `BUILD_TESTING` option (created by the `CTest` module) and force disable tests in externals supporting the same option.