### PR TITLE
yuzu: Move audio settings to audio section

### DIFF
--- a/src/yuzu/configuration/configure_audio.ui
+++ b/src/yuzu/configuration/configure_audio.ui
@@ -39,7 +39,7 @@
         <item>
          <widget class="QLabel" name="output_label">
           <property name="text">
-           <string>Output Device</string>
+           <string>Output Device:</string>
           </property>
          </widget>
         </item>
@@ -53,12 +53,42 @@
         <item>
          <widget class="QLabel" name="input_label">
           <property name="text">
-           <string>Input Device</string>
+           <string>Input Device:</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QComboBox" name="input_combo_box"/>
+        </item>
+       </layout>
+      </item>
+       <item>
+       <layout class="QHBoxLayout" name="mode_layout">
+        <item>
+         <widget class="QLabel" name="mode_label">
+          <property name="text">
+           <string>Sound Ouput Mode:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+          <widget class="QComboBox" name="combo_sound">
+            <item>
+              <property name="text">
+                <string>Mono</string>
+              </property>
+            </item>
+            <item>
+              <property name="text">
+                <string>Stereo</string>
+              </property>
+            </item>
+            <item>
+              <property name="text">
+                <string>Surround</string>
+              </property>
+            </item>
+          </widget>
         </item>
        </layout>
       </item>
@@ -148,6 +178,17 @@
          </item>
         </layout>
        </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="mute_layout">
+         <item>
+           <widget class="QCheckBox" name="toggle_background_mute">
+             <property name="text">
+               <string>Mute audio when in background</string>
+             </property>
+           </widget>
+         </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -42,7 +42,6 @@ void ConfigureGeneral::SetConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing.GetValue());
     ui->toggle_user_on_boot->setChecked(UISettings::values.select_user_on_boot.GetValue());
     ui->toggle_background_pause->setChecked(UISettings::values.pause_when_in_background.GetValue());
-    ui->toggle_background_mute->setChecked(UISettings::values.mute_when_in_background.GetValue());
     ui->toggle_hide_mouse->setChecked(UISettings::values.hide_mouse.GetValue());
 
     ui->toggle_speed_limit->setChecked(Settings::values.use_speed_limit.GetValue());
@@ -88,7 +87,6 @@ void ConfigureGeneral::ApplyConfiguration() {
         UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
         UISettings::values.select_user_on_boot = ui->toggle_user_on_boot->isChecked();
         UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
-        UISettings::values.mute_when_in_background = ui->toggle_background_mute->isChecked();
         UISettings::values.hide_mouse = ui->toggle_hide_mouse->isChecked();
 
         // Guard if during game and set to game-specific value

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -90,13 +90,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="toggle_background_mute">
-            <property name="text">
-             <string>Mute audio when in background</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="toggle_hide_mouse">
             <property name="text">
              <string>Hide mouse on inactivity</string>

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -116,14 +116,12 @@ void ConfigureSystem::SetConfiguration() {
         ui->combo_language->setCurrentIndex(Settings::values.language_index.GetValue());
         ui->combo_region->setCurrentIndex(Settings::values.region_index.GetValue());
         ui->combo_time_zone->setCurrentIndex(Settings::values.time_zone_index.GetValue());
-        ui->combo_sound->setCurrentIndex(Settings::values.sound_index.GetValue());
     } else {
         ConfigurationShared::SetPerGameSetting(ui->combo_language,
                                                &Settings::values.language_index);
         ConfigurationShared::SetPerGameSetting(ui->combo_region, &Settings::values.region_index);
         ConfigurationShared::SetPerGameSetting(ui->combo_time_zone,
                                                &Settings::values.time_zone_index);
-        ConfigurationShared::SetPerGameSetting(ui->combo_sound, &Settings::values.sound_index);
 
         ConfigurationShared::SetHighlight(ui->label_language,
                                           !Settings::values.language_index.UsingGlobal());
@@ -131,8 +129,6 @@ void ConfigureSystem::SetConfiguration() {
                                           !Settings::values.region_index.UsingGlobal());
         ConfigurationShared::SetHighlight(ui->label_timezone,
                                           !Settings::values.time_zone_index.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->label_sound,
-                                          !Settings::values.sound_index.UsingGlobal());
     }
 }
 
@@ -164,7 +160,6 @@ void ConfigureSystem::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.region_index, ui->combo_region);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.time_zone_index,
                                              ui->combo_time_zone);
-    ConfigurationShared::ApplyPerGameSetting(&Settings::values.sound_index, ui->combo_sound);
 
     if (Settings::IsConfiguringGlobal()) {
         // Guard if during game and set to game-specific value
@@ -202,7 +197,6 @@ void ConfigureSystem::SetupPerGameUI() {
         ui->combo_language->setEnabled(Settings::values.language_index.UsingGlobal());
         ui->combo_region->setEnabled(Settings::values.region_index.UsingGlobal());
         ui->combo_time_zone->setEnabled(Settings::values.time_zone_index.UsingGlobal());
-        ui->combo_sound->setEnabled(Settings::values.sound_index.UsingGlobal());
         ui->rng_seed_checkbox->setEnabled(Settings::values.rng_seed.UsingGlobal());
         ui->rng_seed_edit->setEnabled(Settings::values.rng_seed.UsingGlobal());
 
@@ -215,8 +209,6 @@ void ConfigureSystem::SetupPerGameUI() {
                                             Settings::values.region_index.GetValue(true));
     ConfigurationShared::SetColoredComboBox(ui->combo_time_zone, ui->label_timezone,
                                             Settings::values.time_zone_index.GetValue(true));
-    ConfigurationShared::SetColoredComboBox(ui->combo_sound, ui->label_sound,
-                                            Settings::values.sound_index.GetValue(true));
 
     ConfigurationShared::SetColoredTristate(
         ui->rng_seed_checkbox, Settings::values.rng_seed.UsingGlobal(),

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -40,8 +40,6 @@ static bool IsValidLocale(u32 region_index, u32 language_index) {
 ConfigureSystem::ConfigureSystem(Core::System& system_, QWidget* parent)
     : QWidget(parent), ui{std::make_unique<Ui::ConfigureSystem>()}, system{system_} {
     ui->setupUi(this);
-    connect(ui->button_regenerate_console_id, &QPushButton::clicked, this,
-            &ConfigureSystem::RefreshConsoleID);
 
     connect(ui->rng_seed_checkbox, &QCheckBox::stateChanged, this, [this](int state) {
         ui->rng_seed_edit->setEnabled(state == Qt::Checked);
@@ -75,9 +73,6 @@ ConfigureSystem::ConfigureSystem(Core::System& system_, QWidget* parent)
     connect(ui->combo_language, qOverload<int>(&QComboBox::currentIndexChanged), this,
             locale_check);
     connect(ui->combo_region, qOverload<int>(&QComboBox::currentIndexChanged), this, locale_check);
-
-    ui->label_console_id->setVisible(Settings::IsConfiguringGlobal());
-    ui->button_regenerate_console_id->setVisible(Settings::IsConfiguringGlobal());
 
     SetupPerGameUI();
 
@@ -200,23 +195,6 @@ void ConfigureSystem::ApplyConfiguration() {
             break;
         }
     }
-}
-
-void ConfigureSystem::RefreshConsoleID() {
-    QMessageBox::StandardButton reply;
-    QString warning_text = tr("This will replace your current virtual Switch with a new one. "
-                              "Your current virtual Switch will not be recoverable. "
-                              "This might have unexpected effects in games. This might fail, "
-                              "if you use an outdated config savegame. Continue?");
-    reply = QMessageBox::critical(this, tr("Warning"), warning_text,
-                                  QMessageBox::No | QMessageBox::Yes);
-    if (reply == QMessageBox::No) {
-        return;
-    }
-
-    u64 console_id{};
-    ui->label_console_id->setText(
-        tr("Console ID: 0x%1").arg(QString::number(console_id, 16).toUpper()));
 }
 
 void ConfigureSystem::SetupPerGameUI() {

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -35,8 +35,6 @@ private:
 
     void ReadSystemSettings();
 
-    void RefreshConsoleID();
-
     void SetupPerGameUI();
 
     std::unique_ptr<Ui::ConfigureSystem> ui;

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -411,7 +411,7 @@
             </item>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="4" column="0">
            <widget class="QCheckBox" name="custom_rtc_checkbox">
             <property name="text">
              <string>Custom RTC</string>
@@ -425,14 +425,14 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="5" column="0">
            <widget class="QCheckBox" name="rng_seed_checkbox">
             <property name="text">
              <string>RNG Seed</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="device_name_label">
             <property name="text">
              <string>Device Name</string>
@@ -458,13 +458,6 @@
             </item>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_console_id">
-            <property name="text">
-             <string>Console ID:</string>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="label_sound">
             <property name="text">
@@ -472,7 +465,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="4" column="1">
            <widget class="QDateTimeEdit" name="custom_rtc_edit">
             <property name="minimumDate">
              <date>
@@ -483,14 +476,14 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="6" column="1">
            <widget class="QLineEdit" name="device_name_edit">
             <property name="maxLength">
              <number>128</number>
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="5" column="1">
            <widget class="QLineEdit" name="rng_seed_edit">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -508,22 +501,6 @@
             </property>
             <property name="maxLength">
              <number>8</number>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QPushButton" name="button_regenerate_console_id">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="layoutDirection">
-             <enum>Qt::RightToLeft</enum>
-            </property>
-            <property name="text">
-             <string>Regenerate</string>
             </property>
            </widget>
           </item>

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -439,32 +439,6 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="combo_sound">
-            <item>
-             <property name="text">
-              <string>Mono</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Stereo</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Surround</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_sound">
-            <property name="text">
-             <string>Sound output mode</string>
-            </property>
-           </widget>
-          </item>
           <item row="4" column="1">
            <widget class="QDateTimeEdit" name="custom_rtc_edit">
             <property name="minimumDate">


### PR DESCRIPTION
Audio settings should be in the audio section. Also removed vestigial setting called console ID since it actually did nothing.