### PR TITLE
qt: Fix log softlock

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -307,6 +307,8 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
     system->Initialize();
 
     Common::Log::Initialize();
+    Common::Log::Start();
+
     LoadTranslation();
 
     setAcceptDrops(true);
@@ -448,8 +450,6 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
 #endif
 
     SetupPrepareForSleep();
-
-    Common::Log::Start();
 
     QStringList args = QApplication::arguments();
 


### PR DESCRIPTION
Some users where having softlocks at boot. For some reason we don't start logging right away but we do push logs into the queue. If we fill the queue before the log starts yuzu softlocks.