### PR TITLE
yuzu: Read mouse scroll

### DIFF
--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -76,7 +76,7 @@ void MappingFactory::RegisterButton(const MappingData& data) {
         break;
     case EngineInputType::Analog:
         // Ignore mouse axis when mapping buttons
-        if (data.engine == "mouse") {
+        if (data.engine == "mouse" && data.index != 4) {
             return;
         }
         new_input.Set("axis", data.index);

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -1466,6 +1466,12 @@ void ConfigureInputPlayer::mousePressEvent(QMouseEvent* event) {
     input_subsystem->GetMouse()->PressButton(0, 0, 0, 0, button);
 }
 
+void ConfigureInputPlayer::wheelEvent(QWheelEvent* event) {
+    const int x = event->angleDelta().x();
+    const int y = event->angleDelta().y();
+    input_subsystem->GetMouse()->MouseWheelChange(x, y);
+}
+
 void ConfigureInputPlayer::keyPressEvent(QKeyEvent* event) {
     if (!input_setter || !event) {
         return;

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -116,6 +116,9 @@ private:
     /// Handle mouse button press events.
     void mousePressEvent(QMouseEvent* event) override;
 
+    /// Handle mouse wheel move events.
+    void wheelEvent(QWheelEvent* event) override;
+
     /// Handle key press events.
     void keyPressEvent(QKeyEvent* event) override;
 


### PR DESCRIPTION
Enable listening to the mouse scroll input while we are on the controller configuration. This allows the mouse scroll to be mapped to any button.

Closes: #9603 