### PR TITLE
Allow >1 cpu threads on video decoding, disable multi-frame decoding

### DIFF
--- a/src/video_core/host1x/codecs/codec.cpp
+++ b/src/video_core/host1x/codecs/codec.cpp
@@ -152,6 +152,8 @@ bool Codec::CreateGpuAvDevice() {
 void Codec::InitializeAvCodecContext() {
     av_codec_ctx = avcodec_alloc_context3(av_codec);
     av_opt_set(av_codec_ctx->priv_data, "tune", "zerolatency", 0);
+    av_codec_ctx->thread_count = 0;
+    av_codec_ctx->thread_type &= ~FF_THREAD_FRAME;
 }
 
 void Codec::InitializeGpuDecoder() {


### PR DESCRIPTION
Currently we're only CPU decoding videos with 1 thread, we can get a boost by allowing libav to choose the thread count, which should be >1. We might have to limit the threads here if libav is too greedy, but I think this is ok for testing at least.

Also gets rid of the default-set FF_THREAD_FRAME flag. Docs say: 
> Use of FF_THREAD_FRAME will increase decoding delay by one frame per thread,
> so clients which cannot provide future frames should not use it.

We work on a per-frame basis, so this should be disabled. Plus it crashes libav if you use this with >1 thread in Yuzu it seems.

This should help some users with slow video decoding when GPU-decoding isn't supported. For me, it fixes the choppy audio in the SSHD intro video, due to frame decoding taking >16ms. Sped up the SSBU video for another user on Discord as well.

Could use a bit of testing just to make sure libav isn't too greedy with the threads and cause perf issues though.