### PR TITLE
glsl_emit_context: Remove redeclarations of gl_SampleID and gl_SampleMask

### DIFF
--- a/src/shader_recompiler/backend/glsl/glsl_emit_context.cpp
+++ b/src/shader_recompiler/backend/glsl/glsl_emit_context.cpp
@@ -310,12 +310,6 @@ EmitContext::EmitContext(IR::Program& program, Bindings& bindings, const Profile
         if (runtime_info.force_early_z) {
             header += "layout(early_fragment_tests)in;";
         }
-        if (info.uses_sample_id) {
-            header += "in int gl_SampleID;";
-        }
-        if (info.stores_sample_mask) {
-            header += "out int gl_SampleMask[];";
-        }
         break;
     case Stage::Compute:
         stage_name = "cs";


### PR DESCRIPTION
These built-ins seem to be available without needing to be declared for fragment shaders, similar i.e. to gl_FragDepth.