### PR TITLE
input_common: Implement dedicated motion from mouse

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -363,7 +363,17 @@ void EmulatedController::ReloadInput() {
                     SetMotion(callback, index);
                 },
         });
-        motion_devices[index]->ForceUpdate();
+
+        // Restore motion state
+        auto& emulated_motion = controller.motion_values[index].emulated;
+        auto& motion = controller.motion_state[index];
+        emulated_motion.ResetRotations();
+        emulated_motion.ResetQuaternion();
+        motion.accel = emulated_motion.GetAcceleration();
+        motion.gyro = emulated_motion.GetGyroscope();
+        motion.rotation = emulated_motion.GetRotations();
+        motion.orientation = emulated_motion.GetOrientation();
+        motion.is_at_rest = !emulated_motion.IsMoving(motion_sensitivity);
     }
 
     for (std::size_t index = 0; index < camera_devices.size(); ++index) {

--- a/src/core/hid/motion_input.cpp
+++ b/src/core/hid/motion_input.cpp
@@ -10,6 +10,8 @@ MotionInput::MotionInput() {
     // Initialize PID constants with default values
     SetPID(0.3f, 0.005f, 0.0f);
     SetGyroThreshold(ThresholdStandard);
+    ResetQuaternion();
+    ResetRotations();
 }
 
 void MotionInput::SetPID(f32 new_kp, f32 new_ki, f32 new_kd) {
@@ -20,10 +22,18 @@ void MotionInput::SetPID(f32 new_kp, f32 new_ki, f32 new_kd) {
 
 void MotionInput::SetAcceleration(const Common::Vec3f& acceleration) {
     accel = acceleration;
+
+    accel.x = std::clamp(accel.x, -AccelMaxValue, AccelMaxValue);
+    accel.y = std::clamp(accel.y, -AccelMaxValue, AccelMaxValue);
+    accel.z = std::clamp(accel.z, -AccelMaxValue, AccelMaxValue);
 }
 
 void MotionInput::SetGyroscope(const Common::Vec3f& gyroscope) {
     gyro = gyroscope - gyro_bias;
+
+    gyro.x = std::clamp(gyro.x, -GyroMaxValue, GyroMaxValue);
+    gyro.y = std::clamp(gyro.y, -GyroMaxValue, GyroMaxValue);
+    gyro.z = std::clamp(gyro.z, -GyroMaxValue, GyroMaxValue);
 
     // Auto adjust drift to minimize drift
     if (!IsMoving(IsAtRestRelaxed)) {
@@ -59,6 +69,10 @@ void MotionInput::EnableReset(bool reset) {
 
 void MotionInput::ResetRotations() {
     rotations = {};
+}
+
+void MotionInput::ResetQuaternion() {
+    quat = {{0.0f, 0.0f, -1.0f}, 0.0f};
 }
 
 bool MotionInput::IsMoving(f32 sensitivity) const {

--- a/src/core/hid/motion_input.h
+++ b/src/core/hid/motion_input.h
@@ -20,6 +20,9 @@ public:
     static constexpr float IsAtRestStandard = 0.01f;
     static constexpr float IsAtRestThight = 0.005f;
 
+    static constexpr float GyroMaxValue = 5.0f;
+    static constexpr float AccelMaxValue = 7.0f;
+
     explicit MotionInput();
 
     MotionInput(const MotionInput&) = default;
@@ -40,6 +43,7 @@ public:
 
     void EnableReset(bool reset);
     void ResetRotations();
+    void ResetQuaternion();
 
     void UpdateRotation(u64 elapsed_time);
     void UpdateOrientation(u64 elapsed_time);
@@ -69,7 +73,7 @@ private:
     Common::Vec3f derivative_error;
 
     // Quaternion containing the device orientation
-    Common::Quaternion<f32> quat{{0.0f, 0.0f, -1.0f}, 0.0f};
+    Common::Quaternion<f32> quat;
 
     // Number of full rotations in each axis
     Common::Vec3f rotations;

--- a/src/input_common/drivers/mouse.h
+++ b/src/input_common/drivers/mouse.h
@@ -96,6 +96,8 @@ public:
 
 private:
     void UpdateThread(std::stop_token stop_token);
+    void UpdateStickInput();
+    void UpdateMotionInput();
     void StopPanning();
 
     Common::Input::ButtonNames GetUIButtonName(const Common::ParamPackage& params) const;
@@ -103,9 +105,10 @@ private:
     Common::Vec2<int> mouse_origin;
     Common::Vec2<int> last_mouse_position;
     Common::Vec2<float> last_mouse_change;
+    Common::Vec3<float> last_motion_change;
     Common::Vec2<int> wheel_position;
     bool button_pressed;
-    int mouse_panning_timout{};
+    int mouse_panning_timeout{};
     std::jthread update_thread;
 };
 

--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -142,14 +142,10 @@ void MappingFactory::RegisterMotion(const MappingData& data) {
     new_input.Set("port", static_cast<int>(data.pad.port));
     new_input.Set("pad", static_cast<int>(data.pad.pad));
 
-    // If engine is mouse map the mouse position as 3 axis motion
+    // If engine is mouse map it automatically to mouse motion
     if (data.engine == "mouse") {
-        new_input.Set("axis_x", 1);
-        new_input.Set("invert_x", "-");
-        new_input.Set("axis_y", 0);
-        new_input.Set("axis_z", 4);
-        new_input.Set("range", 1.0f);
-        new_input.Set("deadzone", 0.0f);
+        new_input.Set("motion", 0);
+        new_input.Set("pad", 1);
         input_queue.Push(new_input);
         return;
     }


### PR DESCRIPTION
Yuzu already had motion from mouse. However it was pretty bad. Metroid prime on hybrid mode uses only gyro data. Even better just two axis. This is 1:1 mapping and provides excellent camera control with mouse panning on this game.

The dedicated motion doesn't include any clamping of inputs and has a different sensitivity allowing to be used without changing the config. As for other games they will probably still have bad motion as they use full motion instead of just gyro.