### PR TITLE
qt: add option to disable controller applet

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -836,6 +836,7 @@ void Config::ReadUIValues() {
     ReadBasicSetting(UISettings::values.pause_when_in_background);
     ReadBasicSetting(UISettings::values.mute_when_in_background);
     ReadBasicSetting(UISettings::values.hide_mouse);
+    ReadBasicSetting(UISettings::values.controller_applet_disabled);
     ReadBasicSetting(UISettings::values.disable_web_applet);
 
     qt_config->endGroup();
@@ -1456,6 +1457,7 @@ void Config::SaveUIValues() {
     WriteBasicSetting(UISettings::values.pause_when_in_background);
     WriteBasicSetting(UISettings::values.mute_when_in_background);
     WriteBasicSetting(UISettings::values.hide_mouse);
+    WriteBasicSetting(UISettings::values.controller_applet_disabled);
     WriteBasicSetting(UISettings::values.disable_web_applet);
 
     qt_config->endGroup();

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -44,6 +44,8 @@ void ConfigureGeneral::SetConfiguration() {
     ui->toggle_background_pause->setChecked(UISettings::values.pause_when_in_background.GetValue());
     ui->toggle_background_mute->setChecked(UISettings::values.mute_when_in_background.GetValue());
     ui->toggle_hide_mouse->setChecked(UISettings::values.hide_mouse.GetValue());
+    ui->toggle_controller_applet_disabled->setEnabled(runtime_lock);
+    ui->toggle_controller_applet_disabled->setChecked(UISettings::values.controller_applet_disabled.GetValue());
 
     ui->toggle_speed_limit->setChecked(Settings::values.use_speed_limit.GetValue());
     ui->speed_limit->setValue(Settings::values.speed_limit.GetValue());
@@ -90,6 +92,7 @@ void ConfigureGeneral::ApplyConfiguration() {
         UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
         UISettings::values.mute_when_in_background = ui->toggle_background_mute->isChecked();
         UISettings::values.hide_mouse = ui->toggle_hide_mouse->isChecked();
+        UISettings::values.controller_applet_disabled = ui->toggle_controller_applet_disabled->isChecked();
 
         // Guard if during game and set to game-specific value
         if (Settings::values.use_speed_limit.UsingGlobal()) {
@@ -136,6 +139,7 @@ void ConfigureGeneral::SetupPerGameUI() {
     ui->toggle_user_on_boot->setVisible(false);
     ui->toggle_background_pause->setVisible(false);
     ui->toggle_hide_mouse->setVisible(false);
+    ui->toggle_controller_applet_disabled->setVisible(false);
 
     ui->button_reset_defaults->setVisible(false);
 

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -103,6 +103,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="toggle_controller_applet_disabled">
+            <property name="text">
+             <string>Disable controller applet</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
        </layout>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1562,6 +1562,7 @@ bool GMainWindow::LoadROM(const QString& filename, u64 program_id, std::size_t p
 
     system->SetAppletFrontendSet({
         std::make_unique<QtAmiiboSettings>(*this),     // Amiibo Settings
+        (UISettings::values.controller_applet_disabled.GetValue() == true) ? nullptr :
         std::make_unique<QtControllerSelector>(*this), // Controller Selector
         std::make_unique<QtErrorDisplay>(*this),       // Error Display
         nullptr,                                       // Mii Editor

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -77,6 +77,8 @@ struct Values {
     Settings::Setting<bool> pause_when_in_background{false, "pauseWhenInBackground"};
     Settings::Setting<bool> mute_when_in_background{false, "muteWhenInBackground"};
     Settings::Setting<bool> hide_mouse{true, "hideInactiveMouse"};
+    Settings::Setting<bool> controller_applet_disabled{false, "disableControllerApplet"};
+
     // Set when Vulkan is known to crash the application
     bool has_broken_vulkan = false;
 


### PR DESCRIPTION
- add checkbox to disable the controller applet UI
- when controller applet is disabled, use the yuzu-cmd fallback controller applet that applies controller config based on rules
- See https://github.com/yuzu-emu/yuzu/issues/8552 for some discussion