### PR TITLE
Qt: RoundPreferFloor scaling mode for win HiDPI

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -4585,7 +4585,7 @@ static void SetHighDPIAttributes() {
 
     if (max_ratio > real_ratio) {
         QApplication::setHighDpiScaleFactorRoundingPolicy(
-            Qt::HighDpiScaleFactorRoundingPolicy::Round);
+            Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
     } else {
         QApplication::setHighDpiScaleFactorRoundingPolicy(
             Qt::HighDpiScaleFactorRoundingPolicy::Floor);


### PR DESCRIPTION
The HiDPI fixes introduced a while back have made a mess of scaling on windows with 4k displays and 150% scaling. This manifests as a huge increase of the window and font sizes and scaling artifacts on the audio and control screens.

Lets use the RoundPreferFloor enum to not force Qt to round up the scaling at 150% and regain the correct behaviour from before.

![image](https://user-images.githubusercontent.com/8155719/232234448-cbf838a6-d358-4e54-89c5-607c27c46c8a.png)
![image](https://user-images.githubusercontent.com/8155719/232234467-a918489d-6f0c-4daf-9552-c1e8ce7e8b7f.png)
