### PR TITLE
Flip S8D24 red and green channels, use float border color

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1064,7 +1064,7 @@ void RasterizerVulkan::UpdateDepthBoundsTestEnable(Tegra::Engines::Maxwell3D::Re
         LOG_WARNING(Render_Vulkan, "Depth bounds is enabled but not supported");
         enabled = false;
     }
-    scheduler.Record([enable = regs.depth_bounds_enable](vk::CommandBuffer cmdbuf) {
+    scheduler.Record([enable = enabled](vk::CommandBuffer cmdbuf) {
         cmdbuf.SetDepthBoundsTestEnableEXT(enable);
     });
 }

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1763,7 +1763,7 @@ Sampler::Sampler(TextureCacheRuntime& runtime, const Tegra::Texture::TSCEntry& t
         .minLod = tsc.mipmap_filter == TextureMipmapFilter::None ? 0.0f : tsc.MinLod(),
         .maxLod = tsc.mipmap_filter == TextureMipmapFilter::None ? 0.25f : tsc.MaxLod(),
         .borderColor =
-            arbitrary_borders ? VK_BORDER_COLOR_INT_CUSTOM_EXT : ConvertBorderColor(color),
+            arbitrary_borders ? VK_BORDER_COLOR_FLOAT_CUSTOM_EXT : ConvertBorderColor(color),
         .unnormalizedCoordinates = VK_FALSE,
     });
 }

--- a/src/video_core/texture_cache/image_view_info.cpp
+++ b/src/video_core/texture_cache/image_view_info.cpp
@@ -74,6 +74,12 @@ ImageViewInfo::ImageViewInfo(const TICEntry& config, s32 base_layer) noexcept
         ASSERT_MSG(false, "Invalid texture_type={}", static_cast<int>(config.texture_type.Value()));
         break;
     }
+
+    // S8_UINT_D24_UNORM is not supported directly, and we use D24S8 instead.
+    // To make sure shaders grab the right channels, swap R and G.
+    if (format == PixelFormat::S8_UINT_D24_UNORM) {
+        y_source = std::exchange(x_source, y_source);
+    }
 }
 
 ImageViewInfo::ImageViewInfo(ImageViewType type_, PixelFormat format_,


### PR DESCRIPTION
Second attempt at this. I think the root issue is that we can't actually use S8D24 directly, we only have D24S8, so for S8D24 we should forcibly flip R/G. This way fixes Story of Seasons without breaking Xenoblade.

Fixes #9805.