### PR TITLE
texture_cache: Fix tracking of MSAA image views

### DIFF
--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -100,6 +100,10 @@ ImageInfo::ImageInfo(const TICEntry& config) noexcept {
         ASSERT_MSG(false, "Invalid texture_type={}", static_cast<int>(config.texture_type.Value()));
         break;
     }
+    if (num_samples > 1) {
+        size.width *= NumSamplesX(config.msaa_mode);
+        size.height *= NumSamplesY(config.msaa_mode);
+    }
     if (type != ImageType::Linear) {
         // FIXME: Call this without passing *this
         layer_stride = CalculateLayerStride(*this);

--- a/src/video_core/texture_cache/samples_helper.h
+++ b/src/video_core/texture_cache/samples_helper.h
@@ -51,4 +51,48 @@ namespace VideoCommon {
     return 1;
 }
 
+[[nodiscard]] inline int NumSamplesX(Tegra::Texture::MsaaMode msaa_mode) {
+    using Tegra::Texture::MsaaMode;
+    switch (msaa_mode) {
+    case MsaaMode::Msaa1x1:
+        return 1;
+    case MsaaMode::Msaa2x1:
+    case MsaaMode::Msaa2x1_D3D:
+    case MsaaMode::Msaa2x2:
+    case MsaaMode::Msaa2x2_VC4:
+    case MsaaMode::Msaa2x2_VC12:
+        return 2;
+    case MsaaMode::Msaa4x2:
+    case MsaaMode::Msaa4x2_D3D:
+    case MsaaMode::Msaa4x2_VC8:
+    case MsaaMode::Msaa4x2_VC24:
+    case MsaaMode::Msaa4x4:
+        return 4;
+    }
+    ASSERT_MSG(false, "Invalid MSAA mode={}", static_cast<int>(msaa_mode));
+    return 1;
+}
+
+[[nodiscard]] inline int NumSamplesY(Tegra::Texture::MsaaMode msaa_mode) {
+    using Tegra::Texture::MsaaMode;
+    switch (msaa_mode) {
+    case MsaaMode::Msaa1x1:
+    case MsaaMode::Msaa2x1:
+    case MsaaMode::Msaa2x1_D3D:
+        return 1;
+    case MsaaMode::Msaa2x2:
+    case MsaaMode::Msaa2x2_VC4:
+    case MsaaMode::Msaa2x2_VC12:
+    case MsaaMode::Msaa4x2:
+    case MsaaMode::Msaa4x2_D3D:
+    case MsaaMode::Msaa4x2_VC8:
+    case MsaaMode::Msaa4x2_VC24:
+        return 2;
+    case MsaaMode::Msaa4x4:
+        return 4;
+    }
+    ASSERT_MSG(false, "Invalid MSAA mode={}", static_cast<int>(msaa_mode));
+    return 1;
+}
+
 } // namespace VideoCommon


### PR DESCRIPTION
The texture cache was failing to track image views of MSAA render targets. 

It seems that when an MSAA render target is bound, its dimensions are already scaled by the number of MSAA samples. This was not the case for image views of render targets, which retained the original image dimensions. 

This caused the texture cache to improperly bind the image view as it would not satisfy the subresource check since it had differing dimensions. This was confirmed on a small homebrew test I made. 
Further testing in games with missing/corrupted graphics would be appreciated


Fixes FE: Engage character portraits

|      Before | After        |
|---------|----------|
|  ![before](https://user-images.githubusercontent.com/52414509/215244011-e0645d5d-1c7a-4414-84f9-14f72516d451.png)  |  ![after](https://user-images.githubusercontent.com/52414509/215244060-2dbc62c8-6b51-411f-a152-25d608427464.png)  |