### PR TITLE
vulkan_device: avoid attempt to access empty optional

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1520,8 +1520,12 @@ void Device::SetupFamilies(VkSurfaceKHR surface) {
         LOG_ERROR(Render_Vulkan, "Device lacks a present queue");
         throw vk::Exception(VK_ERROR_FEATURE_NOT_PRESENT);
     }
-    graphics_family = *graphics;
-    present_family = *present;
+    if (graphics) {
+        graphics_family = *graphics;
+    }
+    if (present) {
+        present_family = *present;
+    }
 }
 
 void Device::SetupFeatures() {


### PR DESCRIPTION
Fixes the second issue described in #9560