### PR TITLE
core: hid: Fix native mouse mapping

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -76,6 +76,13 @@ void LogSettings() {
     log_setting("Debugging_GDBStub", values.use_gdbstub.GetValue());
     log_setting("Input_EnableMotion", values.motion_enabled.GetValue());
     log_setting("Input_EnableVibration", values.vibration_enabled.GetValue());
+    log_setting("Input_EnableTouch", values.touchscreen.enabled);
+    log_setting("Input_EnableMouse", values.mouse_enabled.GetValue());
+    log_setting("Input_EnableKeyboard", values.keyboard_enabled.GetValue());
+    log_setting("Input_EnableRingController", values.enable_ring_controller.GetValue());
+    log_setting("Input_EnableIrSensor", values.enable_ir_sensor.GetValue());
+    log_setting("Input_EnableCustomJoycon", values.enable_joycon_driver.GetValue());
+    log_setting("Input_EnableCustomProController", values.enable_procon_driver.GetValue());
     log_setting("Input_EnableRawInput", values.enable_raw_input.GetValue());
 }
 

--- a/src/core/hid/emulated_devices.h
+++ b/src/core/hid/emulated_devices.h
@@ -23,8 +23,8 @@ using KeyboardModifierDevices = std::array<std::unique_ptr<Common::Input::InputD
                                            Settings::NativeKeyboard::NumKeyboardMods>;
 using MouseButtonDevices = std::array<std::unique_ptr<Common::Input::InputDevice>,
                                       Settings::NativeMouseButton::NumMouseButtons>;
-using MouseAnalogDevices = std::array<std::unique_ptr<Common::Input::InputDevice>,
-                                      Settings::NativeMouseWheel::NumMouseWheels>;
+using MouseWheelDevices = std::array<std::unique_ptr<Common::Input::InputDevice>,
+                                     Settings::NativeMouseWheel::NumMouseWheels>;
 using MouseStickDevice = std::unique_ptr<Common::Input::InputDevice>;
 
 using MouseButtonParams =
@@ -36,7 +36,7 @@ using KeyboardModifierValues =
     std::array<Common::Input::ButtonStatus, Settings::NativeKeyboard::NumKeyboardMods>;
 using MouseButtonValues =
     std::array<Common::Input::ButtonStatus, Settings::NativeMouseButton::NumMouseButtons>;
-using MouseAnalogValues =
+using MouseWheelValues =
     std::array<Common::Input::AnalogStatus, Settings::NativeMouseWheel::NumMouseWheels>;
 using MouseStickValue = Common::Input::TouchStatus;
 
@@ -50,7 +50,7 @@ struct DeviceStatus {
     KeyboardValues keyboard_values{};
     KeyboardModifierValues keyboard_moddifier_values{};
     MouseButtonValues mouse_button_values{};
-    MouseAnalogValues mouse_analog_values{};
+    MouseWheelValues mouse_wheel_values{};
     MouseStickValue mouse_stick_value{};
 
     // Data for HID serices
@@ -110,15 +110,6 @@ public:
 
     /// Reverts any mapped changes made that weren't saved
     void RestoreConfig();
-
-    // Returns the current mapped ring device
-    Common::ParamPackage GetRingParam() const;
-
-    /**
-     * Updates the current mapped ring device
-     * @param param ParamPackage with ring sensor data to be mapped
-     */
-    void SetRingParam(Common::ParamPackage param);
 
     /// Returns the latest status of button input from the keyboard with parameters
     KeyboardValues GetKeyboardValues() const;
@@ -187,19 +178,13 @@ private:
      * @param callback A CallbackStatus containing the wheel status
      * @param index wheel ID to be updated
      */
-    void SetMouseAnalog(const Common::Input::CallbackStatus& callback, std::size_t index);
+    void SetMouseWheel(const Common::Input::CallbackStatus& callback, std::size_t index);
 
     /**
      * Updates the mouse position status of the mouse device
      * @param callback A CallbackStatus containing the position status
      */
-    void SetMouseStick(const Common::Input::CallbackStatus& callback);
-
-    /**
-     * Updates the ring analog sensor status of the ring controller
-     * @param callback A CallbackStatus containing the force status
-     */
-    void SetRingAnalog(const Common::Input::CallbackStatus& callback);
+    void SetMousePosition(const Common::Input::CallbackStatus& callback);
 
     /**
      * Triggers a callback that something has changed on the device status
@@ -212,7 +197,7 @@ private:
     KeyboardDevices keyboard_devices;
     KeyboardModifierDevices keyboard_modifier_devices;
     MouseButtonDevices mouse_button_devices;
-    MouseAnalogDevices mouse_analog_devices;
+    MouseWheelDevices mouse_wheel_devices;
     MouseStickDevice mouse_stick_device;
 
     mutable std::mutex mutex;

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -65,6 +65,11 @@ void Controller_Gesture::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
 }
 
 void Controller_Gesture::ReadTouchInput() {
+    if (!Settings::values.touchscreen.enabled) {
+        fingers = {};
+        return;
+    }
+
     const auto touch_status = console->GetTouch();
     for (std::size_t id = 0; id < fingers.size(); ++id) {
         fingers[id] = touch_status[id];

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -33,10 +33,11 @@ void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
         return;
     }
 
+    next_state = {};
+
     const auto& last_entry = shared_memory->mouse_lifo.ReadCurrentEntry().state;
     next_state.sampling_number = last_entry.sampling_number + 1;
 
-    next_state.attribute.raw = 0;
     if (Settings::values.mouse_enabled) {
         const auto& mouse_button_state = emulated_devices->GetMouseButtons();
         const auto& mouse_position_state = emulated_devices->GetMousePosition();

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -58,6 +58,11 @@ void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timin
         }
 
         if (!finger.pressed && current_touch.pressed) {
+            // Ignore all touch fingers if disabled
+            if (!Settings::values.touchscreen.enabled) {
+                continue;
+            }
+
             finger.attribute.start_touch.Assign(1);
             finger.pressed = true;
             finger.position = current_touch.position;


### PR DESCRIPTION
Mouse input was completely broken for multiple reasons. The most important one is that we map it as a normal joystick, a joystick has properties like deadzone, range, that aren't by default zero this caused the final output to be completely different from the actual mouse input.

As side fixes. 
Rename some functions to describe better what they do.
Simplifies mouse and keyboard mappings.
Disabling touch actually disables touch. 
Input settings are logged.