### PR TITLE
config: Fix per game Force max clock

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -1312,9 +1312,7 @@ void Config::SaveRendererValues() {
                  static_cast<u32>(Settings::values.renderer_backend.GetValue(global)),
                  static_cast<u32>(Settings::values.renderer_backend.GetDefault()),
                  Settings::values.renderer_backend.UsingGlobal());
-    WriteSetting(QString::fromStdString(Settings::values.renderer_force_max_clock.GetLabel()),
-                 static_cast<u32>(Settings::values.renderer_force_max_clock.GetValue(global)),
-                 static_cast<u32>(Settings::values.renderer_force_max_clock.GetDefault()));
+    WriteGlobalSetting(Settings::values.renderer_force_max_clock);
     WriteGlobalSetting(Settings::values.vulkan_device);
     WriteSetting(QString::fromStdString(Settings::values.fullscreen_mode.GetLabel()),
                  static_cast<u32>(Settings::values.fullscreen_mode.GetValue(global)),

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -45,8 +45,6 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
                                                &Settings::values.max_anisotropy);
         ConfigurationShared::SetHighlight(ui->label_gpu_accuracy,
                                           !Settings::values.gpu_accuracy.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->renderer_force_max_clock,
-                                          !Settings::values.renderer_force_max_clock.UsingGlobal());
         ConfigurationShared::SetHighlight(ui->af_label,
                                           !Settings::values.max_anisotropy.UsingGlobal());
     }


### PR DESCRIPTION
This setting wasn't saving properly in per game config. Now it should work.