### PR TITLE
core: Async save fs access log

### DIFF
--- a/src/core/reporter.h
+++ b/src/core/reporter.h
@@ -23,6 +23,7 @@ struct LogMessage;
 namespace Core {
 
 class System;
+class FSAccessLogger;
 
 class Reporter {
 public:
@@ -78,6 +79,8 @@ private:
     bool IsReportingEnabled() const;
 
     System& system;
+
+    std::unique_ptr<FSAccessLogger> fs_access_logger;
 };
 
 } // namespace Core


### PR DESCRIPTION
FINAL FANTASY VII [0100A5B00BDC6000] have large number of file access logs will be written during the start game, and the current implementation cannot meet the performance requirements, so an asynchronous solution is estimated to replace the current implementation.

