### PR TITLE
Qt: Reintroduce scaling for touch input

### DIFF
--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -147,6 +147,8 @@ public:
 
     qreal windowPixelRatio() const;
 
+    std::pair<u32, u32> ScaleTouch(const QPointF& pos) const;
+
     void closeEvent(QCloseEvent* event) override;
 
     void resizeEvent(QResizeEvent* event) override;


### PR DESCRIPTION
Partially reverts #9815. Seems like only mouse input doesn't need scaling but touch input does.