### PR TITLE
kernel: add missing header for libc++

### DIFF
--- a/src/core/hle/kernel/k_scoped_lock.h
+++ b/src/core/hle/kernel/k_scoped_lock.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <concepts>
+#include <memory>
 #include <type_traits>
 
 namespace Kernel {


### PR DESCRIPTION
[Found](https://github.com/yuzu-emu/yuzu/files/10897537/yuzu-s20230303.log) with libc++ >= 16 (without polyfill_ranges.h) and `-DYUZU_USE_PRECOMPILED_HEADERS=OFF` ([as workaround](https://github.com/freebsd/freebsd-ports/commit/f98c438a0191)).