### PR TITLE
nfc: Initialize device when controller is connected

### DIFF
--- a/src/core/hle/service/nfc/nfc_device.cpp
+++ b/src/core/hle/service/nfc/nfc_device.cpp
@@ -42,8 +42,18 @@ NfcDevice::~NfcDevice() {
 };
 
 void NfcDevice::NpadUpdate(Core::HID::ControllerTriggerType type) {
-    if (type == Core::HID::ControllerTriggerType::Connected ||
-        type == Core::HID::ControllerTriggerType::Disconnected) {
+    if (!is_initalized) {
+        return;
+    }
+
+    if (type == Core::HID::ControllerTriggerType::Connected) {
+        Initialize();
+        availability_change_event->Signal();
+        return;
+    }
+
+    if (type == Core::HID::ControllerTriggerType::Disconnected) {
+        device_state = NFP::DeviceState::Unavailable;
         availability_change_event->Signal();
         return;
     }
@@ -113,6 +123,7 @@ void NfcDevice::Initialize() {
     device_state =
         npad_device->HasNfc() ? NFP::DeviceState::Initialized : NFP::DeviceState::Unavailable;
     encrypted_tag_data = {};
+    is_initalized = true;
 }
 
 void NfcDevice::Finalize() {
@@ -121,6 +132,7 @@ void NfcDevice::Finalize() {
         StopDetection();
     }
     device_state = NFP::DeviceState::Unavailable;
+    is_initalized = false;
 }
 
 Result NfcDevice::StartDetection(NFP::TagProtocol allowed_protocol) {

--- a/src/core/hle/service/nfc/nfc_device.h
+++ b/src/core/hle/service/nfc/nfc_device.h
@@ -67,6 +67,7 @@ private:
     Kernel::KEvent* deactivate_event = nullptr;
     Kernel::KEvent* availability_change_event = nullptr;
 
+    bool is_initalized{};
     NFP::TagProtocol allowed_protocols{};
     NFP::DeviceState device_state{NFP::DeviceState::Unavailable};
 

--- a/src/core/hle/service/nfp/nfp_device.cpp
+++ b/src/core/hle/service/nfp/nfp_device.cpp
@@ -66,8 +66,18 @@ NfpDevice::~NfpDevice() {
 };
 
 void NfpDevice::NpadUpdate(Core::HID::ControllerTriggerType type) {
-    if (type == Core::HID::ControllerTriggerType::Connected ||
-        type == Core::HID::ControllerTriggerType::Disconnected) {
+    if (!is_initalized) {
+        return;
+    }
+
+    if (type == Core::HID::ControllerTriggerType::Connected) {
+        Initialize();
+        availability_change_event->Signal();
+        return;
+    }
+
+    if (type == Core::HID::ControllerTriggerType::Disconnected) {
+        device_state = DeviceState::Unavailable;
         availability_change_event->Signal();
         return;
     }
@@ -145,6 +155,7 @@ void NfpDevice::Initialize() {
     device_state = npad_device->HasNfc() ? DeviceState::Initialized : DeviceState::Unavailable;
     encrypted_tag_data = {};
     tag_data = {};
+    is_initalized = true;
 }
 
 void NfpDevice::Finalize() {
@@ -155,6 +166,7 @@ void NfpDevice::Finalize() {
         StopDetection();
     }
     device_state = DeviceState::Unavailable;
+    is_initalized = false;
 }
 
 Result NfpDevice::StartDetection(TagProtocol allowed_protocol) {

--- a/src/core/hle/service/nfp/nfp_device.h
+++ b/src/core/hle/service/nfp/nfp_device.h
@@ -92,6 +92,7 @@ private:
     Kernel::KEvent* deactivate_event = nullptr;
     Kernel::KEvent* availability_change_event = nullptr;
 
+    bool is_initalized{};
     bool is_data_moddified{};
     bool is_app_area_open{};
     TagProtocol allowed_protocols{};


### PR DESCRIPTION
Minor bug I found while testing the feature. We need to initialize or finalize the controller when the connection status changes.