### PR TITLE
gpu_thread: Remove OnCommandListEndCommand

### DIFF
--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -99,7 +99,7 @@ struct GPU::Impl {
 
     /// Signal the ending of command list.
     void OnCommandListEnd() {
-        gpu_thread.OnCommandListEnd();
+        rasterizer->ReleaseFences();
     }
 
     /// Request a host GPU memory flush from the CPU.

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -40,8 +40,6 @@ static void RunThread(std::stop_token stop_token, Core::System& system,
             scheduler.Push(submit_list->channel, std::move(submit_list->entries));
         } else if (const auto* data = std::get_if<SwapBuffersCommand>(&next.data)) {
             renderer.SwapBuffers(data->framebuffer ? &*data->framebuffer : nullptr);
-        } else if (std::holds_alternative<OnCommandListEndCommand>(next.data)) {
-            rasterizer->ReleaseFences();
         } else if (std::holds_alternative<GPUTickCommand>(next.data)) {
             system.GPU().TickWork();
         } else if (const auto* flush = std::get_if<FlushRegionCommand>(&next.data)) {
@@ -108,10 +106,6 @@ void ThreadManager::InvalidateRegion(VAddr addr, u64 size) {
 void ThreadManager::FlushAndInvalidateRegion(VAddr addr, u64 size) {
     // Skip flush on asynch mode, as FlushAndInvalidateRegion is not used for anything too important
     rasterizer->OnCPUWrite(addr, size);
-}
-
-void ThreadManager::OnCommandListEnd() {
-    PushCommand(OnCommandListEndCommand());
 }
 
 u64 ThreadManager::PushCommand(CommandData&& command_data, bool block) {

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -77,16 +77,12 @@ struct FlushAndInvalidateRegionCommand final {
     u64 size;
 };
 
-/// Command called within the gpu, to schedule actions after a command list end
-struct OnCommandListEndCommand final {};
-
 /// Command to make the gpu look into pending requests
 struct GPUTickCommand final {};
 
 using CommandData =
     std::variant<std::monostate, SubmitListCommand, SwapBuffersCommand, FlushRegionCommand,
-                 InvalidateRegionCommand, FlushAndInvalidateRegionCommand, OnCommandListEndCommand,
-                 GPUTickCommand>;
+                 InvalidateRegionCommand, FlushAndInvalidateRegionCommand, GPUTickCommand>;
 
 struct CommandDataContainer {
     CommandDataContainer() = default;
@@ -133,8 +129,6 @@ public:
 
     /// Notify rasterizer that any caches of the specified region should be flushed and invalidated
     void FlushAndInvalidateRegion(VAddr addr, u64 size);
-
-    void OnCommandListEnd();
 
     void TickGPU();
 


### PR DESCRIPTION
Call rasterizer->ReleaseFences() directly

Tegra::Control::Scheduler::Push calls Tegra::DmaPusher::DispatchCalls which calls Tegra::GPU::OnCommandListEnd

This in turn would make the gpu thread produce to its own command queue.

After this is tested and shows no regressions I will bring back the bounded queue. I believe this is the root cause of the problems the bounded queue encountered.