### PR TITLE
input_common: sdl: Only send last vibration command

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -652,12 +652,27 @@ bool SDLDriver::IsVibrationEnabled(const PadIdentifier& identifier) {
 }
 
 void SDLDriver::SendVibrations() {
+    std::vector<VibrationRequest> filtered_vibrations{};
     while (!vibration_queue.Empty()) {
         VibrationRequest request;
         vibration_queue.Pop(request);
         const auto joystick = GetSDLJoystickByGUID(request.identifier.guid.RawString(),
                                                    static_cast<int>(request.identifier.port));
-        joystick->RumblePlay(request.vibration);
+        const auto it = std::find_if(filtered_vibrations.begin(), filtered_vibrations.end(),
+                                     [request](VibrationRequest vibration) {
+                                         return vibration.identifier == request.identifier;
+                                     });
+        if (it == filtered_vibrations.end()) {
+            filtered_vibrations.push_back(std::move(request));
+            continue;
+        }
+        *it = request;
+    }
+
+    for (const auto& vibration : filtered_vibrations) {
+        const auto joystick = GetSDLJoystickByGUID(vibration.identifier.guid.RawString(),
+                                                   static_cast<int>(vibration.identifier.port));
+        joystick->RumblePlay(vibration.vibration);
     }
 }
 


### PR DESCRIPTION
On the endless quest of vibration issues. Turns out if you have more than one player with the same controller connected or even using dual joycon with a single controller you can get two consecutive vibration commands to the same controller.

My solution this time was to just grab the latest element from the queue rated to a specific controller. Ignoring the rest and ensuring the controller can handle the vibration.