### PR TITLE
x64: Make use of waitpkg instructions for power efficient sleeps

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -160,6 +160,8 @@ if(ARCHITECTURE_x86_64)
         PRIVATE
             x64/cpu_detect.cpp
             x64/cpu_detect.h
+            x64/cpu_wait.cpp
+            x64/cpu_wait.h
             x64/native_clock.cpp
             x64/native_clock.h
             x64/xbyak_abi.h

--- a/src/common/telemetry.cpp
+++ b/src/common/telemetry.cpp
@@ -97,6 +97,7 @@ void AppendCPUInfo(FieldCollection& fc) {
     add_field("CPU_Extension_x64_PCLMULQDQ", caps.pclmulqdq);
     add_field("CPU_Extension_x64_POPCNT", caps.popcnt);
     add_field("CPU_Extension_x64_SHA", caps.sha);
+    add_field("CPU_Extension_x64_WAITPKG", caps.waitpkg);
 #else
     fc.AddField(FieldType::UserSystem, "CPU_Model", "Other");
 #endif

--- a/src/common/x64/cpu_detect.cpp
+++ b/src/common/x64/cpu_detect.cpp
@@ -144,6 +144,7 @@ static CPUCaps Detect() {
             caps.bmi2 = Common::Bit<8>(cpu_id[1]);
             caps.sha = Common::Bit<29>(cpu_id[1]);
 
+            caps.waitpkg = Common::Bit<5>(cpu_id[2]);
             caps.gfni = Common::Bit<8>(cpu_id[2]);
 
             __cpuidex(cpu_id, 0x00000007, 0x00000001);

--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -67,6 +67,7 @@ struct CPUCaps {
     bool pclmulqdq : 1;
     bool popcnt : 1;
     bool sha : 1;
+    bool waitpkg : 1;
 };
 
 /**

--- a/src/common/x64/cpu_wait.cpp
+++ b/src/common/x64/cpu_wait.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <thread>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+#include "common/x64/cpu_detect.h"
+#include "common/x64/cpu_wait.h"
+
+namespace Common::X64 {
+
+#ifdef _MSC_VER
+__forceinline static u64 FencedRDTSC() {
+    _mm_lfence();
+    _ReadWriteBarrier();
+    const u64 result = __rdtsc();
+    _mm_lfence();
+    _ReadWriteBarrier();
+    return result;
+}
+
+__forceinline static void TPAUSE() {
+    // 100,000 cycles is a reasonable amount of time to wait to save on CPU resources.
+    // For reference:
+    // At 1 GHz, 100K cycles is 100us
+    // At 2 GHz, 100K cycles is 50us
+    // At 4 GHz, 100K cycles is 25us
+    static constexpr auto PauseCycles = 100'000;
+    _tpause(0, FencedRDTSC() + PauseCycles);
+}
+#else
+static u64 FencedRDTSC() {
+    u64 result;
+    asm volatile("lfence\n\t"
+                 "rdtsc\n\t"
+                 "shl $32, %%rdx\n\t"
+                 "or %%rdx, %0\n\t"
+                 "lfence"
+                 : "=a"(result)
+                 :
+                 : "rdx", "memory", "cc");
+    return result;
+}
+
+static void TPAUSE() {
+    // 100,000 cycles is a reasonable amount of time to wait to save on CPU resources.
+    // For reference:
+    // At 1 GHz, 100K cycles is 100us
+    // At 2 GHz, 100K cycles is 50us
+    // At 4 GHz, 100K cycles is 25us
+    static constexpr auto PauseCycles = 100'000;
+    const auto tsc = FencedRDTSC() + PauseCycles;
+    const auto eax = static_cast<u32>(tsc & 0xFFFFFFFF);
+    const auto edx = static_cast<u32>(tsc >> 32);
+    asm volatile("tpause %0" : : "r"(0), "d"(edx), "a"(eax));
+}
+#endif
+
+void MicroSleep() {
+    static const bool has_waitpkg = GetCPUCaps().waitpkg;
+
+    if (has_waitpkg) {
+        TPAUSE();
+    } else {
+        std::this_thread::yield();
+    }
+}
+
+} // namespace Common::X64

--- a/src/common/x64/cpu_wait.cpp
+++ b/src/common/x64/cpu_wait.cpp
@@ -33,16 +33,13 @@ __forceinline static void TPAUSE() {
 }
 #else
 static u64 FencedRDTSC() {
-    u64 result;
+    u64 eax;
+    u64 edx;
     asm volatile("lfence\n\t"
                  "rdtsc\n\t"
-                 "shl $32, %%rdx\n\t"
-                 "or %%rdx, %0\n\t"
-                 "lfence"
-                 : "=a"(result)
-                 :
-                 : "rdx", "memory", "cc");
-    return result;
+                 "lfence\n\t"
+                 : "=a"(eax), "=d"(edx));
+    return (edx << 32) | eax;
 }
 
 static void TPAUSE() {

--- a/src/common/x64/cpu_wait.h
+++ b/src/common/x64/cpu_wait.h
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace Common::X64 {
+
+void MicroSleep();
+
+} // namespace Common::X64

--- a/src/common/x64/native_clock.cpp
+++ b/src/common/x64/native_clock.cpp
@@ -27,16 +27,13 @@ __forceinline static u64 FencedRDTSC() {
 }
 #else
 static u64 FencedRDTSC() {
-    u64 result;
+    u64 eax;
+    u64 edx;
     asm volatile("lfence\n\t"
                  "rdtsc\n\t"
-                 "shl $32, %%rdx\n\t"
-                 "or %%rdx, %0\n\t"
-                 "lfence"
-                 : "=a"(result)
-                 :
-                 : "rdx", "memory", "cc");
-    return result;
+                 "lfence\n\t"
+                 : "=a"(eax), "=d"(edx));
+    return (edx << 32) | eax;
 }
 #endif
 

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -10,6 +10,10 @@
 #include "common/windows/timer_resolution.h"
 #endif
 
+#ifdef ARCHITECTURE_x86_64
+#include "common/x64/cpu_wait.h"
+#endif
+
 #include "common/microprofile.h"
 #include "core/core_timing.h"
 #include "core/core_timing_util.h"
@@ -269,7 +273,11 @@ void CoreTiming::ThreadLoop() {
                         if (wait_time >= timer_resolution_ns) {
                             Common::Windows::SleepForOneTick();
                         } else {
+#ifdef ARCHITECTURE_x86_64
+                            Common::X64::MicroSleep();
+#else
                             std::this_thread::yield();
+#endif
                         }
                     }
 


### PR DESCRIPTION
Intel introduced the new waitpkg instructions starting with their 12th Gen Alder Lake CPUs.
Of particular interest is [TPAUSE](https://www.felixcloutier.com/x86/tpause), which enables the processor to go to a lower power state while waiting for the TSC counter deadline to pass.

We have chosen a value of 100,000 cycles as a standard value to wait for, as it provides a balance between power savings and timer precision.
For reference:
At 1 GHz, 100K cycles is 100us
At 2 GHz, 100K cycles is 50us
At 4 GHz, 100K cycles is 25us

This has resulted in measurable power savings (10-20%), building upon the power savings from #9889, but exclusive to CPUs supporting these instructions (Intel 12th gen and newer for now).