### PR TITLE
 buffer_cache: Add logic for non-NVN storage buffer tracking

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -366,7 +366,8 @@ private:
 
     void NotifyBufferDeletion();
 
-    [[nodiscard]] Binding StorageBufferBinding(GPUVAddr ssbo_addr, bool is_written = false) const;
+    [[nodiscard]] Binding StorageBufferBinding(GPUVAddr ssbo_addr, u32 cbuf_index,
+                                               bool is_written = false) const;
 
     [[nodiscard]] TextureBufferBinding GetTextureBufferBinding(GPUVAddr gpu_addr, u32 size,
                                                                PixelFormat format);
@@ -749,7 +750,7 @@ void BufferCache<P>::BindGraphicsStorageBuffer(size_t stage, size_t ssbo_index, 
 
     const auto& cbufs = maxwell3d->state.shader_stages[stage];
     const GPUVAddr ssbo_addr = cbufs.const_buffers[cbuf_index].address + cbuf_offset;
-    storage_buffers[stage][ssbo_index] = StorageBufferBinding(ssbo_addr, is_written);
+    storage_buffers[stage][ssbo_index] = StorageBufferBinding(ssbo_addr, cbuf_index, is_written);
 }
 
 template <class P>
@@ -789,7 +790,7 @@ void BufferCache<P>::BindComputeStorageBuffer(size_t ssbo_index, u32 cbuf_index,
 
     const auto& cbufs = launch_desc.const_buffer_config;
     const GPUVAddr ssbo_addr = cbufs[cbuf_index].Address() + cbuf_offset;
-    compute_storage_buffers[ssbo_index] = StorageBufferBinding(ssbo_addr, is_written);
+    compute_storage_buffers[ssbo_index] = StorageBufferBinding(ssbo_addr, cbuf_index, is_written);
 }
 
 template <class P>
@@ -1935,11 +1936,26 @@ void BufferCache<P>::NotifyBufferDeletion() {
 
 template <class P>
 typename BufferCache<P>::Binding BufferCache<P>::StorageBufferBinding(GPUVAddr ssbo_addr,
+                                                                      u32 cbuf_index,
                                                                       bool is_written) const {
     const GPUVAddr gpu_addr = gpu_memory->Read<u64>(ssbo_addr);
-    const u32 size = gpu_memory->Read<u32>(ssbo_addr + 8);
+    const auto size = [&]() {
+        const bool is_nvn_cbuf = cbuf_index == 0;
+        // The NVN driver buffer (index 0) is known to pack the SSBO address followed by its size.
+        if (is_nvn_cbuf) {
+            return gpu_memory->Read<u32>(ssbo_addr + 8);
+        }
+        // Other titles (notably Doom Eternal) may use STG/LDG on buffer addresses in custom defined
+        // cbufs, which do not store the sizes adjacent to the addresses, so use the fully
+        // mapped buffer size for now.
+        const u32 memory_layout_size = static_cast<u32>(gpu_memory->GetMemoryLayoutSize(gpu_addr));
+        LOG_INFO(HW_GPU, "Binding storage buffer for cbuf index {}, MemoryLayoutSize 0x{:X}",
+                 cbuf_index, memory_layout_size);
+        return memory_layout_size;
+    }();
     const std::optional<VAddr> cpu_addr = gpu_memory->GpuToCpuAddress(gpu_addr);
     if (!cpu_addr || size == 0) {
+        LOG_WARNING(HW_GPU, "Failed to find storage buffer for cbuf index {}", cbuf_index);
         return NULL_BINDING;
     }
     const VAddr cpu_end = Common::AlignUp(*cpu_addr + size, Core::Memory::YUZU_PAGESIZE);


### PR DESCRIPTION
TL;DR Fixes some graphical issues and a crash during the initial loading screen in `Doom Eternal` with the latest update, and potentially other titles.

#### Problematic assumptions

In NVN, global memory ops such as `STG/LDG` generally act on SSBOs whose address and size is stored in a driver reserved constant buffer at index 0. The memory layout for this reserved memory is 16 byte aligned in the format:
```
u32 ssbo_0_addr_lo
u32 ssbo_0_addr_hi
u32 ssbo_0_size
u32 padding
```
Currently, the shader Global To Storage pass uses this information to add an optimization to directly bind the ssbo that the memory op is acting on, rather than go through the indirection of the constant buffer.

Doom Eternal uncovered a flaw in this optimization. This title seems to be using global memory ops on raw SSBO addresses (potentially something equivalent to `VK_KHR_buffer_device_address`) stored in custom constant buffers, which do not follow the format of NVN's cbuf_0 convention.

The layout of the cbuf Doom Eternal uses is tightly packed addresses, with no indicator of the expected binding size.
```
u32 ssbo_0_addr_lo
u32 ssbo_0_addr_hi
u32 ssbo_1_addr_lo
u32 ssbo_1_addr_hi
...
```
The optimization pass would sometimes read these global memory operations assuming they were in the NVN convention, which would then use the adjacent buffer's `addr_lo` as the size for the ssbo, leading to unmapped reads and memory overflows.


#### Solution (for now)

For SSBOs that are not in the NVN constant buffer, the size can be estimated based on the arguments to `MapBufferEx` for its address.
This essentially queries the size of the mapped buffer that the SSBO addr resides in, and binds that entire buffer range for the shader to access.

This seems overkill, since the SSBO for the specific draw call/dispatch may be a subregion of the entire buffer.
I'm not sure how else to confirm the SSBO size, so for now this seems like the safest approach. 
