### PR TITLE
Revert "shader_recompiler: Align SSBO offsets to meet host requirements"

### DIFF
--- a/src/shader_recompiler/frontend/maxwell/translate_program.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate_program.cpp
@@ -292,7 +292,7 @@ IR::Program TranslateProgram(ObjectPool<IR::Inst>& inst_pool, ObjectPool<IR::Blo
 
     Optimization::PositionPass(env, program);
 
-    Optimization::GlobalMemoryToStorageBufferPass(program, host_info);
+    Optimization::GlobalMemoryToStorageBufferPass(program);
     Optimization::TexturePass(env, program, host_info);
 
     if (Settings::values.resolution_info.active) {

--- a/src/shader_recompiler/host_translate_info.h
+++ b/src/shader_recompiler/host_translate_info.h
@@ -15,7 +15,6 @@ struct HostTranslateInfo {
     bool needs_demote_reorder{}; ///< True when the device needs DemoteToHelperInvocation reordered
     bool support_snorm_render_buffer{};  ///< True when the device supports SNORM render buffers
     bool support_viewport_index_layer{}; ///< True when the device supports gl_Layer in VS
-    u32 min_ssbo_alignment{};            ///< Minimum alignment supported by the device for SSBOs
     bool support_geometry_shader_passthrough{}; ///< True when the device supports geometry
                                                 ///< passthrough shaders
 };

--- a/src/shader_recompiler/ir_opt/passes.h
+++ b/src/shader_recompiler/ir_opt/passes.h
@@ -15,7 +15,7 @@ namespace Shader::Optimization {
 void CollectShaderInfoPass(Environment& env, IR::Program& program);
 void ConstantPropagationPass(Environment& env, IR::Program& program);
 void DeadCodeEliminationPass(IR::Program& program);
-void GlobalMemoryToStorageBufferPass(IR::Program& program, const HostTranslateInfo& host_info);
+void GlobalMemoryToStorageBufferPass(IR::Program& program);
 void IdentityRemovalPass(IR::Program& program);
 void LowerFp16ToFp32(IR::Program& program);
 void LowerInt64ToInt32(IR::Program& program);

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1938,21 +1938,14 @@ typename BufferCache<P>::Binding BufferCache<P>::StorageBufferBinding(GPUVAddr s
                                                                       bool is_written) const {
     const GPUVAddr gpu_addr = gpu_memory->Read<u64>(ssbo_addr);
     const u32 size = gpu_memory->Read<u32>(ssbo_addr + 8);
-    const u32 alignment = runtime.GetStorageBufferAlignment();
-
-    const GPUVAddr aligned_gpu_addr = Common::AlignDown(gpu_addr, alignment);
-    const u32 aligned_size =
-        Common::AlignUp(static_cast<u32>(gpu_addr - aligned_gpu_addr) + size, alignment);
-
-    const std::optional<VAddr> cpu_addr = gpu_memory->GpuToCpuAddress(aligned_gpu_addr);
+    const std::optional<VAddr> cpu_addr = gpu_memory->GpuToCpuAddress(gpu_addr);
     if (!cpu_addr || size == 0) {
         return NULL_BINDING;
     }
-
-    const VAddr cpu_end = Common::AlignUp(*cpu_addr + aligned_size, Core::Memory::YUZU_PAGESIZE);
+    const VAddr cpu_end = Common::AlignUp(*cpu_addr + size, Core::Memory::YUZU_PAGESIZE);
     const Binding binding{
         .cpu_addr = *cpu_addr,
-        .size = is_written ? aligned_size : static_cast<u32>(cpu_end - *cpu_addr),
+        .size = is_written ? size : static_cast<u32>(cpu_end - *cpu_addr),
         .buffer_id = BufferId{},
     };
     return binding;

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -160,10 +160,6 @@ public:
         return device.CanReportMemoryUsage();
     }
 
-    u32 GetStorageBufferAlignment() const {
-        return static_cast<u32>(device.GetShaderStorageBufferAlignment());
-    }
-
 private:
     static constexpr std::array PABO_LUT{
         GL_VERTEX_PROGRAM_PARAMETER_BUFFER_NV,          GL_TESS_CONTROL_PROGRAM_PARAMETER_BUFFER_NV,

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -236,7 +236,6 @@ ShaderCache::ShaderCache(RasterizerOpenGL& rasterizer_, Core::Frontend::EmuWindo
           .needs_demote_reorder = device.IsAmd(),
           .support_snorm_render_buffer = false,
           .support_viewport_index_layer = device.HasVertexViewportLayer(),
-          .min_ssbo_alignment = static_cast<u32>(device.GetShaderStorageBufferAlignment()),
           .support_geometry_shader_passthrough = device.HasGeometryShaderPassthrough(),
       } {
     if (use_asynchronous_shaders) {

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -330,10 +330,6 @@ bool BufferCacheRuntime::CanReportMemoryUsage() const {
     return device.CanReportMemoryUsage();
 }
 
-u32 BufferCacheRuntime::GetStorageBufferAlignment() const {
-    return static_cast<u32>(device.GetStorageBufferAlignment());
-}
-
 void BufferCacheRuntime::Finish() {
     scheduler.Finish();
 }

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -73,8 +73,6 @@ public:
 
     bool CanReportMemoryUsage() const;
 
-    u32 GetStorageBufferAlignment() const;
-
     [[nodiscard]] StagingBufferRef UploadStagingBuffer(size_t size);
 
     [[nodiscard]] StagingBufferRef DownloadStagingBuffer(size_t size);

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -344,7 +344,6 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
             driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE,
         .support_snorm_render_buffer = true,
         .support_viewport_index_layer = device.IsExtShaderViewportIndexLayerSupported(),
-        .min_ssbo_alignment = static_cast<u32>(device.GetStorageBufferAlignment()),
         .support_geometry_shader_passthrough = device.IsNvGeometryShaderPassthroughSupported(),
     };
 


### PR DESCRIPTION
Temporary to fix #9579 (MUA3 rendering issues) while the underlying cause is sorted out