### PR TITLE
kernel: add timer pointer to KThreadQueue

### DIFF
--- a/src/core/hle/kernel/k_address_arbiter.cpp
+++ b/src/core/hle/kernel/k_address_arbiter.cpp
@@ -237,10 +237,11 @@ Result KAddressArbiter::SignalAndModifyByWaitingCountIfEqual(VAddr addr, s32 val
 Result KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement, s64 timeout) {
     // Prepare to wait.
     KThread* cur_thread = GetCurrentThreadPointer(kernel);
+    KHardwareTimer* timer{};
     ThreadQueueImplForKAddressArbiter wait_queue(kernel, std::addressof(thread_tree));
 
     {
-        KScopedSchedulerLockAndSleep slp{kernel, cur_thread, timeout};
+        KScopedSchedulerLockAndSleep slp{kernel, std::addressof(timer), cur_thread, timeout};
 
         // Check that the thread isn't terminating.
         if (cur_thread->IsTerminationRequested()) {
@@ -279,6 +280,7 @@ Result KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement, s6
         thread_tree.insert(*cur_thread);
 
         // Wait for the thread to finish.
+        wait_queue.SetHardwareTimer(timer);
         cur_thread->BeginWait(std::addressof(wait_queue));
         cur_thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::Arbitration);
     }
@@ -290,10 +292,11 @@ Result KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement, s6
 Result KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
     // Prepare to wait.
     KThread* cur_thread = GetCurrentThreadPointer(kernel);
+    KHardwareTimer* timer{};
     ThreadQueueImplForKAddressArbiter wait_queue(kernel, std::addressof(thread_tree));
 
     {
-        KScopedSchedulerLockAndSleep slp{kernel, cur_thread, timeout};
+        KScopedSchedulerLockAndSleep slp{kernel, std::addressof(timer), cur_thread, timeout};
 
         // Check that the thread isn't terminating.
         if (cur_thread->IsTerminationRequested()) {
@@ -325,6 +328,7 @@ Result KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
         thread_tree.insert(*cur_thread);
 
         // Wait for the thread to finish.
+        wait_queue.SetHardwareTimer(timer);
         cur_thread->BeginWait(std::addressof(wait_queue));
         cur_thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::Arbitration);
     }

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -1268,9 +1268,10 @@ Result KThread::Sleep(s64 timeout) {
     ASSERT(timeout > 0);
 
     ThreadQueueImplForKThreadSleep wait_queue_(kernel);
+    KHardwareTimer* timer{};
     {
         // Setup the scheduling lock and sleep.
-        KScopedSchedulerLockAndSleep slp(kernel, this, timeout);
+        KScopedSchedulerLockAndSleep slp(kernel, std::addressof(timer), this, timeout);
 
         // Check if the thread should terminate.
         if (this->IsTerminationRequested()) {
@@ -1279,6 +1280,7 @@ Result KThread::Sleep(s64 timeout) {
         }
 
         // Wait for the sleep to end.
+        wait_queue_.SetHardwareTimer(timer);
         this->BeginWait(std::addressof(wait_queue_));
         SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::Sleep);
     }

--- a/src/core/hle/kernel/k_thread_queue.cpp
+++ b/src/core/hle/kernel/k_thread_queue.cpp
@@ -22,7 +22,9 @@ void KThreadQueue::EndWait(KThread* waiting_thread, Result wait_result) {
     waiting_thread->ClearWaitQueue();
 
     // Cancel the thread task.
-    kernel.HardwareTimer().CancelTask(waiting_thread);
+    if (m_hardware_timer != nullptr) {
+        m_hardware_timer->CancelTask(waiting_thread);
+    }
 }
 
 void KThreadQueue::CancelWait(KThread* waiting_thread, Result wait_result, bool cancel_timer_task) {
@@ -36,8 +38,8 @@ void KThreadQueue::CancelWait(KThread* waiting_thread, Result wait_result, bool 
     waiting_thread->ClearWaitQueue();
 
     // Cancel the thread task.
-    if (cancel_timer_task) {
-        kernel.HardwareTimer().CancelTask(waiting_thread);
+    if (cancel_timer_task && m_hardware_timer != nullptr) {
+        m_hardware_timer->CancelTask(waiting_thread);
     }
 }
 

--- a/src/core/hle/kernel/k_thread_queue.h
+++ b/src/core/hle/kernel/k_thread_queue.h
@@ -8,10 +8,16 @@
 
 namespace Kernel {
 
+class KHardwareTimer;
+
 class KThreadQueue {
 public:
-    explicit KThreadQueue(KernelCore& kernel_) : kernel{kernel_} {}
+    explicit KThreadQueue(KernelCore& kernel_) : kernel{kernel_}, m_hardware_timer{} {}
     virtual ~KThreadQueue() = default;
+
+    void SetHardwareTimer(KHardwareTimer* timer) {
+        m_hardware_timer = timer;
+    }
 
     virtual void NotifyAvailable(KThread* waiting_thread, KSynchronizationObject* signaled_object,
                                  Result wait_result);
@@ -20,7 +26,7 @@ public:
 
 private:
     KernelCore& kernel;
-    KThread::WaiterList wait_list{};
+    KHardwareTimer* m_hardware_timer{};
 };
 
 class KThreadQueueWithoutEndWait : public KThreadQueue {


### PR DESCRIPTION
The old behavior was equivalent for one timer, but would not necessarily be equivalent for multiple timers.