### PR TITLE
Revert "MemoryManager: use fastmem directly."

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -440,7 +440,7 @@ struct Memory::Impl {
         }
 
         if (Settings::IsFastmemEnabled()) {
-            const bool is_read_enable = !Settings::IsGPULevelExtreme() || !cached;
+            const bool is_read_enable = Settings::IsGPULevelHigh() || !cached;
             system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
         }
 

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -6,7 +6,6 @@
 #include "common/alignment.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "common/settings.h"
 #include "core/core.h"
 #include "core/device_memory.h"
 #include "core/hle/kernel/k_page_table.h"
@@ -46,11 +45,6 @@ MemoryManager::MemoryManager(Core::System& system_, u64 address_space_bits_, u64
     big_page_table_cpu.resize(big_page_table_size);
     big_page_continous.resize(big_page_table_size / continous_bits, 0);
     entries.resize(page_table_size / 32, 0);
-    if (!Settings::IsGPULevelExtreme() && Settings::IsFastmemEnabled()) {
-        fastmem_arena = system.DeviceMemory().buffer.VirtualBasePointer();
-    } else {
-        fastmem_arena = nullptr;
-    }
 }
 
 MemoryManager::~MemoryManager() = default;
@@ -360,7 +354,7 @@ inline void MemoryManager::MemoryOperation(GPUVAddr gpu_src_addr, std::size_t si
     }
 }
 
-template <bool is_safe, bool use_fastmem>
+template <bool is_safe>
 void MemoryManager::ReadBlockImpl(GPUVAddr gpu_src_addr, void* dest_buffer, std::size_t size,
                                   [[maybe_unused]] VideoCommon::CacheType which) const {
     auto set_to_zero = [&]([[maybe_unused]] std::size_t page_index,
@@ -374,12 +368,8 @@ void MemoryManager::ReadBlockImpl(GPUVAddr gpu_src_addr, void* dest_buffer, std:
         if constexpr (is_safe) {
             rasterizer->FlushRegion(cpu_addr_base, copy_amount, which);
         }
-        if constexpr (use_fastmem) {
-            std::memcpy(dest_buffer, &fastmem_arena[cpu_addr_base], copy_amount);
-        } else {
-            u8* physical = memory.GetPointer(cpu_addr_base);
-            std::memcpy(dest_buffer, physical, copy_amount);
-        }
+        u8* physical = memory.GetPointer(cpu_addr_base);
+        std::memcpy(dest_buffer, physical, copy_amount);
         dest_buffer = static_cast<u8*>(dest_buffer) + copy_amount;
     };
     auto mapped_big = [&](std::size_t page_index, std::size_t offset, std::size_t copy_amount) {
@@ -388,15 +378,11 @@ void MemoryManager::ReadBlockImpl(GPUVAddr gpu_src_addr, void* dest_buffer, std:
         if constexpr (is_safe) {
             rasterizer->FlushRegion(cpu_addr_base, copy_amount, which);
         }
-        if constexpr (use_fastmem) {
-            std::memcpy(dest_buffer, &fastmem_arena[cpu_addr_base], copy_amount);
+        if (!IsBigPageContinous(page_index)) [[unlikely]] {
+            memory.ReadBlockUnsafe(cpu_addr_base, dest_buffer, copy_amount);
         } else {
-            if (!IsBigPageContinous(page_index)) [[unlikely]] {
-                memory.ReadBlockUnsafe(cpu_addr_base, dest_buffer, copy_amount);
-            } else {
-                u8* physical = memory.GetPointer(cpu_addr_base);
-                std::memcpy(dest_buffer, physical, copy_amount);
-            }
+            u8* physical = memory.GetPointer(cpu_addr_base);
+            std::memcpy(dest_buffer, physical, copy_amount);
         }
         dest_buffer = static_cast<u8*>(dest_buffer) + copy_amount;
     };
@@ -410,20 +396,12 @@ void MemoryManager::ReadBlockImpl(GPUVAddr gpu_src_addr, void* dest_buffer, std:
 
 void MemoryManager::ReadBlock(GPUVAddr gpu_src_addr, void* dest_buffer, std::size_t size,
                               VideoCommon::CacheType which) const {
-    if (fastmem_arena) [[likely]] {
-        ReadBlockImpl<true, true>(gpu_src_addr, dest_buffer, size, which);
-        return;
-    }
-    ReadBlockImpl<true, false>(gpu_src_addr, dest_buffer, size, which);
+    ReadBlockImpl<true>(gpu_src_addr, dest_buffer, size, which);
 }
 
 void MemoryManager::ReadBlockUnsafe(GPUVAddr gpu_src_addr, void* dest_buffer,
                                     const std::size_t size) const {
-    if (fastmem_arena) [[likely]] {
-        ReadBlockImpl<false, true>(gpu_src_addr, dest_buffer, size, VideoCommon::CacheType::None);
-        return;
-    }
-    ReadBlockImpl<false, false>(gpu_src_addr, dest_buffer, size, VideoCommon::CacheType::None);
+    ReadBlockImpl<false>(gpu_src_addr, dest_buffer, size, VideoCommon::CacheType::None);
 }
 
 template <bool is_safe>

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -141,7 +141,7 @@ private:
     inline void MemoryOperation(GPUVAddr gpu_src_addr, std::size_t size, FuncMapped&& func_mapped,
                                 FuncReserved&& func_reserved, FuncUnmapped&& func_unmapped) const;
 
-    template <bool is_safe, bool use_fastmem>
+    template <bool is_safe>
     void ReadBlockImpl(GPUVAddr gpu_src_addr, void* dest_buffer, std::size_t size,
                        VideoCommon::CacheType which) const;
 
@@ -215,7 +215,6 @@ private:
 
     std::vector<u64> big_page_continous;
     std::vector<std::pair<VAddr, std::size_t>> page_stash{};
-    u8* fastmem_arena{};
 
     constexpr static size_t continous_bits = 64;
 


### PR DESCRIPTION
This reverts commit af5ecb0b15d4449f58434e70eed835cf71fc5527.

Fixes https://github.com/yuzu-emu/yuzu/issues/9669 as per @piplup55.

Without testing I would assume this would be because of a race between protect and read/write.