### PR TITLE
renderer_vulkan: disable clock boost on unvalidated devices

### DIFF
--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -110,7 +110,7 @@ RendererVulkan::RendererVulkan(Core::TelemetrySession& telemetry_session_,
                   screen_info),
       rasterizer(render_window, gpu, cpu_memory, screen_info, device, memory_allocator,
                  state_tracker, scheduler) {
-    if (Settings::values.renderer_force_max_clock.GetValue()) {
+    if (Settings::values.renderer_force_max_clock.GetValue() && device.ShouldBoostClocks()) {
         turbo_mode.emplace(instance, dld);
     }
     Report();

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -991,6 +991,18 @@ std::string Device::GetDriverName() const {
     }
 }
 
+bool Device::ShouldBoostClocks() const {
+    const bool validated_driver =
+        driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE ||
+        driver_id == VK_DRIVER_ID_MESA_RADV || driver_id == VK_DRIVER_ID_NVIDIA_PROPRIETARY ||
+        driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS ||
+        driver_id == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA;
+
+    const bool is_steam_deck = properties.vendorID == 0x1002 && properties.deviceID == 0x163F;
+
+    return validated_driver && !is_steam_deck;
+}
+
 static std::vector<const char*> ExtensionsRequiredForInstanceVersion(u32 available_version) {
     std::vector<const char*> extensions{REQUIRED_EXTENSIONS.begin(), REQUIRED_EXTENSIONS.end()};
 

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -106,6 +106,8 @@ public:
         return driver_id;
     }
 
+    bool ShouldBoostClocks() const;
+
     /// Returns uniform buffer alignment requeriment.
     VkDeviceSize GetUniformBufferAlignment() const {
         return properties.limits.minUniformBufferOffsetAlignment;


### PR DESCRIPTION
Steam Deck is reported to be broken with this setting, so prevent it from taking effect there.