### PR TITLE
externals: update Vulkan-Headers to v1.3.246 to fix -Werror=switch with system package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ find_package(ZLIB 1.2 REQUIRED)
 find_package(zstd 1.5 REQUIRED)
 
 if (NOT YUZU_USE_EXTERNAL_VULKAN_HEADERS)
-    find_package(Vulkan 1.3.238 REQUIRED)
+    find_package(Vulkan 1.3.246 REQUIRED)
 endif()
 
 if (ENABLE_LIBUSB)

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -375,6 +375,8 @@ const char* ToString(VkResult result) noexcept {
         return "VK_RESULT_MAX_ENUM";
     case VkResult::VK_ERROR_COMPRESSION_EXHAUSTED_EXT:
         return "VK_ERROR_COMPRESSION_EXHAUSTED_EXT";
+    case VkResult::VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT:
+        return "VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT";
     }
     return "Unknown";
 }


### PR DESCRIPTION
[VK_EXT_shader_object](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_object.html) extends `VkResult`. Some distros [already updated](https://repology.org/project/vulkan-headers/history).

```c++
src/video_core/vulkan_common/vulkan_wrapper.cpp:285:13: error: enumeration value 'VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT' not handled in switch [-Werror,-Wswitch]
    switch (result) {
            ^~~~~~
```
