### PR TITLE
config: Fix controller config from resetting

### DIFF
--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -189,6 +189,8 @@ QList<QWidget*> ConfigureInput::GetSubTabs() const {
 }
 
 void ConfigureInput::ApplyConfiguration() {
+    const bool was_global = Settings::values.players.UsingGlobal();
+    Settings::values.players.SetGlobal(true);
     for (auto* controller : player_controllers) {
         controller->ApplyConfiguration();
     }
@@ -201,6 +203,7 @@ void ConfigureInput::ApplyConfiguration() {
 
     Settings::values.vibration_enabled.SetValue(ui->vibrationGroup->isChecked());
     Settings::values.motion_enabled.SetValue(ui->motionGroup->isChecked());
+    Settings::values.players.SetGlobal(was_global);
 }
 
 void ConfigureInput::changeEvent(QEvent* event) {


### PR DESCRIPTION
Since per-game controller config was added, all controller config that was modified while the game was running was lost when the game closed. This generated annoying issues where you had to configure your controller every time you forgot to do it while the game was closed. 

This PR fixes that issue. Special thanks to epicboy since he did everything. I'm just making the PR.