### PR TITLE
externals: Update cpp-httplib to latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ endif()
 
 if (ENABLE_WEB_SERVICE)
     find_package(cpp-jwt 1.4 CONFIG)
-    find_package(httplib 0.11 MODULE)
+    find_package(httplib 0.12 MODULE)
 endif()
 
 if (YUZU_TESTS)

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -71,7 +71,7 @@ struct Client::Impl {
                              const std::string& jwt_ = "", const std::string& username_ = "",
                              const std::string& token_ = "") {
         if (cli == nullptr) {
-            cli = std::make_unique<httplib::Client>(host.c_str());
+            cli = std::make_unique<httplib::Client>(host);
         }
 
         if (!cli->is_valid()) {

--- a/src/yuzu/discord_impl.cpp
+++ b/src/yuzu/discord_impl.cpp
@@ -76,7 +76,7 @@ void DiscordImpl::Update() {
         // New Check for game cover
         httplib::Client cli(game_cover_url);
 
-        if (auto res = cli.Head(fmt::format("/images/game/boxart/{}.png", icon_name).c_str())) {
+        if (auto res = cli.Head(fmt::format("/images/game/boxart/{}.png", icon_name))) {
             if (res->status == 200) {
                 game_cover_url += fmt::format("/images/game/boxart/{}.png", icon_name);
             } else {


### PR DESCRIPTION
`find_package(httplib 0.11 MODULE)` will refuse library with version >= 0.12.

Maybe solve https://github.com/yuzu-emu/yuzu/issues/9840.

In fact this won't solve this particular issue because the library involved uses pkgconfig file instead of cmake config file (so any version greater than 0.11 would be accepted), but the update is welcome anyway :p