### PR TITLE
gl_shader_cache: Force context flush when loading disk shader cache

### DIFF
--- a/src/video_core/renderer_opengl/gl_compute_pipeline.h
+++ b/src/video_core/renderer_opengl/gl_compute_pipeline.h
@@ -50,7 +50,8 @@ class ComputePipeline {
 public:
     explicit ComputePipeline(const Device& device, TextureCache& texture_cache_,
                              BufferCache& buffer_cache_, ProgramManager& program_manager_,
-                             const Shader::Info& info_, std::string code, std::vector<u32> code_v);
+                             const Shader::Info& info_, std::string code, std::vector<u32> code_v,
+                             bool force_context_flush = false);
 
     void Configure();
 
@@ -65,6 +66,8 @@ public:
     }
 
 private:
+    void WaitForBuild();
+
     TextureCache& texture_cache;
     BufferCache& buffer_cache;
     Tegra::MemoryManager* gpu_memory;
@@ -81,6 +84,11 @@ private:
 
     bool use_storage_buffers{};
     bool writes_global_memory{};
+
+    std::mutex built_mutex;
+    std::condition_variable built_condvar;
+    OGLSync built_fence{};
+    bool is_built{false};
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.h
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.h
@@ -78,7 +78,7 @@ public:
                               std::array<std::string, 5> sources,
                               std::array<std::vector<u32>, 5> sources_spirv,
                               const std::array<const Shader::Info*, 5>& infos,
-                              const GraphicsPipelineKey& key_);
+                              const GraphicsPipelineKey& key_, bool force_context_flush = false);
 
     void Configure(bool is_indexed) {
         configure_func(this, is_indexed);

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -58,7 +58,8 @@ private:
 
     std::unique_ptr<ComputePipeline> CreateComputePipeline(ShaderContext::ShaderPools& pools,
                                                            const ComputePipelineKey& key,
-                                                           Shader::Environment& env);
+                                                           Shader::Environment& env,
+                                                           bool force_context_flush = false);
 
     std::unique_ptr<ShaderWorker> CreateWorkers() const;
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -50,7 +50,8 @@ private:
 
     std::unique_ptr<GraphicsPipeline> CreateGraphicsPipeline(
         ShaderContext::ShaderPools& pools, const GraphicsPipelineKey& key,
-        std::span<Shader::Environment* const> envs, bool build_in_parallel);
+        std::span<Shader::Environment* const> envs, bool use_shader_workers,
+        bool force_context_flush = false);
 
     std::unique_ptr<ComputePipeline> CreateComputePipeline(const ComputePipelineKey& key,
                                                            const VideoCommon::ShaderInfo* shader);


### PR DESCRIPTION
The disk shader cache was building pipelines on async worker threads using a shared GL context, but these built pipelines wouldn't always necessarily be available to the main context.

This was especially an issue for async shader compilation, where there was roundabout logic that made the async worker threads indicate that the pipelines were built despite not calling `glFlush`.

this change forces a context flush when loading disk shader cache, and ensures that the async thread's work is complete before attempting to use the pipeline. This will fix persistent graphical issues especially with async shaders enabled.

The easiest repro I had to test this was DKC:TF title screen, where it was previously graphically messed up/missing elements with async shaders + disk pipeline cache enabled:

<img src="https://user-images.githubusercontent.com/52414509/215373674-b7ef0823-32d8-494f-b62f-7e7c8c7da92f.png" data-canonical-src="https://user-images.githubusercontent.com/52414509/215373674-b7ef0823-32d8-494f-b62f-7e7c8c7da92f.png" width="400" height="242" />


With these changes, async shaders on OpenGL should be safe from persisting graphical corruption.