### PR TITLE
general: rename CurrentProcess to ApplicationProcess 

### DIFF
--- a/src/audio_core/renderer/system.cpp
+++ b/src/audio_core/renderer/system.cpp
@@ -127,7 +127,7 @@ Result System::Initialize(const AudioRendererParameterInternal& params,
     render_device = params.rendering_device;
     execution_mode = params.execution_mode;
 
-    core.Memory().ZeroBlock(*core.Kernel().CurrentProcess(), transfer_memory->GetSourceAddress(),
+    core.Memory().ZeroBlock(*core.ApplicationProcess(), transfer_memory->GetSourceAddress(),
                             transfer_memory_size);
 
     // Note: We're not actually using the transfer memory because it's a pain to code for.

--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -270,7 +270,7 @@ void SinkStream::Stall() {
     if (stalled_lock) {
         return;
     }
-    stalled_lock = system.StallProcesses();
+    stalled_lock = system.StallApplication();
 }
 
 void SinkStream::Unstall() {
@@ -278,7 +278,7 @@ void SinkStream::Unstall() {
     if (!stalled_lock) {
         return;
     }
-    system.UnstallProcesses();
+    system.UnstallApplication();
     stalled_lock.unlock();
 }
 

--- a/src/core/arm/arm_interface.cpp
+++ b/src/core/arm/arm_interface.cpp
@@ -43,9 +43,9 @@ void ARM_Interface::SymbolicateBacktrace(Core::System& system, std::vector<Backt
 
     std::map<std::string, Symbols::Symbols> symbols;
     for (const auto& module : modules) {
-        symbols.insert_or_assign(module.second,
-                                 Symbols::GetSymbols(module.first, system.Memory(),
-                                                     system.CurrentProcess()->Is64BitProcess()));
+        symbols.insert_or_assign(
+            module.second, Symbols::GetSymbols(module.first, system.Memory(),
+                                               system.ApplicationProcess()->Is64BitProcess()));
     }
 
     for (auto& entry : out) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -186,7 +186,7 @@ struct System::Impl {
     void Run() {
         std::unique_lock<std::mutex> lk(suspend_guard);
 
-        kernel.Suspend(false);
+        kernel.SuspendApplication(false);
         core_timing.SyncPause(false);
         is_paused.store(false, std::memory_order_relaxed);
     }
@@ -195,7 +195,7 @@ struct System::Impl {
         std::unique_lock<std::mutex> lk(suspend_guard);
 
         core_timing.SyncPause(true);
-        kernel.Suspend(true);
+        kernel.SuspendApplication(true);
         is_paused.store(true, std::memory_order_relaxed);
     }
 
@@ -203,17 +203,17 @@ struct System::Impl {
         return is_paused.load(std::memory_order_relaxed);
     }
 
-    std::unique_lock<std::mutex> StallProcesses() {
+    std::unique_lock<std::mutex> StallApplication() {
         std::unique_lock<std::mutex> lk(suspend_guard);
-        kernel.Suspend(true);
+        kernel.SuspendApplication(true);
         core_timing.SyncPause(true);
         return lk;
     }
 
-    void UnstallProcesses() {
+    void UnstallApplication() {
         if (!IsPaused()) {
             core_timing.SyncPause(false);
-            kernel.Suspend(false);
+            kernel.SuspendApplication(false);
         }
     }
 
@@ -221,7 +221,7 @@ struct System::Impl {
         debugger = std::make_unique<Debugger>(system, port);
     }
 
-    SystemResultStatus SetupForMainProcess(System& system, Frontend::EmuWindow& emu_window) {
+    SystemResultStatus SetupForApplicationProcess(System& system, Frontend::EmuWindow& emu_window) {
         LOG_DEBUG(Core, "initialized OK");
 
         // Setting changes may require a full system reinitialization (e.g., disabling multicore).
@@ -273,7 +273,7 @@ struct System::Impl {
             return SystemResultStatus::ErrorGetLoader;
         }
 
-        SystemResultStatus init_result{SetupForMainProcess(system, emu_window)};
+        SystemResultStatus init_result{SetupForApplicationProcess(system, emu_window)};
         if (init_result != SystemResultStatus::Success) {
             LOG_CRITICAL(Core, "Failed to initialize system (Error {})!",
                          static_cast<int>(init_result));
@@ -302,7 +302,7 @@ struct System::Impl {
                 static_cast<u32>(SystemResultStatus::ErrorLoader) + static_cast<u32>(load_result));
         }
         AddGlueRegistrationForProcess(*app_loader, *main_process);
-        kernel.MakeCurrentProcess(main_process);
+        kernel.MakeApplicationProcess(main_process);
         kernel.InitializeCores();
 
         // Initialize cheat engine
@@ -585,12 +585,12 @@ void System::DetachDebugger() {
     }
 }
 
-std::unique_lock<std::mutex> System::StallProcesses() {
-    return impl->StallProcesses();
+std::unique_lock<std::mutex> System::StallApplication() {
+    return impl->StallApplication();
 }
 
-void System::UnstallProcesses() {
-    impl->UnstallProcesses();
+void System::UnstallApplication() {
+    impl->UnstallApplication();
 }
 
 void System::InitializeDebugger() {
@@ -648,8 +648,8 @@ const Kernel::GlobalSchedulerContext& System::GlobalSchedulerContext() const {
     return impl->kernel.GlobalSchedulerContext();
 }
 
-Kernel::KProcess* System::CurrentProcess() {
-    return impl->kernel.CurrentProcess();
+Kernel::KProcess* System::ApplicationProcess() {
+    return impl->kernel.ApplicationProcess();
 }
 
 Core::DeviceMemory& System::DeviceMemory() {
@@ -660,8 +660,8 @@ const Core::DeviceMemory& System::DeviceMemory() const {
     return *impl->device_memory;
 }
 
-const Kernel::KProcess* System::CurrentProcess() const {
-    return impl->kernel.CurrentProcess();
+const Kernel::KProcess* System::ApplicationProcess() const {
+    return impl->kernel.ApplicationProcess();
 }
 
 ARM_Interface& System::ArmInterface(std::size_t core_index) {
@@ -760,8 +760,8 @@ const Core::SpeedLimiter& System::SpeedLimiter() const {
     return impl->speed_limiter;
 }
 
-u64 System::GetCurrentProcessProgramID() const {
-    return impl->kernel.CurrentProcess()->GetProgramID();
+u64 System::GetApplicationProcessProgramID() const {
+    return impl->kernel.ApplicationProcess()->GetProgramID();
 }
 
 Loader::ResultStatus System::GetGameName(std::string& out) const {
@@ -880,11 +880,11 @@ bool System::GetExitLock() const {
     return impl->exit_lock;
 }
 
-void System::SetCurrentProcessBuildID(const CurrentBuildProcessID& id) {
+void System::SetApplicationProcessBuildID(const CurrentBuildProcessID& id) {
     impl->build_id = id;
 }
 
-const System::CurrentBuildProcessID& System::GetCurrentProcessBuildID() const {
+const System::CurrentBuildProcessID& System::GetApplicationProcessBuildID() const {
     return impl->build_id;
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -184,8 +184,8 @@ public:
     /// Forcibly detach the debugger if it is running.
     void DetachDebugger();
 
-    std::unique_lock<std::mutex> StallProcesses();
-    void UnstallProcesses();
+    std::unique_lock<std::mutex> StallApplication();
+    void UnstallApplication();
 
     /**
      * Initialize the debugger.
@@ -295,11 +295,11 @@ public:
     /// Gets the manager for the guest device memory
     [[nodiscard]] const Core::DeviceMemory& DeviceMemory() const;
 
-    /// Provides a pointer to the current process
-    [[nodiscard]] Kernel::KProcess* CurrentProcess();
+    /// Provides a pointer to the application process
+    [[nodiscard]] Kernel::KProcess* ApplicationProcess();
 
-    /// Provides a constant pointer to the current process.
-    [[nodiscard]] const Kernel::KProcess* CurrentProcess() const;
+    /// Provides a constant pointer to the application process.
+    [[nodiscard]] const Kernel::KProcess* ApplicationProcess() const;
 
     /// Provides a reference to the core timing instance.
     [[nodiscard]] Timing::CoreTiming& CoreTiming();
@@ -331,7 +331,7 @@ public:
     /// Provides a constant reference to the speed limiter
     [[nodiscard]] const Core::SpeedLimiter& SpeedLimiter() const;
 
-    [[nodiscard]] u64 GetCurrentProcessProgramID() const;
+    [[nodiscard]] u64 GetApplicationProcessProgramID() const;
 
     /// Gets the name of the current game
     [[nodiscard]] Loader::ResultStatus GetGameName(std::string& out) const;
@@ -396,8 +396,8 @@ public:
     void SetExitLock(bool locked);
     [[nodiscard]] bool GetExitLock() const;
 
-    void SetCurrentProcessBuildID(const CurrentBuildProcessID& id);
-    [[nodiscard]] const CurrentBuildProcessID& GetCurrentProcessBuildID() const;
+    void SetApplicationProcessBuildID(const CurrentBuildProcessID& id);
+    [[nodiscard]] const CurrentBuildProcessID& GetApplicationProcessBuildID() const;
 
     /// Register a host thread as an emulated CPU Core.
     void RegisterCoreThread(std::size_t id);

--- a/src/core/debugger/gdbstub.cpp
+++ b/src/core/debugger/gdbstub.cpp
@@ -96,7 +96,7 @@ static std::string EscapeXML(std::string_view data) {
 
 GDBStub::GDBStub(DebuggerBackend& backend_, Core::System& system_)
     : DebuggerFrontend(backend_), system{system_} {
-    if (system.CurrentProcess()->Is64BitProcess()) {
+    if (system.ApplicationProcess()->Is64BitProcess()) {
         arch = std::make_unique<GDBStubA64>();
     } else {
         arch = std::make_unique<GDBStubA32>();
@@ -340,15 +340,15 @@ void GDBStub::HandleBreakpointInsert(std::string_view command) {
         success = true;
         break;
     case BreakpointType::WriteWatch:
-        success = system.CurrentProcess()->InsertWatchpoint(system, addr, size,
-                                                            Kernel::DebugWatchpointType::Write);
+        success = system.ApplicationProcess()->InsertWatchpoint(system, addr, size,
+                                                                Kernel::DebugWatchpointType::Write);
         break;
     case BreakpointType::ReadWatch:
-        success = system.CurrentProcess()->InsertWatchpoint(system, addr, size,
-                                                            Kernel::DebugWatchpointType::Read);
+        success = system.ApplicationProcess()->InsertWatchpoint(system, addr, size,
+                                                                Kernel::DebugWatchpointType::Read);
         break;
     case BreakpointType::AccessWatch:
-        success = system.CurrentProcess()->InsertWatchpoint(
+        success = system.ApplicationProcess()->InsertWatchpoint(
             system, addr, size, Kernel::DebugWatchpointType::ReadOrWrite);
         break;
     case BreakpointType::Hardware:
@@ -391,15 +391,15 @@ void GDBStub::HandleBreakpointRemove(std::string_view command) {
         break;
     }
     case BreakpointType::WriteWatch:
-        success = system.CurrentProcess()->RemoveWatchpoint(system, addr, size,
-                                                            Kernel::DebugWatchpointType::Write);
+        success = system.ApplicationProcess()->RemoveWatchpoint(system, addr, size,
+                                                                Kernel::DebugWatchpointType::Write);
         break;
     case BreakpointType::ReadWatch:
-        success = system.CurrentProcess()->RemoveWatchpoint(system, addr, size,
-                                                            Kernel::DebugWatchpointType::Read);
+        success = system.ApplicationProcess()->RemoveWatchpoint(system, addr, size,
+                                                                Kernel::DebugWatchpointType::Read);
         break;
     case BreakpointType::AccessWatch:
-        success = system.CurrentProcess()->RemoveWatchpoint(
+        success = system.ApplicationProcess()->RemoveWatchpoint(
             system, addr, size, Kernel::DebugWatchpointType::ReadOrWrite);
         break;
     case BreakpointType::Hardware:
@@ -482,7 +482,7 @@ static std::optional<std::string> GetNameFromThreadType64(Core::Memory::Memory& 
 
 static std::optional<std::string> GetThreadName(Core::System& system,
                                                 const Kernel::KThread* thread) {
-    if (system.CurrentProcess()->Is64BitProcess()) {
+    if (system.ApplicationProcess()->Is64BitProcess()) {
         return GetNameFromThreadType64(system.Memory(), thread);
     } else {
         return GetNameFromThreadType32(system.Memory(), thread);
@@ -555,7 +555,7 @@ void GDBStub::HandleQuery(std::string_view command) {
             SendReply(fmt::format("TextSeg={:x}", main->first));
         } else {
             SendReply(fmt::format("TextSeg={:x}",
-                                  system.CurrentProcess()->PageTable().GetCodeRegionStart()));
+                                  system.ApplicationProcess()->PageTable().GetCodeRegionStart()));
         }
     } else if (command.starts_with("Xfer:libraries:read::")) {
         Loader::AppLoader::Modules modules;
@@ -729,7 +729,7 @@ void GDBStub::HandleRcmd(const std::vector<u8>& command) {
     std::string_view command_str{reinterpret_cast<const char*>(&command[0]), command.size()};
     std::string reply;
 
-    auto* process = system.CurrentProcess();
+    auto* process = system.ApplicationProcess();
     auto& page_table = process->PageTable();
 
     const char* commands = "Commands:\n"

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -172,7 +172,7 @@ std::string SaveDataFactory::GetFullPath(Core::System& system, VirtualDir dir,
     // be interpreted as the title id of the current process.
     if (type == SaveDataType::SaveData || type == SaveDataType::DeviceSaveData) {
         if (title_id == 0) {
-            title_id = system.GetCurrentProcessProgramID();
+            title_id = system.GetApplicationProcessProgramID();
         }
     }
 

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -148,7 +148,7 @@ public:
         if (context->GetManager()->IsDomain()) {
             context->AddDomainObject(std::move(iface));
         } else {
-            kernel.CurrentProcess()->GetResourceLimit()->Reserve(
+            kernel.ApplicationProcess()->GetResourceLimit()->Reserve(
                 Kernel::LimitableResource::SessionCountMax, 1);
 
             auto* session = Kernel::KSession::Create(kernel);

--- a/src/core/hle/kernel/k_client_port.cpp
+++ b/src/core/hle/kernel/k_client_port.cpp
@@ -61,7 +61,7 @@ bool KClientPort::IsSignaled() const {
 Result KClientPort::CreateSession(KClientSession** out) {
     // Reserve a new session from the resource limit.
     //! FIXME: we are reserving this from the wrong resource limit!
-    KScopedResourceReservation session_reservation(kernel.CurrentProcess()->GetResourceLimit(),
+    KScopedResourceReservation session_reservation(kernel.ApplicationProcess()->GetResourceLimit(),
                                                    LimitableResource::SessionCountMax);
     R_UNLESS(session_reservation.Succeeded(), ResultLimitReached);
 

--- a/src/core/hle/kernel/k_client_port.cpp
+++ b/src/core/hle/kernel/k_client_port.cpp
@@ -60,6 +60,7 @@ bool KClientPort::IsSignaled() const {
 
 Result KClientPort::CreateSession(KClientSession** out) {
     // Reserve a new session from the resource limit.
+    //! FIXME: we are reserving this from the wrong resource limit!
     KScopedResourceReservation session_reservation(kernel.CurrentProcess()->GetResourceLimit(),
                                                    LimitableResource::SessionCountMax);
     R_UNLESS(session_reservation.Succeeded(), ResultLimitReached);

--- a/src/core/hle/kernel/k_code_memory.cpp
+++ b/src/core/hle/kernel/k_code_memory.cpp
@@ -21,7 +21,7 @@ KCodeMemory::KCodeMemory(KernelCore& kernel_)
 
 Result KCodeMemory::Initialize(Core::DeviceMemory& device_memory, VAddr addr, size_t size) {
     // Set members.
-    m_owner = kernel.CurrentProcess();
+    m_owner = GetCurrentProcessPointer(kernel);
 
     // Get the owner page table.
     auto& page_table = m_owner->PageTable();
@@ -74,7 +74,7 @@ Result KCodeMemory::Map(VAddr address, size_t size) {
     R_UNLESS(!m_is_mapped, ResultInvalidState);
 
     // Map the memory.
-    R_TRY(kernel.CurrentProcess()->PageTable().MapPageGroup(
+    R_TRY(GetCurrentProcess(kernel).PageTable().MapPageGroup(
         address, *m_page_group, KMemoryState::CodeOut, KMemoryPermission::UserReadWrite));
 
     // Mark ourselves as mapped.
@@ -91,8 +91,8 @@ Result KCodeMemory::Unmap(VAddr address, size_t size) {
     KScopedLightLock lk(m_lock);
 
     // Unmap the memory.
-    R_TRY(kernel.CurrentProcess()->PageTable().UnmapPageGroup(address, *m_page_group,
-                                                              KMemoryState::CodeOut));
+    R_TRY(GetCurrentProcess(kernel).PageTable().UnmapPageGroup(address, *m_page_group,
+                                                               KMemoryState::CodeOut));
 
     // Mark ourselves as unmapped.
     m_is_mapped = false;

--- a/src/core/hle/kernel/k_condition_variable.cpp
+++ b/src/core/hle/kernel/k_condition_variable.cpp
@@ -164,8 +164,8 @@ Result KConditionVariable::WaitForAddress(Handle handle, VAddr addr, u32 value) 
         R_SUCCEED_IF(test_tag != (handle | Svc::HandleWaitMask));
 
         // Get the lock owner thread.
-        owner_thread = kernel.CurrentProcess()
-                           ->GetHandleTable()
+        owner_thread = GetCurrentProcess(kernel)
+                           .GetHandleTable()
                            .GetObjectWithoutPseudoHandle<KThread>(handle)
                            .ReleasePointerUnsafe();
         R_UNLESS(owner_thread != nullptr, ResultInvalidHandle);
@@ -213,8 +213,8 @@ void KConditionVariable::SignalImpl(KThread* thread) {
             thread->EndWait(ResultSuccess);
         } else {
             // Get the previous owner.
-            KThread* owner_thread = kernel.CurrentProcess()
-                                        ->GetHandleTable()
+            KThread* owner_thread = GetCurrentProcess(kernel)
+                                        .GetHandleTable()
                                         .GetObjectWithoutPseudoHandle<KThread>(
                                             static_cast<Handle>(prev_tag & ~Svc::HandleWaitMask))
                                         .ReleasePointerUnsafe();

--- a/src/core/hle/kernel/k_handle_table.h
+++ b/src/core/hle/kernel/k_handle_table.h
@@ -90,7 +90,7 @@ public:
         // Handle pseudo-handles.
         if constexpr (std::derived_from<KProcess, T>) {
             if (handle == Svc::PseudoHandle::CurrentProcess) {
-                auto* const cur_process = m_kernel.CurrentProcess();
+                auto* const cur_process = GetCurrentProcessPointer(m_kernel);
                 ASSERT(cur_process != nullptr);
                 return cur_process;
             }

--- a/src/core/hle/kernel/k_handle_table.h
+++ b/src/core/hle/kernel/k_handle_table.h
@@ -90,7 +90,8 @@ public:
         // Handle pseudo-handles.
         if constexpr (std::derived_from<KProcess, T>) {
             if (handle == Svc::PseudoHandle::CurrentProcess) {
-                auto* const cur_process = GetCurrentProcessPointer(m_kernel);
+                //! FIXME: this is the wrong process!
+                auto* const cur_process = m_kernel.ApplicationProcess();
                 ASSERT(cur_process != nullptr);
                 return cur_process;
             }

--- a/src/core/hle/kernel/k_interrupt_manager.cpp
+++ b/src/core/hle/kernel/k_interrupt_manager.cpp
@@ -16,7 +16,7 @@ void HandleInterrupt(KernelCore& kernel, s32 core_id) {
 
     auto& current_thread = GetCurrentThread(kernel);
 
-    if (auto* process = kernel.CurrentProcess(); process) {
+    if (auto* process = GetCurrentProcessPointer(kernel); process) {
         // If the user disable count is set, we may need to pin the current thread.
         if (current_thread.GetUserDisableCount() && !process->GetPinnedThread(core_id)) {
             KScopedSchedulerLock sl{kernel};

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -328,7 +328,7 @@ u64 KScheduler::UpdateHighestPriorityThreadsImpl(KernelCore& kernel) {
 }
 
 void KScheduler::SwitchThread(KThread* next_thread) {
-    KProcess* const cur_process = kernel.CurrentProcess();
+    KProcess* const cur_process = GetCurrentProcessPointer(kernel);
     KThread* const cur_thread = GetCurrentThreadPointer(kernel);
 
     // We never want to schedule a null thread, so use the idle thread if we don't have a next.
@@ -689,11 +689,11 @@ void KScheduler::RotateScheduledQueue(KernelCore& kernel, s32 core_id, s32 prior
 void KScheduler::YieldWithoutCoreMigration(KernelCore& kernel) {
     // Validate preconditions.
     ASSERT(CanSchedule(kernel));
-    ASSERT(kernel.CurrentProcess() != nullptr);
+    ASSERT(GetCurrentProcessPointer(kernel) != nullptr);
 
     // Get the current thread and process.
     KThread& cur_thread = GetCurrentThread(kernel);
-    KProcess& cur_process = *kernel.CurrentProcess();
+    KProcess& cur_process = GetCurrentProcess(kernel);
 
     // If the thread's yield count matches, there's nothing for us to do.
     if (cur_thread.GetYieldScheduleCount() == cur_process.GetScheduledCount()) {
@@ -728,11 +728,11 @@ void KScheduler::YieldWithoutCoreMigration(KernelCore& kernel) {
 void KScheduler::YieldWithCoreMigration(KernelCore& kernel) {
     // Validate preconditions.
     ASSERT(CanSchedule(kernel));
-    ASSERT(kernel.CurrentProcess() != nullptr);
+    ASSERT(GetCurrentProcessPointer(kernel) != nullptr);
 
     // Get the current thread and process.
     KThread& cur_thread = GetCurrentThread(kernel);
-    KProcess& cur_process = *kernel.CurrentProcess();
+    KProcess& cur_process = GetCurrentProcess(kernel);
 
     // If the thread's yield count matches, there's nothing for us to do.
     if (cur_thread.GetYieldScheduleCount() == cur_process.GetScheduledCount()) {
@@ -816,11 +816,11 @@ void KScheduler::YieldWithCoreMigration(KernelCore& kernel) {
 void KScheduler::YieldToAnyThread(KernelCore& kernel) {
     // Validate preconditions.
     ASSERT(CanSchedule(kernel));
-    ASSERT(kernel.CurrentProcess() != nullptr);
+    ASSERT(GetCurrentProcessPointer(kernel) != nullptr);
 
     // Get the current thread and process.
     KThread& cur_thread = GetCurrentThread(kernel);
-    KProcess& cur_process = *kernel.CurrentProcess();
+    KProcess& cur_process = GetCurrentProcess(kernel);
 
     // If the thread's yield count matches, there's nothing for us to do.
     if (cur_thread.GetYieldScheduleCount() == cur_process.GetScheduledCount()) {

--- a/src/core/hle/kernel/k_session.cpp
+++ b/src/core/hle/kernel/k_session.cpp
@@ -34,7 +34,7 @@ void KSession::Initialize(KClientPort* port_, const std::string& name_) {
 
     // Set our owner process.
     //! FIXME: this is the wrong process!
-    process = kernel.CurrentProcess();
+    process = kernel.ApplicationProcess();
     process->Open();
 
     // Set our port.

--- a/src/core/hle/kernel/k_session.cpp
+++ b/src/core/hle/kernel/k_session.cpp
@@ -33,6 +33,7 @@ void KSession::Initialize(KClientPort* port_, const std::string& name_) {
     name = name_;
 
     // Set our owner process.
+    //! FIXME: this is the wrong process!
     process = kernel.CurrentProcess();
     process->Open();
 

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -1266,6 +1266,14 @@ KThread& GetCurrentThread(KernelCore& kernel) {
     return *GetCurrentThreadPointer(kernel);
 }
 
+KProcess* GetCurrentProcessPointer(KernelCore& kernel) {
+    return GetCurrentThread(kernel).GetOwnerProcess();
+}
+
+KProcess& GetCurrentProcess(KernelCore& kernel) {
+    return *GetCurrentProcessPointer(kernel);
+}
+
 s32 GetCurrentCoreId(KernelCore& kernel) {
     return GetCurrentThread(kernel).GetCurrentCore();
 }

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -110,6 +110,8 @@ enum class StepState : u32 {
 void SetCurrentThread(KernelCore& kernel, KThread* thread);
 [[nodiscard]] KThread* GetCurrentThreadPointer(KernelCore& kernel);
 [[nodiscard]] KThread& GetCurrentThread(KernelCore& kernel);
+[[nodiscard]] KProcess* GetCurrentProcessPointer(KernelCore& kernel);
+[[nodiscard]] KProcess& GetCurrentProcess(KernelCore& kernel);
 [[nodiscard]] s32 GetCurrentCoreId(KernelCore& kernel);
 
 class KThread final : public KAutoObjectWithSlabHeapAndContainer<KThread, KWorkerTask>,

--- a/src/core/hle/kernel/k_transfer_memory.cpp
+++ b/src/core/hle/kernel/k_transfer_memory.cpp
@@ -16,7 +16,7 @@ KTransferMemory::~KTransferMemory() = default;
 Result KTransferMemory::Initialize(VAddr address_, std::size_t size_,
                                    Svc::MemoryPermission owner_perm_) {
     // Set members.
-    owner = kernel.CurrentProcess();
+    owner = GetCurrentProcessPointer(kernel);
 
     // TODO(bunnei): Lock for transfer memory
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -131,17 +131,17 @@ public:
     /// Adds the given shared pointer to an internal list of active processes.
     void AppendNewProcess(KProcess* process);
 
-    /// Makes the given process the new current process.
-    void MakeCurrentProcess(KProcess* process);
+    /// Makes the given process the new application process.
+    void MakeApplicationProcess(KProcess* process);
 
-    /// Retrieves a pointer to the current process.
-    KProcess* CurrentProcess();
+    /// Retrieves a pointer to the application process.
+    KProcess* ApplicationProcess();
 
-    /// Retrieves a const pointer to the current process.
-    const KProcess* CurrentProcess() const;
+    /// Retrieves a const pointer to the application process.
+    const KProcess* ApplicationProcess() const;
 
-    /// Closes the current process.
-    void CloseCurrentProcess();
+    /// Closes the application process.
+    void CloseApplicationProcess();
 
     /// Retrieves the list of processes.
     const std::vector<KProcess*>& GetProcessList() const;
@@ -288,11 +288,11 @@ public:
     /// Gets the shared memory object for HIDBus services.
     const Kernel::KSharedMemory& GetHidBusSharedMem() const;
 
-    /// Suspend/unsuspend all processes.
-    void Suspend(bool suspend);
+    /// Suspend/unsuspend application process.
+    void SuspendApplication(bool suspend);
 
-    /// Exceptional exit all processes.
-    void ExceptionalExit();
+    /// Exceptional exit application process.
+    void ExceptionalExitApplication();
 
     /// Notify emulated CPU cores to shut down.
     void ShutdownCores();

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -4426,7 +4426,7 @@ void Call(Core::System& system, u32 imm) {
     auto& kernel = system.Kernel();
     kernel.EnterSVCProfile();
 
-    if (system.CurrentProcess()->Is64BitProcess()) {
+    if (GetCurrentProcess(system.Kernel()).Is64BitProcess()) {
         Call64(system, imm);
     } else {
         Call32(system, imm);

--- a/src/core/hle/kernel/svc/svc_activity.cpp
+++ b/src/core/hle/kernel/svc/svc_activity.cpp
@@ -23,11 +23,12 @@ Result SetThreadActivity(Core::System& system, Handle thread_handle,
 
     // Get the thread from its handle.
     KScopedAutoObject thread =
-        system.Kernel().CurrentProcess()->GetHandleTable().GetObject<KThread>(thread_handle);
+        GetCurrentProcess(system.Kernel()).GetHandleTable().GetObject<KThread>(thread_handle);
     R_UNLESS(thread.IsNotNull(), ResultInvalidHandle);
 
     // Check that the activity is being set on a non-current thread for the current process.
-    R_UNLESS(thread->GetOwnerProcess() == system.Kernel().CurrentProcess(), ResultInvalidHandle);
+    R_UNLESS(thread->GetOwnerProcess() == GetCurrentProcessPointer(system.Kernel()),
+             ResultInvalidHandle);
     R_UNLESS(thread.GetPointerUnsafe() != GetCurrentThreadPointer(system.Kernel()), ResultBusy);
 
     // Set the activity.

--- a/src/core/hle/kernel/svc/svc_address_arbiter.cpp
+++ b/src/core/hle/kernel/svc/svc_address_arbiter.cpp
@@ -72,7 +72,7 @@ Result WaitForAddress(Core::System& system, VAddr address, ArbitrationType arb_t
         timeout = timeout_ns;
     }
 
-    return system.Kernel().CurrentProcess()->WaitAddressArbiter(address, arb_type, value, timeout);
+    return GetCurrentProcess(system.Kernel()).WaitAddressArbiter(address, arb_type, value, timeout);
 }
 
 // Signals to an address (via Address Arbiter)
@@ -95,8 +95,8 @@ Result SignalToAddress(Core::System& system, VAddr address, SignalType signal_ty
         return ResultInvalidEnumValue;
     }
 
-    return system.Kernel().CurrentProcess()->SignalAddressArbiter(address, signal_type, value,
-                                                                  count);
+    return GetCurrentProcess(system.Kernel())
+        .SignalAddressArbiter(address, signal_type, value, count);
 }
 
 Result WaitForAddress64(Core::System& system, VAddr address, ArbitrationType arb_type, s32 value,

--- a/src/core/hle/kernel/svc/svc_cache.cpp
+++ b/src/core/hle/kernel/svc/svc_cache.cpp
@@ -38,7 +38,7 @@ Result FlushProcessDataCache(Core::System& system, Handle process_handle, u64 ad
 
     // Get the process from its handle.
     KScopedAutoObject process =
-        system.Kernel().CurrentProcess()->GetHandleTable().GetObject<KProcess>(process_handle);
+        GetCurrentProcess(system.Kernel()).GetHandleTable().GetObject<KProcess>(process_handle);
     R_UNLESS(process.IsNotNull(), ResultInvalidHandle);
 
     // Verify the region is within range.

--- a/src/core/hle/kernel/svc/svc_condition_variable.cpp
+++ b/src/core/hle/kernel/svc/svc_condition_variable.cpp
@@ -43,8 +43,8 @@ Result WaitProcessWideKeyAtomic(Core::System& system, VAddr address, VAddr cv_ke
     }
 
     // Wait on the condition variable.
-    return system.Kernel().CurrentProcess()->WaitConditionVariable(
-        address, Common::AlignDown(cv_key, sizeof(u32)), tag, timeout);
+    return GetCurrentProcess(system.Kernel())
+        .WaitConditionVariable(address, Common::AlignDown(cv_key, sizeof(u32)), tag, timeout);
 }
 
 /// Signal process wide key
@@ -52,8 +52,8 @@ void SignalProcessWideKey(Core::System& system, VAddr cv_key, s32 count) {
     LOG_TRACE(Kernel_SVC, "called, cv_key=0x{:X}, count=0x{:08X}", cv_key, count);
 
     // Signal the condition variable.
-    return system.Kernel().CurrentProcess()->SignalConditionVariable(
-        Common::AlignDown(cv_key, sizeof(u32)), count);
+    return GetCurrentProcess(system.Kernel())
+        .SignalConditionVariable(Common::AlignDown(cv_key, sizeof(u32)), count);
 }
 
 Result WaitProcessWideKeyAtomic64(Core::System& system, uint64_t address, uint64_t cv_key,

--- a/src/core/hle/kernel/svc/svc_device_address_space.cpp
+++ b/src/core/hle/kernel/svc/svc_device_address_space.cpp
@@ -37,15 +37,16 @@ Result CreateDeviceAddressSpace(Core::System& system, Handle* out, uint64_t das_
     KDeviceAddressSpace::Register(system.Kernel(), das);
 
     // Add to the handle table.
-    R_TRY(system.CurrentProcess()->GetHandleTable().Add(out, das));
+    R_TRY(GetCurrentProcess(system.Kernel()).GetHandleTable().Add(out, das));
 
     R_SUCCEED();
 }
 
 Result AttachDeviceAddressSpace(Core::System& system, DeviceName device_name, Handle das_handle) {
     // Get the device address space.
-    KScopedAutoObject das =
-        system.CurrentProcess()->GetHandleTable().GetObject<KDeviceAddressSpace>(das_handle);
+    KScopedAutoObject das = GetCurrentProcess(system.Kernel())
+                                .GetHandleTable()
+                                .GetObject<KDeviceAddressSpace>(das_handle);
     R_UNLESS(das.IsNotNull(), ResultInvalidHandle);
 
     // Attach.
@@ -54,8 +55,9 @@ Result AttachDeviceAddressSpace(Core::System& system, DeviceName device_name, Ha
 
 Result DetachDeviceAddressSpace(Core::System& system, DeviceName device_name, Handle das_handle) {
     // Get the device address space.
-    KScopedAutoObject das =
-        system.CurrentProcess()->GetHandleTable().GetObject<KDeviceAddressSpace>(das_handle);
+    KScopedAutoObject das = GetCurrentProcess(system.Kernel())
+                                .GetHandleTable()
+                                .GetObject<KDeviceAddressSpace>(das_handle);
     R_UNLESS(das.IsNotNull(), ResultInvalidHandle);
 
     // Detach.
@@ -94,13 +96,14 @@ Result MapDeviceAddressSpaceByForce(Core::System& system, Handle das_handle, Han
     R_UNLESS(reserved == 0, ResultInvalidEnumValue);
 
     // Get the device address space.
-    KScopedAutoObject das =
-        system.CurrentProcess()->GetHandleTable().GetObject<KDeviceAddressSpace>(das_handle);
+    KScopedAutoObject das = GetCurrentProcess(system.Kernel())
+                                .GetHandleTable()
+                                .GetObject<KDeviceAddressSpace>(das_handle);
     R_UNLESS(das.IsNotNull(), ResultInvalidHandle);
 
     // Get the process.
     KScopedAutoObject process =
-        system.CurrentProcess()->GetHandleTable().GetObject<KProcess>(process_handle);
+        GetCurrentProcess(system.Kernel()).GetHandleTable().GetObject<KProcess>(process_handle);
     R_UNLESS(process.IsNotNull(), ResultInvalidHandle);
 
     // Validate that the process address is within range.
@@ -134,13 +137,14 @@ Result MapDeviceAddressSpaceAligned(Core::System& system, Handle das_handle, Han
     R_UNLESS(reserved == 0, ResultInvalidEnumValue);
 
     // Get the device address space.
-    KScopedAutoObject das =
-        system.CurrentProcess()->GetHandleTable().GetObject<KDeviceAddressSpace>(das_handle);
+    KScopedAutoObject das = GetCurrentProcess(system.Kernel())
+                                .GetHandleTable()
+                                .GetObject<KDeviceAddressSpace>(das_handle);
     R_UNLESS(das.IsNotNull(), ResultInvalidHandle);
 
     // Get the process.
     KScopedAutoObject process =
-        system.CurrentProcess()->GetHandleTable().GetObject<KProcess>(process_handle);
+        GetCurrentProcess(system.Kernel()).GetHandleTable().GetObject<KProcess>(process_handle);
     R_UNLESS(process.IsNotNull(), ResultInvalidHandle);
 
     // Validate that the process address is within range.
@@ -165,13 +169,14 @@ Result UnmapDeviceAddressSpace(Core::System& system, Handle das_handle, Handle p
              ResultInvalidCurrentMemory);
 
     // Get the device address space.
-    KScopedAutoObject das =
-        system.CurrentProcess()->GetHandleTable().GetObject<KDeviceAddressSpace>(das_handle);
+    KScopedAutoObject das = GetCurrentProcess(system.Kernel())
+                                .GetHandleTable()
+                                .GetObject<KDeviceAddressSpace>(das_handle);
     R_UNLESS(das.IsNotNull(), ResultInvalidHandle);
 
     // Get the process.
     KScopedAutoObject process =
-        system.CurrentProcess()->GetHandleTable().GetObject<KProcess>(process_handle);
+        GetCurrentProcess(system.Kernel()).GetHandleTable().GetObject<KProcess>(process_handle);
     R_UNLESS(process.IsNotNull(), ResultInvalidHandle);
 
     // Validate that the process address is within range.

--- a/src/core/hle/kernel/svc/svc_event.cpp
+++ b/src/core/hle/kernel/svc/svc_event.cpp
@@ -15,7 +15,7 @@ Result SignalEvent(Core::System& system, Handle event_handle) {
     LOG_DEBUG(Kernel_SVC, "called, event_handle=0x{:08X}", event_handle);
 
     // Get the current handle table.
-    const KHandleTable& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
+    const KHandleTable& handle_table = GetCurrentProcess(system.Kernel()).GetHandleTable();
 
     // Get the event.
     KScopedAutoObject event = handle_table.GetObject<KEvent>(event_handle);
@@ -28,7 +28,7 @@ Result ClearEvent(Core::System& system, Handle event_handle) {
     LOG_TRACE(Kernel_SVC, "called, event_handle=0x{:08X}", event_handle);
 
     // Get the current handle table.
-    const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
+    const auto& handle_table = GetCurrentProcess(system.Kernel()).GetHandleTable();
 
     // Try to clear the writable event.
     {
@@ -56,10 +56,10 @@ Result CreateEvent(Core::System& system, Handle* out_write, Handle* out_read) {
 
     // Get the kernel reference and handle table.
     auto& kernel = system.Kernel();
-    auto& handle_table = kernel.CurrentProcess()->GetHandleTable();
+    auto& handle_table = GetCurrentProcess(kernel).GetHandleTable();
 
     // Reserve a new event from the process resource limit
-    KScopedResourceReservation event_reservation(kernel.CurrentProcess(),
+    KScopedResourceReservation event_reservation(GetCurrentProcessPointer(kernel),
                                                  LimitableResource::EventCountMax);
     R_UNLESS(event_reservation.Succeeded(), ResultLimitReached);
 
@@ -68,7 +68,7 @@ Result CreateEvent(Core::System& system, Handle* out_write, Handle* out_read) {
     R_UNLESS(event != nullptr, ResultOutOfResource);
 
     // Initialize the event.
-    event->Initialize(kernel.CurrentProcess());
+    event->Initialize(GetCurrentProcessPointer(kernel));
 
     // Commit the thread reservation.
     event_reservation.Commit();

--- a/src/core/hle/kernel/svc/svc_info.cpp
+++ b/src/core/hle/kernel/svc/svc_info.cpp
@@ -44,7 +44,7 @@ Result GetInfo(Core::System& system, u64* result, InfoType info_id_type, Handle 
             return ResultInvalidEnumValue;
         }
 
-        const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
+        const auto& handle_table = GetCurrentProcess(system.Kernel()).GetHandleTable();
         KScopedAutoObject process = handle_table.GetObject<KProcess>(handle);
         if (process.IsNull()) {
             LOG_ERROR(Kernel_SVC, "Process is not valid! info_id={}, info_sub_id={}, handle={:08X}",
@@ -154,7 +154,7 @@ Result GetInfo(Core::System& system, u64* result, InfoType info_id_type, Handle 
             return ResultInvalidCombination;
         }
 
-        KProcess* const current_process = system.Kernel().CurrentProcess();
+        KProcess* const current_process = GetCurrentProcessPointer(system.Kernel());
         KHandleTable& handle_table = current_process->GetHandleTable();
         const auto resource_limit = current_process->GetResourceLimit();
         if (!resource_limit) {
@@ -183,7 +183,7 @@ Result GetInfo(Core::System& system, u64* result, InfoType info_id_type, Handle 
             return ResultInvalidCombination;
         }
 
-        *result = system.Kernel().CurrentProcess()->GetRandomEntropy(info_sub_id);
+        *result = GetCurrentProcess(system.Kernel()).GetRandomEntropy(info_sub_id);
         return ResultSuccess;
 
     case InfoType::InitialProcessIdRange:
@@ -200,9 +200,9 @@ Result GetInfo(Core::System& system, u64* result, InfoType info_id_type, Handle 
             return ResultInvalidCombination;
         }
 
-        KScopedAutoObject thread =
-            system.Kernel().CurrentProcess()->GetHandleTable().GetObject<KThread>(
-                static_cast<Handle>(handle));
+        KScopedAutoObject thread = GetCurrentProcess(system.Kernel())
+                                       .GetHandleTable()
+                                       .GetObject<KThread>(static_cast<Handle>(handle));
         if (thread.IsNull()) {
             LOG_ERROR(Kernel_SVC, "Thread handle does not exist, handle=0x{:08X}",
                       static_cast<Handle>(handle));
@@ -249,7 +249,7 @@ Result GetInfo(Core::System& system, u64* result, InfoType info_id_type, Handle 
         R_UNLESS(info_sub_id == 0, ResultInvalidCombination);
 
         // Get the handle table.
-        KProcess* current_process = system.Kernel().CurrentProcess();
+        KProcess* current_process = GetCurrentProcessPointer(system.Kernel());
         KHandleTable& handle_table = current_process->GetHandleTable();
 
         // Get a new handle for the current process.

--- a/src/core/hle/kernel/svc/svc_ipc.cpp
+++ b/src/core/hle/kernel/svc/svc_ipc.cpp
@@ -12,11 +12,9 @@ namespace Kernel::Svc {
 
 /// Makes a blocking IPC call to a service.
 Result SendSyncRequest(Core::System& system, Handle handle) {
-    auto& kernel = system.Kernel();
-
     // Get the client session from its handle.
     KScopedAutoObject session =
-        kernel.CurrentProcess()->GetHandleTable().GetObject<KClientSession>(handle);
+        GetCurrentProcess(system.Kernel()).GetHandleTable().GetObject<KClientSession>(handle);
     R_UNLESS(session.IsNotNull(), ResultInvalidHandle);
 
     LOG_TRACE(Kernel_SVC, "called handle=0x{:08X}({})", handle, session->GetName());
@@ -40,7 +38,7 @@ Result SendAsyncRequestWithUserBuffer(Core::System& system, Handle* out_event_ha
 Result ReplyAndReceive(Core::System& system, s32* out_index, uint64_t handles_addr, s32 num_handles,
                        Handle reply_target, s64 timeout_ns) {
     auto& kernel = system.Kernel();
-    auto& handle_table = GetCurrentThread(kernel).GetOwnerProcess()->GetHandleTable();
+    auto& handle_table = GetCurrentProcess(kernel).GetHandleTable();
 
     R_UNLESS(0 <= num_handles && num_handles <= ArgumentHandleCountMax, ResultOutOfRange);
     R_UNLESS(system.Memory().IsValidVirtualAddressRange(

--- a/src/core/hle/kernel/svc/svc_lock.cpp
+++ b/src/core/hle/kernel/svc/svc_lock.cpp
@@ -24,7 +24,7 @@ Result ArbitrateLock(Core::System& system, Handle thread_handle, VAddr address, 
         return ResultInvalidAddress;
     }
 
-    return system.Kernel().CurrentProcess()->WaitForAddress(thread_handle, address, tag);
+    return GetCurrentProcess(system.Kernel()).WaitForAddress(thread_handle, address, tag);
 }
 
 /// Unlock a mutex
@@ -43,7 +43,7 @@ Result ArbitrateUnlock(Core::System& system, VAddr address) {
         return ResultInvalidAddress;
     }
 
-    return system.Kernel().CurrentProcess()->SignalToAddress(address);
+    return GetCurrentProcess(system.Kernel()).SignalToAddress(address);
 }
 
 Result ArbitrateLock64(Core::System& system, Handle thread_handle, uint64_t address, uint32_t tag) {

--- a/src/core/hle/kernel/svc/svc_memory.cpp
+++ b/src/core/hle/kernel/svc/svc_memory.cpp
@@ -113,7 +113,7 @@ Result SetMemoryPermission(Core::System& system, VAddr address, u64 size, Memory
     R_UNLESS(IsValidSetMemoryPermission(perm), ResultInvalidNewMemoryPermission);
 
     // Validate that the region is in range for the current process.
-    auto& page_table = system.Kernel().CurrentProcess()->PageTable();
+    auto& page_table = GetCurrentProcess(system.Kernel()).PageTable();
     R_UNLESS(page_table.Contains(address, size), ResultInvalidCurrentMemory);
 
     // Set the memory attribute.
@@ -137,7 +137,7 @@ Result SetMemoryAttribute(Core::System& system, VAddr address, u64 size, u32 mas
     R_UNLESS((mask | attr | SupportedMask) == SupportedMask, ResultInvalidCombination);
 
     // Validate that the region is in range for the current process.
-    auto& page_table{system.Kernel().CurrentProcess()->PageTable()};
+    auto& page_table{GetCurrentProcess(system.Kernel()).PageTable()};
     R_UNLESS(page_table.Contains(address, size), ResultInvalidCurrentMemory);
 
     // Set the memory attribute.
@@ -149,7 +149,7 @@ Result MapMemory(Core::System& system, VAddr dst_addr, VAddr src_addr, u64 size)
     LOG_TRACE(Kernel_SVC, "called, dst_addr=0x{:X}, src_addr=0x{:X}, size=0x{:X}", dst_addr,
               src_addr, size);
 
-    auto& page_table{system.Kernel().CurrentProcess()->PageTable()};
+    auto& page_table{GetCurrentProcess(system.Kernel()).PageTable()};
 
     if (const Result result{MapUnmapMemorySanityChecks(page_table, dst_addr, src_addr, size)};
         result.IsError()) {
@@ -164,7 +164,7 @@ Result UnmapMemory(Core::System& system, VAddr dst_addr, VAddr src_addr, u64 siz
     LOG_TRACE(Kernel_SVC, "called, dst_addr=0x{:X}, src_addr=0x{:X}, size=0x{:X}", dst_addr,
               src_addr, size);
 
-    auto& page_table{system.Kernel().CurrentProcess()->PageTable()};
+    auto& page_table{GetCurrentProcess(system.Kernel()).PageTable()};
 
     if (const Result result{MapUnmapMemorySanityChecks(page_table, dst_addr, src_addr, size)};
         result.IsError()) {

--- a/src/core/hle/kernel/svc/svc_physical_memory.cpp
+++ b/src/core/hle/kernel/svc/svc_physical_memory.cpp
@@ -16,7 +16,7 @@ Result SetHeapSize(Core::System& system, VAddr* out_address, u64 size) {
     R_UNLESS(size < MainMemorySizeMax, ResultInvalidSize);
 
     // Set the heap size.
-    R_TRY(system.Kernel().CurrentProcess()->PageTable().SetHeapSize(out_address, size));
+    R_TRY(GetCurrentProcess(system.Kernel()).PageTable().SetHeapSize(out_address, size));
 
     return ResultSuccess;
 }
@@ -45,7 +45,7 @@ Result MapPhysicalMemory(Core::System& system, VAddr addr, u64 size) {
         return ResultInvalidMemoryRegion;
     }
 
-    KProcess* const current_process{system.Kernel().CurrentProcess()};
+    KProcess* const current_process{GetCurrentProcessPointer(system.Kernel())};
     auto& page_table{current_process->PageTable()};
 
     if (current_process->GetSystemResourceSize() == 0) {
@@ -94,7 +94,7 @@ Result UnmapPhysicalMemory(Core::System& system, VAddr addr, u64 size) {
         return ResultInvalidMemoryRegion;
     }
 
-    KProcess* const current_process{system.Kernel().CurrentProcess()};
+    KProcess* const current_process{GetCurrentProcessPointer(system.Kernel())};
     auto& page_table{current_process->PageTable()};
 
     if (current_process->GetSystemResourceSize() == 0) {

--- a/src/core/hle/kernel/svc/svc_port.cpp
+++ b/src/core/hle/kernel/svc/svc_port.cpp
@@ -34,7 +34,7 @@ Result ConnectToNamedPort(Core::System& system, Handle* out, VAddr port_name_add
 
     // Get the current handle table.
     auto& kernel = system.Kernel();
-    auto& handle_table = kernel.CurrentProcess()->GetHandleTable();
+    auto& handle_table = GetCurrentProcess(kernel).GetHandleTable();
 
     // Find the client port.
     auto port = kernel.CreateNamedServicePort(port_name);

--- a/src/core/hle/kernel/svc/svc_process_memory.cpp
+++ b/src/core/hle/kernel/svc/svc_process_memory.cpp
@@ -45,7 +45,7 @@ Result SetProcessMemoryPermission(Core::System& system, Handle process_handle, V
 
     // Get the process from its handle.
     KScopedAutoObject process =
-        system.CurrentProcess()->GetHandleTable().GetObject<KProcess>(process_handle);
+        GetCurrentProcess(system.Kernel()).GetHandleTable().GetObject<KProcess>(process_handle);
     R_UNLESS(process.IsNotNull(), ResultInvalidHandle);
 
     // Validate that the address is in range.
@@ -71,7 +71,7 @@ Result MapProcessMemory(Core::System& system, VAddr dst_address, Handle process_
     R_UNLESS((src_address < src_address + size), ResultInvalidCurrentMemory);
 
     // Get the processes.
-    KProcess* dst_process = system.CurrentProcess();
+    KProcess* dst_process = GetCurrentProcessPointer(system.Kernel());
     KScopedAutoObject src_process =
         dst_process->GetHandleTable().GetObjectWithoutPseudoHandle<KProcess>(process_handle);
     R_UNLESS(src_process.IsNotNull(), ResultInvalidHandle);
@@ -114,7 +114,7 @@ Result UnmapProcessMemory(Core::System& system, VAddr dst_address, Handle proces
     R_UNLESS((src_address < src_address + size), ResultInvalidCurrentMemory);
 
     // Get the processes.
-    KProcess* dst_process = system.CurrentProcess();
+    KProcess* dst_process = GetCurrentProcessPointer(system.Kernel());
     KScopedAutoObject src_process =
         dst_process->GetHandleTable().GetObjectWithoutPseudoHandle<KProcess>(process_handle);
     R_UNLESS(src_process.IsNotNull(), ResultInvalidHandle);
@@ -174,7 +174,7 @@ Result MapProcessCodeMemory(Core::System& system, Handle process_handle, u64 dst
         return ResultInvalidCurrentMemory;
     }
 
-    const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
+    const auto& handle_table = GetCurrentProcess(system.Kernel()).GetHandleTable();
     KScopedAutoObject process = handle_table.GetObject<KProcess>(process_handle);
     if (process.IsNull()) {
         LOG_ERROR(Kernel_SVC, "Invalid process handle specified (handle=0x{:08X}).",
@@ -242,7 +242,7 @@ Result UnmapProcessCodeMemory(Core::System& system, Handle process_handle, u64 d
         return ResultInvalidCurrentMemory;
     }
 
-    const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
+    const auto& handle_table = GetCurrentProcess(system.Kernel()).GetHandleTable();
     KScopedAutoObject process = handle_table.GetObject<KProcess>(process_handle);
     if (process.IsNull()) {
         LOG_ERROR(Kernel_SVC, "Invalid process handle specified (handle=0x{:08X}).",

--- a/src/core/hle/kernel/svc/svc_query_memory.cpp
+++ b/src/core/hle/kernel/svc/svc_query_memory.cpp
@@ -22,7 +22,7 @@ Result QueryMemory(Core::System& system, uint64_t out_memory_info, PageInfo* out
 Result QueryProcessMemory(Core::System& system, uint64_t out_memory_info, PageInfo* out_page_info,
                           Handle process_handle, uint64_t address) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X} address={:X}", process_handle, address);
-    const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
+    const auto& handle_table = GetCurrentProcess(system.Kernel()).GetHandleTable();
     KScopedAutoObject process = handle_table.GetObject<KProcess>(process_handle);
     if (process.IsNull()) {
         LOG_ERROR(Kernel_SVC, "Process handle does not exist, process_handle=0x{:08X}",

--- a/src/core/hle/kernel/svc/svc_resource_limit.cpp
+++ b/src/core/hle/kernel/svc/svc_resource_limit.cpp
@@ -27,7 +27,7 @@ Result CreateResourceLimit(Core::System& system, Handle* out_handle) {
     KResourceLimit::Register(kernel, resource_limit);
 
     // Add the limit to the handle table.
-    R_TRY(kernel.CurrentProcess()->GetHandleTable().Add(out_handle, resource_limit));
+    R_TRY(GetCurrentProcess(kernel).GetHandleTable().Add(out_handle, resource_limit));
 
     return ResultSuccess;
 }
@@ -41,9 +41,9 @@ Result GetResourceLimitLimitValue(Core::System& system, s64* out_limit_value,
     R_UNLESS(IsValidResourceType(which), ResultInvalidEnumValue);
 
     // Get the resource limit.
-    auto& kernel = system.Kernel();
-    KScopedAutoObject resource_limit =
-        kernel.CurrentProcess()->GetHandleTable().GetObject<KResourceLimit>(resource_limit_handle);
+    KScopedAutoObject resource_limit = GetCurrentProcess(system.Kernel())
+                                           .GetHandleTable()
+                                           .GetObject<KResourceLimit>(resource_limit_handle);
     R_UNLESS(resource_limit.IsNotNull(), ResultInvalidHandle);
 
     // Get the limit value.
@@ -61,9 +61,9 @@ Result GetResourceLimitCurrentValue(Core::System& system, s64* out_current_value
     R_UNLESS(IsValidResourceType(which), ResultInvalidEnumValue);
 
     // Get the resource limit.
-    auto& kernel = system.Kernel();
-    KScopedAutoObject resource_limit =
-        kernel.CurrentProcess()->GetHandleTable().GetObject<KResourceLimit>(resource_limit_handle);
+    KScopedAutoObject resource_limit = GetCurrentProcess(system.Kernel())
+                                           .GetHandleTable()
+                                           .GetObject<KResourceLimit>(resource_limit_handle);
     R_UNLESS(resource_limit.IsNotNull(), ResultInvalidHandle);
 
     // Get the current value.
@@ -81,9 +81,9 @@ Result SetResourceLimitLimitValue(Core::System& system, Handle resource_limit_ha
     R_UNLESS(IsValidResourceType(which), ResultInvalidEnumValue);
 
     // Get the resource limit.
-    auto& kernel = system.Kernel();
-    KScopedAutoObject resource_limit =
-        kernel.CurrentProcess()->GetHandleTable().GetObject<KResourceLimit>(resource_limit_handle);
+    KScopedAutoObject resource_limit = GetCurrentProcess(system.Kernel())
+                                           .GetHandleTable()
+                                           .GetObject<KResourceLimit>(resource_limit_handle);
     R_UNLESS(resource_limit.IsNotNull(), ResultInvalidHandle);
 
     // Set the limit value.

--- a/src/core/hle/kernel/svc/svc_session.cpp
+++ b/src/core/hle/kernel/svc/svc_session.cpp
@@ -13,7 +13,7 @@ namespace {
 
 template <typename T>
 Result CreateSession(Core::System& system, Handle* out_server, Handle* out_client, u64 name) {
-    auto& process = *system.CurrentProcess();
+    auto& process = GetCurrentProcess(system.Kernel());
     auto& handle_table = process.GetHandleTable();
 
     // Declare the session we're going to allocate.

--- a/src/core/hle/kernel/svc/svc_shared_memory.cpp
+++ b/src/core/hle/kernel/svc/svc_shared_memory.cpp
@@ -42,7 +42,7 @@ Result MapSharedMemory(Core::System& system, Handle shmem_handle, VAddr address,
     R_UNLESS(IsValidSharedMemoryPermission(map_perm), ResultInvalidNewMemoryPermission);
 
     // Get the current process.
-    auto& process = *system.Kernel().CurrentProcess();
+    auto& process = GetCurrentProcess(system.Kernel());
     auto& page_table = process.PageTable();
 
     // Get the shared memory.
@@ -75,7 +75,7 @@ Result UnmapSharedMemory(Core::System& system, Handle shmem_handle, VAddr addres
     R_UNLESS((address < address + size), ResultInvalidCurrentMemory);
 
     // Get the current process.
-    auto& process = *system.Kernel().CurrentProcess();
+    auto& process = GetCurrentProcess(system.Kernel());
     auto& page_table = process.PageTable();
 
     // Get the shared memory.

--- a/src/core/hle/kernel/svc/svc_transfer_memory.cpp
+++ b/src/core/hle/kernel/svc/svc_transfer_memory.cpp
@@ -39,11 +39,11 @@ Result CreateTransferMemory(Core::System& system, Handle* out, VAddr address, u6
     R_UNLESS(IsValidTransferMemoryPermission(map_perm), ResultInvalidNewMemoryPermission);
 
     // Get the current process and handle table.
-    auto& process = *kernel.CurrentProcess();
+    auto& process = GetCurrentProcess(kernel);
     auto& handle_table = process.GetHandleTable();
 
     // Reserve a new transfer memory from the process resource limit.
-    KScopedResourceReservation trmem_reservation(kernel.CurrentProcess(),
+    KScopedResourceReservation trmem_reservation(&process,
                                                  LimitableResource::TransferMemoryCountMax);
     R_UNLESS(trmem_reservation.Succeeded(), ResultLimitReached);
 

--- a/src/core/hle/kernel/svc_generator.py
+++ b/src/core/hle/kernel/svc_generator.py
@@ -592,7 +592,7 @@ void Call(Core::System& system, u32 imm) {
     auto& kernel = system.Kernel();
     kernel.EnterSVCProfile();
 
-    if (system.CurrentProcess()->Is64BitProcess()) {
+    if (GetCurrentProcess(system.Kernel()).Is64BitProcess()) {
         Call64(system, imm);
     } else {
         Call32(system, imm);

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -762,7 +762,7 @@ Result Module::Interface::InitializeApplicationInfoBase() {
     // processes emulated. As we don't actually have pid support we should assume we're just using
     // our own process
     const auto launch_property =
-        system.GetARPManager().GetLaunchProperty(system.GetCurrentProcessProgramID());
+        system.GetARPManager().GetLaunchProperty(system.GetApplicationProcessProgramID());
 
     if (launch_property.Failed()) {
         LOG_ERROR(Service_ACC, "Failed to get launch property");
@@ -806,7 +806,7 @@ void Module::Interface::IsUserAccountSwitchLocked(Kernel::HLERequestContext& ctx
     bool is_locked = false;
 
     if (res != Loader::ResultStatus::Success) {
-        const FileSys::PatchManager pm{system.GetCurrentProcessProgramID(),
+        const FileSys::PatchManager pm{system.GetApplicationProcessProgramID(),
                                        system.GetFileSystemController(),
                                        system.GetContentProvider()};
         const auto nacp_unique = pm.GetControlMetadata().first;

--- a/src/core/hle/service/am/applets/applet_error.cpp
+++ b/src/core/hle/service/am/applets/applet_error.cpp
@@ -166,7 +166,7 @@ void Error::Execute() {
     }
 
     const auto callback = [this] { DisplayCompleted(); };
-    const auto title_id = system.GetCurrentProcessProgramID();
+    const auto title_id = system.GetApplicationProcessProgramID();
     const auto& reporter{system.GetReporter()};
 
     switch (mode) {

--- a/src/core/hle/service/am/applets/applet_general_backend.cpp
+++ b/src/core/hle/service/am/applets/applet_general_backend.cpp
@@ -186,7 +186,7 @@ void PhotoViewer::Execute() {
     const auto callback = [this] { ViewFinished(); };
     switch (mode) {
     case PhotoViewerAppletMode::CurrentApp:
-        frontend.ShowPhotosForApplication(system.GetCurrentProcessProgramID(), callback);
+        frontend.ShowPhotosForApplication(system.GetApplicationProcessProgramID(), callback);
         break;
     case PhotoViewerAppletMode::AllApps:
         frontend.ShowAllPhotos(callback);

--- a/src/core/hle/service/am/applets/applet_web_browser.cpp
+++ b/src/core/hle/service/am/applets/applet_web_browser.cpp
@@ -393,7 +393,7 @@ void WebBrowser::InitializeOffline() {
     switch (document_kind) {
     case DocumentKind::OfflineHtmlPage:
     default:
-        title_id = system.GetCurrentProcessProgramID();
+        title_id = system.GetApplicationProcessProgramID();
         nca_type = FileSys::ContentRecordType::HtmlDocument;
         additional_paths = "html-document";
         break;

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -155,7 +155,7 @@ void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
 
-    const auto current = system.GetCurrentProcessProgramID();
+    const auto current = system.GetApplicationProcessProgramID();
 
     const auto& disabled = Settings::values.disabled_addons[current];
     if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end()) {
@@ -182,7 +182,7 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AOC, "called with offset={}, count={}, process_id={}", offset, count,
               process_id);
 
-    const auto current = system.GetCurrentProcessProgramID();
+    const auto current = system.GetApplicationProcessProgramID();
 
     std::vector<u32> out;
     const auto& disabled = Settings::values.disabled_addons[current];
@@ -228,7 +228,7 @@ void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(ResultSuccess);
 
-    const auto title_id = system.GetCurrentProcessProgramID();
+    const auto title_id = system.GetApplicationProcessProgramID();
     const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                    system.GetContentProvider()};
 

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -455,7 +455,7 @@ void AudRenU::OpenAudioRenderer(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    const auto& handle_table{system.CurrentProcess()->GetHandleTable()};
+    const auto& handle_table{system.ApplicationProcess()->GetHandleTable()};
     auto process{handle_table.GetObject<Kernel::KProcess>(process_handle)};
     auto transfer_memory{
         process->GetHandleTable().GetObject<Kernel::KTransferMemory>(transfer_memory_handle)};

--- a/src/core/hle/service/bcat/bcat_module.cpp
+++ b/src/core/hle/service/bcat/bcat_module.cpp
@@ -176,8 +176,8 @@ private:
     void RequestSyncDeliveryCache(Kernel::HLERequestContext& ctx) {
         LOG_DEBUG(Service_BCAT, "called");
 
-        backend.Synchronize({system.GetCurrentProcessProgramID(),
-                             GetCurrentBuildID(system.GetCurrentProcessBuildID())},
+        backend.Synchronize({system.GetApplicationProcessProgramID(),
+                             GetCurrentBuildID(system.GetApplicationProcessBuildID())},
                             GetProgressBackend(SyncType::Normal));
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
@@ -193,8 +193,8 @@ private:
 
         LOG_DEBUG(Service_BCAT, "called, name={}", name);
 
-        backend.SynchronizeDirectory({system.GetCurrentProcessProgramID(),
-                                      GetCurrentBuildID(system.GetCurrentProcessBuildID())},
+        backend.SynchronizeDirectory({system.GetApplicationProcessProgramID(),
+                                      GetCurrentBuildID(system.GetApplicationProcessBuildID())},
                                      name, GetProgressBackend(SyncType::Directory));
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
@@ -554,7 +554,7 @@ private:
 void Module::Interface::CreateDeliveryCacheStorageService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_BCAT, "called");
 
-    const auto title_id = system.GetCurrentProcessProgramID();
+    const auto title_id = system.GetApplicationProcessProgramID();
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IDeliveryCacheStorageService>(system, fsc.GetBCATDirectory(title_id));

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -63,7 +63,7 @@ enum class FatalType : u32 {
 };
 
 static void GenerateErrorReport(Core::System& system, Result error_code, const FatalInfo& info) {
-    const auto title_id = system.GetCurrentProcessProgramID();
+    const auto title_id = system.GetApplicationProcessProgramID();
     std::string crash_report = fmt::format(
         "Yuzu {}-{} crash report\n"
         "Title ID:                        {:016x}\n"

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -317,7 +317,7 @@ ResultVal<FileSys::VirtualFile> FileSystemController::OpenRomFSCurrentProcess() 
         return ResultUnknown;
     }
 
-    return romfs_factory->OpenCurrentProcess(system.GetCurrentProcessProgramID());
+    return romfs_factory->OpenCurrentProcess(system.GetApplicationProcessProgramID());
 }
 
 ResultVal<FileSys::VirtualFile> FileSystemController::OpenPatchedRomFS(
@@ -502,7 +502,7 @@ FileSys::SaveDataSize FileSystemController::ReadSaveDataSize(FileSys::SaveDataTy
         const auto res = system.GetAppLoader().ReadControlData(nacp);
 
         if (res != Loader::ResultStatus::Success) {
-            const FileSys::PatchManager pm{system.GetCurrentProcessProgramID(),
+            const FileSys::PatchManager pm{system.GetApplicationProcessProgramID(),
                                            system.GetFileSystemController(),
                                            system.GetContentProvider()};
             const auto metadata = pm.GetControlMetadata();

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -1036,8 +1036,9 @@ void FSP_SRV::OpenDataStorageWithProgramIndex(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS, "called, program_index={}", program_index);
 
-    auto patched_romfs = fsc.OpenPatchedRomFSWithProgramIndex(
-        system.GetCurrentProcessProgramID(), program_index, FileSys::ContentRecordType::Program);
+    auto patched_romfs =
+        fsc.OpenPatchedRomFSWithProgramIndex(system.GetApplicationProcessProgramID(), program_index,
+                                             FileSys::ContentRecordType::Program);
 
     if (patched_romfs.Failed()) {
         // TODO: Find the right error code to use here

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -1830,7 +1830,7 @@ void Hid::InitializeSevenSixAxisSensor(Kernel::HLERequestContext& ctx) {
     ASSERT_MSG(t_mem_1_size == 0x1000, "t_mem_1_size is not 0x1000 bytes");
     ASSERT_MSG(t_mem_2_size == 0x7F000, "t_mem_2_size is not 0x7F000 bytes");
 
-    auto t_mem_1 = system.CurrentProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(
+    auto t_mem_1 = system.ApplicationProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(
         t_mem_1_handle);
 
     if (t_mem_1.IsNull()) {
@@ -1840,7 +1840,7 @@ void Hid::InitializeSevenSixAxisSensor(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    auto t_mem_2 = system.CurrentProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(
+    auto t_mem_2 = system.ApplicationProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(
         t_mem_2_handle);
 
     if (t_mem_2.IsNull()) {
@@ -2127,8 +2127,8 @@ void Hid::WritePalmaWaveEntry(Kernel::HLERequestContext& ctx) {
 
     ASSERT_MSG(t_mem_size == 0x3000, "t_mem_size is not 0x3000 bytes");
 
-    auto t_mem =
-        system.CurrentProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(t_mem_handle);
+    auto t_mem = system.ApplicationProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(
+        t_mem_handle);
 
     if (t_mem.IsNull()) {
         LOG_ERROR(Service_HID, "t_mem is a nullptr for handle=0x{:08X}", t_mem_handle);

--- a/src/core/hle/service/hid/hidbus.cpp
+++ b/src/core/hle/service/hid/hidbus.cpp
@@ -449,8 +449,8 @@ void HidBus::EnableJoyPollingReceiveMode(Kernel::HLERequestContext& ctx) {
 
     ASSERT_MSG(t_mem_size == 0x1000, "t_mem_size is not 0x1000 bytes");
 
-    auto t_mem =
-        system.CurrentProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(t_mem_handle);
+    auto t_mem = system.ApplicationProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(
+        t_mem_handle);
 
     if (t_mem.IsNull()) {
         LOG_ERROR(Service_HID, "t_mem is a nullptr for handle=0x{:08X}", t_mem_handle);

--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -196,8 +196,8 @@ void IRS::RunImageTransferProcessor(Kernel::HLERequestContext& ctx) {
     const auto parameters{rp.PopRaw<Parameters>()};
     const auto t_mem_handle{ctx.GetCopyHandle(0)};
 
-    auto t_mem =
-        system.CurrentProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(t_mem_handle);
+    auto t_mem = system.ApplicationProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(
+        t_mem_handle);
 
     if (t_mem.IsNull()) {
         LOG_ERROR(Service_IRS, "t_mem is a nullptr for handle=0x{:08X}", t_mem_handle);
@@ -445,8 +445,8 @@ void IRS::RunImageTransferExProcessor(Kernel::HLERequestContext& ctx) {
     const auto parameters{rp.PopRaw<Parameters>()};
     const auto t_mem_handle{ctx.GetCopyHandle(0)};
 
-    auto t_mem =
-        system.CurrentProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(t_mem_handle);
+    auto t_mem = system.ApplicationProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(
+        t_mem_handle);
 
     u8* transfer_memory = system.Memory().GetPointer(t_mem->GetSourceAddress());
 

--- a/src/core/hle/service/jit/jit.cpp
+++ b/src/core/hle/service/jit/jit.cpp
@@ -353,9 +353,9 @@ public:
             return;
         }
 
-        // Fetch using the handle table for the current process here,
+        // Fetch using the handle table for the application process here,
         // since we are not multiprocess yet.
-        const auto& handle_table{system.CurrentProcess()->GetHandleTable()};
+        const auto& handle_table{system.ApplicationProcess()->GetHandleTable()};
 
         auto process{handle_table.GetObject<Kernel::KProcess>(process_handle)};
         if (process.IsNull()) {

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -246,7 +246,7 @@ public:
             return;
         }
 
-        if (system.GetCurrentProcessProgramID() != header.application_id) {
+        if (system.GetApplicationProcessProgramID() != header.application_id) {
             LOG_ERROR(Service_LDR,
                       "Attempting to load NRR with title ID other than current process. (actual "
                       "{:016X})!",
@@ -542,15 +542,16 @@ public:
         }
 
         // Map memory for the NRO
-        const auto map_result{MapNro(system.CurrentProcess(), nro_address, nro_size, bss_address,
-                                     bss_size, nro_size + bss_size)};
+        const auto map_result{MapNro(system.ApplicationProcess(), nro_address, nro_size,
+                                     bss_address, bss_size, nro_size + bss_size)};
         if (map_result.Failed()) {
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(map_result.Code());
         }
 
         // Load the NRO into the mapped memory
-        if (const auto result{LoadNro(system.CurrentProcess(), header, nro_address, *map_result)};
+        if (const auto result{
+                LoadNro(system.ApplicationProcess(), header, nro_address, *map_result)};
             result.IsError()) {
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(map_result.Code());
@@ -570,7 +571,7 @@ public:
 
     Result UnmapNro(const NROInfo& info) {
         // Each region must be unmapped separately to validate memory state
-        auto& page_table{system.CurrentProcess()->PageTable()};
+        auto& page_table{system.ApplicationProcess()->PageTable()};
 
         if (info.bss_size != 0) {
             CASCADE_CODE(page_table.UnmapCodeMemory(
@@ -641,7 +642,7 @@ public:
         LOG_WARNING(Service_LDR, "(STUBBED) called");
 
         initialized = true;
-        current_map_addr = system.CurrentProcess()->PageTable().GetAliasCodeRegionStart();
+        current_map_addr = system.ApplicationProcess()->PageTable().GetAliasCodeRegionStart();
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultSuccess);

--- a/src/core/hle/service/nfp/nfp_device.cpp
+++ b/src/core/hle/service/nfp/nfp_device.cpp
@@ -618,7 +618,7 @@ Result NfpDevice::RecreateApplicationArea(u32 access_id, std::span<const u8> dat
                             sizeof(ApplicationArea) - data.size());
 
     // TODO: Investigate why the title id needs to be moddified
-    tag_data.title_id = system.GetCurrentProcessProgramID();
+    tag_data.title_id = system.GetApplicationProcessProgramID();
     tag_data.title_id = tag_data.title_id | 0x30000000ULL;
     tag_data.settings.settings.appdata_initialized.Assign(1);
     tag_data.application_area_id = access_id;

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -150,9 +150,9 @@ NvResult nvhost_ctrl::IocCtrlEventWait(std::span<const u8> input, std::vector<u8
     const auto check_failing = [&]() {
         if (events[slot].fails > 2) {
             {
-                auto lk = system.StallProcesses();
+                auto lk = system.StallApplication();
                 host1x_syncpoint_manager.WaitHost(fence_id, target_value);
-                system.UnstallProcesses();
+                system.UnstallApplication();
             }
             params.value.raw = target_value;
             return true;

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -127,7 +127,7 @@ NvResult nvmap::IocAlloc(std::span<const u8> input, std::vector<u8>& output) {
         return result;
     }
     bool is_out_io{};
-    ASSERT(system.CurrentProcess()
+    ASSERT(system.ApplicationProcess()
                ->PageTable()
                .LockForMapDeviceAddressSpace(&is_out_io, handle_description->address,
                                              handle_description->size,
@@ -254,7 +254,7 @@ NvResult nvmap::IocFree(std::span<const u8> input, std::vector<u8>& output) {
 
     if (auto freeInfo{file.FreeHandle(params.handle, false)}) {
         if (freeInfo->can_unlock) {
-            ASSERT(system.CurrentProcess()
+            ASSERT(system.ApplicationProcess()
                        ->PageTable()
                        .UnlockForDeviceAddressSpace(freeInfo->address, freeInfo->size)
                        .IsSuccess());

--- a/src/core/hle/service/pctl/pctl_module.cpp
+++ b/src/core/hle/service/pctl/pctl_module.cpp
@@ -187,7 +187,7 @@ private:
 
         // TODO(ogniK): Recovery flag initialization for pctl:r
 
-        const auto tid = system.GetCurrentProcessProgramID();
+        const auto tid = system.GetApplicationProcessProgramID();
         if (tid != 0) {
             const FileSys::PatchManager pm{tid, system.GetFileSystemController(),
                                            system.GetContentProvider()};

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -71,7 +71,7 @@ private:
                   Type, process_id, data1.size(), data2.size());
 
         const auto& reporter{system.GetReporter()};
-        reporter.SavePlayReport(Type, system.GetCurrentProcessProgramID(), {data1, data2},
+        reporter.SavePlayReport(Type, system.GetApplicationProcessProgramID(), {data1, data2},
                                 process_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -99,7 +99,7 @@ private:
                   Type, user_id[1], user_id[0], process_id, data1.size(), data2.size());
 
         const auto& reporter{system.GetReporter()};
-        reporter.SavePlayReport(Type, system.GetCurrentProcessProgramID(), {data1, data2},
+        reporter.SavePlayReport(Type, system.GetApplicationProcessProgramID(), {data1, data2},
                                 process_id, user_id);
 
         IPC::ResponseBuilder rb{ctx, 2};

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -145,7 +145,7 @@ std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::KProcess& process, Core::
 
     // Apply cheats if they exist and the program has a valid title ID
     if (pm) {
-        system.SetCurrentProcessBuildID(nso_header.build_id);
+        system.SetApplicationProcessBuildID(nso_header.build_id);
         const auto cheats = pm->CreateCheatList(nso_header.build_id);
         if (!cheats.empty()) {
             system.RegisterCheatList(cheats, nso_header.build_id, load_base, image_size);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -247,11 +247,11 @@ struct Memory::Impl {
     }
 
     void ReadBlock(const VAddr src_addr, void* dest_buffer, const std::size_t size) {
-        ReadBlockImpl<false>(*system.CurrentProcess(), src_addr, dest_buffer, size);
+        ReadBlockImpl<false>(*system.ApplicationProcess(), src_addr, dest_buffer, size);
     }
 
     void ReadBlockUnsafe(const VAddr src_addr, void* dest_buffer, const std::size_t size) {
-        ReadBlockImpl<true>(*system.CurrentProcess(), src_addr, dest_buffer, size);
+        ReadBlockImpl<true>(*system.ApplicationProcess(), src_addr, dest_buffer, size);
     }
 
     template <bool UNSAFE>
@@ -279,11 +279,11 @@ struct Memory::Impl {
     }
 
     void WriteBlock(const VAddr dest_addr, const void* src_buffer, const std::size_t size) {
-        WriteBlockImpl<false>(*system.CurrentProcess(), dest_addr, src_buffer, size);
+        WriteBlockImpl<false>(*system.ApplicationProcess(), dest_addr, src_buffer, size);
     }
 
     void WriteBlockUnsafe(const VAddr dest_addr, const void* src_buffer, const std::size_t size) {
-        WriteBlockImpl<true>(*system.CurrentProcess(), dest_addr, src_buffer, size);
+        WriteBlockImpl<true>(*system.ApplicationProcess(), dest_addr, src_buffer, size);
     }
 
     void ZeroBlock(const Kernel::KProcess& process, const VAddr dest_addr, const std::size_t size) {
@@ -711,7 +711,7 @@ void Memory::UnmapRegion(Common::PageTable& page_table, VAddr base, u64 size) {
 }
 
 bool Memory::IsValidVirtualAddress(const VAddr vaddr) const {
-    const Kernel::KProcess& process = *system.CurrentProcess();
+    const Kernel::KProcess& process = *system.ApplicationProcess();
     const auto& page_table = process.PageTable().PageTableImpl();
     const size_t page = vaddr >> YUZU_PAGEBITS;
     if (page >= page_table.pointers.size()) {

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -191,10 +191,10 @@ void CheatEngine::Initialize() {
         });
     core_timing.ScheduleLoopingEvent(CHEAT_ENGINE_NS, CHEAT_ENGINE_NS, event);
 
-    metadata.process_id = system.CurrentProcess()->GetProcessID();
-    metadata.title_id = system.GetCurrentProcessProgramID();
+    metadata.process_id = system.ApplicationProcess()->GetProcessID();
+    metadata.title_id = system.GetApplicationProcessProgramID();
 
-    const auto& page_table = system.CurrentProcess()->PageTable();
+    const auto& page_table = system.ApplicationProcess()->PageTable();
     metadata.heap_extents = {
         .base = page_table.GetHeapRegionStart(),
         .size = page_table.GetHeapRegionSize(),

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -110,7 +110,7 @@ json GetProcessorStateData(const std::string& architecture, u64 entry_point, u64
 }
 
 json GetProcessorStateDataAuto(Core::System& system) {
-    const auto* process{system.CurrentProcess()};
+    const auto* process{system.ApplicationProcess()};
     auto& arm{system.CurrentArmInterface()};
 
     Core::ARM_Interface::ThreadContext64 context{};
@@ -234,7 +234,7 @@ void Reporter::SaveSvcBreakReport(u32 type, bool signal_debugger, u64 info1, u64
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.GetCurrentProcessProgramID();
+    const auto title_id = system.GetApplicationProcessProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     auto break_out = json{
@@ -261,7 +261,7 @@ void Reporter::SaveUnimplementedFunctionReport(Kernel::HLERequestContext& ctx, u
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.GetCurrentProcessProgramID();
+    const auto title_id = system.GetApplicationProcessProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     auto function_out = GetHLERequestContextData(ctx, system.Memory());
@@ -283,7 +283,7 @@ void Reporter::SaveUnimplementedAppletReport(
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.GetCurrentProcessProgramID();
+    const auto title_id = system.GetApplicationProcessProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     out["applet_common_args"] = {
@@ -376,7 +376,7 @@ void Reporter::SaveUserReport() const {
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.GetCurrentProcessProgramID();
+    const auto title_id = system.GetApplicationProcessProgramID();
 
     SaveToFile(GetFullDataAuto(timestamp, title_id, system),
                GetPath("user_report", title_id, timestamp));

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -67,7 +67,7 @@ void EmuThread::run() {
     emit LoadProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
     if (Settings::values.use_disk_shader_cache.GetValue()) {
         m_system.Renderer().ReadRasterizer()->LoadDiskResources(
-            m_system.GetCurrentProcessProgramID(), stop_token,
+            m_system.GetApplicationProcessProgramID(), stop_token,
             [this](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {
                 emit LoadProgress(stage, value, total);
             });

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1779,7 +1779,7 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
             std::filesystem::path{Common::U16StringFromBuffer(filename.utf16(), filename.size())}
                 .filename());
     }
-    const bool is_64bit = system->Kernel().CurrentProcess()->Is64BitProcess();
+    const bool is_64bit = system->Kernel().ApplicationProcess()->Is64BitProcess();
     const auto instruction_set_suffix = is_64bit ? tr("(64-bit)") : tr("(32-bit)");
     title_name = tr("%1 %2", "%1 is the title name. %2 indicates if the title is 64-bit or 32-bit")
                      .arg(QString::fromStdString(title_name), instruction_set_suffix)
@@ -3532,7 +3532,7 @@ void GMainWindow::OnToggleGraphicsAPI() {
 }
 
 void GMainWindow::OnConfigurePerGame() {
-    const u64 title_id = system->GetCurrentProcessProgramID();
+    const u64 title_id = system->GetApplicationProcessProgramID();
     OpenPerGameConfiguration(title_id, current_game_path.toStdString());
 }
 
@@ -3691,7 +3691,7 @@ void GMainWindow::OnCaptureScreenshot() {
         return;
     }
 
-    const u64 title_id = system->GetCurrentProcessProgramID();
+    const u64 title_id = system->GetApplicationProcessProgramID();
     const auto screenshot_path =
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::ScreenshotsDir));
     const auto date =

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -405,7 +405,7 @@ int main(int argc, char** argv) {
 
     if (Settings::values.use_disk_shader_cache.GetValue()) {
         system.Renderer().ReadRasterizer()->LoadDiskResources(
-            system.GetCurrentProcessProgramID(), std::stop_token{},
+            system.GetApplicationProcessProgramID(), std::stop_token{},
             [](VideoCore::LoadCallbackStage, size_t value, size_t total) {});
     }
 


### PR DESCRIPTION
CurrentProcess -> refers to the process on the current core
ApplicationProcess -> refers to the started application

The changes to the SVC handlers should now allow for threads of non-application processes to be able to call them.