### PR TITLE
Implement asynchronous presentation

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -205,6 +205,7 @@ void RestoreGlobalState(bool is_powered_on) {
     // Renderer
     values.fsr_sharpening_slider.SetGlobal(true);
     values.renderer_backend.SetGlobal(true);
+    values.async_presentation.SetGlobal(true);
     values.renderer_force_max_clock.SetGlobal(true);
     values.vulkan_device.SetGlobal(true);
     values.fullscreen_mode.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -422,6 +422,7 @@ struct Values {
     // Renderer
     SwitchableSetting<RendererBackend, true> renderer_backend{
         RendererBackend::Vulkan, RendererBackend::OpenGL, RendererBackend::Null, "backend"};
+    SwitchableSetting<bool> async_presentation{false, "async_presentation"};
     SwitchableSetting<bool> renderer_force_max_clock{false, "force_max_clock"};
     Setting<bool> renderer_debug{false, "debug"};
     Setting<bool> renderer_shader_feedback{false, "shader_feedback"};

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -179,6 +179,8 @@ add_library(video_core STATIC
     renderer_vulkan/vk_master_semaphore.h
     renderer_vulkan/vk_pipeline_cache.cpp
     renderer_vulkan/vk_pipeline_cache.h
+    renderer_vulkan/vk_present_manager.cpp
+    renderer_vulkan/vk_present_manager.h
     renderer_vulkan/vk_query_cache.cpp
     renderer_vulkan/vk_query_cache.h
     renderer_vulkan/vk_rasterizer.cpp

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -9,6 +9,7 @@
 #include "common/dynamic_library.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_vulkan/vk_blit_screen.h"
+#include "video_core/renderer_vulkan/vk_present_manager.h"
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_state_tracker.h"
@@ -76,6 +77,7 @@ private:
     StateTracker state_tracker;
     Scheduler scheduler;
     Swapchain swapchain;
+    PresentManager present_manager;
     BlitScreen blit_screen;
     RasterizerVulkan rasterizer;
     std::optional<TurboMode> turbo_mode;

--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -450,7 +450,7 @@ void BlitScreen::DrawToSwapchain(Frame* frame, const Tegra::FramebufferConfig& f
     const Layout::FramebufferLayout layout = render_window.GetFramebufferLayout();
     if (layout.width != frame->width || layout.height != frame->height ||
         is_srgb != frame->is_srgb) {
-        scheduler.Finish();
+        Recreate();
         present_manager.RecreateFrame(frame, layout.width, layout.height, is_srgb,
                                       image_view_format, *renderpass);
     }

--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/microprofile.h"
+#include "common/thread.h"
+#include "video_core/renderer_vulkan/vk_present_manager.h"
+#include "video_core/renderer_vulkan/vk_scheduler.h"
+#include "video_core/renderer_vulkan/vk_swapchain.h"
+#include "video_core/vulkan_common/vulkan_device.h"
+
+namespace Vulkan {
+
+MICROPROFILE_DEFINE(Vulkan_WaitPresent, "Vulkan", "Wait For Present", MP_RGB(128, 128, 128));
+MICROPROFILE_DEFINE(Vulkan_CopyToSwapchain, "Vulkan", "Copy to swapchain", MP_RGB(192, 255, 192));
+
+namespace {
+
+bool CanBlitToSwapchain(const vk::PhysicalDevice& physical_device, VkFormat format) {
+    const VkFormatProperties props{physical_device.GetFormatProperties(format)};
+    return (props.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT);
+}
+
+[[nodiscard]] VkImageSubresourceLayers MakeImageSubresourceLayers() {
+    return VkImageSubresourceLayers{
+        .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+        .mipLevel = 0,
+        .baseArrayLayer = 0,
+        .layerCount = 1,
+    };
+}
+
+[[nodiscard]] VkImageBlit MakeImageBlit(s32 frame_width, s32 frame_height, s32 swapchain_width,
+                                        s32 swapchain_height) {
+    return VkImageBlit{
+        .srcSubresource = MakeImageSubresourceLayers(),
+        .srcOffsets =
+            {
+                {
+                    .x = 0,
+                    .y = 0,
+                    .z = 0,
+                },
+                {
+                    .x = frame_width,
+                    .y = frame_height,
+                    .z = 1,
+                },
+            },
+        .dstSubresource = MakeImageSubresourceLayers(),
+        .dstOffsets =
+            {
+                {
+                    .x = 0,
+                    .y = 0,
+                    .z = 0,
+                },
+                {
+                    .x = swapchain_width,
+                    .y = swapchain_height,
+                    .z = 1,
+                },
+            },
+    };
+}
+
+[[nodiscard]] VkImageCopy MakeImageCopy(u32 frame_width, u32 frame_height, u32 swapchain_width,
+                                        u32 swapchain_height) {
+    return VkImageCopy{
+        .srcSubresource = MakeImageSubresourceLayers(),
+        .srcOffset =
+            {
+                .x = 0,
+                .y = 0,
+                .z = 0,
+            },
+        .dstSubresource = MakeImageSubresourceLayers(),
+        .dstOffset =
+            {
+                .x = 0,
+                .y = 0,
+                .z = 0,
+            },
+        .extent =
+            {
+                .width = std::min(frame_width, swapchain_width),
+                .height = std::min(frame_height, swapchain_height),
+                .depth = 1,
+            },
+    };
+}
+
+} // Anonymous namespace
+
+PresentManager::PresentManager(Core::Frontend::EmuWindow& render_window_, const Device& device_,
+                               MemoryAllocator& memory_allocator_, Scheduler& scheduler_,
+                               Swapchain& swapchain_)
+    : render_window{render_window_}, device{device_},
+      memory_allocator{memory_allocator_}, scheduler{scheduler_}, swapchain{swapchain_},
+      blit_supported{CanBlitToSwapchain(device.GetPhysical(), swapchain.GetImageViewFormat())},
+      image_count{swapchain.GetImageCount()} {
+
+    auto& dld = device.GetLogical();
+    cmdpool = dld.CreateCommandPool({
+        .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags =
+            VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+        .queueFamilyIndex = device.GetGraphicsFamily(),
+    });
+    auto cmdbuffers = cmdpool.Allocate(image_count);
+
+    frames.resize(image_count);
+    for (u32 i = 0; i < frames.size(); i++) {
+        Frame& frame = frames[i];
+        frame.cmdbuf = vk::CommandBuffer{cmdbuffers[i], device.GetDispatchLoader()};
+        frame.render_ready = dld.CreateSemaphore({
+            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+            .pNext = nullptr,
+            .flags = 0,
+        });
+        frame.present_done = dld.CreateFence({
+            .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+            .pNext = nullptr,
+            .flags = VK_FENCE_CREATE_SIGNALED_BIT,
+        });
+        free_queue.push(&frame);
+    }
+
+    present_thread = std::jthread([this](std::stop_token token) { PresentThread(token); });
+}
+
+PresentManager::~PresentManager() = default;
+
+Frame* PresentManager::GetRenderFrame() {
+    MICROPROFILE_SCOPE(Vulkan_WaitPresent);
+
+    // Wait for free presentation frames
+    std::unique_lock lock{free_mutex};
+    free_cv.wait(lock, [this] { return !free_queue.empty(); });
+
+    // Take the frame from the queue
+    Frame* frame = free_queue.front();
+    free_queue.pop();
+
+    // Wait for the presentation to be finished so all frame resources are free
+    frame->present_done.Wait();
+    frame->present_done.Reset();
+
+    return frame;
+}
+
+void PresentManager::PushFrame(Frame* frame) {
+    std::unique_lock lock{queue_mutex};
+    present_queue.push(frame);
+    frame_cv.notify_one();
+}
+
+void PresentManager::RecreateFrame(Frame* frame, u32 width, u32 height, bool is_srgb,
+                                   VkFormat image_view_format, VkRenderPass rd) {
+    auto& dld = device.GetLogical();
+
+    frame->width = width;
+    frame->height = height;
+    frame->is_srgb = is_srgb;
+
+    frame->image = dld.CreateImage({
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = swapchain.GetImageFormat(),
+        .extent =
+            {
+                .width = width,
+                .height = height,
+                .depth = 1,
+            },
+        .mipLevels = 1,
+        .arrayLayers = 1,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    });
+
+    frame->image_commit = memory_allocator.Commit(frame->image, MemoryUsage::DeviceLocal);
+
+    frame->image_view = dld.CreateImageView({
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .image = *frame->image,
+        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .format = image_view_format,
+        .components =
+            {
+                .r = VK_COMPONENT_SWIZZLE_IDENTITY,
+                .g = VK_COMPONENT_SWIZZLE_IDENTITY,
+                .b = VK_COMPONENT_SWIZZLE_IDENTITY,
+                .a = VK_COMPONENT_SWIZZLE_IDENTITY,
+            },
+        .subresourceRange =
+            {
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .baseMipLevel = 0,
+                .levelCount = 1,
+                .baseArrayLayer = 0,
+                .layerCount = 1,
+            },
+    });
+
+    const VkImageView image_view{*frame->image_view};
+    frame->framebuffer = dld.CreateFramebuffer({
+        .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .renderPass = rd,
+        .attachmentCount = 1,
+        .pAttachments = &image_view,
+        .width = width,
+        .height = height,
+        .layers = 1,
+    });
+}
+
+void PresentManager::WaitPresent() {
+    // Wait for the present queue to be empty
+    {
+        std::unique_lock queue_lock{queue_mutex};
+        frame_cv.wait(queue_lock, [this] { return present_queue.empty(); });
+    }
+
+    // The above condition will be satisfied when the last frame is taken from the queue.
+    // To ensure that frame has been presented as well take hold of the swapchain
+    // mutex.
+    std::scoped_lock swapchain_lock{swapchain_mutex};
+}
+
+void PresentManager::PresentThread(std::stop_token token) {
+    Common::SetCurrentThreadName("VulkanPresent");
+    while (!token.stop_requested()) {
+        std::unique_lock lock{queue_mutex};
+
+        // Wait for presentation frames
+        Common::CondvarWait(frame_cv, lock, token, [this] { return !present_queue.empty(); });
+        if (token.stop_requested()) {
+            return;
+        }
+
+        // Take the frame and notify anyone waiting
+        Frame* frame = present_queue.front();
+        present_queue.pop();
+        frame_cv.notify_one();
+
+        // By exchanging the lock ownership we take the swapchain lock
+        // before the queue lock goes out of scope. This way the swapchain
+        // lock in WaitPresent is guaranteed to occur after here.
+        std::exchange(lock, std::unique_lock{swapchain_mutex});
+
+        CopyToSwapchain(frame);
+
+        // Free the frame for reuse
+        std::scoped_lock fl{free_mutex};
+        free_queue.push(frame);
+        free_cv.notify_one();
+    }
+}
+
+void PresentManager::CopyToSwapchain(Frame* frame) {
+    MICROPROFILE_SCOPE(Vulkan_CopyToSwapchain);
+
+    const auto recreate_swapchain = [&] {
+        swapchain.Create(frame->width, frame->height, frame->is_srgb);
+        image_count = swapchain.GetImageCount();
+    };
+
+    // If the size or colorspace of the incoming frames has changed, recreate the swapchain
+    // to account for that.
+    const bool srgb_changed = swapchain.NeedsRecreation(frame->is_srgb);
+    const bool size_changed =
+        swapchain.GetWidth() != frame->width || swapchain.GetHeight() != frame->height;
+    if (srgb_changed || size_changed) {
+        recreate_swapchain();
+    }
+
+    while (swapchain.AcquireNextImage()) {
+        recreate_swapchain();
+    }
+
+    const vk::CommandBuffer cmdbuf{frame->cmdbuf};
+    cmdbuf.Begin({
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .pNext = nullptr,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+        .pInheritanceInfo = nullptr,
+    });
+
+    const VkImage image{swapchain.CurrentImage()};
+    const VkExtent2D extent = swapchain.GetExtent();
+    const std::array pre_barriers{
+        VkImageMemoryBarrier{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .pNext = nullptr,
+            .srcAccessMask = 0,
+            .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+            .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+            .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = image,
+            .subresourceRange{
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .baseMipLevel = 0,
+                .levelCount = 1,
+                .baseArrayLayer = 0,
+                .layerCount = VK_REMAINING_ARRAY_LAYERS,
+            },
+        },
+        VkImageMemoryBarrier{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .pNext = nullptr,
+            .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+            .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+            .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+            .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = *frame->image,
+            .subresourceRange{
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .baseMipLevel = 0,
+                .levelCount = 1,
+                .baseArrayLayer = 0,
+                .layerCount = VK_REMAINING_ARRAY_LAYERS,
+            },
+        },
+    };
+    const std::array post_barriers{
+        VkImageMemoryBarrier{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .pNext = nullptr,
+            .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+            .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT,
+            .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = image,
+            .subresourceRange{
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .baseMipLevel = 0,
+                .levelCount = 1,
+                .baseArrayLayer = 0,
+                .layerCount = VK_REMAINING_ARRAY_LAYERS,
+            },
+        },
+        VkImageMemoryBarrier{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .pNext = nullptr,
+            .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+            .dstAccessMask = VK_ACCESS_MEMORY_WRITE_BIT,
+            .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = *frame->image,
+            .subresourceRange{
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .baseMipLevel = 0,
+                .levelCount = 1,
+                .baseArrayLayer = 0,
+                .layerCount = VK_REMAINING_ARRAY_LAYERS,
+            },
+        },
+    };
+
+    cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, {},
+                           {}, {}, pre_barriers);
+
+    if (blit_supported) {
+        cmdbuf.BlitImage(*frame->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, image,
+                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                         MakeImageBlit(frame->width, frame->height, extent.width, extent.height),
+                         VK_FILTER_LINEAR);
+    } else {
+        cmdbuf.CopyImage(*frame->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, image,
+                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                         MakeImageCopy(frame->width, frame->height, extent.width, extent.height));
+    }
+
+    cmdbuf.PipelineBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, {},
+                           {}, {}, post_barriers);
+
+    cmdbuf.End();
+
+    const VkSemaphore present_semaphore = swapchain.CurrentPresentSemaphore();
+    const VkSemaphore render_semaphore = swapchain.CurrentRenderSemaphore();
+    const std::array wait_semaphores = {present_semaphore, *frame->render_ready};
+
+    static constexpr std::array<VkPipelineStageFlags, 2> wait_stage_masks{
+        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+    };
+
+    const VkSubmitInfo submit_info{
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .pNext = nullptr,
+        .waitSemaphoreCount = 2U,
+        .pWaitSemaphores = wait_semaphores.data(),
+        .pWaitDstStageMask = wait_stage_masks.data(),
+        .commandBufferCount = 1,
+        .pCommandBuffers = cmdbuf.address(),
+        .signalSemaphoreCount = 1U,
+        .pSignalSemaphores = &render_semaphore,
+    };
+
+    // Submit the image copy/blit to the swapchain
+    {
+        std::scoped_lock lock{scheduler.submit_mutex};
+        switch (const VkResult result =
+                    device.GetGraphicsQueue().Submit(submit_info, *frame->present_done)) {
+        case VK_SUCCESS:
+            break;
+        case VK_ERROR_DEVICE_LOST:
+            device.ReportLoss();
+            [[fallthrough]];
+        default:
+            vk::Check(result);
+            break;
+        }
+    }
+
+    // Present
+    swapchain.Present(render_semaphore);
+}
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_present_manager.h
+++ b/src/video_core/renderer_vulkan/vk_present_manager.h
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+
+#include "common/common_types.h"
+#include "common/polyfill_thread.h"
+#include "video_core/vulkan_common/vulkan_memory_allocator.h"
+#include "video_core/vulkan_common/vulkan_wrapper.h"
+
+namespace Core::Frontend {
+class EmuWindow;
+} // namespace Core::Frontend
+
+namespace Vulkan {
+
+class Device;
+class Scheduler;
+class Swapchain;
+
+struct Frame {
+    u32 width;
+    u32 height;
+    bool is_srgb;
+    vk::Image image;
+    vk::ImageView image_view;
+    vk::Framebuffer framebuffer;
+    MemoryCommit image_commit;
+    vk::CommandBuffer cmdbuf;
+    vk::Semaphore render_ready;
+    vk::Fence present_done;
+};
+
+class PresentManager {
+public:
+    PresentManager(Core::Frontend::EmuWindow& render_window, const Device& device,
+                   MemoryAllocator& memory_allocator, Scheduler& scheduler, Swapchain& swapchain);
+    ~PresentManager();
+
+    /// Returns the last used presentation frame
+    Frame* GetRenderFrame();
+
+    /// Pushes a frame for presentation
+    void PushFrame(Frame* frame);
+
+    /// Recreates the present frame to match the provided parameters
+    void RecreateFrame(Frame* frame, u32 width, u32 height, bool is_srgb,
+                       VkFormat image_view_format, VkRenderPass rd);
+
+    /// Waits for the present thread to finish presenting all queued frames.
+    void WaitPresent();
+
+private:
+    void PresentThread(std::stop_token token);
+
+    void CopyToSwapchain(Frame* frame);
+
+private:
+    Core::Frontend::EmuWindow& render_window;
+    const Device& device;
+    MemoryAllocator& memory_allocator;
+    Scheduler& scheduler;
+    Swapchain& swapchain;
+    vk::CommandPool cmdpool;
+    std::vector<Frame> frames;
+    std::queue<Frame*> present_queue;
+    std::queue<Frame*> free_queue;
+    std::condition_variable_any frame_cv;
+    std::condition_variable free_cv;
+    std::mutex swapchain_mutex;
+    std::mutex queue_mutex;
+    std::mutex free_mutex;
+    std::jthread present_thread;
+    bool blit_supported{};
+    std::size_t image_count;
+};
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_present_manager.h
+++ b/src/video_core/renderer_vulkan/vk_present_manager.h
@@ -75,7 +75,8 @@ private:
     std::mutex queue_mutex;
     std::mutex free_mutex;
     std::jthread present_thread;
-    bool blit_supported{};
+    bool blit_supported;
+    bool use_present_thread;
     std::size_t image_count;
 };
 

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -34,7 +34,7 @@ public:
     ~Scheduler();
 
     /// Sends the current execution context to the GPU.
-    void Flush(VkSemaphore signal_semaphore = nullptr, VkSemaphore wait_semaphore = nullptr);
+    u64 Flush(VkSemaphore signal_semaphore = nullptr, VkSemaphore wait_semaphore = nullptr);
 
     /// Sends the current execution context to the GPU and waits for it to complete.
     void Finish(VkSemaphore signal_semaphore = nullptr, VkSemaphore wait_semaphore = nullptr);
@@ -105,6 +105,8 @@ public:
     [[nodiscard]] MasterSemaphore& GetMasterSemaphore() const noexcept {
         return *master_semaphore;
     }
+
+    std::mutex submit_mutex;
 
 private:
     class Command {
@@ -201,7 +203,7 @@ private:
 
     void AllocateWorkerCommandBuffer();
 
-    void SubmitExecution(VkSemaphore signal_semaphore, VkSemaphore wait_semaphore);
+    u64 SubmitExecution(VkSemaphore signal_semaphore, VkSemaphore wait_semaphore);
 
     void AllocateNewContext();
 

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -99,18 +99,16 @@ void Swapchain::Create(u32 width_, u32 height_, bool srgb) {
         return;
     }
 
-    device.GetLogical().WaitIdle();
     Destroy();
 
     CreateSwapchain(capabilities, srgb);
     CreateSemaphores();
-    CreateImageViews();
 
     resource_ticks.clear();
     resource_ticks.resize(image_count);
 }
 
-void Swapchain::AcquireNextImage() {
+bool Swapchain::AcquireNextImage() {
     const VkResult result = device.GetLogical().AcquireNextImageKHR(
         *swapchain, std::numeric_limits<u64>::max(), *present_semaphores[frame_index],
         VK_NULL_HANDLE, &image_index);
@@ -127,8 +125,11 @@ void Swapchain::AcquireNextImage() {
         LOG_ERROR(Render_Vulkan, "vkAcquireNextImageKHR returned {}", vk::ToString(result));
         break;
     }
+
     scheduler.Wait(resource_ticks[image_index]);
     resource_ticks[image_index] = scheduler.CurrentTick();
+
+    return is_suboptimal || is_outdated;
 }
 
 void Swapchain::Present(VkSemaphore render_semaphore) {
@@ -143,6 +144,7 @@ void Swapchain::Present(VkSemaphore render_semaphore) {
         .pImageIndices = &image_index,
         .pResults = nullptr,
     };
+    std::scoped_lock lock{scheduler.submit_mutex};
     switch (const VkResult result = present_queue.Present(present_info)) {
     case VK_SUCCESS:
         break;
@@ -168,7 +170,7 @@ void Swapchain::CreateSwapchain(const VkSurfaceCapabilitiesKHR& capabilities, bo
     const auto present_modes{physical_device.GetSurfacePresentModesKHR(surface)};
 
     const VkCompositeAlphaFlagBitsKHR alpha_flags{ChooseAlphaFlags(capabilities)};
-    const VkSurfaceFormatKHR surface_format{ChooseSwapSurfaceFormat(formats)};
+    surface_format = ChooseSwapSurfaceFormat(formats);
     present_mode = ChooseSwapPresentMode(present_modes);
 
     u32 requested_image_count{capabilities.minImageCount + 1};
@@ -193,7 +195,7 @@ void Swapchain::CreateSwapchain(const VkSurfaceCapabilitiesKHR& capabilities, bo
         .imageColorSpace = surface_format.colorSpace,
         .imageExtent = {},
         .imageArrayLayers = 1,
-        .imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+        .imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
         .imageSharingMode = VK_SHARING_MODE_EXCLUSIVE,
         .queueFamilyIndexCount = 0,
         .pQueueFamilyIndices = nullptr,
@@ -241,45 +243,14 @@ void Swapchain::CreateSemaphores() {
     present_semaphores.resize(image_count);
     std::ranges::generate(present_semaphores,
                           [this] { return device.GetLogical().CreateSemaphore(); });
-}
-
-void Swapchain::CreateImageViews() {
-    VkImageViewCreateInfo ci{
-        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
-        .pNext = nullptr,
-        .flags = 0,
-        .image = {},
-        .viewType = VK_IMAGE_VIEW_TYPE_2D,
-        .format = image_view_format,
-        .components =
-            {
-                .r = VK_COMPONENT_SWIZZLE_IDENTITY,
-                .g = VK_COMPONENT_SWIZZLE_IDENTITY,
-                .b = VK_COMPONENT_SWIZZLE_IDENTITY,
-                .a = VK_COMPONENT_SWIZZLE_IDENTITY,
-            },
-        .subresourceRange =
-            {
-                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-                .baseMipLevel = 0,
-                .levelCount = 1,
-                .baseArrayLayer = 0,
-                .layerCount = 1,
-            },
-    };
-
-    image_views.resize(image_count);
-    for (std::size_t i = 0; i < image_count; i++) {
-        ci.image = images[i];
-        image_views[i] = device.GetLogical().CreateImageView(ci);
-    }
+    render_semaphores.resize(image_count);
+    std::ranges::generate(render_semaphores,
+                          [this] { return device.GetLogical().CreateSemaphore(); });
 }
 
 void Swapchain::Destroy() {
     frame_index = 0;
     present_semaphores.clear();
-    framebuffers.clear();
-    image_views.clear();
     swapchain.reset();
 }
 

--- a/src/video_core/renderer_vulkan/vk_swapchain.h
+++ b/src/video_core/renderer_vulkan/vk_swapchain.h
@@ -27,7 +27,7 @@ public:
     void Create(u32 width, u32 height, bool srgb);
 
     /// Acquires the next image in the swapchain, waits as needed.
-    void AcquireNextImage();
+    bool AcquireNextImage();
 
     /// Presents the rendered image to the swapchain.
     void Present(VkSemaphore render_semaphore);
@@ -52,6 +52,11 @@ public:
         return is_suboptimal;
     }
 
+    /// Returns true when the swapchain format is in the srgb color space
+    bool IsSrgb() const {
+        return current_srgb;
+    }
+
     VkExtent2D GetSize() const {
         return extent;
     }
@@ -64,20 +69,32 @@ public:
         return image_index;
     }
 
+    std::size_t GetFrameIndex() const {
+        return frame_index;
+    }
+
     VkImage GetImageIndex(std::size_t index) const {
         return images[index];
     }
 
-    VkImageView GetImageViewIndex(std::size_t index) const {
-        return *image_views[index];
+    VkImage CurrentImage() const {
+        return images[image_index];
     }
 
     VkFormat GetImageViewFormat() const {
         return image_view_format;
     }
 
+    VkFormat GetImageFormat() const {
+        return surface_format.format;
+    }
+
     VkSemaphore CurrentPresentSemaphore() const {
         return *present_semaphores[frame_index];
+    }
+
+    VkSemaphore CurrentRenderSemaphore() const {
+        return *render_semaphores[frame_index];
     }
 
     u32 GetWidth() const {
@@ -86,6 +103,10 @@ public:
 
     u32 GetHeight() const {
         return height;
+    }
+
+    VkExtent2D GetExtent() const {
+        return extent;
     }
 
 private:
@@ -107,10 +128,9 @@ private:
 
     std::size_t image_count{};
     std::vector<VkImage> images;
-    std::vector<vk::ImageView> image_views;
-    std::vector<vk::Framebuffer> framebuffers;
     std::vector<u64> resource_ticks;
     std::vector<vk::Semaphore> present_semaphores;
+    std::vector<vk::Semaphore> render_semaphores;
 
     u32 width;
     u32 height;
@@ -121,6 +141,7 @@ private:
     VkFormat image_view_format{};
     VkExtent2D extent{};
     VkPresentModeKHR present_mode{};
+    VkSurfaceFormatKHR surface_format{};
 
     bool current_srgb{};
     bool current_fps_unlocked{};

--- a/src/video_core/renderer_vulkan/vk_update_descriptor.h
+++ b/src/video_core/renderer_vulkan/vk_update_descriptor.h
@@ -29,6 +29,12 @@ struct DescriptorUpdateEntry {
 };
 
 class UpdateDescriptorQueue final {
+    // This should be plenty for the vast majority of cases. Most desktop platforms only
+    // provide up to 3 swapchain images.
+    static constexpr size_t FRAMES_IN_FLIGHT = 5;
+    static constexpr size_t FRAME_PAYLOAD_SIZE = 0x10000;
+    static constexpr size_t PAYLOAD_SIZE = FRAME_PAYLOAD_SIZE * FRAMES_IN_FLIGHT;
+
 public:
     explicit UpdateDescriptorQueue(const Device& device_, Scheduler& scheduler_);
     ~UpdateDescriptorQueue();
@@ -73,9 +79,11 @@ private:
     const Device& device;
     Scheduler& scheduler;
 
+    size_t frame_index{0};
     DescriptorUpdateEntry* payload_cursor = nullptr;
+    DescriptorUpdateEntry* payload_start = nullptr;
     const DescriptorUpdateEntry* upload_start = nullptr;
-    std::array<DescriptorUpdateEntry, 0x10000> payload;
+    std::array<DescriptorUpdateEntry, PAYLOAD_SIZE> payload;
 };
 
 } // namespace Vulkan

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -692,6 +692,7 @@ void Config::ReadRendererValues() {
     qt_config->beginGroup(QStringLiteral("Renderer"));
 
     ReadGlobalSetting(Settings::values.renderer_backend);
+    ReadGlobalSetting(Settings::values.async_presentation);
     ReadGlobalSetting(Settings::values.renderer_force_max_clock);
     ReadGlobalSetting(Settings::values.vulkan_device);
     ReadGlobalSetting(Settings::values.fullscreen_mode);
@@ -1313,6 +1314,7 @@ void Config::SaveRendererValues() {
                  static_cast<u32>(Settings::values.renderer_backend.GetValue(global)),
                  static_cast<u32>(Settings::values.renderer_backend.GetDefault()),
                  Settings::values.renderer_backend.UsingGlobal());
+    WriteGlobalSetting(Settings::values.async_presentation);
     WriteGlobalSetting(Settings::values.renderer_force_max_clock);
     WriteGlobalSetting(Settings::values.vulkan_device);
     WriteSetting(QString::fromStdString(Settings::values.fullscreen_mode.GetLabel()),

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -22,11 +22,13 @@ ConfigureGraphicsAdvanced::~ConfigureGraphicsAdvanced() = default;
 void ConfigureGraphicsAdvanced::SetConfiguration() {
     const bool runtime_lock = !system.IsPoweredOn();
     ui->use_vsync->setEnabled(runtime_lock);
+    ui->async_present->setEnabled(runtime_lock);
     ui->renderer_force_max_clock->setEnabled(runtime_lock);
     ui->async_astc->setEnabled(runtime_lock);
     ui->use_asynchronous_shaders->setEnabled(runtime_lock);
     ui->anisotropic_filtering_combobox->setEnabled(runtime_lock);
 
+    ui->async_present->setChecked(Settings::values.async_presentation.GetValue());
     ui->renderer_force_max_clock->setChecked(Settings::values.renderer_force_max_clock.GetValue());
     ui->use_vsync->setChecked(Settings::values.use_vsync.GetValue());
     ui->async_astc->setChecked(Settings::values.async_astc.GetValue());
@@ -54,6 +56,8 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
 
 void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.gpu_accuracy, ui->gpu_accuracy);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.async_presentation,
+                                             ui->async_present, async_present);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.renderer_force_max_clock,
                                              ui->renderer_force_max_clock,
                                              renderer_force_max_clock);
@@ -90,6 +94,7 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     // Disable if not global (only happens during game)
     if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setEnabled(Settings::values.gpu_accuracy.UsingGlobal());
+        ui->async_present->setEnabled(Settings::values.async_presentation.UsingGlobal());
         ui->renderer_force_max_clock->setEnabled(
             Settings::values.renderer_force_max_clock.UsingGlobal());
         ui->use_vsync->setEnabled(Settings::values.use_vsync.UsingGlobal());
@@ -107,6 +112,8 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         return;
     }
 
+    ConfigurationShared::SetColoredTristate(ui->async_present, Settings::values.async_presentation,
+                                            async_present);
     ConfigurationShared::SetColoredTristate(ui->renderer_force_max_clock,
                                             Settings::values.renderer_force_max_clock,
                                             renderer_force_max_clock);

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -36,6 +36,7 @@ private:
 
     std::unique_ptr<Ui::ConfigureGraphicsAdvanced> ui;
 
+    ConfigurationShared::CheckState async_present;
     ConfigurationShared::CheckState renderer_force_max_clock;
     ConfigurationShared::CheckState use_vsync;
     ConfigurationShared::CheckState async_astc;

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>404</width>
-    <height>321</height>
+    <height>376</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -70,6 +70,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="async_present">
+          <property name="text">
+           <string>Enable asynchronous presentation (Vulkan only)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="renderer_force_max_clock">
           <property name="toolTip">
            <string>Runs work in the background while waiting for graphics commands to keep the GPU from lowering its clock speed.</string>
@@ -112,7 +119,7 @@
         <item>
          <widget class="QCheckBox" name="use_fast_gpu_time">
           <property name="toolTip">
-            <string>Enables Fast GPU Time. This option will force most games to run at their highest native resolution.</string>
+           <string>Enables Fast GPU Time. This option will force most games to run at their highest native resolution.</string>
           </property>
           <property name="text">
            <string>Use Fast GPU Time (Hack)</string>
@@ -122,7 +129,7 @@
         <item>
          <widget class="QCheckBox" name="use_pessimistic_flushes">
           <property name="toolTip">
-            <string>Enables pessimistic buffer flushes. This option will force unmodified buffers to be flushed, which can cost performance.</string>
+           <string>Enables pessimistic buffer flushes. This option will force unmodified buffers to be flushed, which can cost performance.</string>
           </property>
           <property name="text">
            <string>Use pessimistic buffer flushes (Hack)</string>
@@ -132,7 +139,7 @@
         <item>
          <widget class="QCheckBox" name="use_vulkan_driver_pipeline_cache">
           <property name="toolTip">
-            <string>Enables GPU vendor-specific pipeline cache. This option can improve shader loading time significantly in cases where the Vulkan driver does not store pipeline cache files internally.</string>
+           <string>Enables GPU vendor-specific pipeline cache. This option can improve shader loading time significantly in cases where the Vulkan driver does not store pipeline cache files internally.</string>
           </property>
           <property name="text">
            <string>Use Vulkan pipeline cache</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -300,6 +300,7 @@ void Config::ReadValues() {
 
     // Renderer
     ReadSetting("Renderer", Settings::values.renderer_backend);
+    ReadSetting("Renderer", Settings::values.async_presentation);
     ReadSetting("Renderer", Settings::values.renderer_force_max_clock);
     ReadSetting("Renderer", Settings::values.renderer_debug);
     ReadSetting("Renderer", Settings::values.renderer_shader_feedback);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -264,6 +264,10 @@ cpuopt_unsafe_ignore_global_monitor =
 # 0: OpenGL, 1 (default): Vulkan
 backend =
 
+# Whether to enable asynchronous presentation (Vulkan only)
+# 0 (default): Off, 1: On
+async_presentation =
+
 # Enable graphics API debugging mode.
 # 0 (default): Disabled, 1: Enabled
 debug =


### PR DESCRIPTION
While #9931 fixed a lot of scheduler stalls that occured in DispatchWork, the backend's ability to generate frames in async is still limited due to the fact that WaitWorker must be called at the end of each frame, which may be expensive depending on what the scheduler is [doing](https://github.com/yuzu-emu/yuzu/blob/master/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp#L496). Thus the main goal of this PR is to offload swapchain operations to a separate thread to avoid such a wait and allow the backend to have multiple frames in flight.

The present manager class handles all swapchain calls. It maintains a separate thread that acquires and presents any frames that are pushed to the present queue. The GPU thread will send render frames and wait for free ones, to prevent synchronization errors. Plain semaphores and fences are used since I wasn't able to make it work with timeline semaphores.

I've tested this on both NVIDIA and AMD, window resizing seems to work reliably in addition to screenshots. However due to the nature of the changes some things might break so more testing is needed.