### PR TITLE
cmake: use correct boost imported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 # =======================================================================
 
 # Enforce the search mode of non-required packages for better and shorter failure messages
+find_package(Boost 1.73.0 REQUIRED context)
 find_package(enet 1.3 MODULE)
 find_package(fmt 9 REQUIRED)
 find_package(inih MODULE)
@@ -251,19 +252,6 @@ endif()
 
 if (YUZU_TESTS)
     find_package(Catch2 3.0.1 REQUIRED)
-endif()
-
-find_package(Boost 1.73.0 COMPONENTS context)
-if (Boost_FOUND)
-    set(Boost_LIBRARIES Boost::boost)
-    # Conditionally add Boost::context only if the found Boost package provides it
-    # The old version is missing Boost::context, so we want to avoid adding in that case
-    # The new version requires adding Boost::context to prevent linking issues
-    if (TARGET Boost::context)
-        list(APPEND Boost_LIBRARIES Boost::context)
-    endif()
-else()
-    message(FATAL_ERROR "Boost 1.73.0 or newer not found")
 endif()
 
 # boost:asio has functions that require AcceptEx et al
@@ -462,14 +450,6 @@ if (ENABLE_SDL2)
     endif()
 endif()
 
-# Reexport some targets that are named differently when using the upstream CmakeConfig
-# In order to ALIAS targets to a new name, they first need to be IMPORTED_GLOBAL
-# Dynarmic checks for target `boost` and so we want to make sure it can find it through our system instead of using their external
-if (TARGET Boost::boost)
-    set_target_properties(Boost::boost PROPERTIES IMPORTED_GLOBAL TRUE)
-    add_library(boost ALIAS Boost::boost)
-endif()
-
 # List of all FFmpeg components required
 set(FFmpeg_COMPONENTS
     avcodec
@@ -585,11 +565,7 @@ function(create_target_directory_groups target_name)
 endfunction()
 
 # Prevent boost from linking against libs when building
-add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY
-    -DBOOST_SYSTEM_NO_LIB
-    -DBOOST_DATE_TIME_NO_LIB
-    -DBOOST_REGEX_NO_LIB
-)
+target_link_libraries(Boost::headers INTERFACE Boost::disable_autolinking)
 # Adjustments for MSVC + Ninja
 if (MSVC AND CMAKE_GENERATOR STREQUAL "Ninja")
     add_compile_options(

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -176,7 +176,7 @@ endif()
 
 create_target_directory_groups(common)
 
-target_link_libraries(common PUBLIC ${Boost_LIBRARIES} fmt::fmt microprofile Threads::Threads)
+target_link_libraries(common PUBLIC Boost::context Boost::headers fmt::fmt microprofile Threads::Threads)
 target_link_libraries(common PRIVATE lz4::lz4 zstd::zstd LLVM::Demangle)
 
 if (YUZU_USE_PRECOMPILED_HEADERS)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -832,7 +832,7 @@ endif()
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core network video_core)
-target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls Opus::opus)
+target_link_libraries(core PUBLIC Boost::headers PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls Opus::opus)
 if (MINGW)
     target_link_libraries(core PRIVATE ${MSWSOCK_LIBRARY})
 endif()

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -89,7 +89,7 @@ if (ENABLE_LIBUSB)
 endif()
 
 create_target_directory_groups(input_common)
-target_link_libraries(input_common PUBLIC core PRIVATE common Boost::boost)
+target_link_libraries(input_common PUBLIC core PRIVATE common Boost::headers)
 
 if (YUZU_USE_PRECOMPILED_HEADERS)
     target_precompile_headers(input_common PRIVATE precompiled_headers.h)

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(network STATIC
 
 create_target_directory_groups(network)
 
-target_link_libraries(network PRIVATE common enet::enet Boost::boost)
+target_link_libraries(network PRIVATE common enet::enet Boost::headers)
 if (ENABLE_WEB_SERVICE)
     target_compile_definitions(network PRIVATE -DENABLE_WEB_SERVICE)
     target_link_libraries(network PRIVATE web_service)

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -314,7 +314,7 @@ endif()
 create_target_directory_groups(yuzu)
 
 target_link_libraries(yuzu PRIVATE common core input_common network video_core)
-target_link_libraries(yuzu PRIVATE Boost::boost glad Qt${QT_MAJOR_VERSION}::Widgets)
+target_link_libraries(yuzu PRIVATE Boost::headers glad Qt${QT_MAJOR_VERSION}::Widgets)
 target_link_libraries(yuzu PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 target_link_libraries(yuzu PRIVATE Vulkan::Headers)


### PR DESCRIPTION
The true imported target name since CMake 3.15 is `Boost::headers` instead of `Boost::boost`. Also remove old hacks not needed anymore (hopefully :p).