### PR TITLE
video_core/vulkan: Fixed loading of Vulkan driver pipeline cache

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -793,7 +793,8 @@ vk::PipelineCache PipelineCache::LoadVulkanPipelineCache(const std::filesystem::
             return create_pipeline_cache(0, nullptr);
         }
 
-        const size_t cache_size = static_cast<size_t>(end) - magic_number.size();
+        static constexpr size_t header_size = magic_number.size() + sizeof(cache_version);
+        const size_t cache_size = static_cast<size_t>(end) - header_size;
         std::vector<char> cache_data(cache_size);
         file.read(cache_data.data(), cache_size);
 


### PR DESCRIPTION
The header size of the Vulkan driver pipeline cache files was incorrect in `PipelineCache::LoadVulkanPipelineCache`, for which reason the pipeline cache wasn't read correctly and got invalidated on each load. I forgot to adjust it when adding the cache version to the file header. Sorry for that guys!