### PR TITLE
input_common: Increase mouse sensitivity range

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -503,7 +503,7 @@ struct Values {
     Setting<bool> tas_loop{false, "tas_loop"};
 
     Setting<bool> mouse_panning{false, "mouse_panning"};
-    Setting<u8, true> mouse_panning_sensitivity{10, 1, 100, "mouse_panning_sensitivity"};
+    Setting<u8, true> mouse_panning_sensitivity{50, 1, 100, "mouse_panning_sensitivity"};
     Setting<bool> mouse_enabled{false, "mouse_enabled"};
 
     Setting<bool> emulate_analog_keyboard{false, "emulate_analog_keyboard"};

--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -146,6 +146,7 @@ void MappingFactory::RegisterMotion(const MappingData& data) {
     if (data.engine == "mouse") {
         new_input.Set("motion", 0);
         new_input.Set("pad", 1);
+        new_input.Set("threshold", 0.001f);
         input_queue.Push(new_input);
         return;
     }


### PR DESCRIPTION
After talking with some metroid fans we arrived at the conclusion that high dpi mouses move really fast and even 1% still too fast for yuzu. Motion from mouse also felt with a considerable delay and a bit choppy.

I addressed this issue by making the default sensitivity 50% instead of 10%, removing the smoothing filter, lowering the motion threshold, clamping the rotation speed and accumulating all inputs until they are delivered. This improves the feedback and play ability with mouse and keyboard.