### PR TITLE
Fix a bug with the Reverb command in reading from the pre delay line

### DIFF
--- a/src/audio_core/renderer/command/effect/reverb.cpp
+++ b/src/audio_core/renderer/command/effect/reverb.cpp
@@ -308,7 +308,8 @@ static void ApplyReverbEffect(const ReverbInfo::ParameterVersion2& params, Rever
         }
 
         Common::FixedPoint<50, 14> pre_delay_sample{
-            state.pre_delay_line.Read() * Common::FixedPoint<50, 14>::from_base(params.late_gain)};
+            state.pre_delay_line.TapOut(state.pre_delay_time) *
+            Common::FixedPoint<50, 14>::from_base(params.late_gain)};
 
         std::array<Common::FixedPoint<50, 14>, ReverbInfo::MaxDelayLines> mix_matrix{
             state.prev_feedback_output[2] + state.prev_feedback_output[1] + pre_delay_sample,

--- a/src/audio_core/renderer/effect/i3dl2.h
+++ b/src/audio_core/renderer/effect/i3dl2.h
@@ -104,7 +104,8 @@ public:
         }
 
         void Write(const Common::FixedPoint<50, 14> sample) {
-            *(input++) = sample;
+            *input = sample;
+            input++;
             if (input >= buffer_end) {
                 input = buffer.data();
             }

--- a/src/audio_core/renderer/effect/reverb.h
+++ b/src/audio_core/renderer/effect/reverb.h
@@ -79,12 +79,10 @@ public:
                 return;
             }
             sample_count = delay_time;
-            input = &buffer[(output - buffer.data() + sample_count) % (sample_count_max + 1)];
+            input = &buffer[0];
         }
 
         Common::FixedPoint<50, 14> Tick(const Common::FixedPoint<50, 14> sample) {
-            Write(sample);
-
             auto out_sample{Read()};
 
             output++;
@@ -92,6 +90,7 @@ public:
                 output = buffer.data();
             }
 
+            Write(sample);
             return out_sample;
         }
 
@@ -100,7 +99,8 @@ public:
         }
 
         void Write(const Common::FixedPoint<50, 14> sample) {
-            *(input++) = sample;
+            *input = sample;
+            input++;
             if (input >= buffer_end) {
                 input = buffer.data();
             }


### PR DESCRIPTION
I had the Reverb and I3dl2Reverb delay lines set up the same way, but they're actually not the same. I3dl2 uses separate input and output pointers for reading/writing, whereas Reverb uses just a single one. Since Reverb uses just a single pointer, I've made input/output both begin at index 0, and ensure they always increment together, and that it reads before writing.

The pre delay line in particular was having problems due to never calling Tick on it, which updates the output pointer. It was writing in samples and increasing its input pointer, but it only ever read from output[0]. Instead, that one access should be a TapOut (which reads via input rather than output), with the pre delay time from the state as the index.

This should (hopefully) fix the rare broken audio in any games using Reverb, like New Super Mario Bros U Deluxe.