### PR TITLE
nvnflinger: correct swap interval handling

### DIFF
--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -312,8 +312,6 @@ void NVFlinger::Compose() {
 }
 
 s64 NVFlinger::GetNextTicks() const {
-    static constexpr s64 max_hertz = 120LL;
-
     const auto& settings = Settings::values;
     auto speed_scale = 1.f;
     if (settings.use_multi_core.GetValue()) {
@@ -327,9 +325,11 @@ s64 NVFlinger::GetNextTicks() const {
         }
     }
 
-    const auto next_ticks = ((1000000000 * (1LL << swap_interval)) / max_hertz);
+    // As an extension, treat nonpositive swap interval as framerate multiplier.
+    const f32 effective_fps = swap_interval <= 0 ? 120.f * static_cast<f32>(1 - swap_interval)
+                                                 : 60.f / static_cast<f32>(swap_interval);
 
-    return static_cast<s64>(speed_scale * static_cast<float>(next_ticks));
+    return static_cast<s64>(speed_scale * (1000000000.f / effective_fps));
 }
 
 } // namespace Service::NVFlinger

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -133,7 +133,7 @@ private:
     /// layers.
     u32 next_buffer_queue_id = 1;
 
-    u32 swap_interval = 1;
+    s32 swap_interval = 1;
 
     /// Event that handles screen composition.
     std::shared_ptr<Core::Timing::EventType> multi_composition_event;


### PR DESCRIPTION
Swap interval refers to how many vsync events to wait after presenting the queued item, so a value of 3 should wait for 3\*16.67ms (20 fps), but we were waiting for 4\*16.67ms (15 fps) instead, and so forth. Values normally used by games are 1 and 2, which correspond to 60 and 30 fps respectively, so it never broke in that case.

This also adds the ability to use non-positive values as an extension, which are implemented as multiples of 120 fps. This behavior doesn't exist on console, but is useful for framerate mods.