### PR TITLE
[audio_core] Use different state offset for each biquad filter channel

### DIFF
--- a/src/audio_core/renderer/command/command_buffer.cpp
+++ b/src/audio_core/renderer/command/command_buffer.cpp
@@ -251,8 +251,8 @@ void CommandBuffer::GenerateBiquadFilterCommand(const s32 node_id, EffectInfoBas
 
     const auto& parameter{
         *reinterpret_cast<BiquadFilterInfo::ParameterVersion1*>(effect_info.GetParameter())};
-    const auto state{
-        reinterpret_cast<VoiceState::BiquadFilterState*>(effect_info.GetStateBuffer())};
+    const auto state{reinterpret_cast<VoiceState::BiquadFilterState*>(
+        effect_info.GetStateBuffer() + channel * sizeof(VoiceState::BiquadFilterState))};
 
     cmd.input = buffer_offset + parameter.inputs[channel];
     cmd.output = buffer_offset + parameter.outputs[channel];


### PR DESCRIPTION
Biquad filter commands are generated for each channel, and each command is meant to use a separate state, but I wasn't accounting for this properly and using the same state offset for every biquad command, so each one was trampling over others. This PR fixes the noise generated in games which use biquad commands, like Metroid and Fire Emblem and surely a lot more.