### PR TITLE
video_core: Implement vulkan clear specified channel

### DIFF
--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -45,6 +45,8 @@ set(SHADER_FILES
     smaa_neighborhood_blending.vert
     smaa_neighborhood_blending.frag
     vulkan_blit_depth_stencil.frag
+    vulkan_color_clear.frag
+    vulkan_color_clear.vert
     vulkan_fidelityfx_fsr_easu_fp16.comp
     vulkan_fidelityfx_fsr_easu_fp32.comp
     vulkan_fidelityfx_fsr_rcas_fp16.comp

--- a/src/video_core/host_shaders/vulkan_color_clear.frag
+++ b/src/video_core/host_shaders/vulkan_color_clear.frag
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#version 460 core
+
+layout (push_constant) uniform PushConstants {
+    vec4 clear_color;
+};
+
+layout(location = 0) out vec4 color;
+
+void main() {
+    color = clear_color;
+}

--- a/src/video_core/host_shaders/vulkan_color_clear.vert
+++ b/src/video_core/host_shaders/vulkan_color_clear.vert
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#version 460 core
+
+void main() {
+    float x = float((gl_VertexIndex & 1) << 2);
+    float y = float((gl_VertexIndex & 2) << 1);
+    gl_Position = vec4(x - 1.0, y - 1.0, 0.0, 1.0);
+}

--- a/src/video_core/renderer_vulkan/blit_image.h
+++ b/src/video_core/renderer_vulkan/blit_image.h
@@ -61,6 +61,9 @@ public:
 
     void ConvertS8D24ToABGR8(const Framebuffer* dst_framebuffer, ImageView& src_image_view);
 
+    void ClearColor(const Framebuffer* dst_framebuffer, u8 color_mask,
+                    const std::array<f32, 4>& clear_color, const Region2D& dst_region);
+
 private:
     void Convert(VkPipeline pipeline, const Framebuffer* dst_framebuffer,
                  const ImageView& src_image_view);
@@ -71,6 +74,8 @@ private:
     [[nodiscard]] VkPipeline FindOrEmplaceColorPipeline(const BlitImagePipelineKey& key);
 
     [[nodiscard]] VkPipeline FindOrEmplaceDepthStencilPipeline(const BlitImagePipelineKey& key);
+
+    [[nodiscard]] VkPipeline FindOrEmplaceClearColorPipeline(const BlitImagePipelineKey& key);
 
     void ConvertPipeline(vk::Pipeline& pipeline, VkRenderPass renderpass, bool is_target_depth);
 
@@ -97,9 +102,12 @@ private:
     DescriptorAllocator two_textures_descriptor_allocator;
     vk::PipelineLayout one_texture_pipeline_layout;
     vk::PipelineLayout two_textures_pipeline_layout;
+    vk::PipelineLayout clear_color_pipeline_layout;
     vk::ShaderModule full_screen_vert;
     vk::ShaderModule blit_color_to_color_frag;
     vk::ShaderModule blit_depth_stencil_frag;
+    vk::ShaderModule clear_color_vert;
+    vk::ShaderModule clear_color_frag;
     vk::ShaderModule convert_depth_to_float_frag;
     vk::ShaderModule convert_float_to_depth_frag;
     vk::ShaderModule convert_abgr8_to_d24s8_frag;
@@ -112,6 +120,8 @@ private:
     std::vector<vk::Pipeline> blit_color_pipelines;
     std::vector<BlitImagePipelineKey> blit_depth_stencil_keys;
     std::vector<vk::Pipeline> blit_depth_stencil_pipelines;
+    std::vector<BlitImagePipelineKey> clear_color_keys;
+    std::vector<vk::Pipeline> clear_color_pipelines;
     vk::Pipeline convert_d32_to_r32_pipeline;
     vk::Pipeline convert_r32_to_d32_pipeline;
     vk::Pipeline convert_d16_to_r16_pipeline;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -394,7 +394,15 @@ void RasterizerVulkan::Clear(u32 layer_count) {
                 cmdbuf.ClearAttachments(attachment, clear_rect);
             });
         } else {
-            UNIMPLEMENTED_MSG("Unimplemented Clear only the specified channel");
+            u8 color_mask = static_cast<u8>(regs.clear_surface.R | regs.clear_surface.G << 1 |
+                                            regs.clear_surface.B << 2 | regs.clear_surface.A << 3);
+            Region2D dst_region = {
+                Offset2D{.x = clear_rect.rect.offset.x, .y = clear_rect.rect.offset.y},
+                Offset2D{.x = clear_rect.rect.offset.x +
+                              static_cast<s32>(clear_rect.rect.extent.width),
+                         .y = clear_rect.rect.offset.y +
+                              static_cast<s32>(clear_rect.rect.extent.height)}};
+            blit_image.ClearColor(framebuffer, color_mask, regs.clear_color, dst_region);
         }
     }
 


### PR DESCRIPTION
Vulkan cleaning does not support the mask parameter, so we need to enumerate it by draw. The current solution is to use the blend state to mask specific channels to solve the problem.

For example, clear BGA not R channel.
Before:
![230c8550-2d24-4e9a-aebd-2b75b5b53d5f](https://user-images.githubusercontent.com/3349963/212832462-1b1a022b-9b12-49c2-b219-b13c60618b76.jpeg)

After:
![9a057987-a003-4207-a0a3-1d78431a120b](https://user-images.githubusercontent.com/3349963/212832490-bb1a28c3-a3b1-4790-98ed-5a62513c791f.jpeg)

This should fix some other games, feel free to test it.