### PR TITLE
input_common: Implement SetLowPowerMode and TriggersElapsed

### DIFF
--- a/src/input_common/helpers/joycon_driver.cpp
+++ b/src/input_common/helpers/joycon_driver.cpp
@@ -86,6 +86,7 @@ DriverResult JoyconDriver::InitializeDevice() {
 
     // Get fixed joycon info
     generic_protocol->GetVersionNumber(version);
+    generic_protocol->SetLowPowerMode(false);
     generic_protocol->GetColor(color);
     if (handle_device_type == ControllerType::Pro) {
         // Some 3rd party controllers aren't pro controllers
@@ -324,6 +325,8 @@ DriverResult JoyconDriver::SetPollingMode() {
     if (result != DriverResult::Success) {
         LOG_ERROR(Input, "Error enabling active mode");
     }
+    // Switch calls this function after enabling active mode
+    generic_protocol->TriggersElapsed();
 
     disable_input_thread = false;
     return result;

--- a/src/input_common/helpers/joycon_protocol/generic_functions.cpp
+++ b/src/input_common/helpers/joycon_protocol/generic_functions.cpp
@@ -19,6 +19,17 @@ DriverResult GenericProtocol::EnableActiveMode() {
     return SetReportMode(ReportMode::STANDARD_FULL_60HZ);
 }
 
+DriverResult GenericProtocol::SetLowPowerMode(bool enable) {
+    ScopedSetBlocking sb(this);
+    const std::array<u8, 1> buffer{static_cast<u8>(enable ? 1 : 0)};
+    return SendSubCommand(SubCommand::LOW_POWER_MODE, buffer);
+}
+
+DriverResult GenericProtocol::TriggersElapsed() {
+    ScopedSetBlocking sb(this);
+    return SendSubCommand(SubCommand::TRIGGERS_ELAPSED, {});
+}
+
 DriverResult GenericProtocol::GetDeviceInfo(DeviceInfo& device_info) {
     ScopedSetBlocking sb(this);
     std::vector<u8> output;

--- a/src/input_common/helpers/joycon_protocol/generic_functions.h
+++ b/src/input_common/helpers/joycon_protocol/generic_functions.h
@@ -25,6 +25,12 @@ public:
     /// Enables active mode. This mode will return the current status every 5-15ms
     DriverResult EnableActiveMode();
 
+    /// Enables or disables the low power mode
+    DriverResult SetLowPowerMode(bool enable);
+
+    /// Unknown function used by the switch
+    DriverResult TriggersElapsed();
+
     /**
      * Sends a request to obtain the joycon firmware and mac from handle
      * @returns controller device info

--- a/src/input_common/helpers/joycon_protocol/joycon_types.h
+++ b/src/input_common/helpers/joycon_protocol/joycon_types.h
@@ -129,6 +129,7 @@ enum class SubCommand : u8 {
     LOW_POWER_MODE = 0x08,
     SPI_FLASH_READ = 0x10,
     SPI_FLASH_WRITE = 0x11,
+    SPI_SECTOR_ERASE = 0x12,
     RESET_MCU = 0x20,
     SET_MCU_CONFIG = 0x21,
     SET_MCU_STATE = 0x22,


### PR DESCRIPTION
Disables low power mode when a joycon is connected and calls TriggersElapsed after the report mode is set. I didn't notice any difference but it might increase the signal strength of the joycons. It also mimics a bit closer to what the switch does.
```
Left Joycon
[ts:  35065ms t: mc::BtdrvMitmThread    p: 17/17] Get Device Info
[ts:  35129ms t: mc::BtdrvMitmThread    p: 17/17] Low Power Mode  [0x00]
[ts:  35193ms t: mc::BtdrvMitmThread    p: 17/17] SPI Read address [0x6000], size [0x10]
[ts:  35246ms t: mc::BtdrvMitmThread    p: 17/17] SPI Read address [0x6050], size [0x0d]
[ts:  35298ms t: mc::BtdrvMitmThread    p: 17/17] Report Mode STANDARD_FULL_60HZ
[ts:  35358ms t: mc::BtdrvMitmThread    p: 17/17] Triggers Elapsed????
[ts:  35429ms t: mc::BtdrvMitmThread    p: 17/17] SPI Read address [0x6080], size [0x18]
[ts:  35484ms t: mc::BtdrvMitmThread    p: 17/17] SPI Read address [0x6098], size [0x12]
[ts:  35546ms t: mc::BtdrvMitmThread    p: 17/17] SPI Read address [0x8010], size [0x18]
[ts:  35604ms t: mc::BtdrvMitmThread    p: 17/17] SPI Read address [0x603d], size [0x19]
[ts:  35671ms t: mc::BtdrvMitmThread    p: 17/17] SPI Read address [0x6020], size [0x18]
[ts:  35748ms t: mc::BtdrvMitmThread    p: 17/17] Enable IMU [0x02]
[ts:  35808ms t: mc::BtdrvMitmThread    p: 17/17] Enable Vibration [0x01]
[ts:  35877ms t: mc::BtdrvMitmThread    p: 17/17] Set Player Leds [0x01]
```