### PR TITLE
input_common: joycon: Remove Magic numbers from common protocol

### DIFF
--- a/src/input_common/drivers/joycon.cpp
+++ b/src/input_common/drivers/joycon.cpp
@@ -668,12 +668,10 @@ std::string Joycons::JoyconName(Joycon::ControllerType type) const {
         return "Right Joycon";
     case Joycon::ControllerType::Pro:
         return "Pro Controller";
-    case Joycon::ControllerType::Grip:
-        return "Grip Controller";
     case Joycon::ControllerType::Dual:
         return "Dual Joycon";
     default:
-        return "Unknown Joycon";
+        return "Unknown Switch Controller";
     }
 }
 } // namespace InputCommon

--- a/src/input_common/drivers/joycon.h
+++ b/src/input_common/drivers/joycon.h
@@ -15,7 +15,7 @@ using SerialNumber = std::array<u8, 15>;
 struct Battery;
 struct Color;
 struct MotionData;
-enum class ControllerType;
+enum class ControllerType : u8;
 enum class DriverResult;
 enum class IrsResolution;
 class JoyconDriver;

--- a/src/input_common/helpers/joycon_protocol/common_protocol.h
+++ b/src/input_common/helpers/joycon_protocol/common_protocol.h
@@ -57,22 +57,31 @@ public:
      * Sends data to the joycon device
      * @param buffer data to be send
      */
-    DriverResult SendData(std::span<const u8> buffer);
+    DriverResult SendRawData(std::span<const u8> buffer);
+
+    template <typename Output>
+        requires std::is_trivially_copyable_v<Output>
+    DriverResult SendData(const Output& output) {
+        std::array<u8, sizeof(Output)> buffer;
+        std::memcpy(buffer.data(), &output, sizeof(Output));
+        return SendRawData(buffer);
+    }
 
     /**
      * Waits for incoming data of the joycon device that matchs the subcommand
      * @param sub_command type of data to be returned
-     * @returns a buffer containing the responce
+     * @returns a buffer containing the response
      */
-    DriverResult GetSubCommandResponse(SubCommand sub_command, std::vector<u8>& output);
+    DriverResult GetSubCommandResponse(SubCommand sub_command, SubCommandResponse& output);
 
     /**
      * Sends a sub command to the device and waits for it's reply
      * @param sc sub command to be send
      * @param buffer data to be send
-     * @returns output buffer containing the responce
+     * @returns output buffer containing the response
      */
-    DriverResult SendSubCommand(SubCommand sc, std::span<const u8> buffer, std::vector<u8>& output);
+    DriverResult SendSubCommand(SubCommand sc, std::span<const u8> buffer,
+                                SubCommandResponse& output);
 
     /**
      * Sends a sub command to the device and waits for it's reply and ignores the output
@@ -97,14 +106,14 @@ public:
     /**
      * Reads the SPI memory stored on the joycon
      * @param Initial address location
-     * @returns output buffer containing the responce
+     * @returns output buffer containing the response
      */
     DriverResult ReadRawSPI(SpiAddress addr, std::span<u8> output);
 
     /**
      * Reads the SPI memory stored on the joycon
      * @param Initial address location
-     * @returns output object containing the responce
+     * @returns output object containing the response
      */
     template <typename Output>
         requires std::is_trivially_copyable_v<Output>
@@ -136,19 +145,19 @@ public:
     /**
      * Waits until there's MCU data available. On timeout returns error
      * @param report mode of the expected reply
-     * @returns a buffer containing the responce
+     * @returns a buffer containing the response
      */
-    DriverResult GetMCUDataResponse(ReportMode report_mode_, std::vector<u8>& output);
+    DriverResult GetMCUDataResponse(ReportMode report_mode_, MCUCommandResponse& output);
 
     /**
      * Sends data to the MCU chip and waits for it's reply
      * @param report mode of the expected reply
      * @param sub command to be send
      * @param buffer data to be send
-     * @returns output buffer containing the responce
+     * @returns output buffer containing the response
      */
     DriverResult SendMCUData(ReportMode report_mode, SubCommand sc, std::span<const u8> buffer,
-                             std::vector<u8>& output);
+                             MCUCommandResponse& output);
 
     /**
      * Wait's until the MCU chip is on the specified mode

--- a/src/input_common/helpers/joycon_protocol/generic_functions.cpp
+++ b/src/input_common/helpers/joycon_protocol/generic_functions.cpp
@@ -38,7 +38,7 @@ DriverResult GenericProtocol::GetDeviceInfo(DeviceInfo& device_info) {
 
     device_info = {};
     if (result == DriverResult::Success) {
-        memcpy(&device_info, output.data(), sizeof(DeviceInfo));
+        memcpy(&device_info, output.data() + 15, sizeof(DeviceInfo));
     }
 
     return result;

--- a/src/input_common/helpers/joycon_protocol/generic_functions.cpp
+++ b/src/input_common/helpers/joycon_protocol/generic_functions.cpp
@@ -32,13 +32,13 @@ DriverResult GenericProtocol::TriggersElapsed() {
 
 DriverResult GenericProtocol::GetDeviceInfo(DeviceInfo& device_info) {
     ScopedSetBlocking sb(this);
-    std::vector<u8> output;
+    SubCommandResponse output{};
 
     const auto result = SendSubCommand(SubCommand::REQ_DEV_INFO, {}, output);
 
     device_info = {};
     if (result == DriverResult::Success) {
-        memcpy(&device_info, output.data() + 15, sizeof(DeviceInfo));
+        device_info = output.device_info;
     }
 
     return result;

--- a/src/input_common/helpers/joycon_protocol/irs.cpp
+++ b/src/input_common/helpers/joycon_protocol/irs.cpp
@@ -132,7 +132,7 @@ DriverResult IrsProtocol::RequestImage(std::span<u8> buffer) {
 DriverResult IrsProtocol::ConfigureIrs() {
     LOG_DEBUG(Input, "Configure IRS");
     constexpr std::size_t max_tries = 28;
-    std::vector<u8> output;
+    SubCommandResponse output{};
     std::size_t tries = 0;
 
     const IrsConfigure irs_configuration{
@@ -158,7 +158,7 @@ DriverResult IrsProtocol::ConfigureIrs() {
         if (tries++ >= max_tries) {
             return DriverResult::WrongReply;
         }
-    } while (output[15] != 0x0b);
+    } while (output.command_data[0] != 0x0b);
 
     return DriverResult::Success;
 }
@@ -167,7 +167,7 @@ DriverResult IrsProtocol::WriteRegistersStep1() {
     LOG_DEBUG(Input, "WriteRegistersStep1");
     DriverResult result{DriverResult::Success};
     constexpr std::size_t max_tries = 28;
-    std::vector<u8> output;
+    SubCommandResponse output{};
     std::size_t tries = 0;
 
     const IrsWriteRegisters irs_registers{
@@ -218,7 +218,8 @@ DriverResult IrsProtocol::WriteRegistersStep1() {
         if (tries++ >= max_tries) {
             return DriverResult::WrongReply;
         }
-    } while (!(output[15] == 0x13 && output[17] == 0x07) && output[15] != 0x23);
+    } while (!(output.command_data[0] == 0x13 && output.command_data[2] == 0x07) &&
+             output.command_data[0] != 0x23);
 
     return DriverResult::Success;
 }
@@ -226,7 +227,7 @@ DriverResult IrsProtocol::WriteRegistersStep1() {
 DriverResult IrsProtocol::WriteRegistersStep2() {
     LOG_DEBUG(Input, "WriteRegistersStep2");
     constexpr std::size_t max_tries = 28;
-    std::vector<u8> output;
+    SubCommandResponse output{};
     std::size_t tries = 0;
 
     const IrsWriteRegisters irs_registers{
@@ -260,7 +261,7 @@ DriverResult IrsProtocol::WriteRegistersStep2() {
         if (tries++ >= max_tries) {
             return DriverResult::WrongReply;
         }
-    } while (output[15] != 0x13 && output[15] != 0x23);
+    } while (output.command_data[0] != 0x13 && output.command_data[0] != 0x23);
 
     return DriverResult::Success;
 }

--- a/src/input_common/helpers/joycon_protocol/joycon_types.h
+++ b/src/input_common/helpers/joycon_protocol/joycon_types.h
@@ -26,13 +26,19 @@ constexpr std::array<u8, 8> DefaultVibrationBuffer{0x0, 0x1, 0x40, 0x40, 0x0, 0x
 using MacAddress = std::array<u8, 6>;
 using SerialNumber = std::array<u8, 15>;
 
-enum class ControllerType {
-    None,
-    Left,
-    Right,
-    Pro,
-    Grip,
-    Dual,
+enum class ControllerType : u8 {
+    None = 0x00,
+    Left = 0x01,
+    Right = 0x02,
+    Pro = 0x03,
+    Dual = 0x05, // TODO: Verify this id
+    LarkHvc1 = 0x07,
+    LarkHvc2 = 0x08,
+    LarkNesLeft = 0x09,
+    LarkNesRight = 0x0A,
+    Lucia = 0x0B,
+    Lagon = 0x0C,
+    Lager = 0x0D,
 };
 
 enum class PadAxes {
@@ -143,9 +149,10 @@ enum class SubCommand : u8 {
     ENABLE_VIBRATION = 0x48,
     GET_REGULATED_VOLTAGE = 0x50,
     SET_EXTERNAL_CONFIG = 0x58,
-    UNKNOWN_RINGCON = 0x59,
-    UNKNOWN_RINGCON2 = 0x5A,
-    UNKNOWN_RINGCON3 = 0x5C,
+    GET_EXTERNAL_DEVICE_INFO = 0x59,
+    ENABLE_EXTERNAL_POLLING = 0x5A,
+    DISABLE_EXTERNAL_POLLING = 0x5B,
+    SET_EXTERNAL_FORMAT_CONFIG = 0x5C,
 };
 
 enum class UsbSubCommand : u8 {
@@ -165,19 +172,25 @@ enum class CalibrationMagic : u8 {
 };
 
 enum class SpiAddress {
-    SERIAL_NUMBER = 0X6000,
-    DEVICE_TYPE = 0X6012,
-    COLOR_EXIST = 0X601B,
-    FACT_LEFT_DATA = 0X603d,
-    FACT_RIGHT_DATA = 0X6046,
-    COLOR_DATA = 0X6050,
-    FACT_IMU_DATA = 0X6020,
-    USER_LEFT_MAGIC = 0X8010,
-    USER_LEFT_DATA = 0X8012,
-    USER_RIGHT_MAGIC = 0X801B,
-    USER_RIGHT_DATA = 0X801D,
-    USER_IMU_MAGIC = 0X8026,
-    USER_IMU_DATA = 0X8028,
+    MAGIC = 0x0000,
+    MAC_ADDRESS = 0x0015,
+    PAIRING_INFO = 0x2000,
+    SHIPMENT = 0x5000,
+    SERIAL_NUMBER = 0x6000,
+    DEVICE_TYPE = 0x6012,
+    FORMAT_VERSION = 0x601B,
+    FACT_IMU_DATA = 0x6020,
+    FACT_LEFT_DATA = 0x603d,
+    FACT_RIGHT_DATA = 0x6046,
+    COLOR_DATA = 0x6050,
+    DESIGN_VARIATION = 0x605C,
+    SENSOR_DATA = 0x6080,
+    USER_LEFT_MAGIC = 0x8010,
+    USER_LEFT_DATA = 0x8012,
+    USER_RIGHT_MAGIC = 0x801B,
+    USER_RIGHT_DATA = 0x801D,
+    USER_IMU_MAGIC = 0x8026,
+    USER_IMU_DATA = 0x8028,
 };
 
 enum class ReportMode : u8 {
@@ -357,6 +370,11 @@ enum class IrRegistersAddress : u16 {
     DenoiseSmoothing = 0x6701,
     DenoiseEdge = 0x6801,
     DenoiseColor = 0x6901,
+};
+
+enum class ExternalDeviceId : u8 {
+    RingController = 0x20,
+    Starlink = 0x28,
 };
 
 enum class DriverResult {
@@ -605,9 +623,11 @@ static_assert(sizeof(FirmwareVersion) == 0x2, "FirmwareVersion is an invalid siz
 
 struct DeviceInfo {
     FirmwareVersion firmware;
+    std::array<u8, 2> unknown_1;
     MacAddress mac_address;
+    std::array<u8, 2> unknown_2;
 };
-static_assert(sizeof(DeviceInfo) == 0x8, "DeviceInfo is an invalid size");
+static_assert(sizeof(DeviceInfo) == 0xC, "DeviceInfo is an invalid size");
 
 struct MotionStatus {
     bool is_enabled;

--- a/src/input_common/helpers/joycon_protocol/nfc.h
+++ b/src/input_common/helpers/joycon_protocol/nfc.h
@@ -45,13 +45,13 @@ private:
 
     DriverResult GetAmiiboData(std::vector<u8>& data);
 
-    DriverResult SendStartPollingRequest(std::vector<u8>& output);
+    DriverResult SendStartPollingRequest(MCUCommandResponse& output);
 
-    DriverResult SendStopPollingRequest(std::vector<u8>& output);
+    DriverResult SendStopPollingRequest(MCUCommandResponse& output);
 
-    DriverResult SendStartWaitingRecieveRequest(std::vector<u8>& output);
+    DriverResult SendStartWaitingRecieveRequest(MCUCommandResponse& output);
 
-    DriverResult SendReadAmiiboRequest(std::vector<u8>& output, NFCPages ntag_pages);
+    DriverResult SendReadAmiiboRequest(MCUCommandResponse& output, NFCPages ntag_pages);
 
     NFCReadBlockCommand GetReadBlockCommand(NFCPages pages) const;
 

--- a/src/input_common/helpers/joycon_protocol/poller.cpp
+++ b/src/input_common/helpers/joycon_protocol/poller.cpp
@@ -31,9 +31,7 @@ void JoyconPoller::ReadActiveMode(std::span<u8> buffer, const MotionStatus& moti
     case Joycon::ControllerType::Pro:
         UpdateActiveProPadInput(data, motion_status);
         break;
-    case Joycon::ControllerType::Grip:
-    case Joycon::ControllerType::Dual:
-    case Joycon::ControllerType::None:
+    default:
         break;
     }
 
@@ -58,9 +56,7 @@ void JoyconPoller::ReadPassiveMode(std::span<u8> buffer) {
     case Joycon::ControllerType::Pro:
         UpdatePasiveProPadInput(data);
         break;
-    case Joycon::ControllerType::Grip:
-    case Joycon::ControllerType::Dual:
-    case Joycon::ControllerType::None:
+    default:
         break;
     }
 }

--- a/src/input_common/helpers/joycon_protocol/ringcon.cpp
+++ b/src/input_common/helpers/joycon_protocol/ringcon.cpp
@@ -70,7 +70,7 @@ DriverResult RingConProtocol::StartRingconPolling() {
 DriverResult RingConProtocol::IsRingConnected(bool& is_connected) {
     LOG_DEBUG(Input, "IsRingConnected");
     constexpr std::size_t max_tries = 28;
-    std::vector<u8> output;
+    SubCommandResponse output{};
     std::size_t tries = 0;
     is_connected = false;
 
@@ -84,7 +84,7 @@ DriverResult RingConProtocol::IsRingConnected(bool& is_connected) {
         if (tries++ >= max_tries) {
             return DriverResult::NoDeviceDetected;
         }
-    } while (output[16] != static_cast<u8>(ExternalDeviceId::RingController));
+    } while (output.external_device_id != ExternalDeviceId::RingController);
 
     is_connected = true;
     return DriverResult::Success;

--- a/src/input_common/helpers/joycon_protocol/ringcon.cpp
+++ b/src/input_common/helpers/joycon_protocol/ringcon.cpp
@@ -70,14 +70,12 @@ DriverResult RingConProtocol::StartRingconPolling() {
 DriverResult RingConProtocol::IsRingConnected(bool& is_connected) {
     LOG_DEBUG(Input, "IsRingConnected");
     constexpr std::size_t max_tries = 28;
-    constexpr u8 ring_controller_id = 0x20;
     std::vector<u8> output;
     std::size_t tries = 0;
     is_connected = false;
 
     do {
-        std::array<u8, 1> empty_data{};
-        const auto result = SendSubCommand(SubCommand::UNKNOWN_RINGCON, empty_data, output);
+        const auto result = SendSubCommand(SubCommand::GET_EXTERNAL_DEVICE_INFO, {}, output);
 
         if (result != DriverResult::Success) {
             return result;
@@ -86,7 +84,7 @@ DriverResult RingConProtocol::IsRingConnected(bool& is_connected) {
         if (tries++ >= max_tries) {
             return DriverResult::NoDeviceDetected;
         }
-    } while (output[16] != ring_controller_id);
+    } while (output[16] != static_cast<u8>(ExternalDeviceId::RingController));
 
     is_connected = true;
     return DriverResult::Success;
@@ -100,14 +98,14 @@ DriverResult RingConProtocol::ConfigureRing() {
         0x00, 0x00, 0x00, 0x0A, 0x64, 0x0B, 0xE6, 0xA9, 0x22, 0x00, 0x00, 0x04, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0xA8, 0xE1, 0x34, 0x36};
 
-    const DriverResult result = SendSubCommand(SubCommand::UNKNOWN_RINGCON3, ring_config);
+    const DriverResult result = SendSubCommand(SubCommand::SET_EXTERNAL_FORMAT_CONFIG, ring_config);
 
     if (result != DriverResult::Success) {
         return result;
     }
 
     static constexpr std::array<u8, 4> ringcon_data{0x04, 0x01, 0x01, 0x02};
-    return SendSubCommand(SubCommand::UNKNOWN_RINGCON2, ringcon_data);
+    return SendSubCommand(SubCommand::ENABLE_EXTERNAL_POLLING, ringcon_data);
 }
 
 bool RingConProtocol::IsEnabled() const {


### PR DESCRIPTION
Same deal as previous PR. Removes the usage of vectors and return proper structs. Eliminating all magic numbers in the process.