### PR TITLE
qt: additional fixes for reentrant shutdown

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1839,9 +1839,11 @@ void GMainWindow::OnEmulationStopTimeExpired() {
 
 void GMainWindow::OnEmulationStopped() {
     shutdown_timer.stop();
-    emu_thread->disconnect();
-    emu_thread->wait();
-    emu_thread = nullptr;
+    if (emu_thread) {
+        emu_thread->disconnect();
+        emu_thread->wait();
+        emu_thread.reset();
+    }
 
     if (shutdown_dialog) {
         shutdown_dialog->deleteLater();
@@ -3029,6 +3031,8 @@ void GMainWindow::OnStopGame() {
 
     if (OnShutdownBegin()) {
         OnShutdownBeginDialog();
+    } else {
+        OnEmulationStopped();
     }
 }
 


### PR DESCRIPTION
Fixes more crashes in games that are able to close themselves in response to a request for shutdown.