### PR TITLE
container_hash: use climits

### DIFF
--- a/src/common/container_hash.h
+++ b/src/common/container_hash.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 #include <array>
+#include <climits>
 #include <cstdint>
 #include <limits>
 #include <type_traits>


### PR DESCRIPTION
```
In file included from src/video_core/macro/macro.cpp:9:
src/./common/container_hash.h: In function ‘void Common::HashCombine(std::size_t&, const T&)’:
src/./common/container_hash.h:67:58: error: ‘CHAR_BIT’ was not declared in this scope
   67 |     seed = detail::HashCombineImpl<sizeof(std::size_t) * CHAR_BIT>::fn(seed, detail::HashValue(v));
      |                                                          ^~~~~~~~
src/./common/container_hash.h:10:1: note: ‘CHAR_BIT’ is defined in header ‘<climits>’; did you forget to ‘#include <climits>’?
    9 | #include <vector>
  +++ |+#include <climits>
   10 | 
src/./common/container_hash.h:67:66: error: template argument 1 is invalid
   67 |     seed = detail::HashCombineImpl<sizeof(std::size_t) * CHAR_BIT>::fn(seed, detail::HashValue(v));
      |                                                                  ^
```