### PR TITLE
core: Add support for loading NSPs with personalized tickets.

### DIFF
--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -556,28 +556,35 @@ static std::optional<u64> FindTicketOffset(const std::array<u8, size>& data) {
     return offset;
 }
 
-std::optional<std::pair<Key128, Key128>> ParseTicket(const Ticket& ticket,
-                                                     const RSAKeyPair<2048>& key) {
+std::optional<Key128> KeyManager::ParseTicketTitleKey(const Ticket& ticket) {
+    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
+        LOG_WARNING(Crypto,
+                    "Skipping ticket title key parsing due to missing ETicket RSA key-pair.");
+        return std::nullopt;
+    }
+
     if (!ticket.IsValid()) {
+        LOG_WARNING(Crypto, "Attempted to parse title key of invalid ticket.");
+        return std::nullopt;
+    }
+
+    if (ticket.GetData().rights_id == Key128{}) {
+        LOG_WARNING(Crypto, "Attempted to parse title key of ticket with no rights ID.");
         return std::nullopt;
     }
 
     const auto issuer = ticket.GetData().issuer;
     if (IsAllZeroArray(issuer)) {
+        LOG_WARNING(Crypto, "Attempted to parse title key of ticket with invalid issuer.");
         return std::nullopt;
     }
+
     if (issuer[0] != 'R' || issuer[1] != 'o' || issuer[2] != 'o' || issuer[3] != 't') {
-        LOG_INFO(Crypto, "Attempting to parse ticket with non-standard certificate authority.");
-    }
-
-    Key128 rights_id = ticket.GetData().rights_id;
-
-    if (rights_id == Key128{}) {
-        return std::nullopt;
+        LOG_WARNING(Crypto, "Parsing ticket with non-standard certificate authority.");
     }
 
     if (ticket.GetData().type == TitleKeyType::Common) {
-        return std::make_pair(rights_id, ticket.GetData().title_key_common);
+        return ticket.GetData().title_key_common;
     }
 
     mbedtls_mpi D; // RSA Private Exponent
@@ -590,9 +597,12 @@ std::optional<std::pair<Key128, Key128>> ParseTicket(const Ticket& ticket,
     mbedtls_mpi_init(&S);
     mbedtls_mpi_init(&M);
 
-    mbedtls_mpi_read_binary(&D, key.decryption_key.data(), key.decryption_key.size());
-    mbedtls_mpi_read_binary(&N, key.modulus.data(), key.modulus.size());
-    mbedtls_mpi_read_binary(&S, ticket.GetData().title_key_block.data(), 0x100);
+    const auto& title_key_block = ticket.GetData().title_key_block;
+    mbedtls_mpi_read_binary(&D, eticket_rsa_keypair.decryption_key.data(),
+                            eticket_rsa_keypair.decryption_key.size());
+    mbedtls_mpi_read_binary(&N, eticket_rsa_keypair.modulus.data(),
+                            eticket_rsa_keypair.modulus.size());
+    mbedtls_mpi_read_binary(&S, title_key_block.data(), title_key_block.size());
 
     mbedtls_mpi_exp_mod(&M, &S, &D, &N, nullptr);
 
@@ -620,8 +630,7 @@ std::optional<std::pair<Key128, Key128>> ParseTicket(const Ticket& ticket,
 
     Key128 key_temp{};
     std::memcpy(key_temp.data(), m_2.data() + *offset, key_temp.size());
-
-    return std::make_pair(rights_id, key_temp);
+    return key_temp;
 }
 
 KeyManager::KeyManager() {
@@ -1199,30 +1208,12 @@ void KeyManager::PopulateTickets() {
     const Common::FS::IOFile save_e2{system_save_e2_path, Common::FS::FileAccessMode::Read,
                                      Common::FS::FileType::BinaryFile};
 
+    auto tickets = GetTicketblob(save_e1);
     const auto blob2 = GetTicketblob(save_e2);
-    auto res = GetTicketblob(save_e1);
+    tickets.insert(tickets.end(), blob2.begin(), blob2.end());
 
-    const auto idx = res.size();
-    res.insert(res.end(), blob2.begin(), blob2.end());
-
-    for (std::size_t i = 0; i < res.size(); ++i) {
-        const auto common = i < idx;
-        const auto pair = ParseTicket(res[i], eticket_rsa_keypair);
-        if (!pair) {
-            continue;
-        }
-
-        const auto& [rid, key] = *pair;
-        u128 rights_id;
-        std::memcpy(rights_id.data(), rid.data(), rid.size());
-
-        if (common) {
-            common_tickets[rights_id] = res[i];
-        } else {
-            personal_tickets[rights_id] = res[i];
-        }
-
-        SetKey(S128KeyType::Titlekey, key, rights_id[1], rights_id[0]);
+    for (const auto& ticket : tickets) {
+        AddTicket(ticket);
     }
 }
 
@@ -1354,39 +1345,33 @@ const std::map<u128, Ticket>& KeyManager::GetPersonalizedTickets() const {
     return personal_tickets;
 }
 
-bool KeyManager::AddTicketCommon(Ticket raw) {
-    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
+bool KeyManager::AddTicket(const Ticket& ticket) {
+    if (!ticket.IsValid()) {
+        LOG_WARNING(Crypto, "Attempted to add invalid ticket.");
         return false;
     }
 
-    const auto pair = ParseTicket(raw, eticket_rsa_keypair);
-    if (!pair) {
-        return false;
-    }
-
-    const auto& [rid, key] = *pair;
+    const auto& rid = ticket.GetData().rights_id;
     u128 rights_id;
     std::memcpy(rights_id.data(), rid.data(), rid.size());
-    common_tickets[rights_id] = raw;
-    SetKey(S128KeyType::Titlekey, key, rights_id[1], rights_id[0]);
-    return true;
-}
-
-bool KeyManager::AddTicketPersonalized(Ticket raw) {
-    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
-        return false;
+    if (ticket.GetData().type == Core::Crypto::TitleKeyType::Common) {
+        common_tickets[rights_id] = ticket;
+    } else {
+        personal_tickets[rights_id] = ticket;
     }
 
-    const auto pair = ParseTicket(raw, eticket_rsa_keypair);
-    if (!pair) {
-        return false;
+    if (HasKey(S128KeyType::Titlekey, rights_id[1], rights_id[0])) {
+        LOG_DEBUG(Crypto,
+                  "Skipping parsing title key from ticket for known rights ID {:016X}{:016X}.",
+                  rights_id[1], rights_id[0]);
+        return true;
     }
 
-    const auto& [rid, key] = *pair;
-    u128 rights_id;
-    std::memcpy(rights_id.data(), rid.data(), rid.size());
-    personal_tickets[rights_id] = raw;
-    SetKey(S128KeyType::Titlekey, key, rights_id[1], rights_id[0]);
+    const auto key = ParseTicketTitleKey(ticket);
+    if (!key) {
+        return false;
+    }
+    SetKey(S128KeyType::Titlekey, key.value(), rights_id[1], rights_id[0]);
     return true;
 }
 } // namespace Core::Crypto

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -557,12 +557,6 @@ static std::optional<u64> FindTicketOffset(const std::array<u8, size>& data) {
 }
 
 std::optional<Key128> KeyManager::ParseTicketTitleKey(const Ticket& ticket) {
-    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
-        LOG_WARNING(Crypto,
-                    "Skipping ticket title key parsing due to missing ETicket RSA key-pair.");
-        return std::nullopt;
-    }
-
     if (!ticket.IsValid()) {
         LOG_WARNING(Crypto, "Attempted to parse title key of invalid ticket.");
         return std::nullopt;
@@ -585,6 +579,13 @@ std::optional<Key128> KeyManager::ParseTicketTitleKey(const Ticket& ticket) {
 
     if (ticket.GetData().type == TitleKeyType::Common) {
         return ticket.GetData().title_key_common;
+    }
+
+    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
+        LOG_WARNING(
+            Crypto,
+            "Skipping personalized ticket title key parsing due to missing ETicket RSA key-pair.");
+        return std::nullopt;
     }
 
     mbedtls_mpi D; // RSA Private Exponent
@@ -1188,10 +1189,6 @@ void KeyManager::DeriveETicket(PartitionDataManager& data,
 }
 
 void KeyManager::PopulateTickets() {
-    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
-        return;
-    }
-
     if (!common_tickets.empty() && !personal_tickets.empty()) {
         return;
     }

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -210,6 +210,36 @@ Ticket Ticket::SynthesizeCommon(Key128 title_key, const std::array<u8, 16>& righ
     return Ticket{out};
 }
 
+bool Ticket::Read(Ticket& ticket_out, const FileSys::VirtualFile& file) {
+    SignatureType sig_type;
+    if (file->Read(reinterpret_cast<u8*>(&sig_type), sizeof(sig_type), 0) < sizeof(sig_type)) {
+        return false;
+    }
+
+    switch (sig_type) {
+    case SignatureType::RSA_4096_SHA1:
+    case SignatureType::RSA_4096_SHA256: {
+        ticket_out.data.emplace<RSA4096Ticket>();
+        file->Read(reinterpret_cast<u8*>(&ticket_out.data), sizeof(RSA4096Ticket), 0);
+        return true;
+    }
+    case SignatureType::RSA_2048_SHA1:
+    case SignatureType::RSA_2048_SHA256: {
+        ticket_out.data.emplace<RSA2048Ticket>();
+        file->Read(reinterpret_cast<u8*>(&ticket_out.data), sizeof(RSA2048Ticket), 0);
+        return true;
+    }
+    case SignatureType::ECDSA_SHA1:
+    case SignatureType::ECDSA_SHA256: {
+        ticket_out.data.emplace<ECDSATicket>();
+        file->Read(reinterpret_cast<u8*>(&ticket_out.data), sizeof(ECDSATicket), 0);
+        return true;
+    }
+    default:
+        return false;
+    }
+}
+
 Key128 GenerateKeyEncryptionKey(Key128 source, Key128 master, Key128 kek_seed, Key128 key_seed) {
     Key128 out{};
 
@@ -290,9 +320,9 @@ void KeyManager::DeriveGeneralPurposeKeys(std::size_t crypto_revision) {
     }
 }
 
-RSAKeyPair<2048> KeyManager::GetETicketRSAKey() const {
+void KeyManager::DeriveETicketRSAKey() {
     if (IsAllZeroArray(eticket_extended_kek) || !HasKey(S128KeyType::ETicketRSAKek)) {
-        return {};
+        return;
     }
 
     const auto eticket_final = GetKey(S128KeyType::ETicketRSAKek);
@@ -304,12 +334,12 @@ RSAKeyPair<2048> KeyManager::GetETicketRSAKey() const {
     rsa_1.Transcode(eticket_extended_kek.data() + 0x10, eticket_extended_kek.size() - 0x10,
                     extended_dec.data(), Op::Decrypt);
 
-    RSAKeyPair<2048> rsa_key{};
-    std::memcpy(rsa_key.decryption_key.data(), extended_dec.data(), rsa_key.decryption_key.size());
-    std::memcpy(rsa_key.modulus.data(), extended_dec.data() + 0x100, rsa_key.modulus.size());
-    std::memcpy(rsa_key.exponent.data(), extended_dec.data() + 0x200, rsa_key.exponent.size());
-
-    return rsa_key;
+    std::memcpy(eticket_rsa_keypair.decryption_key.data(), extended_dec.data(),
+                eticket_rsa_keypair.decryption_key.size());
+    std::memcpy(eticket_rsa_keypair.modulus.data(), extended_dec.data() + 0x100,
+                eticket_rsa_keypair.modulus.size());
+    std::memcpy(eticket_rsa_keypair.exponent.data(), extended_dec.data() + 0x200,
+                eticket_rsa_keypair.exponent.size());
 }
 
 Key128 DeriveKeyblobMACKey(const Key128& keyblob_key, const Key128& mac_source) {
@@ -519,8 +549,7 @@ std::optional<std::pair<Key128, Key128>> ParseTicket(const Ticket& ticket,
         return std::nullopt;
     }
 
-    if (!std::any_of(ticket.GetData().title_key_common_pad.begin(),
-                     ticket.GetData().title_key_common_pad.end(), [](u8 b) { return b != 0; })) {
+    if (ticket.GetData().type == TitleKeyType::Common) {
         return std::make_pair(rights_id, ticket.GetData().title_key_common);
     }
 
@@ -669,6 +698,14 @@ void KeyManager::LoadFromFile(const std::filesystem::path& file_path, bool is_ti
                 encrypted_keyblobs[index] = Common::HexStringToArray<0xB0>(out[1]);
             } else if (out[0].compare(0, 20, "eticket_extended_kek") == 0) {
                 eticket_extended_kek = Common::HexStringToArray<576>(out[1]);
+            } else if (out[0].compare(0, 19, "eticket_rsa_keypair") == 0) {
+                const auto key_data = Common::HexStringToArray<528>(out[1]);
+                std::memcpy(eticket_rsa_keypair.decryption_key.data(), key_data.data(),
+                            eticket_rsa_keypair.decryption_key.size());
+                std::memcpy(eticket_rsa_keypair.modulus.data(), key_data.data() + 0x100,
+                            eticket_rsa_keypair.modulus.size());
+                std::memcpy(eticket_rsa_keypair.exponent.data(), key_data.data() + 0x200,
+                            eticket_rsa_keypair.exponent.size());
             } else {
                 for (const auto& kv : KEYS_VARIABLE_LENGTH) {
                     if (!ValidCryptoRevisionString(out[0], kv.second.size(), 2)) {
@@ -1110,13 +1147,12 @@ void KeyManager::DeriveETicket(PartitionDataManager& data,
 
     eticket_extended_kek = data.GetETicketExtendedKek();
     WriteKeyToFile(KeyCategory::Console, "eticket_extended_kek", eticket_extended_kek);
+    DeriveETicketRSAKey();
     PopulateTickets();
 }
 
 void KeyManager::PopulateTickets() {
-    const auto rsa_key = GetETicketRSAKey();
-
-    if (rsa_key == RSAKeyPair<2048>{}) {
+    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
         return;
     }
 
@@ -1144,7 +1180,7 @@ void KeyManager::PopulateTickets() {
 
     for (std::size_t i = 0; i < res.size(); ++i) {
         const auto common = i < idx;
-        const auto pair = ParseTicket(res[i], rsa_key);
+        const auto pair = ParseTicket(res[i], eticket_rsa_keypair);
         if (!pair) {
             continue;
         }
@@ -1292,12 +1328,11 @@ const std::map<u128, Ticket>& KeyManager::GetPersonalizedTickets() const {
 }
 
 bool KeyManager::AddTicketCommon(Ticket raw) {
-    const auto rsa_key = GetETicketRSAKey();
-    if (rsa_key == RSAKeyPair<2048>{}) {
+    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
         return false;
     }
 
-    const auto pair = ParseTicket(raw, rsa_key);
+    const auto pair = ParseTicket(raw, eticket_rsa_keypair);
     if (!pair) {
         return false;
     }
@@ -1311,12 +1346,11 @@ bool KeyManager::AddTicketCommon(Ticket raw) {
 }
 
 bool KeyManager::AddTicketPersonalized(Ticket raw) {
-    const auto rsa_key = GetETicketRSAKey();
-    if (rsa_key == RSAKeyPair<2048>{}) {
+    if (eticket_rsa_keypair == RSAKeyPair<2048>{}) {
         return false;
     }
 
-    const auto pair = ParseTicket(raw, rsa_key);
+    const auto pair = ParseTicket(raw, eticket_rsa_keypair);
     if (!pair) {
         return false;
     }
@@ -1324,7 +1358,7 @@ bool KeyManager::AddTicketPersonalized(Ticket raw) {
     const auto& [rid, key] = *pair;
     u128 rights_id;
     std::memcpy(rights_id.data(), rid.data(), rid.size());
-    common_tickets[rights_id] = raw;
+    personal_tickets[rights_id] = raw;
     SetKey(S128KeyType::Titlekey, key, rights_id[1], rights_id[0]);
     return true;
 }

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -96,8 +96,9 @@ struct ECDSATicket {
 };
 
 struct Ticket {
-    std::variant<RSA4096Ticket, RSA2048Ticket, ECDSATicket> data;
+    std::variant<std::monostate, RSA4096Ticket, RSA2048Ticket, ECDSATicket> data;
 
+    bool IsValid() const;
     SignatureType GetSignatureType() const;
     TicketData& GetData();
     const TicketData& GetData() const;

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -290,8 +290,7 @@ public:
     const std::map<u128, Ticket>& GetCommonTickets() const;
     const std::map<u128, Ticket>& GetPersonalizedTickets() const;
 
-    bool AddTicketCommon(Ticket raw);
-    bool AddTicketPersonalized(Ticket raw);
+    bool AddTicket(const Ticket& ticket);
 
     void ReloadKeys();
     bool AreKeysLoaded() const;
@@ -324,6 +323,9 @@ private:
 
     void SetKeyWrapped(S128KeyType id, Key128 key, u64 field1 = 0, u64 field2 = 0);
     void SetKeyWrapped(S256KeyType id, Key256 key, u64 field1 = 0, u64 field2 = 0);
+
+    /// Parses the title key section of a ticket.
+    std::optional<Key128> ParseTicketTitleKey(const Ticket& ticket);
 };
 
 Key128 GenerateKeyEncryptionKey(Key128 source, Key128 master, Key128 kek_seed, Key128 key_seed);
@@ -337,10 +339,5 @@ std::optional<Key128> DeriveSDSeed();
 Loader::ResultStatus DeriveSDKeys(std::array<Key256, 2>& sd_keys, KeyManager& keys);
 
 std::vector<Ticket> GetTicketblob(const Common::FS::IOFile& ticket_save);
-
-// Returns a pair of {rights_id, titlekey}. Fails if the ticket has no certificate authority
-// (offset 0x140-0x144 is zero)
-std::optional<std::pair<Key128, Key128>> ParseTicket(const Ticket& ticket,
-                                                     const RSAKeyPair<2048>& eticket_extended_key);
 
 } // namespace Core::Crypto

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -304,6 +304,7 @@ private:
     // Map from rights ID to ticket
     std::map<u128, Ticket> common_tickets;
     std::map<u128, Ticket> personal_tickets;
+    bool ticket_databases_loaded = false;
 
     std::array<std::array<u8, 0xB0>, 0x20> encrypted_keyblobs{};
     std::array<std::array<u8, 0x90>, 0x20> keyblobs{};

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -29,8 +29,6 @@ enum class ResultStatus : u16;
 
 namespace Core::Crypto {
 
-constexpr u64 TICKET_FILE_TITLEKEY_OFFSET = 0x180;
-
 using Key128 = std::array<u8, 0x10>;
 using Key256 = std::array<u8, 0x20>;
 using SHA256Hash = std::array<u8, 0x20>;
@@ -106,6 +104,7 @@ struct Ticket {
     u64 GetSize() const;
 
     static Ticket SynthesizeCommon(Key128 title_key, const std::array<u8, 0x10>& rights_id);
+    static bool Read(Ticket& ticket_out, const FileSys::VirtualFile& file);
 };
 
 static_assert(sizeof(Key128) == 16, "Key128 must be 128 bytes big.");
@@ -283,6 +282,7 @@ private:
     std::array<std::array<u8, 0xB0>, 0x20> encrypted_keyblobs{};
     std::array<std::array<u8, 0x90>, 0x20> keyblobs{};
     std::array<u8, 576> eticket_extended_kek{};
+    RSAKeyPair<2048> eticket_rsa_keypair{};
 
     bool dev_mode;
     void LoadFromFile(const std::filesystem::path& file_path, bool is_title_keys);
@@ -293,7 +293,7 @@ private:
 
     void DeriveGeneralPurposeKeys(std::size_t crypto_revision);
 
-    RSAKeyPair<2048> GetETicketRSAKey() const;
+    void DeriveETicketRSAKey();
 
     void SetKeyWrapped(S128KeyType id, Key128 key, u64 field1 = 0, u64 field2 = 0);
     void SetKeyWrapped(S256KeyType id, Key256 key, u64 field1 = 0, u64 field2 = 0);

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -190,8 +190,8 @@ void NSP::SetTicketKeys(const std::vector<VirtualFile>& files) {
             continue;
         }
 
-        Core::Crypto::Ticket ticket{};
-        if (!Core::Crypto::Ticket::Read(ticket, ticket_file)) {
+        auto ticket = Core::Crypto::Ticket::Read(ticket_file);
+        if (!ticket.IsValid()) {
             LOG_WARNING(Common_Filesystem, "Could not read NSP ticket {}", ticket_file->GetName());
             continue;
         }

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -164,24 +164,6 @@ VirtualFile NSP::GetNCAFile(u64 title_id, ContentRecordType type, TitleType titl
     return nullptr;
 }
 
-std::vector<Core::Crypto::Key128> NSP::GetTitlekey() const {
-    if (extracted)
-        LOG_WARNING(Service_FS, "called on an NSP that is of type extracted.");
-    std::vector<Core::Crypto::Key128> out;
-    for (const auto& ticket_file : ticket_files) {
-        if (ticket_file == nullptr ||
-            ticket_file->GetSize() <
-                Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET + sizeof(Core::Crypto::Key128)) {
-            continue;
-        }
-
-        out.emplace_back();
-        ticket_file->Read(out.back().data(), out.back().size(),
-                          Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET);
-    }
-    return out;
-}
-
 std::vector<VirtualFile> NSP::GetFiles() const {
     return pfs->GetFiles();
 }
@@ -208,22 +190,17 @@ void NSP::SetTicketKeys(const std::vector<VirtualFile>& files) {
             continue;
         }
 
-        if (ticket_file->GetSize() <
-            Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET + sizeof(Core::Crypto::Key128)) {
+        Core::Crypto::Ticket ticket{};
+        if (!Core::Crypto::Ticket::Read(ticket, ticket_file)) {
+            LOG_WARNING(Common_Filesystem, "Could not read NSP ticket {}", ticket_file->GetName());
             continue;
         }
 
-        Core::Crypto::Key128 key{};
-        ticket_file->Read(key.data(), key.size(), Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET);
-
-        // We get the name without the extension in order to create the rights ID.
-        std::string name_only(ticket_file->GetName());
-        name_only.erase(name_only.size() - 4);
-
-        const auto rights_id_raw = Common::HexStringToArray<16>(name_only);
-        u128 rights_id;
-        std::memcpy(rights_id.data(), rights_id_raw.data(), sizeof(u128));
-        keys.SetKey(Core::Crypto::S128KeyType::Titlekey, key, rights_id[1], rights_id[0]);
+        if (ticket.GetData().type == Core::Crypto::TitleKeyType::Common) {
+            keys.AddTicketCommon(ticket);
+        } else {
+            keys.AddTicketPersonalized(ticket);
+        }
     }
 }
 

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -191,15 +191,9 @@ void NSP::SetTicketKeys(const std::vector<VirtualFile>& files) {
         }
 
         auto ticket = Core::Crypto::Ticket::Read(ticket_file);
-        if (!ticket.IsValid()) {
-            LOG_WARNING(Common_Filesystem, "Could not read NSP ticket {}", ticket_file->GetName());
+        if (!keys.AddTicket(ticket)) {
+            LOG_WARNING(Common_Filesystem, "Could not load NSP ticket {}", ticket_file->GetName());
             continue;
-        }
-
-        if (ticket.GetData().type == Core::Crypto::TitleKeyType::Common) {
-            keys.AddTicketCommon(ticket);
-        } else {
-            keys.AddTicketPersonalized(ticket);
         }
     }
 }

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -53,7 +53,6 @@ public:
                                 TitleType title_type = TitleType::Application) const;
     VirtualFile GetNCAFile(u64 title_id, ContentRecordType type,
                            TitleType title_type = TitleType::Application) const;
-    std::vector<Core::Crypto::Key128> GetTitlekey() const;
 
     std::vector<VirtualFile> GetFiles() const override;
 

--- a/src/core/hle/service/es/es.cpp
+++ b/src/core/hle/service/es/es.cpp
@@ -122,20 +122,25 @@ private:
     }
 
     void ImportTicket(HLERequestContext& ctx) {
-        const auto ticket = ctx.ReadBuffer();
+        const auto raw_ticket = ctx.ReadBuffer();
         [[maybe_unused]] const auto cert = ctx.ReadBuffer(1);
 
-        if (ticket.size() < sizeof(Core::Crypto::Ticket)) {
+        if (raw_ticket.size() < sizeof(Core::Crypto::Ticket)) {
             LOG_ERROR(Service_ETicket, "The input buffer is not large enough!");
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERROR_INVALID_ARGUMENT);
             return;
         }
 
-        Core::Crypto::Ticket raw{};
-        std::memcpy(&raw, ticket.data(), sizeof(Core::Crypto::Ticket));
+        Core::Crypto::Ticket ticket = Core::Crypto::Ticket::Read(raw_ticket);
+        if (!ticket.IsValid()) {
+            LOG_ERROR(Service_ETicket, "The ticket is invalid!");
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERROR_INVALID_ARGUMENT);
+            return;
+        }
 
-        if (!keys.AddTicketPersonalized(raw)) {
+        if (!keys.AddTicketPersonalized(ticket)) {
             LOG_ERROR(Service_ETicket, "The ticket could not be imported!");
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERROR_INVALID_ARGUMENT);

--- a/src/core/hle/service/es/es.cpp
+++ b/src/core/hle/service/es/es.cpp
@@ -133,14 +133,7 @@ private:
         }
 
         Core::Crypto::Ticket ticket = Core::Crypto::Ticket::Read(raw_ticket);
-        if (!ticket.IsValid()) {
-            LOG_ERROR(Service_ETicket, "The ticket is invalid!");
-            IPC::ResponseBuilder rb{ctx, 2};
-            rb.Push(ERROR_INVALID_ARGUMENT);
-            return;
-        }
-
-        if (!keys.AddTicketPersonalized(ticket)) {
+        if (!keys.AddTicket(ticket)) {
             LOG_ERROR(Service_ETicket, "The ticket could not be imported!");
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
Adds support for loading personalized (encrypted title key) tickets from NSP files. Previously the relevant code would assume a common key and load in the first 16 bytes of the key area. Now, the code properly reads the ticket and loads it in as personalized or common depending on the type.

This also adds support for eticket_rsa_keypair key material, which was added to the Lockpick_RCM output sometime late last year and can be used instead of needing to derive the key material from other system files. The key pair is also now derived ahead of time and stored in KeyManager instead of re-deriving it every time it is needed.