### PR TITLE
native_clock: Re-adjust the RDTSC frequency to its real frequency

### DIFF
--- a/src/audio_core/renderer/adsp/audio_renderer.cpp
+++ b/src/audio_core/renderer/adsp/audio_renderer.cpp
@@ -135,7 +135,7 @@ void AudioRenderer::ThreadFunc() {
     static constexpr char name[]{"AudioRenderer"};
     MicroProfileOnThreadCreate(name);
     Common::SetCurrentThreadName(name);
-    Common::SetCurrentThreadPriority(Common::ThreadPriority::Critical);
+    Common::SetCurrentThreadPriority(Common::ThreadPriority::High);
     if (mailbox->ADSPWaitMessage() != RenderMessage::AudioRenderer_InitializeOK) {
         LOG_ERROR(Service_Audio,
                   "ADSP Audio Renderer -- Failed to receive initialize message from host!");

--- a/src/common/steady_clock.h
+++ b/src/common/steady_clock.h
@@ -20,4 +20,15 @@ struct SteadyClock {
     [[nodiscard]] static time_point Now() noexcept;
 };
 
+struct RealTimeClock {
+    using rep = s64;
+    using period = std::nano;
+    using duration = std::chrono::nanoseconds;
+    using time_point = std::chrono::time_point<RealTimeClock>;
+
+    static constexpr bool is_steady = false;
+
+    [[nodiscard]] static time_point Now() noexcept;
+};
+
 } // namespace Common

--- a/src/common/x64/native_clock.cpp
+++ b/src/common/x64/native_clock.cpp
@@ -72,13 +72,13 @@ NativeClock::NativeClock(u64 emulated_cpu_frequency_, u64 emulated_clock_frequen
                          u64 rtsc_frequency_)
     : WallClock(emulated_cpu_frequency_, emulated_clock_frequency_, true), rtsc_frequency{
                                                                                rtsc_frequency_} {
-    // Thread to re-adjust the RDTSC frequency after 30 seconds has elapsed.
+    // Thread to re-adjust the RDTSC frequency after 10 seconds has elapsed.
     time_sync_thread = std::jthread{[this](std::stop_token token) {
         // Get the current time.
         const auto start_time = Common::RealTimeClock::Now();
         const u64 tsc_start = FencedRDTSC();
-        // Wait for 30 seconds.
-        if (!Common::StoppableTimedWait(token, std::chrono::seconds{30})) {
+        // Wait for 10 seconds.
+        if (!Common::StoppableTimedWait(token, std::chrono::seconds{10})) {
             return;
         }
         const auto end_time = Common::RealTimeClock::Now();

--- a/src/common/x64/native_clock.cpp
+++ b/src/common/x64/native_clock.cpp
@@ -53,11 +53,11 @@ u64 EstimateRDTSCFrequency() {
     FencedRDTSC();
 
     // Get the current time.
-    const auto start_time = Common::SteadyClock::Now();
+    const auto start_time = Common::RealTimeClock::Now();
     const u64 tsc_start = FencedRDTSC();
     // Wait for 250 milliseconds.
     std::this_thread::sleep_for(std::chrono::milliseconds{250});
-    const auto end_time = Common::SteadyClock::Now();
+    const auto end_time = Common::RealTimeClock::Now();
     const u64 tsc_end = FencedRDTSC();
     // Calculate differences.
     const u64 timer_diff = static_cast<u64>(
@@ -75,13 +75,13 @@ NativeClock::NativeClock(u64 emulated_cpu_frequency_, u64 emulated_clock_frequen
     // Thread to re-adjust the RDTSC frequency after 30 seconds has elapsed.
     time_sync_thread = std::jthread{[this](std::stop_token token) {
         // Get the current time.
-        const auto start_time = Common::SteadyClock::Now();
+        const auto start_time = Common::RealTimeClock::Now();
         const u64 tsc_start = FencedRDTSC();
         // Wait for 30 seconds.
         if (!Common::StoppableTimedWait(token, std::chrono::seconds{30})) {
             return;
         }
-        const auto end_time = Common::SteadyClock::Now();
+        const auto end_time = Common::RealTimeClock::Now();
         const u64 tsc_end = FencedRDTSC();
         // Calculate differences.
         const u64 timer_diff = static_cast<u64>(

--- a/src/common/x64/native_clock.cpp
+++ b/src/common/x64/native_clock.cpp
@@ -72,13 +72,29 @@ NativeClock::NativeClock(u64 emulated_cpu_frequency_, u64 emulated_clock_frequen
                          u64 rtsc_frequency_)
     : WallClock(emulated_cpu_frequency_, emulated_clock_frequency_, true), rtsc_frequency{
                                                                                rtsc_frequency_} {
+    // Thread to re-adjust the RDTSC frequency after 30 seconds has elapsed.
+    time_sync_thread = std::jthread{[this](std::stop_token token) {
+        // Get the current time.
+        const auto start_time = Common::SteadyClock::Now();
+        const u64 tsc_start = FencedRDTSC();
+        // Wait for 30 seconds.
+        if (!Common::StoppableTimedWait(token, std::chrono::seconds{30})) {
+            return;
+        }
+        const auto end_time = Common::SteadyClock::Now();
+        const u64 tsc_end = FencedRDTSC();
+        // Calculate differences.
+        const u64 timer_diff = static_cast<u64>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count());
+        const u64 tsc_diff = tsc_end - tsc_start;
+        const u64 tsc_freq = MultiplyAndDivide64(tsc_diff, 1000000000ULL, timer_diff);
+        rtsc_frequency = tsc_freq;
+        CalculateAndSetFactors();
+    }};
+
     time_point.inner.last_measure = FencedRDTSC();
     time_point.inner.accumulated_ticks = 0U;
-    ns_rtsc_factor = GetFixedPoint64Factor(NS_RATIO, rtsc_frequency);
-    us_rtsc_factor = GetFixedPoint64Factor(US_RATIO, rtsc_frequency);
-    ms_rtsc_factor = GetFixedPoint64Factor(MS_RATIO, rtsc_frequency);
-    clock_rtsc_factor = GetFixedPoint64Factor(emulated_clock_frequency, rtsc_frequency);
-    cpu_rtsc_factor = GetFixedPoint64Factor(emulated_cpu_frequency, rtsc_frequency);
+    CalculateAndSetFactors();
 }
 
 u64 NativeClock::GetRTSC() {
@@ -136,6 +152,14 @@ u64 NativeClock::GetClockCycles() {
 u64 NativeClock::GetCPUCycles() {
     const u64 rtsc_value = GetRTSC();
     return MultiplyHigh(rtsc_value, cpu_rtsc_factor);
+}
+
+void NativeClock::CalculateAndSetFactors() {
+    ns_rtsc_factor = GetFixedPoint64Factor(NS_RATIO, rtsc_frequency);
+    us_rtsc_factor = GetFixedPoint64Factor(US_RATIO, rtsc_frequency);
+    ms_rtsc_factor = GetFixedPoint64Factor(MS_RATIO, rtsc_frequency);
+    clock_rtsc_factor = GetFixedPoint64Factor(emulated_clock_frequency, rtsc_frequency);
+    cpu_rtsc_factor = GetFixedPoint64Factor(emulated_cpu_frequency, rtsc_frequency);
 }
 
 } // namespace X64

--- a/src/common/x64/native_clock.h
+++ b/src/common/x64/native_clock.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/polyfill_thread.h"
 #include "common/wall_clock.h"
 
 namespace Common {
@@ -28,6 +29,8 @@ public:
 private:
     u64 GetRTSC();
 
+    void CalculateAndSetFactors();
+
     union alignas(16) TimePoint {
         TimePoint() : pack{} {}
         u128 pack{};
@@ -47,6 +50,8 @@ private:
     u64 ms_rtsc_factor{};
 
     u64 rtsc_frequency;
+
+    std::jthread time_sync_thread;
 };
 } // namespace X64
 

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -53,7 +53,7 @@ void CoreTiming::ThreadEntry(CoreTiming& instance) {
     static constexpr char name[] = "HostTiming";
     MicroProfileOnThreadCreate(name);
     Common::SetCurrentThreadName(name);
-    Common::SetCurrentThreadPriority(Common::ThreadPriority::Critical);
+    Common::SetCurrentThreadPriority(Common::ThreadPriority::High);
     instance.on_thread_init();
     instance.ThreadLoop();
     MicroProfileOnThreadExit();

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -192,7 +192,7 @@ void CpuManager::RunThread(std::stop_token token, std::size_t core) {
     }
     MicroProfileOnThreadCreate(name.c_str());
     Common::SetCurrentThreadName(name.c_str());
-    Common::SetCurrentThreadPriority(Common::ThreadPriority::High);
+    Common::SetCurrentThreadPriority(Common::ThreadPriority::Critical);
     auto& data = core_data[core];
     data.host_context = Common::Fiber::ThreadToFiber();
 

--- a/src/core/hle/service/hid/controllers/stubbed.cpp
+++ b/src/core/hle/service/hid/controllers/stubbed.cpp
@@ -26,7 +26,7 @@ void Controller_Stubbed::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
     }
 
     CommonHeader header{};
-    header.timestamp = core_timing.GetCPUTicks();
+    header.timestamp = core_timing.GetGlobalTimeNs().count();
     header.total_entry_count = 17;
     header.entry_count = 0;
     header.last_entry_index = 0;

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -32,7 +32,7 @@ void Controller_Touchscreen::OnInit() {}
 void Controller_Touchscreen::OnRelease() {}
 
 void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
-    shared_memory->touch_screen_lifo.timestamp = core_timing.GetCPUTicks();
+    shared_memory->touch_screen_lifo.timestamp = core_timing.GetGlobalTimeNs().count();
 
     if (!IsControllerActivated()) {
         shared_memory->touch_screen_lifo.buffer_count = 0;
@@ -85,7 +85,7 @@ void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timin
     const auto active_fingers_count =
         static_cast<std::size_t>(std::distance(active_fingers.begin(), end_iter));
 
-    const u64 tick = core_timing.GetCPUTicks();
+    const u64 timestamp = static_cast<u64>(core_timing.GetGlobalTimeNs().count());
     const auto& last_entry = shared_memory->touch_screen_lifo.ReadCurrentEntry().state;
 
     next_state.sampling_number = last_entry.sampling_number + 1;
@@ -102,8 +102,8 @@ void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timin
             touch_entry.diameter_x = Settings::values.touchscreen.diameter_x;
             touch_entry.diameter_y = Settings::values.touchscreen.diameter_y;
             touch_entry.rotation_angle = Settings::values.touchscreen.rotation_angle;
-            touch_entry.delta_time = tick - active_fingers[id].last_touch;
-            fingers[active_fingers[id].id].last_touch = tick;
+            touch_entry.delta_time = timestamp - active_fingers[id].last_touch;
+            fingers[active_fingers[id].id].last_touch = timestamp;
             touch_entry.finger = active_fingers[id].id;
             touch_entry.attribute.raw = active_fingers[id].attribute.raw;
         } else {

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -126,8 +126,8 @@ double PerfStats::GetLastFrameTimeScale() const {
 }
 
 void SpeedLimiter::DoSpeedLimiting(microseconds current_system_time_us) {
-    if (!Settings::values.use_speed_limit.GetValue() ||
-        Settings::values.use_multi_core.GetValue()) {
+    if (Settings::values.use_multi_core.GetValue() ||
+        !Settings::values.use_speed_limit.GetValue()) {
         return;
     }
 

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -25,7 +25,7 @@ static void RunThread(std::stop_token stop_token, Core::System& system,
     SCOPE_EXIT({ MicroProfileOnThreadExit(); });
 
     Common::SetCurrentThreadName(name.c_str());
-    Common::SetCurrentThreadPriority(Common::ThreadPriority::High);
+    Common::SetCurrentThreadPriority(Common::ThreadPriority::Critical);
     system.RegisterHostThread();
 
     auto current_context = context.Acquire();


### PR DESCRIPTION
The initial RDTSC frequency, [as determined by CPUID or estimated](https://github.com/yuzu-emu/yuzu/blob/a7792e5ff83523142230951ac7eacbd7685dc40b/src/common/wall_clock.cpp#L58) may not be accurate to its true frequency and may drift relative to the passage of real time.

This PR re-adjusts the RDTSC frequency in accordance to its real-time frequency after a measurement period of 10 seconds, and is done on a separate temporary thread to avoid blocking execution of the main thread.

This was tested to eliminate any remaining time drift on my system¹ in Super Smash Bros. Ultimate², and is also reported to resolve audio drift in Astral Chain, although I am not able to independently verify the latter. Further testing is needed to determine any potential side-effects of this change.

Before:
![image](https://user-images.githubusercontent.com/39850852/223589386-01fa2b1b-66d6-40dc-898b-06840aaebd93.png)
After:
![image](https://user-images.githubusercontent.com/39850852/223589415-3cb7bf79-bb4f-4188-945b-b2f61d58b1ae.png)

As the system clock is used, this batch script can be used to synchronize system time with NTP on Windows (remove the .txt extension).
[time.bat.txt](https://github.com/yuzu-emu/yuzu/files/10915302/time.bat.txt)

¹ The system tested uses an Intel i7-11700K Rocket Lake CPU
² Time drift on Intel Alder Lake/Raptor Lake CPUs may or may not be fixed, I theorize this has to do with potential differences in timing between the P and E cores although I am unable to confirm this. To aid in this I have promoted the thread priorities for the CPU and GPU threads to time critical.