### PR TITLE
TAS: Show all script lengths for multiplayer

### DIFF
--- a/src/input_common/drivers/tas_input.cpp
+++ b/src/input_common/drivers/tas_input.cpp
@@ -156,10 +156,12 @@ void Tas::RecordInput(u64 buttons, TasAnalog left_axis, TasAnalog right_axis) {
     };
 }
 
-std::tuple<TasState, size_t, size_t> Tas::GetStatus() const {
+std::tuple<TasState, size_t, std::array<size_t, PLAYER_NUMBER>> Tas::GetStatus() const {
     TasState state;
+    std::array<size_t, PLAYER_NUMBER> lengths{0};
     if (is_recording) {
-        return {TasState::Recording, 0, record_commands.size()};
+        lengths[0] = record_commands.size();
+        return {TasState::Recording, record_commands.size(), lengths};
     }
 
     if (is_running) {
@@ -168,7 +170,11 @@ std::tuple<TasState, size_t, size_t> Tas::GetStatus() const {
         state = TasState::Stopped;
     }
 
-    return {state, current_command, script_length};
+    for (size_t i = 0; i < PLAYER_NUMBER; i++) {
+        lengths[i] = commands[i].size();
+    }
+
+    return {state, current_command, lengths};
 }
 
 void Tas::UpdateThread() {

--- a/src/input_common/drivers/tas_input.h
+++ b/src/input_common/drivers/tas_input.h
@@ -124,7 +124,7 @@ public:
      * Current playback progress ;
      * Total length of script file currently loaded or being recorded
      */
-    std::tuple<TasState, size_t, size_t> GetStatus() const;
+    std::tuple<TasState, size_t, std::array<size_t, PLAYER_NUMBER>> GetStatus() const;
 
 private:
     enum class TasAxis : u8;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3726,15 +3726,36 @@ void GMainWindow::UpdateWindowTitle(std::string_view title_name, std::string_vie
     }
 }
 
+std::string GMainWindow::CreateTASFramesString(
+    std::array<size_t, InputCommon::TasInput::PLAYER_NUMBER> frames) const {
+    std::string string = "";
+    size_t maxPlayerIndex = 0;
+    for (size_t i = 0; i < frames.size(); i++) {
+        if (frames[i] != 0) {
+            if (maxPlayerIndex != 0)
+                string += ", ";
+            while (maxPlayerIndex++ != i)
+                string += "0, ";
+            string += std::to_string(frames[i]);
+        }
+    }
+    return string;
+}
+
 QString GMainWindow::GetTasStateDescription() const {
     auto [tas_status, current_tas_frame, total_tas_frames] = input_subsystem->GetTas()->GetStatus();
+    std::string tas_frames_string = CreateTASFramesString(total_tas_frames);
     switch (tas_status) {
     case InputCommon::TasInput::TasState::Running:
-        return tr("TAS state: Running %1/%2").arg(current_tas_frame).arg(total_tas_frames);
+        return tr("TAS state: Running %1/%2")
+            .arg(current_tas_frame)
+            .arg(QString::fromStdString(tas_frames_string));
     case InputCommon::TasInput::TasState::Recording:
-        return tr("TAS state: Recording %1").arg(total_tas_frames);
+        return tr("TAS state: Recording %1").arg(total_tas_frames[0]);
     case InputCommon::TasInput::TasState::Stopped:
-        return tr("TAS state: Idle %1/%2").arg(current_tas_frame).arg(total_tas_frames);
+        return tr("TAS state: Idle %1/%2")
+            .arg(current_tas_frame)
+            .arg(QString::fromStdString(tas_frames_string));
     default:
         return tr("TAS State: Invalid");
     }

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -12,6 +12,7 @@
 
 #include "common/announce_multiplayer_room.h"
 #include "common/common_types.h"
+#include "input_common/drivers/tas_input.h"
 #include "yuzu/compatibility_list.h"
 #include "yuzu/hotkeys.h"
 
@@ -265,6 +266,9 @@ private:
     void RequestGameResume();
     void changeEvent(QEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
+
+    std::string CreateTASFramesString(
+        std::array<size_t, InputCommon::TasInput::PLAYER_NUMBER> frames) const;
 
 #ifdef __unix__
     void SetupSigInterrupts();


### PR DESCRIPTION
When multiple scripts are loaded for multiple controllers at the same time, the progress display in the toolbar of Yuzu should reflect the length of all files, if they have individually different lengths. Example: `TAS state: Running 35/100, 20, 0, 40`.

Non-existant files are assumed to be 0 frames long, if none of the following files contain any data, it won't display them. Example: `TAS state: Idle 0/30`, if only the first file contains a script for 30 frames.