### PR TITLE
vulkan: fix more excessive waiting in scheduler

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -65,12 +65,13 @@ void Scheduler::WaitWorker() {
     DispatchWork();
 
     // Ensure the queue is drained.
-    std::unique_lock ql{queue_mutex};
-    event_cv.wait(ql, [this] { return work_queue.empty(); });
+    {
+        std::unique_lock ql{queue_mutex};
+        event_cv.wait(ql, [this] { return work_queue.empty(); });
+    }
 
     // Now wait for execution to finish.
-    // This needs to be done in the same order as WorkerThread.
-    std::unique_lock el{execution_mutex};
+    std::scoped_lock el{execution_mutex};
 }
 
 void Scheduler::DispatchWork() {


### PR DESCRIPTION
Noticed this issue while reviewing #9973. WaitWorker would end up holding the queue mutex until the execution mutex was released, which would cause anything that wanted to push to the queue to wait.