### PR TITLE
net: translate ECONNRESET network error

### DIFF
--- a/src/core/hle/service/sockets/sockets.h
+++ b/src/core/hle/service/sockets/sockets.h
@@ -23,6 +23,7 @@ enum class Errno : u32 {
     INVAL = 22,
     MFILE = 24,
     MSGSIZE = 90,
+    CONNRESET = 104,
     NOTCONN = 107,
     TIMEDOUT = 110,
 };

--- a/src/core/hle/service/sockets/sockets_translate.cpp
+++ b/src/core/hle/service/sockets/sockets_translate.cpp
@@ -27,6 +27,8 @@ Errno Translate(Network::Errno value) {
         return Errno::NOTCONN;
     case Network::Errno::TIMEDOUT:
         return Errno::TIMEDOUT;
+    case Network::Errno::CONNRESET:
+        return Errno::CONNRESET;
     default:
         UNIMPLEMENTED_MSG("Unimplemented errno={}", value);
         return Errno::SUCCESS;

--- a/src/core/internal_network/network.cpp
+++ b/src/core/internal_network/network.cpp
@@ -109,6 +109,8 @@ Errno TranslateNativeError(int e) {
         return Errno::AGAIN;
     case WSAECONNREFUSED:
         return Errno::CONNREFUSED;
+    case WSAECONNRESET:
+        return Errno::CONNRESET;
     case WSAEHOSTUNREACH:
         return Errno::HOSTUNREACH;
     case WSAENETDOWN:
@@ -205,6 +207,8 @@ Errno TranslateNativeError(int e) {
         return Errno::AGAIN;
     case ECONNREFUSED:
         return Errno::CONNREFUSED;
+    case ECONNRESET:
+        return Errno::CONNRESET;
     case EHOSTUNREACH:
         return Errno::HOSTUNREACH;
     case ENETDOWN:

--- a/src/core/internal_network/network.h
+++ b/src/core/internal_network/network.h
@@ -30,6 +30,7 @@ enum class Errno {
     NOTCONN,
     AGAIN,
     CONNREFUSED,
+    CONNRESET,
     HOSTUNREACH,
     NETDOWN,
     NETUNREACH,


### PR DESCRIPTION
To handle TCP-connections more accurate in the emulator, the `ECONNRESET` error message should be translated to the game properly.

This happens for example when the game opens a TCP server to the "outside world", where a client connects to. After some time, the client disconnects - if the game now tries to read from the closed socket, this error should appear on the first read. However, in Yuzu, this gets caught in the application instead and is not being passed into the game, meaning that the game never recognizes the client disconnect.