### PR TITLE
core: kernel: k_process: Use application system resource.

### DIFF
--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -370,7 +370,7 @@ Result KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata, std:
     // Initialize proces address space
     if (const Result result{page_table.InitializeForProcess(
             metadata.GetAddressSpaceType(), false, false, false, KMemoryManager::Pool::Application,
-            0x8000000, code_size, &kernel.GetSystemSystemResource(), resource_limit)};
+            0x8000000, code_size, &kernel.GetAppSystemResource(), resource_limit)};
         result.IsError()) {
         R_RETURN(result);
     }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -1146,6 +1146,14 @@ const KMemoryManager& KernelCore::MemoryManager() const {
     return *impl->memory_manager;
 }
 
+KSystemResource& KernelCore::GetAppSystemResource() {
+    return *impl->app_system_resource;
+}
+
+const KSystemResource& KernelCore::GetAppSystemResource() const {
+    return *impl->app_system_resource;
+}
+
 KSystemResource& KernelCore::GetSystemSystemResource() {
     return *impl->sys_system_resource;
 }

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -246,6 +246,12 @@ public:
     /// Gets the virtual memory manager for the kernel.
     const KMemoryManager& MemoryManager() const;
 
+    /// Gets the application resource manager.
+    KSystemResource& GetAppSystemResource();
+
+    /// Gets the application resource manager.
+    const KSystemResource& GetAppSystemResource() const;
+
     /// Gets the system resource manager.
     KSystemResource& GetSystemSystemResource();
 


### PR DESCRIPTION
Mistake from #9173.

Fixes #9743.