### PR TITLE
Sort overlap_ids by modification tick before copy

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1294,6 +1294,12 @@ ImageId TextureCache<P>::JoinImages(const ImageInfo& info, GPUVAddr gpu_addr, VA
         ScaleDown(new_image);
     }
 
+    std::ranges::sort(overlap_ids, [this](const ImageId lhs, const ImageId rhs) {
+        const ImageBase& lhs_image = slot_images[lhs];
+        const ImageBase& rhs_image = slot_images[rhs];
+        return lhs_image.modification_tick < rhs_image.modification_tick;
+    });
+
     for (const ImageId overlap_id : overlap_ids) {
         Image& overlap = slot_images[overlap_id];
         if (True(overlap.flags & ImageFlagBits::GpuModified)) {


### PR DESCRIPTION
Currently we're copying overlapping image's data in a random order, it should be sorted from oldest modification -> newest to avoid clobbering a more-updated overlap with an older one.