### PR TITLE
Fix: 'Continous' typo

### DIFF
--- a/src/common/range_map.h
+++ b/src/common/range_map.h
@@ -38,12 +38,12 @@ public:
         Map(address, address_end, null_value);
     }
 
-    [[nodiscard]] size_t GetContinousSizeFrom(KeyTBase address) const {
+    [[nodiscard]] size_t GetContinuousSizeFrom(KeyTBase address) const {
         const KeyT new_address = static_cast<KeyT>(address);
         if (new_address < 0) {
             return 0;
         }
-        return ContinousSizeInternal(new_address);
+        return ContinuousSizeInternal(new_address);
     }
 
     [[nodiscard]] ValueT GetValueAt(KeyT address) const {
@@ -59,7 +59,7 @@ private:
     using IteratorType = typename MapType::iterator;
     using ConstIteratorType = typename MapType::const_iterator;
 
-    size_t ContinousSizeInternal(KeyT address) const {
+    size_t ContinuousSizeInternal(KeyT address) const {
         const auto it = GetFirstElementBeforeOrOn(address);
         if (it == container.end() || it->second == null_value) {
             return 0;

--- a/src/tests/common/range_map.cpp
+++ b/src/tests/common/range_map.cpp
@@ -21,9 +21,9 @@ TEST_CASE("Range Map: Setup", "[video_core]") {
     my_map.Map(4000, 4500, MappedEnum::Valid_2);
     my_map.Map(4200, 4400, MappedEnum::Valid_2);
     my_map.Map(4200, 4400, MappedEnum::Valid_1);
-    REQUIRE(my_map.GetContinousSizeFrom(4200) == 200);
-    REQUIRE(my_map.GetContinousSizeFrom(3000) == 200);
-    REQUIRE(my_map.GetContinousSizeFrom(2900) == 0);
+    REQUIRE(my_map.GetContinuousSizeFrom(4200) == 200);
+    REQUIRE(my_map.GetContinuousSizeFrom(3000) == 200);
+    REQUIRE(my_map.GetContinuousSizeFrom(2900) == 0);
 
     REQUIRE(my_map.GetValueAt(2900) == MappedEnum::Invalid);
     REQUIRE(my_map.GetValueAt(3100) == MappedEnum::Valid_1);
@@ -38,20 +38,20 @@ TEST_CASE("Range Map: Setup", "[video_core]") {
 
     my_map.Unmap(0, 6000);
     for (u64 address = 0; address < 10000; address += 1000) {
-        REQUIRE(my_map.GetContinousSizeFrom(address) == 0);
+        REQUIRE(my_map.GetContinuousSizeFrom(address) == 0);
     }
 
     my_map.Map(1000, 3000, MappedEnum::Valid_1);
     my_map.Map(4000, 5000, MappedEnum::Valid_1);
     my_map.Map(2500, 4100, MappedEnum::Valid_1);
-    REQUIRE(my_map.GetContinousSizeFrom(1000) == 4000);
+    REQUIRE(my_map.GetContinuousSizeFrom(1000) == 4000);
 
     my_map.Map(1000, 3000, MappedEnum::Valid_1);
     my_map.Map(4000, 5000, MappedEnum::Valid_2);
     my_map.Map(2500, 4100, MappedEnum::Valid_3);
-    REQUIRE(my_map.GetContinousSizeFrom(1000) == 1500);
-    REQUIRE(my_map.GetContinousSizeFrom(2500) == 1600);
-    REQUIRE(my_map.GetContinousSizeFrom(4100) == 900);
+    REQUIRE(my_map.GetContinuousSizeFrom(1000) == 1500);
+    REQUIRE(my_map.GetContinuousSizeFrom(2500) == 1600);
+    REQUIRE(my_map.GetContinuousSizeFrom(4100) == 900);
     REQUIRE(my_map.GetValueAt(900) == MappedEnum::Invalid);
     REQUIRE(my_map.GetValueAt(1000) == MappedEnum::Valid_1);
     REQUIRE(my_map.GetValueAt(2500) == MappedEnum::Valid_3);
@@ -59,8 +59,8 @@ TEST_CASE("Range Map: Setup", "[video_core]") {
     REQUIRE(my_map.GetValueAt(5000) == MappedEnum::Invalid);
 
     my_map.Map(2000, 6000, MappedEnum::Valid_3);
-    REQUIRE(my_map.GetContinousSizeFrom(1000) == 1000);
-    REQUIRE(my_map.GetContinousSizeFrom(3000) == 3000);
+    REQUIRE(my_map.GetContinuousSizeFrom(1000) == 1000);
+    REQUIRE(my_map.GetContinuousSizeFrom(3000) == 3000);
     REQUIRE(my_map.GetValueAt(1000) == MappedEnum::Valid_1);
     REQUIRE(my_map.GetValueAt(1999) == MappedEnum::Valid_1);
     REQUIRE(my_map.GetValueAt(1500) == MappedEnum::Valid_1);

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1442,7 +1442,7 @@ void BufferCache<P>::UpdateVertexBuffer(u32 index) {
     }
     if (!gpu_memory->IsWithinGPUAddressRange(gpu_addr_end)) {
         address_size =
-            static_cast<u32>(gpu_memory->MaxContinousRange(gpu_addr_begin, address_size));
+            static_cast<u32>(gpu_memory->MaxContinuousRange(gpu_addr_begin, address_size));
     }
     const u32 size = address_size; // TODO: Analyze stride and number of vertices
     vertex_buffers[index] = Binding{

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -94,7 +94,7 @@ public:
     /**
      * Checks if a gpu region is mapped by a single range of cpu addresses.
      */
-    [[nodiscard]] bool IsContinousRange(GPUVAddr gpu_addr, std::size_t size) const;
+    [[nodiscard]] bool IsContinuousRange(GPUVAddr gpu_addr, std::size_t size) const;
 
     /**
      * Checks if a gpu region is mapped entirely.
@@ -123,7 +123,7 @@ public:
     bool IsMemoryDirty(GPUVAddr gpu_addr, size_t size,
                        VideoCommon::CacheType which = VideoCommon::CacheType::All) const;
 
-    size_t MaxContinousRange(GPUVAddr gpu_addr, size_t size) const;
+    size_t MaxContinuousRange(GPUVAddr gpu_addr, size_t size) const;
 
     bool IsWithinGPUAddressRange(GPUVAddr gpu_addr) const {
         return gpu_addr < address_space_size;
@@ -158,8 +158,8 @@ private:
         }
     }
 
-    inline bool IsBigPageContinous(size_t big_page_index) const;
-    inline void SetBigPageContinous(size_t big_page_index, bool value);
+    inline bool IsBigPageContinuous(size_t big_page_index) const;
+    inline void SetBigPageContinuous(size_t big_page_index, bool value);
 
     template <bool is_gpu_address>
     void GetSubmappedRangeImpl(
@@ -213,10 +213,10 @@ private:
     Common::RangeMap<GPUVAddr, PTEKind> kind_map;
     Common::VirtualBuffer<u32> big_page_table_cpu;
 
-    std::vector<u64> big_page_continous;
+    std::vector<u64> big_page_continuous;
     std::vector<std::pair<VAddr, std::size_t>> page_stash{};
 
-    static constexpr size_t continous_bits = 64;
+    static constexpr size_t continuous_bits = 64;
 
     const size_t unique_identifier;
     std::unique_ptr<VideoCommon::InvalidationAccumulator> accumulator;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1269,7 +1269,7 @@ ImageId TextureCache<P>::JoinImages(const ImageInfo& info, GPUVAddr gpu_addr, VA
     const ImageId new_image_id = slot_images.insert(runtime, new_info, gpu_addr, cpu_addr);
     Image& new_image = slot_images[new_image_id];
 
-    if (!gpu_memory->IsContinousRange(new_image.gpu_addr, new_image.guest_size_bytes)) {
+    if (!gpu_memory->IsContinuousRange(new_image.gpu_addr, new_image.guest_size_bytes)) {
         new_image.flags |= ImageFlagBits::Sparse;
     }
 


### PR DESCRIPTION
This changes 'Continous' to its proper spelling 'Continuous'. Found throughout the codebase, so I just labeled the PR as Fix. Let me know if I missed any.