### PR TITLE
kernel: avoid signed overflow UB on MSVC

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(common STATIC
     multi_level_page_table.h
     nvidia_flags.cpp
     nvidia_flags.h
+    overflow.h
     page_table.cpp
     page_table.h
     param_package.cpp

--- a/src/common/overflow.h
+++ b/src/common/overflow.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <type_traits>
+#include "bit_cast.h"
+
+namespace Common {
+
+template <typename T>
+    requires(std::is_integral_v<T> && std::is_signed_v<T>)
+inline T WrappingAdd(T lhs, T rhs) {
+    using U = std::make_unsigned_t<T>;
+
+    U lhs_u = BitCast<U>(lhs);
+    U rhs_u = BitCast<U>(rhs);
+
+    return BitCast<T>(lhs_u + rhs_u);
+}
+
+} // namespace Common

--- a/src/core/hle/kernel/k_resource_limit.cpp
+++ b/src/core/hle/kernel/k_resource_limit.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"
+#include "common/overflow.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/k_resource_limit.h"
@@ -104,7 +105,7 @@ bool KResourceLimit::Reserve(LimitableResource which, s64 value, s64 timeout) {
         ASSERT(current_hints[index] <= current_values[index]);
 
         // If we would overflow, don't allow to succeed.
-        if (current_values[index] + value <= current_values[index]) {
+        if (Common::WrappingAdd(current_values[index], value) <= current_values[index]) {
             break;
         }
 


### PR DESCRIPTION
We specify -fwrapv for non-msvc compilers, but msvc has no equivalent to force wrapping for signed integers. This appears to be the only instance in the kernel where wrapping of signed integers is depended on.