### PR TITLE
timing: wait for completion on unregister

### DIFF
--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -98,10 +98,13 @@ public:
                               const std::shared_ptr<EventType>& event_type,
                               std::uintptr_t user_data = 0, bool absolute_time = false);
 
-    void UnscheduleEvent(const std::shared_ptr<EventType>& event_type, std::uintptr_t user_data);
+    void UnscheduleEvent(const std::shared_ptr<EventType>& event_type, std::uintptr_t user_data,
+                         bool wait = true);
 
-    /// We only permit one event of each type in the queue at a time.
-    void RemoveEvent(const std::shared_ptr<EventType>& event_type);
+    void UnscheduleEventWithoutWait(const std::shared_ptr<EventType>& event_type,
+                                    std::uintptr_t user_data) {
+        UnscheduleEvent(event_type, user_data, false);
+    }
 
     void AddTicks(u64 ticks_to_add);
 

--- a/src/core/hle/kernel/k_hardware_timer.cpp
+++ b/src/core/hle/kernel/k_hardware_timer.cpp
@@ -18,7 +18,8 @@ void KHardwareTimer::Initialize() {
 }
 
 void KHardwareTimer::Finalize() {
-    this->DisableInterrupt();
+    m_kernel.System().CoreTiming().UnscheduleEvent(m_event_type, reinterpret_cast<uintptr_t>(this));
+    m_wakeup_time = std::numeric_limits<s64>::max();
     m_event_type.reset();
 }
 
@@ -59,7 +60,8 @@ void KHardwareTimer::EnableInterrupt(s64 wakeup_time) {
 }
 
 void KHardwareTimer::DisableInterrupt() {
-    m_kernel.System().CoreTiming().UnscheduleEvent(m_event_type, reinterpret_cast<uintptr_t>(this));
+    m_kernel.System().CoreTiming().UnscheduleEventWithoutWait(m_event_type,
+                                                              reinterpret_cast<uintptr_t>(this));
     m_wakeup_time = std::numeric_limits<s64>::max();
 }
 


### PR DESCRIPTION
Removes the duplicated (unused) function RemoveEvent and requires UnregisterEvent to wait for any in-progress callback to complete before returning.

This disallows a dispatched timing callback from executing after UnregisterEvent has returned, which is enough to make unregistration work as expected, and satisfies principle of least surprise. It should fix some semi-rare shutdown crashes.

<details>
<summary>KHardwareTimer info</summary>

KHardwareTimer needs to avoid waiting for the event to complete until it is shut down. It will hold the scheduler lock, and then try to take the advance lock. However, timing callbacks will hold the advance lock, and then try to take the scheduler lock. This will deadlock, given the right timing.

KHardwareTimer callbacks are the only scenario where avoiding the wait is required; this is still robust because it has its own logic for ignoring spurious wakeups. Additionally, in its finalizer, the scheduler lock will not be held, so timing can take the advance lock and wait for callbacks to complete.
</details>