### PR TITLE
Added 'Hide empty rooms' toggle to lobby

### DIFF
--- a/src/yuzu/multiplayer/lobby.cpp
+++ b/src/yuzu/multiplayer/lobby.cpp
@@ -77,6 +77,7 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
     // UI Buttons
     connect(ui->refresh_list, &QPushButton::clicked, this, &Lobby::RefreshLobby);
     connect(ui->games_owned, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterOwned);
+    connect(ui->hide_empty, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterEmpty);
     connect(ui->hide_full, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterFull);
     connect(ui->search, &QLineEdit::textChanged, proxy, &LobbyFilterProxyModel::SetFilterSearch);
     connect(ui->room_list, &QTreeView::doubleClicked, this, &Lobby::OnJoinRoom);
@@ -329,6 +330,16 @@ bool LobbyFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& s
         return true;
     }
 
+    // filter by empty rooms
+    if (filter_empty) {
+        QModelIndex member_list = sourceModel()->index(sourceRow, Column::MEMBER, sourceParent);
+        int player_count =
+            sourceModel()->data(member_list, LobbyItemMemberList::MemberListRole).toList().size();
+        if (player_count == 0) {
+            return false;
+        }
+    }
+
     // filter by filled rooms
     if (filter_full) {
         QModelIndex member_list = sourceModel()->index(sourceRow, Column::MEMBER, sourceParent);
@@ -396,6 +407,11 @@ void LobbyFilterProxyModel::sort(int column, Qt::SortOrder order) {
 
 void LobbyFilterProxyModel::SetFilterOwned(bool filter) {
     filter_owned = filter;
+    invalidate();
+}
+
+void LobbyFilterProxyModel::SetFilterEmpty(bool filter) {
+    filter_empty = filter;
     invalidate();
 }
 

--- a/src/yuzu/multiplayer/lobby.h
+++ b/src/yuzu/multiplayer/lobby.h
@@ -130,12 +130,14 @@ public:
 
 public slots:
     void SetFilterOwned(bool);
+    void SetFilterEmpty(bool);
     void SetFilterFull(bool);
     void SetFilterSearch(const QString&);
 
 private:
     QStandardItemModel* game_list;
     bool filter_owned = false;
+    bool filter_empty = false;
     bool filter_full = false;
     QString filter_search;
 };

--- a/src/yuzu/multiplayer/lobby.ui
+++ b/src/yuzu/multiplayer/lobby.ui
@@ -78,6 +78,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="hide_empty">
+           <property name="text">
+            <string>Hide Empty Rooms</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="hide_full">
            <property name="text">
             <string>Hide Full Rooms</string>


### PR DESCRIPTION
Same as the full rooms toggle, but hides rooms with no other players, in case you want to jump in where people already are. There are a lot of 0/ rooms at some times of day.