### PR TITLE
yuzu: Fix language comobox crash

### DIFF
--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -92,3 +92,13 @@ void ConfigurationShared::InsertGlobalItem(QComboBox* combobox, int global_index
     combobox->insertItem(ConfigurationShared::USE_GLOBAL_INDEX, use_global_text);
     combobox->insertSeparator(ConfigurationShared::USE_GLOBAL_SEPARATOR_INDEX);
 }
+
+int ConfigurationShared::GetComboboxIndex(int global_setting_index, const QComboBox* combobox) {
+    if (Settings::IsConfiguringGlobal()) {
+        return combobox->currentIndex();
+    }
+    if (combobox->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
+        return global_setting_index;
+    }
+    return combobox->currentIndex() - ConfigurationShared::USE_GLOBAL_OFFSET;
+}

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -69,4 +69,7 @@ void SetColoredComboBox(QComboBox* combobox, QWidget* target, int global);
 // Adds the "Use Global Configuration" selection and separator to the beginning of a QComboBox
 void InsertGlobalItem(QComboBox* combobox, int global_index);
 
+// Returns the correct index of a QComboBox taking into account global configuration
+int GetComboboxIndex(int global_setting_index, const QComboBox* combobox);
+
 } // namespace ConfigurationShared

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -31,6 +31,9 @@ constexpr std::array<u32, 7> LOCALE_BLOCKLIST{
 };
 
 static bool IsValidLocale(u32 region_index, u32 language_index) {
+    if (region_index >= LOCALE_BLOCKLIST.size()) {
+        return false;
+    }
     return ((LOCALE_BLOCKLIST.at(region_index) >> language_index) & 1) == 0;
 }
 
@@ -55,8 +58,11 @@ ConfigureSystem::ConfigureSystem(Core::System& system_, QWidget* parent)
     });
 
     const auto locale_check = [this](int index) {
-        const bool valid_locale =
-            IsValidLocale(ui->combo_region->currentIndex(), ui->combo_language->currentIndex());
+        const auto region_index = ConfigurationShared::GetComboboxIndex(
+            Settings::values.region_index.GetValue(true), ui->combo_region);
+        const auto language_index = ConfigurationShared::GetComboboxIndex(
+            Settings::values.language_index.GetValue(true), ui->combo_language);
+        const bool valid_locale = IsValidLocale(region_index, language_index);
         ui->label_warn_invalid_locale->setVisible(!valid_locale);
         if (!valid_locale) {
             ui->label_warn_invalid_locale->setText(

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -42,13 +42,7 @@ private:
     std::unique_ptr<Ui::ConfigureSystem> ui;
     bool enabled = false;
 
-    int language_index = 0;
-    int region_index = 0;
-    int time_zone_index = 0;
-    int sound_index = 0;
-
     ConfigurationShared::CheckState use_rng_seed;
-    ConfigurationShared::CheckState use_custom_rtc;
 
     Core::System& system;
 };


### PR DESCRIPTION
Per game config alters the combobox index. You can't use it directly. This PR fixes that issue and ensures the lookup table is always in bounds to avoid future crashes.

Fixes #9655 