### PR TITLE
yuzu: Write to config file on important config changes

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -1103,6 +1103,7 @@ void Config::SaveValues() {
     SaveRendererValues();
     SaveAudioValues();
     SaveSystemValues();
+    qt_config->sync();
 }
 
 void Config::SaveAudioValues() {

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -870,6 +870,7 @@ void GameList::ToggleFavorite(u64 program_id) {
             tree_view->setRowHidden(0, item_model->invisibleRootItem()->index(), true);
         }
     }
+    SaveConfig();
 }
 
 void GameList::AddFavorite(u64 program_id) {

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -122,6 +122,7 @@ signals:
     void AddDirectory();
     void ShowList(bool show);
     void PopulatingCompleted();
+    void SaveConfig();
 
 private slots:
     void OnItemExpanded(const QModelIndex& item);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1271,6 +1271,7 @@ void GMainWindow::ConnectWidgetEvents() {
     connect(game_list, &GameList::ShowList, this, &GMainWindow::OnGameListShowList);
     connect(game_list, &GameList::PopulatingCompleted,
             [this] { multiplayer_state->UpdateGameList(game_list->GetModel()); });
+    connect(game_list, &GameList::SaveConfig, this, &GMainWindow::OnSaveConfig);
 
     connect(game_list, &GameList::OpenPerGameGeneralRequested, this,
             &GMainWindow::OnGameListOpenPerGameProperties);
@@ -2654,6 +2655,8 @@ void GMainWindow::OnGameListAddDirectory() {
     } else {
         LOG_WARNING(Frontend, "Selected directory is already in the game list");
     }
+
+    OnSaveConfig();
 }
 
 void GMainWindow::OnGameListShowList(bool show) {
@@ -3380,6 +3383,7 @@ void GMainWindow::OnConfigureTas() {
         return;
     } else if (result == QDialog::Accepted) {
         dialog.ApplyConfiguration();
+        OnSaveConfig();
     }
 }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3018,8 +3018,10 @@ void GMainWindow::OnRestartGame() {
     if (!system->IsPoweredOn()) {
         return;
     }
-    // Make a copy since BootGame edits game_path
-    BootGame(QString(current_game_path));
+    // Make a copy since ShutdownGame edits game_path
+    const auto current_game = QString(current_game_path);
+    ShutdownGame();
+    BootGame(current_game);
 }
 
 void GMainWindow::OnPauseGame() {


### PR DESCRIPTION
Qt isn't always writing changes on save. This causes config to be lost on crash. This PR ensures all changes are always saved on the file.

Additionally restarting a game didn't refresh the per game config since the game wasn't stopped before booting the game again.