### PR TITLE
core: hid: Fix stick minimum range

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -10,6 +10,7 @@
 
 namespace Core::HID {
 constexpr s32 HID_JOYSTICK_MAX = 0x7fff;
+constexpr s32 HID_JOYSTICK_MIN = 0x7ffe;
 constexpr s32 HID_TRIGGER_MAX = 0x7fff;
 // Use a common UUID for TAS and Virtual Gamepad
 constexpr Common::UUID TAS_UUID =
@@ -798,9 +799,16 @@ void EmulatedController::SetStick(const Common::Input::CallbackStatus& callback,
         return;
     }
 
+    const auto FloatToShort = [](float a) {
+        if (a > 0) {
+            return static_cast<s32>(a * HID_JOYSTICK_MAX);
+        }
+        return static_cast<s32>(a * HID_JOYSTICK_MIN);
+    };
+
     const AnalogStickState stick{
-        .x = static_cast<s32>(controller.stick_values[index].x.value * HID_JOYSTICK_MAX),
-        .y = static_cast<s32>(controller.stick_values[index].y.value * HID_JOYSTICK_MAX),
+        .x = FloatToShort(controller.stick_values[index].x.value),
+        .y = FloatToShort(controller.stick_values[index].y.value),
     };
 
     switch (index) {


### PR DESCRIPTION
Stick minimum range is -32,766 verified with HW.  As for why it isn't -32768 is unclear to me but there is a particular game where this matters, `EARTH DEFENSE FORCE: WORLD BROTHERS` is unable to read negative values.
![image](https://user-images.githubusercontent.com/5944268/212488237-a10bbf92-aecb-438c-9427-a18721e1f222.png)
