### PR TITLE
main: Re-add QtWebEngine zoom factor

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -805,6 +805,8 @@ void GMainWindow::WebBrowserOpenWebPage(const std::string& main_url,
                                 layout.screen.GetHeight() / scale_ratio);
         web_browser_view.move(layout.screen.left / scale_ratio,
                               (layout.screen.top / scale_ratio) + menuBar()->height());
+        web_browser_view.setZoomFactor(static_cast<qreal>(layout.screen.GetWidth() / scale_ratio) /
+                                       static_cast<qreal>(Layout::ScreenUndocked::Width));
 
         web_browser_view.setFocus();
         web_browser_view.show();


### PR DESCRIPTION
For some reason, I had removed this in https://github.com/yuzu-emu/yuzu/pull/4949/commits/ad6cec71ecd61aa2533d9efa89b68837516f8464

This should fix any improperly scaled web applets.

Should fix #9756 