### PR TITLE
service: nfp: Add plain amiibo support

### DIFF
--- a/src/core/hle/service/nfp/amiibo_crypto.cpp
+++ b/src/core/hle/service/nfp/amiibo_crypto.cpp
@@ -70,6 +70,10 @@ bool IsAmiiboValid(const EncryptedNTAG215File& ntag_file) {
     return true;
 }
 
+bool IsAmiiboValid(const NTAG215File& ntag_file) {
+    return IsAmiiboValid(EncodedDataToNfcData(ntag_file));
+}
+
 NTAG215File NfcDataToEncodedData(const EncryptedNTAG215File& nfc_data) {
     NTAG215File encoded_data{};
 

--- a/src/core/hle/service/nfp/amiibo_crypto.h
+++ b/src/core/hle/service/nfp/amiibo_crypto.h
@@ -60,6 +60,9 @@ static_assert(sizeof(DerivedKeys) == 0x30, "DerivedKeys is an invalid size");
 /// Validates that the amiibo file is not corrupted
 bool IsAmiiboValid(const EncryptedNTAG215File& ntag_file);
 
+/// Validates that the amiibo file is not corrupted
+bool IsAmiiboValid(const NTAG215File& ntag_file);
+
 /// Converts from encrypted file format to encoded file format
 NTAG215File NfcDataToEncodedData(const EncryptedNTAG215File& nfc_data);
 

--- a/src/core/hle/service/nfp/nfp_device.h
+++ b/src/core/hle/service/nfp/nfp_device.h
@@ -95,6 +95,7 @@ private:
     bool is_initalized{};
     bool is_data_moddified{};
     bool is_app_area_open{};
+    bool is_plain_amiibo{};
     TagProtocol allowed_protocols{};
     s64 current_posix_time{};
     MountTarget mount_target{MountTarget::None};

--- a/src/core/hle/service/nfp/nfp_types.h
+++ b/src/core/hle/service/nfp/nfp_types.h
@@ -309,7 +309,8 @@ struct EncryptedNTAG215File {
     u32 CFG1;                        // Defines number of verification attempts
     NTAG215Password password;        // Password data
 };
-static_assert(sizeof(EncryptedNTAG215File) == 0x21C, "EncryptedNTAG215File is an invalid size");
+static_assert(sizeof(EncryptedNTAG215File) == sizeof(NTAG215File),
+              "EncryptedNTAG215File is an invalid size");
 static_assert(std::is_trivially_copyable_v<EncryptedNTAG215File>,
               "EncryptedNTAG215File must be trivially copyable.");
 


### PR DESCRIPTION
It was rather easy to add support now. So why don't have it. This PR allows to load plain amiibo files, since they aren't encrypted there is no need for keys. This still requires a valid amiibo dump.