### PR TITLE
Remove fake vertex bindings when dynamic state is enabled

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -548,31 +548,7 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
     static_vector<VkVertexInputBindingDescription, 32> vertex_bindings;
     static_vector<VkVertexInputBindingDivisorDescriptionEXT, 32> vertex_binding_divisors;
     static_vector<VkVertexInputAttributeDescription, 32> vertex_attributes;
-    if (key.state.dynamic_vertex_input) {
-        const size_t num_vertex_arrays = std::min(
-            key.state.attributes.size(), static_cast<size_t>(device.GetMaxVertexInputBindings()));
-        for (size_t index = 0; index < num_vertex_arrays; ++index) {
-            const u32 type = key.state.DynamicAttributeType(index);
-            if (!stage_infos[0].loads.Generic(index) || type == 0) {
-                continue;
-            }
-            vertex_attributes.push_back({
-                .location = static_cast<u32>(index),
-                .binding = 0,
-                .format = type == 1   ? VK_FORMAT_R32_SFLOAT
-                          : type == 2 ? VK_FORMAT_R32_SINT
-                                      : VK_FORMAT_R32_UINT,
-                .offset = 0,
-            });
-        }
-        if (!vertex_attributes.empty()) {
-            vertex_bindings.push_back({
-                .binding = 0,
-                .stride = 4,
-                .inputRate = VK_VERTEX_INPUT_RATE_VERTEX,
-            });
-        }
-    } else {
+    if (!key.state.dynamic_vertex_input) {
         const size_t num_vertex_arrays = std::min(
             Maxwell::NumVertexArrays, static_cast<size_t>(device.GetMaxVertexInputBindings()));
         for (size_t index = 0; index < num_vertex_arrays; ++index) {


### PR DESCRIPTION
When dynamic state is enabled, the pipeline vertex input state is ignored, and they're set up dynamically on the command buffer instead. For some reason we set "fake" vertex bindings with fixed/incomplete values, which causes Vulkan's validation layers to go crazy spamming unaligned vertex buffer attribute errors, even when these bindings are not used. Seems like a bug with Vulkan validation layers. 

Removing these fake vertex bindings gets rid of the validation console spam with dynamic input.