### PR TITLE
ci: Abort on failure to query Github's API

### DIFF
--- a/.ci/scripts/merge/apply-patches-by-label.py
+++ b/.ci/scripts/merge/apply-patches-by-label.py
@@ -18,7 +18,7 @@ def check_individual(labels):
     return False
 
 def do_page(page):
-    url = 'https://api.github.com/repos/yuzu-emu/yuzu/pulls?page=%s' % page
+    url = f"https://api.github.com/repos/yuzu-emu/yuzu/pulls?page={page}"
     response = requests.get(url)
     response.raise_for_status()
     if (response.ok):
@@ -28,10 +28,10 @@ def do_page(page):
         for pr in j:
             if (check_individual(pr["labels"])):
                 pn = pr["number"]
-                print("Matched PR# %s" % pn)
-                print(subprocess.check_output(["git", "fetch", "https://github.com/yuzu-emu/yuzu.git", "pull/%s/head:pr-%s" % (pn, pn), "-f", "--no-recurse-submodules"]))
-                print(subprocess.check_output(["git", "merge", "--squash", "pr-%s" % pn]))
-                print(subprocess.check_output(["git", "commit", "-m\"Merge %s PR %s\"" % (tagline, pn)]))
+                print(f"Matched PR# {pn}")
+                print(subprocess.check_output(["git", "fetch", "https://github.com/yuzu-emu/yuzu.git", f"pull/{pn}/head:pr-{pn}", "-f", "--no-recurse-submodules"]))
+                print(subprocess.check_output(["git", "merge", "--squash", f"pr-{pn}"]))
+                print(subprocess.check_output(["git", "commit", f"-m\"Merge {tagline} PR {pn}\""]))
 
 try:
     for i in range(1,10):

--- a/.ci/scripts/merge/apply-patches-by-label.py
+++ b/.ci/scripts/merge/apply-patches-by-label.py
@@ -20,6 +20,7 @@ def check_individual(labels):
 def do_page(page):
     url = 'https://api.github.com/repos/yuzu-emu/yuzu/pulls?page=%s' % page
     response = requests.get(url)
+    response.raise_for_status()
     if (response.ok):
         j = json.loads(response.content)
         if j == []:
@@ -33,7 +34,7 @@ def do_page(page):
                 print(subprocess.check_output(["git", "commit", "-m\"Merge %s PR %s\"" % (tagline, pn)]))
 
 try:
-    for i in range(1,30):
+    for i in range(1,10):
         do_page(i)
 except:
     traceback.print_exc(file=sys.stdout)

--- a/.ci/scripts/merge/apply-patches-by-label.py
+++ b/.ci/scripts/merge/apply-patches-by-label.py
@@ -2,14 +2,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Download all pull requests as patches that match a specific label
-# Usage: python download-patches-by-label.py <Label to Match> <Root Path Folder to DL to>
+# Usage: python apply-patches-by-label.py <Label to Match>
 
-import requests, sys, json, urllib3.request, shutil, subprocess, os, traceback
+import json, requests, subprocess, sys, traceback
 
 tagline = sys.argv[2]
-
-http = urllib3.PoolManager()
-dl_list = {}
 
 def check_individual(labels):
     for label in labels:


### PR DESCRIPTION
This raises an exception if the GET request to Github's API returns anything other than 200 OK, ensuring we always have successful merges of tagged PRs. Also, reduces the number of queried pages from 29 to 9 to reduce the number of requests.