### PR TITLE
[video_core] Disable SRGB border color conversion in samplers

### DIFF
--- a/src/video_core/textures/texture.cpp
+++ b/src/video_core/textures/texture.cpp
@@ -14,7 +14,7 @@ namespace Tegra::Texture {
 
 namespace {
 
-constexpr std::array<float, 256> SRGB_CONVERSION_LUT = {
+[[maybe_unused]] constexpr std::array<float, 256> SRGB_CONVERSION_LUT = {
     0.000000f, 0.000000f, 0.000000f, 0.000012f, 0.000021f, 0.000033f, 0.000046f, 0.000062f,
     0.000081f, 0.000102f, 0.000125f, 0.000151f, 0.000181f, 0.000214f, 0.000251f, 0.000293f,
     0.000338f, 0.000388f, 0.000443f, 0.000503f, 0.000568f, 0.000639f, 0.000715f, 0.000798f,
@@ -52,11 +52,13 @@ constexpr std::array<float, 256> SRGB_CONVERSION_LUT = {
 } // Anonymous namespace
 
 std::array<float, 4> TSCEntry::BorderColor() const noexcept {
-    if (!srgb_conversion) {
-        return border_color;
-    }
-    return {SRGB_CONVERSION_LUT[srgb_border_color_r], SRGB_CONVERSION_LUT[srgb_border_color_g],
-            SRGB_CONVERSION_LUT[srgb_border_color_b], border_color[3]};
+    // TODO: Handle SRGB correctly. Using this breaks shadows in some games (Xenoblade).
+    // if (!srgb_conversion) {
+    //    return border_color;
+    //}
+    // return {SRGB_CONVERSION_LUT[srgb_border_color_r], SRGB_CONVERSION_LUT[srgb_border_color_g],
+    //        SRGB_CONVERSION_LUT[srgb_border_color_b], border_color[3]};
+    return border_color;
 }
 
 float TSCEntry::MaxAnisotropy() const noexcept {


### PR DESCRIPTION
Shaders in Xenoblade break with this enabled, as the TSC passes in 8161.0 as the R border colour, but with SRGB conversion enabled we ignore it, and return 1.0 from the SRGB LUT instead. The different between 1.0 and 8161 is very large, and so near edges the values scale up significantly. In the shaders this sampler is used in, the sampled value is used with addition/subtraction on small numbers. In some pixels I was looking at, it's subtracted from a value of ~3.2, and it's then compared > 0.0. Currently this remains positive and passes as needing to be shadowed. With the 8161 border colour value instead, this goes very negative, and fails the check instead, discarding the pixel as a shadow, which seems to be correct behaviour. 

I don't know what the real issue here with SRGB is, because SRGB is enabled in the sampler so it should be used somehow I'm assuming, but ignoring the border colour and returning the LUT value instead doesn't seem to be correct. Do we maybe scale the border colour by the LUT value? I don't know. Seems strange to completely ignore the colour when SRGB is enabled.

Before:
![Untitled](https://user-images.githubusercontent.com/34639600/225802698-3979f835-c6e2-4abc-a093-b3348d518d0c.png)
After:
![Untitled2](https://user-images.githubusercontent.com/34639600/225803405-f3512fe7-0953-49b8-bb76-5ae8aad59c19.png)

Closes #6606.