### PR TITLE
yuzu: config: Remove most special config cases for handheld

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -116,15 +116,12 @@ void EmulatedController::ReloadFromSettings() {
 
     ring_params[0] = Common::ParamPackage(Settings::values.ringcon_analogs);
 
-    SetNpadStyleIndex(MapSettingsTypeToNPad(player.controller_type));
-    original_npad_type = npad_type;
-
     // Player 1 shares config with handheld. Disable controller when handheld is selected
-    if (npad_id_type == NpadIdType::Player1 && npad_type == NpadStyleIndex::Handheld) {
-        Disconnect();
-        ReloadInput();
-        return;
-    }
+    // if (npad_id_type == NpadIdType::Player1 && npad_type == NpadStyleIndex::Handheld) {
+    //    Disconnect();
+    //    ReloadInput();
+    //    return;
+    //}
 
     // Handheld shares config with player 1. Disable controller when handheld isn't selected
     if (npad_id_type == NpadIdType::Handheld && npad_type != NpadStyleIndex::Handheld) {
@@ -134,6 +131,10 @@ void EmulatedController::ReloadFromSettings() {
     }
 
     Disconnect();
+
+    SetNpadStyleIndex(MapSettingsTypeToNPad(player.controller_type));
+    original_npad_type = npad_type;
+
     if (player.connected) {
         Connect();
     }
@@ -600,23 +601,15 @@ bool EmulatedController::IsConfiguring() const {
 }
 
 void EmulatedController::SaveCurrentConfig() {
-    // Other can't alter the config from here
-    if (npad_id_type == NpadIdType::Other) {
+    // Other and Handheld can't alter the config from here
+    if (npad_id_type == NpadIdType::Other || npad_id_type == NpadIdType::Handheld) {
         return;
     }
 
     const auto player_index = NpadIdTypeToConfigIndex(npad_id_type);
     auto& player = Settings::values.players.GetValue()[player_index];
 
-    // Only save the connected status when handheld is connected
-    if (npad_id_type == NpadIdType::Handheld && npad_type == NpadStyleIndex::Handheld) {
-        player.connected = is_connected;
-    }
-
-    if (npad_id_type != NpadIdType::Handheld && npad_type != NpadStyleIndex::Handheld) {
-        player.connected = is_connected;
-    }
-
+    player.connected = is_connected;
     player.controller_type = MapNPadToSettingsType(npad_type);
     for (std::size_t index = 0; index < player.buttons.size(); ++index) {
         player.buttons[index] = button_params[index].Serialize();

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -194,6 +194,7 @@ void ConfigureInput::ApplyConfiguration() {
     }
 
     advanced->ApplyConfiguration();
+    system.HIDCore().ReloadInputDevices();
 
     const bool pre_docked_mode = Settings::values.use_docked_mode.GetValue();
     Settings::values.use_docked_mode.SetValue(ui->radioDocked->isChecked());

--- a/src/yuzu/configuration/configure_input_per_game.cpp
+++ b/src/yuzu/configuration/configure_input_per_game.cpp
@@ -86,17 +86,12 @@ void ConfigureInputPerGame::LoadConfiguration() {
 
         emulated_controller->ReloadFromSettings();
 
-        if (player_index > 0) {
+        if (player_index != HANDHELD_INDEX) {
             continue;
         }
+
         // Handle Handheld cases
-        auto& handheld_player = Settings::values.players.GetValue()[HANDHELD_INDEX];
-        auto* handheld_controller = hid_core.GetEmulatedController(Core::HID::NpadIdType::Handheld);
-        if (player.controller_type == Settings::ControllerType::Handheld) {
-            handheld_player = player;
-        } else {
-            handheld_player = {};
-        }
+        auto handheld_controller = hid_core.GetEmulatedController(Core::HID::NpadIdType::Handheld);
         handheld_controller->ReloadFromSettings();
     }
 }

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -295,26 +295,11 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
       is_powered_on{is_powered_on_}, input_subsystem{input_subsystem_}, profiles(profiles_),
       timeout_timer(std::make_unique<QTimer>()),
       poll_timer(std::make_unique<QTimer>()), bottom_row{bottom_row_}, hid_core{hid_core_} {
-    if (player_index == 0) {
-        auto* emulated_controller_p1 =
-            hid_core.GetEmulatedController(Core::HID::NpadIdType::Player1);
-        auto* emulated_controller_handheld =
-            hid_core.GetEmulatedController(Core::HID::NpadIdType::Handheld);
-        emulated_controller_p1->SaveCurrentConfig();
-        emulated_controller_p1->EnableConfiguration();
-        emulated_controller_handheld->SaveCurrentConfig();
-        emulated_controller_handheld->EnableConfiguration();
-        if (emulated_controller_handheld->IsConnected(true)) {
-            emulated_controller_p1->Disconnect();
-            emulated_controller = emulated_controller_handheld;
-        } else {
-            emulated_controller = emulated_controller_p1;
-        }
-    } else {
-        emulated_controller = hid_core.GetEmulatedControllerByIndex(player_index);
-        emulated_controller->SaveCurrentConfig();
-        emulated_controller->EnableConfiguration();
-    }
+
+    emulated_controller = hid_core.GetEmulatedControllerByIndex(player_index);
+    emulated_controller->SaveCurrentConfig();
+    emulated_controller->EnableConfiguration();
+
     ui->setupUi(this);
 
     setFocusPolicy(Qt::ClickFocus);
@@ -737,29 +722,6 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
         UpdateMotionButtons();
         const Core::HID::NpadStyleIndex type =
             GetControllerTypeFromIndex(ui->comboControllerType->currentIndex());
-
-        if (player_index == 0) {
-            auto* emulated_controller_p1 =
-                hid_core.GetEmulatedController(Core::HID::NpadIdType::Player1);
-            auto* emulated_controller_handheld =
-                hid_core.GetEmulatedController(Core::HID::NpadIdType::Handheld);
-            bool is_connected = emulated_controller->IsConnected(true);
-
-            emulated_controller_p1->SetNpadStyleIndex(type);
-            emulated_controller_handheld->SetNpadStyleIndex(type);
-            if (is_connected) {
-                if (type == Core::HID::NpadStyleIndex::Handheld) {
-                    emulated_controller_p1->Disconnect();
-                    emulated_controller_handheld->Connect(true);
-                    emulated_controller = emulated_controller_handheld;
-                } else {
-                    emulated_controller_handheld->Disconnect();
-                    emulated_controller_p1->Connect(true);
-                    emulated_controller = emulated_controller_p1;
-                }
-            }
-            ui->controllerFrame->SetController(emulated_controller);
-        }
         emulated_controller->SetNpadStyleIndex(type);
     });
 
@@ -795,32 +757,10 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
 }
 
 ConfigureInputPlayer::~ConfigureInputPlayer() {
-    if (player_index == 0) {
-        auto* emulated_controller_p1 =
-            hid_core.GetEmulatedController(Core::HID::NpadIdType::Player1);
-        auto* emulated_controller_handheld =
-            hid_core.GetEmulatedController(Core::HID::NpadIdType::Handheld);
-        emulated_controller_p1->DisableConfiguration();
-        emulated_controller_handheld->DisableConfiguration();
-    } else {
-        emulated_controller->DisableConfiguration();
-    }
+    emulated_controller->DisableConfiguration();
 }
 
 void ConfigureInputPlayer::ApplyConfiguration() {
-    if (player_index == 0) {
-        auto* emulated_controller_p1 =
-            hid_core.GetEmulatedController(Core::HID::NpadIdType::Player1);
-        auto* emulated_controller_handheld =
-            hid_core.GetEmulatedController(Core::HID::NpadIdType::Handheld);
-        emulated_controller_p1->DisableConfiguration();
-        emulated_controller_p1->SaveCurrentConfig();
-        emulated_controller_p1->EnableConfiguration();
-        emulated_controller_handheld->DisableConfiguration();
-        emulated_controller_handheld->SaveCurrentConfig();
-        emulated_controller_handheld->EnableConfiguration();
-        return;
-    }
     emulated_controller->DisableConfiguration();
     emulated_controller->SaveCurrentConfig();
     emulated_controller->EnableConfiguration();


### PR DESCRIPTION
Follow up from #9824. We still have issues with config not working correctly, for this reason I removed completely most special cases for handheld. All config is explicitly set to player 1 and only player 1.  Handheld instead get's the correct config from reloading from settings.

Only issue left is handling the connected status. Since this can be different between both player 1 and handheld.