### PR TITLE
Demote maxwell3d Firmware4 call log to debug

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -467,7 +467,7 @@ void Maxwell3D::ProcessMacroBind(u32 data) {
 }
 
 void Maxwell3D::ProcessFirmwareCall4() {
-    LOG_WARNING(HW_GPU, "(STUBBED) called");
+    LOG_DEBUG(HW_GPU, "(STUBBED) called");
 
     // Firmware call 4 is a blob that changes some registers depending on its parameters.
     // These registers don't affect emulation and so are stubbed by setting 0xd00 to 1.


### PR DESCRIPTION
DeviusDraem doesn't like it, plus we don't really need this logged anyway. Apparently some games spam this excessively.