### PR TITLE
OpenGL: Prefer glClientWaitSync for OGLSync objects

### DIFF
--- a/src/video_core/renderer_opengl/gl_fence_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_fence_manager.cpp
@@ -27,9 +27,7 @@ bool GLInnerFence::IsSignaled() const {
         return true;
     }
     ASSERT(sync_object.handle != 0);
-    GLint sync_status;
-    glGetSynciv(sync_object.handle, GL_SYNC_STATUS, 1, nullptr, &sync_status);
-    return sync_status == GL_SIGNALED;
+    return sync_object.IsSignaled();
 }
 
 void GLInnerFence::Wait() {

--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.cpp
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.cpp
@@ -621,10 +621,7 @@ bool GraphicsPipeline::IsBuilt() noexcept {
     if (built_fence.handle == 0) {
         return false;
     }
-    // Timeout of zero means this is non-blocking
-    const auto sync_status = glClientWaitSync(built_fence.handle, 0, 0);
-    ASSERT(sync_status != GL_WAIT_FAILED);
-    is_built = sync_status != GL_TIMEOUT_EXPIRED;
+    is_built = built_fence.IsSignaled();
     return is_built;
 }
 

--- a/src/video_core/renderer_opengl/gl_resource_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_resource_manager.cpp
@@ -3,6 +3,7 @@
 
 #include <string_view>
 #include <glad/glad.h>
+#include "common/assert.h"
 #include "common/microprofile.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_shader_util.h"
@@ -156,6 +157,15 @@ void OGLSync::Release() {
     // Don't profile here, this one is expected to happen ingame.
     glDeleteSync(handle);
     handle = 0;
+}
+
+bool OGLSync::IsSignaled() const noexcept {
+    // At least on Nvidia, glClientWaitSync with a timeout of 0
+    // is faster than glGetSynciv of GL_SYNC_STATUS.
+    // Timeout of 0 means this check is non-blocking.
+    const auto sync_status = glClientWaitSync(handle, 0, 0);
+    ASSERT(sync_status != GL_WAIT_FAILED);
+    return sync_status != GL_TIMEOUT_EXPIRED;
 }
 
 void OGLFramebuffer::Create() {

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -263,6 +263,9 @@ public:
     /// Deletes the internal OpenGL resource
     void Release();
 
+    /// Checks if the sync has been signaled
+    bool IsSignaled() const noexcept;
+
     GLsync handle = 0;
 };
 

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -714,9 +714,7 @@ std::optional<size_t> TextureCacheRuntime::StagingBuffers::FindBuffer(size_t req
             continue;
         }
         if (syncs[index].handle != 0) {
-            GLint status;
-            glGetSynciv(syncs[index].handle, GL_SYNC_STATUS, 1, nullptr, &status);
-            if (status != GL_SIGNALED) {
+            if (!syncs[index].IsSignaled()) {
                 continue;
             }
             syncs[index].Release();


### PR DESCRIPTION
At least on Nvidia, glClientWaitSync with a timeout of 0 (non-blocking) is faster than glGetSynciv of GL_SYNC_STATUS.