### PR TITLE
Revert #9617 and fix it on input_common

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -11,7 +11,6 @@
 
 namespace Core::HID {
 constexpr s32 HID_JOYSTICK_MAX = 0x7fff;
-constexpr s32 HID_JOYSTICK_MIN = 0x7ffe;
 constexpr s32 HID_TRIGGER_MAX = 0x7fff;
 // Use a common UUID for TAS and Virtual Gamepad
 constexpr Common::UUID TAS_UUID =
@@ -864,16 +863,9 @@ void EmulatedController::SetStick(const Common::Input::CallbackStatus& callback,
         return;
     }
 
-    const auto FloatToShort = [](float a) {
-        if (a > 0) {
-            return static_cast<s32>(a * HID_JOYSTICK_MAX);
-        }
-        return static_cast<s32>(a * HID_JOYSTICK_MIN);
-    };
-
     const AnalogStickState stick{
-        .x = FloatToShort(controller.stick_values[index].x.value),
-        .y = FloatToShort(controller.stick_values[index].y.value),
+        .x = static_cast<s32>(controller.stick_values[index].x.value * HID_JOYSTICK_MAX),
+        .y = static_cast<s32>(controller.stick_values[index].y.value * HID_JOYSTICK_MAX),
     };
 
     switch (index) {

--- a/src/input_common/helpers/stick_from_buttons.cpp
+++ b/src/input_common/helpers/stick_from_buttons.cpp
@@ -11,6 +11,11 @@ namespace InputCommon {
 
 class Stick final : public Common::Input::InputDevice {
 public:
+    // Some games such as EARTH DEFENSE FORCE: WORLD BROTHERS
+    // do not play nicely with the theoretical maximum range.
+    // Using a value one lower from the maximum emulates real stick behavior.
+    static constexpr float MAX_RANGE = 32766.0f / 32767.0f;
+
     using Button = std::unique_ptr<Common::Input::InputDevice>;
 
     Stick(Button up_, Button down_, Button left_, Button right_, Button modifier_, Button updater_,
@@ -196,7 +201,7 @@ public:
     }
 
     void UpdateStatus() {
-        const float coef = modifier_status.value ? modifier_scale : 1.0f;
+        const float coef = modifier_status.value ? modifier_scale : MAX_RANGE;
 
         bool r = right_status;
         bool l = left_status;
@@ -290,7 +295,7 @@ public:
         if (down_status) {
             --y;
         }
-        const float coef = modifier_status.value ? modifier_scale : 1.0f;
+        const float coef = modifier_status.value ? modifier_scale : MAX_RANGE;
         status.x.raw_value = static_cast<float>(x) * coef * (y == 0 ? 1.0f : SQRT_HALF);
         status.y.raw_value = static_cast<float>(y) * coef * (x == 0 ? 1.0f : SQRT_HALF);
         return status;


### PR DESCRIPTION
Reverts all the changes from #9617. I made another homebrew to specifically check the weird value. Turns out -32767 is totally possible just unlikely. I confirmed as well by playing the game on the switch. If you put the stick just right you have the same issue as yuzu. So this is a game bug. Not a yuzu one.

Instead I modified the digital stick output to have a maximum range of 99.996% to allow for this game to work properly with keyboard and similar.