### PR TITLE
Audio synchronisation improvements

### DIFF
--- a/src/audio_core/device/device_session.cpp
+++ b/src/audio_core/device/device_session.cpp
@@ -121,8 +121,7 @@ u64 DeviceSession::GetPlayedSampleCount() const {
 }
 
 std::optional<std::chrono::nanoseconds> DeviceSession::ThreadFunc() {
-    // Add 5ms of samples at a 48K sample rate.
-    played_sample_count += 48'000 * INCREMENT_TIME / 1s;
+    played_sample_count = stream->GetExpectedPlayedSampleCount();
     if (type == Sink::StreamType::Out) {
         system.AudioCore().GetAudioManager().SetEvent(Event::Type::AudioOutManager, true);
     } else {

--- a/src/audio_core/renderer/adsp/audio_renderer.cpp
+++ b/src/audio_core/renderer/adsp/audio_renderer.cpp
@@ -189,6 +189,8 @@ void AudioRenderer::ThreadFunc() {
                     max_time = std::min(command_buffer.time_limit, max_time);
                     command_list_processor.SetProcessTimeMax(max_time);
 
+                    streams[index]->WaitFreeSpace();
+
                     // Process the command list
                     {
                         MICROPROFILE_SCOPE(Audio_Renderer);

--- a/src/audio_core/renderer/adsp/audio_renderer.h
+++ b/src/audio_core/renderer/adsp/audio_renderer.h
@@ -12,6 +12,7 @@
 #include "common/common_types.h"
 #include "common/reader_writer_queue.h"
 #include "common/thread.h"
+#include "common/polyfill_thread.h"
 
 namespace Core {
 namespace Timing {

--- a/src/audio_core/renderer/adsp/audio_renderer.h
+++ b/src/audio_core/renderer/adsp/audio_renderer.h
@@ -10,9 +10,9 @@
 #include "audio_core/renderer/adsp/command_buffer.h"
 #include "audio_core/renderer/adsp/command_list_processor.h"
 #include "common/common_types.h"
+#include "common/polyfill_thread.h"
 #include "common/reader_writer_queue.h"
 #include "common/thread.h"
-#include "common/polyfill_thread.h"
 
 namespace Core {
 namespace Timing {

--- a/src/audio_core/renderer/system_manager.cpp
+++ b/src/audio_core/renderer/system_manager.cpp
@@ -15,7 +15,6 @@ MICROPROFILE_DEFINE(Audio_RenderSystemManager, "Audio", "Render System Manager",
                     MP_RGB(60, 19, 97));
 
 namespace AudioCore::AudioRenderer {
-constexpr std::chrono::nanoseconds RENDER_TIME{5'000'000UL};
 
 SystemManager::SystemManager(Core::System& core_)
     : core{core_}, adsp{core.AudioCore().GetADSP()}, mailbox{adsp.GetRenderMailbox()},

--- a/src/audio_core/renderer/system_manager.cpp
+++ b/src/audio_core/renderer/system_manager.cpp
@@ -17,11 +17,7 @@ MICROPROFILE_DEFINE(Audio_RenderSystemManager, "Audio", "Render System Manager",
 namespace AudioCore::AudioRenderer {
 
 SystemManager::SystemManager(Core::System& core_)
-    : core{core_}, adsp{core.AudioCore().GetADSP()}, mailbox{adsp.GetRenderMailbox()},
-      thread_event{Core::Timing::CreateEvent(
-          "AudioRendererSystemManager", [this](std::uintptr_t, s64 time, std::chrono::nanoseconds) {
-              return ThreadFunc2(time);
-          })} {}
+    : core{core_}, adsp{core.AudioCore().GetADSP()}, mailbox{adsp.GetRenderMailbox()} {}
 
 SystemManager::~SystemManager() {
     Stop();
@@ -32,8 +28,6 @@ bool SystemManager::InitializeUnsafe() {
         if (adsp.Start()) {
             active = true;
             thread = std::jthread([this](std::stop_token stop_token) { ThreadFunc(); });
-            core.CoreTiming().ScheduleLoopingEvent(std::chrono::nanoseconds(0), RENDER_TIME,
-                                                   thread_event);
         }
     }
 
@@ -44,7 +38,6 @@ void SystemManager::Stop() {
     if (!active) {
         return;
     }
-    core.CoreTiming().UnscheduleEvent(thread_event, {});
     active = false;
     update.store(true);
     update.notify_all();
@@ -110,16 +103,7 @@ void SystemManager::ThreadFunc() {
 
         adsp.Signal();
         adsp.Wait();
-
-        update.wait(false);
-        update.store(false);
     }
-}
-
-std::optional<std::chrono::nanoseconds> SystemManager::ThreadFunc2(s64 time) {
-    update.store(true);
-    update.notify_all();
-    return std::nullopt;
 }
 
 } // namespace AudioCore::AudioRenderer

--- a/src/audio_core/renderer/system_manager.h
+++ b/src/audio_core/renderer/system_manager.h
@@ -68,11 +68,6 @@ private:
      */
     void ThreadFunc();
 
-    /**
-     * Signalling core timing thread to run ThreadFunc.
-     */
-    std::optional<std::chrono::nanoseconds> ThreadFunc2(s64 time);
-
     enum class StreamState {
         Filling,
         Steady,
@@ -95,8 +90,6 @@ private:
     ADSP::ADSP& adsp;
     /// AudioRenderer mailbox for communication
     ADSP::AudioRenderer_Mailbox* mailbox{};
-    /// Core timing event to signal main thread
-    std::shared_ptr<Core::Timing::EventType> thread_event;
     /// Atomic for main thread to wait on
     std::atomic<bool> update{};
 };

--- a/src/audio_core/sink/cubeb_sink.cpp
+++ b/src/audio_core/sink/cubeb_sink.cpp
@@ -101,8 +101,6 @@ public:
     ~CubebSinkStream() override {
         LOG_DEBUG(Service_Audio, "Destructing cubeb stream {}", name);
 
-        Unstall();
-
         if (!ctx) {
             return;
         }
@@ -143,8 +141,6 @@ public:
      * Stop the sink stream.
      */
     void Stop() override {
-        Unstall();
-
         if (!ctx || paused) {
             return;
         }

--- a/src/audio_core/sink/sdl2_sink.cpp
+++ b/src/audio_core/sink/sdl2_sink.cpp
@@ -88,7 +88,6 @@ public:
      * Finalize the sink stream.
      */
     void Finalize() override {
-        Unstall();
         if (device == 0) {
             return;
         }
@@ -116,7 +115,6 @@ public:
      * Stop the sink stream.
      */
     void Stop() override {
-        Unstall();
         if (device == 0 || paused) {
             return;
         }

--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -245,9 +245,7 @@ void SinkStream::ProcessAudioOutAndRender(std::span<s16> output_buffer, std::siz
             // Successfully dequeued a new buffer.
             queued_buffers--;
 
-            {
-                std::unique_lock lk{release_mutex};
-            }
+            { std::unique_lock lk{release_mutex}; }
 
             release_cv.notify_one();
         }
@@ -276,7 +274,8 @@ void SinkStream::ProcessAudioOutAndRender(std::span<s16> output_buffer, std::siz
 
     {
         std::scoped_lock lk{sample_count_lock};
-        last_sample_count_update_time = Core::Timing::CyclesToUs(system.CoreTiming().GetClockTicks());
+        last_sample_count_update_time =
+            Core::Timing::CyclesToUs(system.CoreTiming().GetClockTicks());
         min_played_sample_count = max_played_sample_count;
         max_played_sample_count += actual_frames_written;
     }
@@ -315,7 +314,8 @@ u64 SinkStream::GetExpectedPlayedSampleCount() {
 
 void SinkStream::WaitFreeSpace() {
     std::unique_lock lk{release_mutex};
-    release_cv.wait(lk, [this]() { return queued_buffers < max_queue_size || system.IsShuttingDown(); });
+    release_cv.wait(
+        lk, [this]() { return queued_buffers < max_queue_size || system.IsShuttingDown(); });
 }
 
 } // namespace AudioCore::Sink

--- a/src/audio_core/sink/sink_stream.h
+++ b/src/audio_core/sink/sink_stream.h
@@ -16,7 +16,6 @@
 #include "common/reader_writer_queue.h"
 #include "common/ring_buffer.h"
 #include "common/thread.h"
-#include "common/polyfill_thread.h"
 
 namespace Core {
 class System;

--- a/src/audio_core/sink/sink_stream.h
+++ b/src/audio_core/sink/sink_stream.h
@@ -16,6 +16,7 @@
 #include "common/reader_writer_queue.h"
 #include "common/ring_buffer.h"
 #include "common/thread.h"
+#include "common/polyfill_thread.h"
 
 namespace Core {
 class System;
@@ -219,6 +220,11 @@ public:
      */
     u64 GetExpectedPlayedSampleCount();
 
+    /**
+     * Waits for free space in the sample ring buffer
+     */
+    void WaitFreeSpace();
+
 protected:
     /// Core system
     Core::System& system;
@@ -258,6 +264,9 @@ private:
     f32 system_volume{1.0f};
     /// Set via IAudioDevice service calls
     f32 device_volume{1.0f};
+    /// Signalled when ring buffer entries are consumed
+    std::condition_variable release_cv;
+    std::mutex release_mutex;
     std::mutex stall_guard;
     std::unique_lock<std::mutex> stalled_lock;
 };

--- a/src/audio_core/sink/sink_stream.h
+++ b/src/audio_core/sink/sink_stream.h
@@ -55,9 +55,7 @@ struct SinkBuffer {
 class SinkStream {
 public:
     explicit SinkStream(Core::System& system_, StreamType type_) : system{system_}, type{type_} {}
-    virtual ~SinkStream() {
-        Unstall();
-    }
+    virtual ~SinkStream() {}
 
     /**
      * Finalize the sink stream.
@@ -203,16 +201,6 @@ public:
     void ProcessAudioOutAndRender(std::span<s16> output_buffer, std::size_t num_frames);
 
     /**
-     * Stall core processes if the audio thread falls too far behind.
-     */
-    void Stall();
-
-    /**
-     * Unstall core processes.
-     */
-    void Unstall();
-
-    /**
      * Get the total number of samples expected to have been played by this stream.
      *
      * @return The number of samples.
@@ -266,8 +254,6 @@ private:
     /// Signalled when ring buffer entries are consumed
     std::condition_variable release_cv;
     std::mutex release_mutex;
-    std::mutex stall_guard;
-    std::unique_lock<std::mutex> stalled_lock;
 };
 
 using SinkStreamPtr = std::unique_ptr<SinkStream>;


### PR DESCRIPTION
- Should help to prevent stalls from needing to happen by attempting to tie the guest sample tracking to the host
- I am still unsure about the second patch, needs checking against RE to see if this wait time is included in the execution time accounting. The implementation is also kinda dodgy, ideally you'd keep track of reserved and submitted buffers and ensure they match