### PR TITLE
service: btm: Fix handle functions

### DIFF
--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -72,32 +72,36 @@ private:
     void AcquireBleScanEvent(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx, 3, 1};
         rb.Push(ResultSuccess);
+        rb.Push(true);
         rb.PushCopyObjects(scan_event->GetReadableEvent());
     }
 
     void AcquireBleConnectionEvent(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx, 3, 1};
         rb.Push(ResultSuccess);
+        rb.Push(true);
         rb.PushCopyObjects(connection_event->GetReadableEvent());
     }
 
     void AcquireBleServiceDiscoveryEvent(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx, 3, 1};
         rb.Push(ResultSuccess);
+        rb.Push(true);
         rb.PushCopyObjects(service_discovery_event->GetReadableEvent());
     }
 
     void AcquireBleMtuConfigEvent(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx, 3, 1};
         rb.Push(ResultSuccess);
+        rb.Push(true);
         rb.PushCopyObjects(config_event->GetReadableEvent());
     }
 


### PR DESCRIPTION
These functions weren't correctly implemented. They should return a bool if the handle was correctly assigned. This should fix pokemon violet and scarlet on the latest update.