### PR TITLE
texture_cache: OpenGL: Implement MSAA uploads and copies

### DIFF
--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -22,6 +22,8 @@ set(SHADER_FILES
     convert_d24s8_to_abgr8.frag
     convert_depth_to_float.frag
     convert_float_to_depth.frag
+    convert_msaa_to_non_msaa.comp
+    convert_non_msaa_to_msaa.comp
     convert_s8d24_to_abgr8.frag
     full_screen_triangle.vert
     fxaa.frag

--- a/src/video_core/host_shaders/convert_msaa_to_non_msaa.comp
+++ b/src/video_core/host_shaders/convert_msaa_to_non_msaa.comp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#version 450 core
+layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout (binding = 0, rgba8) uniform readonly restrict image2DMSArray msaa_in;
+layout (binding = 1, rgba8) uniform writeonly restrict image2DArray output_img;
+
+void main() {
+    const ivec3 coords = ivec3(gl_GlobalInvocationID);
+    if (any(greaterThanEqual(coords, imageSize(msaa_in)))) {
+        return;
+    }
+
+    // TODO: Specialization constants for num_samples?
+    const int num_samples = imageSamples(msaa_in);
+    for (int curr_sample = 0; curr_sample < num_samples; ++curr_sample) {
+        const vec4 pixel = imageLoad(msaa_in, coords, curr_sample);
+
+        const int single_sample_x = 2 * coords.x + (curr_sample & 1);
+        const int single_sample_y = 2 * coords.y + ((curr_sample / 2) & 1);
+        const ivec3 dest_coords = ivec3(single_sample_x, single_sample_y, coords.z);
+
+        if (any(greaterThanEqual(dest_coords, imageSize(output_img)))) {
+            continue;
+        }
+        imageStore(output_img, dest_coords, pixel);
+    }
+}

--- a/src/video_core/host_shaders/convert_non_msaa_to_msaa.comp
+++ b/src/video_core/host_shaders/convert_non_msaa_to_msaa.comp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#version 450 core
+layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout (binding = 0, rgba8) uniform readonly restrict image2DArray img_in;
+layout (binding = 1, rgba8) uniform writeonly restrict image2DMSArray output_msaa;
+
+void main() {
+    const ivec3 coords = ivec3(gl_GlobalInvocationID);
+    if (any(greaterThanEqual(coords, imageSize(output_msaa)))) {
+        return;
+    }
+
+    // TODO: Specialization constants for num_samples?
+    const int num_samples = imageSamples(output_msaa);
+    for (int curr_sample = 0; curr_sample < num_samples; ++curr_sample) {
+        const int single_sample_x = 2 * coords.x + (curr_sample & 1);
+        const int single_sample_y = 2 * coords.y + ((curr_sample / 2) & 1);
+        const ivec3 single_coords = ivec3(single_sample_x, single_sample_y, coords.z);
+
+        if (any(greaterThanEqual(single_coords, imageSize(img_in)))) {
+            continue;
+        }
+        const vec4 pixel = imageLoad(img_in, single_coords);
+        imageStore(output_msaa, coords, curr_sample, pixel);
+    }
+}

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -557,6 +557,14 @@ void TextureCacheRuntime::CopyImage(Image& dst_image, Image& src_image,
     }
 }
 
+void TextureCacheRuntime::CopyImageMSAA(Image& dst_image, Image& src_image,
+                                        std::span<const VideoCommon::ImageCopy> copies) {
+    LOG_DEBUG(Render_OpenGL, "Copying from {} samples to {} samples", src_image.info.num_samples,
+              dst_image.info.num_samples);
+    // TODO: Leverage the format conversion pass if possible/accurate.
+    util_shaders.CopyMSAA(dst_image, src_image, copies);
+}
+
 void TextureCacheRuntime::ReinterpretImage(Image& dst, Image& src,
                                            std::span<const VideoCommon::ImageCopy> copies) {
     LOG_DEBUG(Render_OpenGL, "Converting {} to {}", src.info.format, dst.info.format);

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -93,11 +93,18 @@ public:
         return device.CanReportMemoryUsage();
     }
 
-    bool ShouldReinterpret([[maybe_unused]] Image& dst, [[maybe_unused]] Image& src) {
+    bool ShouldReinterpret([[maybe_unused]] Image& dst,
+                           [[maybe_unused]] Image& src) const noexcept {
+        return true;
+    }
+
+    bool CanUploadMSAA() const noexcept {
         return true;
     }
 
     void CopyImage(Image& dst, Image& src, std::span<const VideoCommon::ImageCopy> copies);
+
+    void CopyImageMSAA(Image& dst, Image& src, std::span<const VideoCommon::ImageCopy> copies);
 
     void ReinterpretImage(Image& dst, Image& src, std::span<const VideoCommon::ImageCopy> copies);
 

--- a/src/video_core/renderer_opengl/util_shaders.h
+++ b/src/video_core/renderer_opengl/util_shaders.h
@@ -40,6 +40,9 @@ public:
 
     void ConvertS8D24(Image& dst_image, std::span<const VideoCommon::ImageCopy> copies);
 
+    void CopyMSAA(Image& dst_image, Image& src_image,
+                  std::span<const VideoCommon::ImageCopy> copies);
+
 private:
     ProgramManager& program_manager;
 
@@ -51,6 +54,8 @@ private:
     OGLProgram pitch_unswizzle_program;
     OGLProgram copy_bc4_program;
     OGLProgram convert_s8d24_program;
+    OGLProgram convert_ms_to_nonms_program;
+    OGLProgram convert_nonms_to_ms_program;
 };
 
 GLenum StoreFormat(u32 bytes_per_block);

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1230,6 +1230,11 @@ void TextureCacheRuntime::CopyImage(Image& dst, Image& src,
     });
 }
 
+void TextureCacheRuntime::CopyImageMSAA(Image& dst, Image& src,
+                                        std::span<const VideoCommon::ImageCopy> copies) {
+    UNIMPLEMENTED_MSG("Copying images with different samples is not implemented in Vulkan.");
+}
+
 u64 TextureCacheRuntime::GetDeviceLocalMemory() const {
     return device.GetDeviceLocalMemory();
 }

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -70,6 +70,8 @@ public:
 
     void CopyImage(Image& dst, Image& src, std::span<const VideoCommon::ImageCopy> copies);
 
+    void CopyImageMSAA(Image& dst, Image& src, std::span<const VideoCommon::ImageCopy> copies);
+
     bool ShouldReinterpret(Image& dst, Image& src);
 
     void ReinterpretImage(Image& dst, Image& src, std::span<const VideoCommon::ImageCopy> copies);
@@ -77,6 +79,11 @@ public:
     void ConvertImage(Framebuffer* dst, ImageView& dst_view, ImageView& src_view);
 
     bool CanAccelerateImageUpload(Image&) const noexcept {
+        return false;
+    }
+
+    bool CanUploadMSAA() const noexcept {
+        // TODO: Implement buffer to MSAA uploads
         return false;
     }
 

--- a/src/video_core/texture_cache/formatter.cpp
+++ b/src/video_core/texture_cache/formatter.cpp
@@ -22,6 +22,9 @@ std::string Name(const ImageBase& image) {
     const u32 num_layers = image.info.resources.layers;
     const u32 num_levels = image.info.resources.levels;
     std::string resource;
+    if (image.info.num_samples > 1) {
+        resource += fmt::format(":{}xMSAA", image.info.num_samples);
+    }
     if (num_layers > 1) {
         resource += fmt::format(":L{}", num_layers);
     }

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -573,10 +573,6 @@ u32 CalculateUnswizzledSizeBytes(const ImageInfo& info) noexcept {
     if (info.type == ImageType::Buffer) {
         return info.size.width * BytesPerBlock(info.format);
     }
-    if (info.num_samples > 1) {
-        // Multisample images can't be uploaded or downloaded to the host
-        return 0;
-    }
     if (info.type == ImageType::Linear) {
         return info.pitch * Common::DivCeil(info.size.height, DefaultBlockHeight(info.format));
     }
@@ -703,7 +699,6 @@ ImageViewType RenderTargetImageViewType(const ImageInfo& info) noexcept {
 std::vector<ImageCopy> MakeShrinkImageCopies(const ImageInfo& dst, const ImageInfo& src,
                                              SubresourceBase base, u32 up_scale, u32 down_shift) {
     ASSERT(dst.resources.levels >= src.resources.levels);
-    ASSERT(dst.num_samples == src.num_samples);
 
     const bool is_dst_3d = dst.type == ImageType::e3D;
     if (is_dst_3d) {


### PR DESCRIPTION
This is an initial implementation of MSAA image uploads and copies in OpenGL. The main challenge for MSAA support has been replicating the memory layout of MSAA textures, since the APIs forbid calling most typical memory operations on MSAA textures (likely because the memory layout could be device/driver dependent).

Implementing this on Vulkan proved to be a lot more tedious, so for now, it remains unsupported.

This was tested on Sonic Forces, which uses MSAA textures for the background of the map screen:

https://user-images.githubusercontent.com/52414509/217416312-7b7917cf-0a2d-4481-a9a4-7563dc5a9e6e.mp4


https://user-images.githubusercontent.com/52414509/217416319-9d1e4deb-83e4-4cdd-9e8b-04b3200d71f7.mp4

Further testing on other titles known to use MSAA would be appreciated.