### PR TITLE
service: hid: Silence warning on MergeSingleJoyAsDualJoy

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -1388,7 +1388,8 @@ Result Controller_NPad::MergeSingleJoyAsDualJoy(Core::HID::NpadIdType npad_id_1,
         return NpadIsDualJoycon;
     }
 
-    // Disconnect the joycon at the second id and connect the dual joycon at the first index.
+    // Disconnect the joycons and connect them as dual joycon at the first index.
+    DisconnectNpad(npad_id_1);
     DisconnectNpad(npad_id_2);
     controller_1.is_dual_left_connected = true;
     controller_1.is_dual_right_connected = true;


### PR DESCRIPTION
We can't change controller style without disconnecting the controller first. So we need to disconnect both then connect them as dual joycon to avoid any errors. 