### PR TITLE
service: hid: Return error if arguments of SetSupportedNpadIdType is invalid

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -758,12 +758,20 @@ Core::HID::NpadStyleTag Controller_NPad::GetSupportedStyleSet() const {
     return hid_core.GetSupportedStyleTag();
 }
 
-void Controller_NPad::SetSupportedNpadIdTypes(std::span<const u8> data) {
+Result Controller_NPad::SetSupportedNpadIdTypes(std::span<const u8> data) {
+    constexpr std::size_t max_number_npad_ids = 0xa;
     const auto length = data.size();
     ASSERT(length > 0 && (length % sizeof(u32)) == 0);
+    const std::size_t elements = length / sizeof(u32);
+
+    if (elements > max_number_npad_ids) {
+        return InvalidArraySize;
+    }
+
     supported_npad_id_types.clear();
-    supported_npad_id_types.resize(length / sizeof(u32));
+    supported_npad_id_types.resize(elements);
     std::memcpy(supported_npad_id_types.data(), data.data(), length);
+    return ResultSuccess;
 }
 
 void Controller_NPad::GetSupportedNpadIdTypes(u32* data, std::size_t max_length) {

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -96,7 +96,7 @@ public:
     void SetSupportedStyleSet(Core::HID::NpadStyleTag style_set);
     Core::HID::NpadStyleTag GetSupportedStyleSet() const;
 
-    void SetSupportedNpadIdTypes(std::span<const u8> data);
+    Result SetSupportedNpadIdTypes(std::span<const u8> data);
     void GetSupportedNpadIdTypes(u32* data, std::size_t max_length);
     std::size_t GetSupportedNpadIdTypesSize() const;
 

--- a/src/core/hle/service/hid/errors.h
+++ b/src/core/hle/service/hid/errors.h
@@ -18,6 +18,7 @@ constexpr Result NpadIsDualJoycon{ErrorModule::HID, 601};
 constexpr Result NpadIsSameType{ErrorModule::HID, 602};
 constexpr Result InvalidNpadId{ErrorModule::HID, 709};
 constexpr Result NpadNotConnected{ErrorModule::HID, 710};
+constexpr Result InvalidArraySize{ErrorModule::HID, 715};
 constexpr Result InvalidPalmaHandle{ErrorModule::HID, 3302};
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -1025,13 +1025,13 @@ void Hid::SetSupportedNpadIdType(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    applet_resource->GetController<Controller_NPad>(HidController::NPad)
-        .SetSupportedNpadIdTypes(ctx.ReadBuffer());
+    const auto result = applet_resource->GetController<Controller_NPad>(HidController::NPad)
+                            .SetSupportedNpadIdTypes(ctx.ReadBuffer());
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(ResultSuccess);
+    rb.Push(result);
 }
 
 void Hid::ActivateNpad(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
This function only allows up to 10 elements. Any more and the function should return an error without changing anything. No behavior changes are expected in games.