### PR TITLE
vulkan_common: disable vertexInputDynamicState on unsupported driver

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -409,6 +409,7 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         if (is_rdna2) {
             LOG_WARNING(Render_Vulkan,
                         "RADV has broken VK_EXT_vertex_input_dynamic_state on RDNA2 hardware");
+            features.vertex_input_dynamic_state.vertexInputDynamicState = false;
             extensions.vertex_input_dynamic_state = false;
             loaded_extensions.erase(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
         }


### PR DESCRIPTION
Since we do not request the extension in this case, the feature should be left disabled.