### PR TITLE
macOS: Make Yuzu show up in the Launchpad Games folder

### DIFF
--- a/src/yuzu/Info.plist
+++ b/src/yuzu/Info.plist
@@ -34,6 +34,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <string></string>
     <key>CSResourcesFileMapped</key>
     <true/>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
     <key>LSRequiresCarbon</key>
     <true/>
     <key>NSHumanReadableCopyright</key>
@@ -42,7 +44,5 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <string>True</string>
-    <key>LSApplicationCategoryType</key>
-    <string>public.app-category.games</string>
 </dict>
 </plist>

--- a/src/yuzu/Info.plist
+++ b/src/yuzu/Info.plist
@@ -42,5 +42,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <string>True</string>
+    <key>LSApplicationCategoryType</key> 
+    <string>public.app-category.games</string>
 </dict>
 </plist>

--- a/src/yuzu/Info.plist
+++ b/src/yuzu/Info.plist
@@ -42,7 +42,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <string>True</string>
-    <key>LSApplicationCategoryType</key> 
+    <key>LSApplicationCategoryType</key>
     <string>public.app-category.games</string>
 </dict>
 </plist>


### PR DESCRIPTION
https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype This makes it show up in the Launchpad Games folder