### PR TITLE
shaders: Fix TXQ with MSAA textures

### DIFF
--- a/src/shader_recompiler/backend/glasm/emit_glasm_image.cpp
+++ b/src/shader_recompiler/backend/glasm/emit_glasm_image.cpp
@@ -59,6 +59,13 @@ std::string Image(EmitContext& ctx, IR::TextureInstInfo info,
     }
 }
 
+bool IsTextureMsaa(EmitContext& ctx, const IR::TextureInstInfo& info) {
+    if (info.type == TextureType::Buffer) {
+        return false;
+    }
+    return ctx.info.texture_descriptors.at(info.descriptor_index).is_multisample;
+}
+
 std::string_view TextureType(IR::TextureInstInfo info, bool is_ms = false) {
     if (info.is_depth) {
         switch (info.type) {
@@ -535,7 +542,8 @@ void EmitImageQueryDimensions(EmitContext& ctx, IR::Inst& inst, const IR::Value&
                               ScalarS32 lod, [[maybe_unused]] const IR::Value& skip_mips) {
     const auto info{inst.Flags<IR::TextureInstInfo>()};
     const std::string texture{Texture(ctx, info, index)};
-    const std::string_view type{TextureType(info)};
+    const bool is_msaa{IsTextureMsaa(ctx, info)};
+    const std::string_view type{TextureType(info, is_msaa)};
     ctx.Add("TXQ {},{},{},{};", inst, lod, texture, type);
 }
 

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1288,6 +1288,7 @@ void EmitContext::DefineTextures(const Info& info, u32& binding, u32& scaling_in
             .pointer_type = pointer_type,
             .image_type = image_type,
             .count = desc.count,
+            .is_multisample = desc.is_multisample,
         });
         if (profile.supported_spirv >= 0x00010400) {
             interfaces.push_back(id);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -35,6 +35,7 @@ struct TextureDefinition {
     Id pointer_type;
     Id image_type;
     u32 count;
+    bool is_multisample;
 };
 
 struct TextureBufferDefinition {


### PR DESCRIPTION
TXQ can operate on MSAA textures, but has no flag within the instruction indicating if that is the case. The shader backends require knowing if the texture is MSAA as they cannot query LOD related information for MSAA textures.

This implementation relies on an assumption that TLD/`texelFetch` is called on the MSAA texture elsewhere in the shader, which can track if the texture binding is MSAA. 
This assumption will fall apart if there are shaders which query the size of the MSAA texture, but never sample from it. 

Ideally the MSAA mode for the texture is tracked based on its `TICEntry` from the engine environment, as is done here: https://github.com/yuzu-emu/yuzu/blob/3aab57452153c3dfa8591809bc09797da03b44dc/src/shader_recompiler/ir_opt/texture_pass.cpp#L367-L373 

But doing so will invalidate shader caches, so for now, we assume MSAA textures are always sampled with TLD.


With these changes in place, certain submenus in Dokapon UP! finally render.

|      Before | After        |
|---------|----------|
|  ![dokapon_broken](https://user-images.githubusercontent.com/52414509/215349807-5d90d7c6-8a2e-414f-ad89-c43925a12bf9.png) | ![dokapon_fixed](https://user-images.githubusercontent.com/52414509/215349813-927c8551-8c35-4cfe-bf26-59c28ab55776.png) |