### PR TITLE
[audio_core] Use ScratchBuffer to reduce memory allocations

### DIFF
--- a/src/audio_core/device/device_session.h
+++ b/src/audio_core/device/device_session.h
@@ -62,7 +62,7 @@ public:
      *
      * @param buffers - The buffers to play.
      */
-    void AppendBuffers(std::span<const AudioBuffer> buffers) const;
+    void AppendBuffers(std::span<const AudioBuffer> buffers, u32 out_size) const;
 
     /**
      * (Audio In only) Pop samples from the backend, and write them back to this buffer's address.

--- a/src/audio_core/in/audio_in_system.cpp
+++ b/src/audio_core/in/audio_in_system.cpp
@@ -89,9 +89,10 @@ Result System::Start() {
     session->Start();
     state = State::Started;
 
-    std::vector<AudioBuffer> buffers_to_flush{};
-    buffers.RegisterBuffers(buffers_to_flush);
-    session->AppendBuffers(buffers_to_flush);
+    std::array<AudioBuffer, BufferAppendLimit> buffers_to_flush{};
+    u32 out_size{0};
+    buffers.RegisterBuffers(buffers_to_flush, out_size);
+    session->AppendBuffers(buffers_to_flush, out_size);
     session->SetRingSize(static_cast<u32>(buffers_to_flush.size()));
 
     return ResultSuccess;
@@ -134,9 +135,10 @@ bool System::AppendBuffer(const AudioInBuffer& buffer, const u64 tag) {
 
 void System::RegisterBuffers() {
     if (state == State::Started) {
-        std::vector<AudioBuffer> registered_buffers{};
-        buffers.RegisterBuffers(registered_buffers);
-        session->AppendBuffers(registered_buffers);
+        std::array<AudioBuffer, BufferAppendLimit> registered_buffers{};
+        u32 out_size{0};
+        buffers.RegisterBuffers(registered_buffers, out_size);
+        session->AppendBuffers(registered_buffers, out_size);
     }
 }
 

--- a/src/audio_core/out/audio_out_system.cpp
+++ b/src/audio_core/out/audio_out_system.cpp
@@ -89,9 +89,10 @@ Result System::Start() {
     session->Start();
     state = State::Started;
 
-    std::vector<AudioBuffer> buffers_to_flush{};
-    buffers.RegisterBuffers(buffers_to_flush);
-    session->AppendBuffers(buffers_to_flush);
+    std::array<AudioBuffer, BufferAppendLimit> buffers_to_flush{};
+    u32 out_size{0};
+    buffers.RegisterBuffers(buffers_to_flush, out_size);
+    session->AppendBuffers(buffers_to_flush, out_size);
     session->SetRingSize(static_cast<u32>(buffers_to_flush.size()));
 
     return ResultSuccess;
@@ -134,9 +135,10 @@ bool System::AppendBuffer(const AudioOutBuffer& buffer, u64 tag) {
 
 void System::RegisterBuffers() {
     if (state == State::Started) {
-        std::vector<AudioBuffer> registered_buffers{};
-        buffers.RegisterBuffers(registered_buffers);
-        session->AppendBuffers(registered_buffers);
+        std::array<AudioBuffer, BufferAppendLimit> registered_buffers{};
+        u32 out_size{0};
+        buffers.RegisterBuffers(registered_buffers, out_size);
+        session->AppendBuffers(registered_buffers, out_size);
     }
 }
 

--- a/src/audio_core/renderer/command/data_source/decode.cpp
+++ b/src/audio_core/renderer/command/data_source/decode.cpp
@@ -8,6 +8,7 @@
 #include "audio_core/renderer/command/resample/resample.h"
 #include "common/fixed_point.h"
 #include "common/logging/log.h"
+#include "common/scratch_buffer.h"
 #include "core/memory.h"
 
 namespace AudioCore::AudioRenderer {
@@ -29,6 +30,7 @@ static u32 DecodePcm(Core::Memory::Memory& memory, std::span<s16> out_buffer,
                      const DecodeArg& req) {
     constexpr s32 min{std::numeric_limits<s16>::min()};
     constexpr s32 max{std::numeric_limits<s16>::max()};
+    static Common::ScratchBuffer<T> samples;
 
     if (req.buffer == 0 || req.buffer_size == 0) {
         return 0;
@@ -49,7 +51,7 @@ static u32 DecodePcm(Core::Memory::Memory& memory, std::span<s16> out_buffer,
         const u64 size{channel_count * samples_to_decode};
         const u64 size_bytes{size * sizeof(T)};
 
-        std::vector<T> samples(size);
+        samples.resize_destructive(size);
         memory.ReadBlockUnsafe(source, samples.data(), size_bytes);
 
         if constexpr (std::is_floating_point_v<T>) {
@@ -73,7 +75,7 @@ static u32 DecodePcm(Core::Memory::Memory& memory, std::span<s16> out_buffer,
         }
 
         const VAddr source{req.buffer + ((req.start_offset + req.offset) * sizeof(T))};
-        std::vector<T> samples(samples_to_decode);
+        samples.resize_destructive(samples_to_decode);
         memory.ReadBlockUnsafe(source, samples.data(), samples_to_decode * sizeof(T));
 
         if constexpr (std::is_floating_point_v<T>) {
@@ -103,6 +105,7 @@ static u32 DecodeAdpcm(Core::Memory::Memory& memory, std::span<s16> out_buffer,
                        const DecodeArg& req) {
     constexpr u32 SamplesPerFrame{14};
     constexpr u32 NibblesPerFrame{16};
+    static Common::ScratchBuffer<u8> wavebuffer;
 
     if (req.buffer == 0 || req.buffer_size == 0) {
         return 0;
@@ -138,7 +141,7 @@ static u32 DecodeAdpcm(Core::Memory::Memory& memory, std::span<s16> out_buffer,
     }
 
     const auto size{std::max((samples_to_process / 8U) * SamplesPerFrame, 8U)};
-    std::vector<u8> wavebuffer(size);
+    wavebuffer.resize_destructive(size);
     memory.ReadBlockUnsafe(req.buffer + position_in_frame / 2, wavebuffer.data(),
                            wavebuffer.size());
 
@@ -227,6 +230,8 @@ static u32 DecodeAdpcm(Core::Memory::Memory& memory, std::span<s16> out_buffer,
  * @param args   - The wavebuffer data, and information for how to decode it.
  */
 void DecodeFromWaveBuffers(Core::Memory::Memory& memory, const DecodeFromWaveBuffersArgs& args) {
+    Common::ScratchBuffer<s16> temp_buffer(TempBufferSize);
+
     auto& voice_state{*args.voice_state};
     auto remaining_sample_count{args.sample_count};
     auto fraction{voice_state.fraction};
@@ -256,9 +261,8 @@ void DecodeFromWaveBuffers(Core::Memory::Memory& memory, const DecodeFromWaveBuf
 
     bool is_buffer_starved{false};
     u32 offset{voice_state.offset};
-
+    std::memset(temp_buffer.data(), 0, temp_buffer.size() * sizeof(s16));
     auto output_buffer{args.output};
-    std::vector<s16> temp_buffer(TempBufferSize, 0);
 
     while (remaining_sample_count > 0) {
         const auto samples_to_write{std::min(remaining_sample_count, max_remaining_sample_count)};

--- a/src/audio_core/renderer/command/effect/i3dl2_reverb.cpp
+++ b/src/audio_core/renderer/command/effect/i3dl2_reverb.cpp
@@ -6,6 +6,7 @@
 #include "audio_core/renderer/adsp/command_list_processor.h"
 #include "audio_core/renderer/command/effect/i3dl2_reverb.h"
 #include "common/polyfill_ranges.h"
+#include "common/scratch_buffer.h"
 
 namespace AudioCore::AudioRenderer {
 
@@ -408,8 +409,10 @@ void I3dl2ReverbCommand::Dump([[maybe_unused]] const ADSP::CommandListProcessor&
 }
 
 void I3dl2ReverbCommand::Process(const ADSP::CommandListProcessor& processor) {
-    std::vector<std::span<const s32>> input_buffers(parameter.channel_count);
-    std::vector<std::span<s32>> output_buffers(parameter.channel_count);
+    static Common::ScratchBuffer<std::span<const s32>> input_buffers{};
+    static Common::ScratchBuffer<std::span<s32>> output_buffers{};
+    input_buffers.resize_destructive(parameter.channel_count);
+    output_buffers.resize_destructive(parameter.channel_count);
 
     for (u32 i = 0; i < parameter.channel_count; i++) {
         input_buffers[i] = processor.mix_buffers.subspan(inputs[i] * processor.sample_count,

--- a/src/audio_core/renderer/command/sink/circular_buffer.cpp
+++ b/src/audio_core/renderer/command/sink/circular_buffer.cpp
@@ -5,6 +5,7 @@
 
 #include "audio_core/renderer/adsp/command_list_processor.h"
 #include "audio_core/renderer/command/sink/circular_buffer.h"
+#include "common/scratch_buffer.h"
 #include "core/memory.h"
 
 namespace AudioCore::AudioRenderer {
@@ -24,7 +25,9 @@ void CircularBufferSinkCommand::Process(const ADSP::CommandListProcessor& proces
     constexpr s32 min{std::numeric_limits<s16>::min()};
     constexpr s32 max{std::numeric_limits<s16>::max()};
 
-    std::vector<s16> output(processor.sample_count);
+    static Common::ScratchBuffer<s16> output{};
+    output.resize_destructive(processor.sample_count);
+
     for (u32 channel = 0; channel < input_count; channel++) {
         auto input{processor.mix_buffers.subspan(inputs[channel] * processor.sample_count,
                                                  processor.sample_count)};

--- a/src/audio_core/renderer/command/sink/device.cpp
+++ b/src/audio_core/renderer/command/sink/device.cpp
@@ -33,7 +33,8 @@ void DeviceSinkCommand::Process(const ADSP::CommandListProcessor& processor) {
         .consumed{false},
     };
 
-    std::vector<s16> samples(out_buffer.frames * input_count);
+    static Common::ScratchBuffer<s16> samples{};
+    samples.resize_destructive(out_buffer.frames * input_count);
 
     for (u32 channel = 0; channel < input_count; channel++) {
         const auto offset{inputs[channel] * out_buffer.frames};

--- a/src/audio_core/sink/null_sink.h
+++ b/src/audio_core/sink/null_sink.h
@@ -9,6 +9,7 @@
 
 #include "audio_core/sink/sink.h"
 #include "audio_core/sink/sink_stream.h"
+#include "common/scratch_buffer.h"
 
 namespace Core {
 class System;
@@ -20,7 +21,7 @@ public:
     explicit NullSinkStreamImpl(Core::System& system_, StreamType type_)
         : SinkStream{system_, type_} {}
     ~NullSinkStreamImpl() override {}
-    void AppendBuffer(SinkBuffer&, std::vector<s16>&) override {}
+    void AppendBuffer(SinkBuffer&, Common::ScratchBuffer<s16>&) override {}
     std::vector<s16> ReleaseBuffer(u64) override {
         return {};
     }

--- a/src/audio_core/sink/sink_stream.h
+++ b/src/audio_core/sink/sink_stream.h
@@ -14,6 +14,7 @@
 #include "common/common_types.h"
 #include "common/reader_writer_queue.h"
 #include "common/ring_buffer.h"
+#include "common/scratch_buffer.h"
 
 namespace Core {
 class System;
@@ -169,7 +170,7 @@ public:
      * @param buffer  - Audio buffer information to be queued.
      * @param samples - The s16 samples to be queue for playback.
      */
-    virtual void AppendBuffer(SinkBuffer& buffer, std::vector<s16>& samples);
+    virtual void AppendBuffer(SinkBuffer& buffer, Common::ScratchBuffer<s16>& samples);
 
     /**
      * Release a buffer. Audio In only, will fill a buffer with recorded samples.

--- a/src/common/scratch_buffer.h
+++ b/src/common/scratch_buffer.h
@@ -24,6 +24,24 @@ public:
 
     ~ScratchBuffer() = default;
 
+    ScratchBuffer(ScratchBuffer&& rhs) {
+        last_requested_size = rhs.last_requested_size;
+        buffer_capacity = rhs.buffer_capacity;
+        buffer = std::move(rhs.buffer);
+
+        rhs.last_requested_size = 0;
+        rhs.buffer_capacity = 0;
+    }
+
+    void operator=(ScratchBuffer&& rhs) {
+        last_requested_size = rhs.last_requested_size;
+        buffer_capacity = rhs.buffer_capacity;
+        buffer = std::move(rhs.buffer);
+
+        rhs.last_requested_size = 0;
+        rhs.buffer_capacity = 0;
+    }
+
     /// This will only grow the buffer's capacity if size is greater than the current capacity.
     /// The previously held data will remain intact.
     void resize(size_t size) {


### PR DESCRIPTION
This removes a significant number of allocations per second throughout audio_core now that we have scratch buffer. Needs some testing to make sure I didn't mess anything up here. Yuzu felt faster to me with this, but that might be copium on my part.