### PR TITLE
general: fixes for gcc 13

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,17 @@ else()
         add_compile_options("-stdlib=libc++")
     endif()
 
+    # GCC bugs
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        # These diagnostics would be great if they worked, but are just completely broken
+        # and produce bogus errors on external libraries like fmt.
+        add_compile_options(
+            -Wno-array-bounds
+            -Wno-stringop-overread
+            -Wno-stringop-overflow
+        )
+    endif()
+
     # Set file offset size to 64 bits.
     #
     # On modern Unixes, this is typically already the case. The lone exception is

--- a/src/common/intrusive_red_black_tree.h
+++ b/src/common/intrusive_red_black_tree.h
@@ -96,10 +96,6 @@ public:
             return m_node == rhs.m_node;
         }
 
-        constexpr bool operator!=(const Iterator& rhs) const {
-            return !(*this == rhs);
-        }
-
         constexpr pointer operator->() const {
             return m_node;
         }
@@ -322,10 +318,6 @@ public:
     public:
         constexpr bool operator==(const Iterator& rhs) const {
             return m_impl == rhs.m_impl;
-        }
-
-        constexpr bool operator!=(const Iterator& rhs) const {
-            return !(*this == rhs);
         }
 
         constexpr pointer operator->() const {

--- a/src/common/typed_address.h
+++ b/src/common/typed_address.h
@@ -116,16 +116,11 @@ public:
 
     // Comparison operators.
     constexpr bool operator==(const TypedAddress&) const = default;
-    constexpr bool operator!=(const TypedAddress&) const = default;
     constexpr auto operator<=>(const TypedAddress&) const = default;
 
     // For convenience, also define comparison operators versus uint64_t.
     constexpr inline bool operator==(uint64_t rhs) const {
         return m_address == rhs;
-    }
-
-    constexpr inline bool operator!=(uint64_t rhs) const {
-        return m_address != rhs;
     }
 
     // Allow getting the address explicitly, for use in accessors.

--- a/src/core/internal_network/socket_proxy.h
+++ b/src/core/internal_network/socket_proxy.h
@@ -16,9 +16,6 @@ namespace Network {
 
 class ProxySocket : public SocketBase {
 public:
-    YUZU_NON_COPYABLE(ProxySocket);
-    YUZU_NON_MOVEABLE(ProxySocket);
-
     explicit ProxySocket(RoomNetwork& room_network_) noexcept;
     ~ProxySocket() override;
 

--- a/src/core/internal_network/sockets.h
+++ b/src/core/internal_network/sockets.h
@@ -36,13 +36,10 @@ public:
 
     SocketBase() = default;
     explicit SocketBase(SOCKET fd_) : fd{fd_} {}
-
     virtual ~SocketBase() = default;
 
-    virtual SocketBase& operator=(const SocketBase&) = delete;
-
-    // Avoid closing sockets implicitly
-    virtual SocketBase& operator=(SocketBase&&) noexcept = delete;
+    YUZU_NON_COPYABLE(SocketBase);
+    YUZU_NON_MOVEABLE(SocketBase);
 
     virtual Errno Initialize(Domain domain, Type type, Protocol protocol) = 0;
 
@@ -109,13 +106,7 @@ public:
 
     ~Socket() override;
 
-    Socket(const Socket&) = delete;
-    Socket& operator=(const Socket&) = delete;
-
     Socket(Socket&& rhs) noexcept;
-
-    // Avoid closing sockets implicitly
-    Socket& operator=(Socket&&) noexcept = delete;
 
     Errno Initialize(Domain domain, Type type, Protocol protocol) override;
 

--- a/src/web_service/verify_login.cpp
+++ b/src/web_service/verify_login.cpp
@@ -21,7 +21,7 @@ bool VerifyLogin(const std::string& host, const std::string& username, const std
         return username.empty();
     }
 
-    return username == *iter;
+    return *iter == username;
 }
 
 } // namespace WebService


### PR DESCRIPTION
In this round of "why does this break every time", we see that gcc 13 and clang 16 regress implicit conversions in equality comparisons due to a change introduced for C++20 standard compliance (see section 4 "rewritten candidates" here https://en.cppreference.com/w/cpp/language/overload_resolution).

This also sets -Wno-array-bounds, Wno-stringop-overread, -Wno-stringop-overflow for gcc 12+. These would be amazing to have if they worked, but just produce so many bogus diagnostics that there is no point keeping them enabled. Hopefully clang will eventually introduce working versions of the stringop warnings.