### PR TITLE
Allow AMD proprietary drivers to disable vsync

### DIFF
--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -165,7 +165,7 @@ void Swapchain::CreateSwapchain(const VkSurfaceCapabilitiesKHR& capabilities, bo
     const auto present_modes{physical_device.GetSurfacePresentModesKHR(surface)};
 
     const VkSurfaceFormatKHR surface_format{ChooseSwapSurfaceFormat(formats)};
-    present_mode = ChooseSwapPresentMode(present_modes);
+    present_mode = ChooseSwapPresentMode(present_modes, device.GetDriverID());
 
     u32 requested_image_count{capabilities.minImageCount + 1};
     // Ensure Tripple buffering if possible.


### PR DESCRIPTION
The original logic for presentation was done before the vsync toggle in graphics > advanced was added, afaik. 

NVIDIA drivers can run games at framerates higher than the display's refresh rate while in mailbox (triple buffer) mode, but AMD proprietary drivers get locked to the refresh rate of the display. While having tearing is undesired, 

Smash players use high framerate mods to reduce the hardcoded input delay of the game, and not everyone has access to 120+ Hz monitors. 

Letting <120 Hz AMD users have the choice between being able to use the 120 FPS mod with tearing, or stopping tearing and sticking to 60 FPS is a better option IMO. To do this, just use the VSync toggle in advanced graphic settings.

![ayymd](https://user-images.githubusercontent.com/42481638/219852312-6f4e5248-193c-4a06-b951-6bd30def957b.png)