### PR TITLE
input_common: Reintroduce custom pro controller support

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -488,6 +488,7 @@ struct Values {
     Setting<bool> enable_raw_input{false, "enable_raw_input"};
     Setting<bool> controller_navigation{true, "controller_navigation"};
     Setting<bool> enable_joycon_driver{true, "enable_joycon_driver"};
+    Setting<bool> enable_procon_driver{false, "enable_procon_driver"};
 
     SwitchableSetting<bool> vibration_enabled{true, "vibration_enabled"};
     SwitchableSetting<bool> enable_accurate_vibrations{false, "enable_accurate_vibrations"};

--- a/src/input_common/drivers/joycon.h
+++ b/src/input_common/drivers/joycon.h
@@ -106,6 +106,7 @@ private:
     // Joycon types are split by type to ease supporting dualjoycon configurations
     std::array<std::shared_ptr<Joycon::JoyconDriver>, MaxSupportedControllers> left_joycons{};
     std::array<std::shared_ptr<Joycon::JoyconDriver>, MaxSupportedControllers> right_joycons{};
+    std::array<std::shared_ptr<Joycon::JoyconDriver>, MaxSupportedControllers> pro_controller{};
 };
 
 } // namespace InputCommon

--- a/src/input_common/helpers/joycon_driver.cpp
+++ b/src/input_common/helpers/joycon_driver.cpp
@@ -543,9 +543,10 @@ void JoyconDriver::SetCallbacks(const JoyconCallbacks& callbacks) {
 
 DriverResult JoyconDriver::GetDeviceType(SDL_hid_device_info* device_info,
                                          ControllerType& controller_type) {
-    static constexpr std::array<std::pair<u32, ControllerType>, 2> supported_devices{
+    static constexpr std::array<std::pair<u32, ControllerType>, 6> supported_devices{
         std::pair<u32, ControllerType>{0x2006, ControllerType::Left},
         {0x2007, ControllerType::Right},
+        {0x2009, ControllerType::Pro},
     };
     constexpr u16 nintendo_vendor_id = 0x057e;
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -441,6 +441,7 @@ void Config::ReadControlValues() {
     Settings::values.mouse_panning = false;
     ReadBasicSetting(Settings::values.mouse_panning_sensitivity);
     ReadBasicSetting(Settings::values.enable_joycon_driver);
+    ReadBasicSetting(Settings::values.enable_procon_driver);
 
     ReadBasicSetting(Settings::values.tas_enable);
     ReadBasicSetting(Settings::values.tas_loop);
@@ -1141,6 +1142,7 @@ void Config::SaveControlValues() {
     WriteGlobalSetting(Settings::values.motion_enabled);
     WriteBasicSetting(Settings::values.enable_raw_input);
     WriteBasicSetting(Settings::values.enable_joycon_driver);
+    WriteBasicSetting(Settings::values.enable_procon_driver);
     WriteBasicSetting(Settings::values.keyboard_enabled);
     WriteBasicSetting(Settings::values.emulate_analog_keyboard);
     WriteBasicSetting(Settings::values.mouse_panning_sensitivity);

--- a/src/yuzu/configuration/configure_input_advanced.cpp
+++ b/src/yuzu/configuration/configure_input_advanced.cpp
@@ -139,6 +139,7 @@ void ConfigureInputAdvanced::ApplyConfiguration() {
     Settings::values.enable_ring_controller = ui->enable_ring_controller->isChecked();
     Settings::values.enable_ir_sensor = ui->enable_ir_sensor->isChecked();
     Settings::values.enable_joycon_driver = ui->enable_joycon_driver->isChecked();
+    Settings::values.enable_procon_driver = ui->enable_procon_driver->isChecked();
 }
 
 void ConfigureInputAdvanced::LoadConfiguration() {
@@ -174,6 +175,7 @@ void ConfigureInputAdvanced::LoadConfiguration() {
     ui->enable_ring_controller->setChecked(Settings::values.enable_ring_controller.GetValue());
     ui->enable_ir_sensor->setChecked(Settings::values.enable_ir_sensor.GetValue());
     ui->enable_joycon_driver->setChecked(Settings::values.enable_joycon_driver.GetValue());
+    ui->enable_procon_driver->setChecked(Settings::values.enable_procon_driver.GetValue());
 
     UpdateUIEnabled();
 }

--- a/src/yuzu/configuration/configure_input_advanced.ui
+++ b/src/yuzu/configuration/configure_input_advanced.ui
@@ -2712,6 +2712,22 @@
                      </widget>
                    </item>
                    <item row="6" column="0">
+                      <widget class="QCheckBox" name="enable_procon_driver">
+                       <property name="toolTip">
+                         <string>Requires restarting yuzu</string>
+                       </property>
+                       <property name="minimumSize">
+                         <size>
+                           <width>0</width>
+                           <height>23</height>
+                         </size>
+                       </property>
+                       <property name="text">
+                         <string>Enable direct Pro Controller driver [EXPERIMENTAL]</string>
+                       </property>
+                     </widget>
+                   </item>
+                   <item row="7" column="0">
                      <widget class="QCheckBox" name="mouse_panning">
                        <property name="minimumSize">
                          <size>
@@ -2724,7 +2740,7 @@
                        </property>
                      </widget>
                    </item>
-                   <item row="6" column="2">
+                   <item row="7" column="2">
                      <widget class="QSpinBox" name="mouse_panning_sensitivity">
                        <property name="toolTip">
                          <string>Mouse sensitivity</string>
@@ -2746,14 +2762,14 @@
                        </property>
                      </widget>
                    </item>
-                   <item row="7" column="0">
+                   <item row="8" column="0">
                      <widget class="QLabel" name="motion_touch">
                        <property name="text">
                          <string>Motion / Touch</string>
                        </property>
                      </widget>
                    </item>
-                   <item row="7" column="2">
+                   <item row="8" column="2">
                      <widget class="QPushButton" name="buttonMotionTouch">
                        <property name="text">
                          <string>Configure</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -178,6 +178,7 @@ void Config::ReadValues() {
 
     ReadSetting("ControlsGeneral", Settings::values.enable_raw_input);
     ReadSetting("ControlsGeneral", Settings::values.enable_joycon_driver);
+    ReadSetting("ControlsGeneral", Settings::values.enable_procon_driver);
     ReadSetting("ControlsGeneral", Settings::values.emulate_analog_keyboard);
     ReadSetting("ControlsGeneral", Settings::values.vibration_enabled);
     ReadSetting("ControlsGeneral", Settings::values.enable_accurate_vibrations);


### PR DESCRIPTION
This PR brings back the support for pro controllers on the custom joycon driver. It's disabled by default since it still has issues with 3rd party variants. But users who own an original controller can enable this option.