### PR TITLE
yuzu: Set a lower timeout for discord presence

### DIFF
--- a/src/yuzu/discord_impl.cpp
+++ b/src/yuzu/discord_impl.cpp
@@ -75,6 +75,8 @@ void DiscordImpl::Update() {
 
         // New Check for game cover
         httplib::Client cli(game_cover_url);
+        cli.set_connection_timeout(std::chrono::seconds(3));
+        cli.set_read_timeout(std::chrono::seconds(3));
 
         if (auto res = cli.Head(fmt::format("/images/game/boxart/{}.png", icon_name).c_str())) {
             if (res->status == 200) {


### PR DESCRIPTION
If yuzu website is not available this request takes up to 30 seconds on windows. Reduce the time to 3 seconds. This feature isn't critical and we shouldn't waste too much time on it. 