### PR TITLE
Y.F.C Implement Asynchronous Fence manager and Rework Query async downloads

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -462,7 +462,7 @@ struct Memory::Impl {
         }
 
         if (Settings::IsFastmemEnabled()) {
-            const bool is_read_enable = Settings::IsGPULevelHigh() || !cached;
+            const bool is_read_enable = !Settings::IsGPULevelExtreme() || !cached;
             system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
         }
 

--- a/src/video_core/fence_manager.h
+++ b/src/video_core/fence_manager.h
@@ -64,6 +64,7 @@ public:
     }
 
     void SignalFence(std::function<void()>&& func) {
+        rasterizer.InvalidateGPUCache();
         bool delay_fence = Settings::IsGPULevelHigh();
         if constexpr (!can_async_check) {
             TryReleasePendingFences<false>();

--- a/src/video_core/fence_manager.h
+++ b/src/video_core/fence_manager.h
@@ -4,13 +4,20 @@
 #pragma once
 
 #include <algorithm>
+#include <condition_variable>
 #include <cstring>
 #include <deque>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <thread>
 #include <queue>
 
 #include "common/common_types.h"
+#include "common/microprofile.h"
+#include "common/scope_exit.h"
+#include "common/settings.h"
+#include "common/thread.h"
 #include "video_core/delayed_destruction_ring.h"
 #include "video_core/gpu.h"
 #include "video_core/host1x/host1x.h"
@@ -23,15 +30,26 @@ class FenceBase {
 public:
     explicit FenceBase(bool is_stubbed_) : is_stubbed{is_stubbed_} {}
 
+    bool IsStubbed() const {
+        return is_stubbed;
+    }
+
 protected:
     bool is_stubbed;
 };
 
-template <typename TFence, typename TTextureCache, typename TTBufferCache, typename TQueryCache>
+template <typename Traits>
 class FenceManager {
+    using TFence = typename Traits::FenceType;
+    using TTextureCache = typename Traits::TextureCacheType;
+    using TBufferCache = typename Traits::BufferCacheType;
+    using TQueryCache = typename Traits::QueryCacheType;
+    static constexpr bool can_async_check = Traits::HAS_ASYNC_CHECK;
+
 public:
     /// Notify the fence manager about a new frame
     void TickFrame() {
+        std::unique_lock lock(ring_guard);
         delayed_destruction_ring.Tick();
     }
 
@@ -46,16 +64,26 @@ public:
     }
 
     void SignalFence(std::function<void()>&& func) {
-        TryReleasePendingFences();
+        if constexpr (!can_async_check) {
+            TryReleasePendingFences<false>();
+        }
+        std::function<void()> callback = std::move(func);
         const bool should_flush = ShouldFlush();
         CommitAsyncFlushes();
-        uncommitted_operations.emplace_back(std::move(func));
-        CommitOperations();
         TFence new_fence = CreateFence(!should_flush);
-        fences.push(new_fence);
+        if constexpr (can_async_check) {
+            guard.lock();
+        }
+        pending_operations.emplace_back(std::move(uncommitted_operations));
         QueueFence(new_fence);
+        callback();
+        fences.push(std::move(new_fence));
         if (should_flush) {
             rasterizer.FlushCommands();
+        }
+        if constexpr (can_async_check) {
+            guard.unlock();
+            cv.notify_all();
         }
     }
 
@@ -66,29 +94,30 @@ public:
     }
 
     void WaitPendingFences() {
-        while (!fences.empty()) {
-            TFence& current_fence = fences.front();
-            if (ShouldWait()) {
-                WaitFence(current_fence);
-            }
-            PopAsyncFlushes();
-            auto operations = std::move(pending_operations.front());
-            pending_operations.pop_front();
-            for (auto& operation : operations) {
-                operation();
-            }
-            PopFence();
+        if constexpr (!can_async_check) {
+            TryReleasePendingFences<true>();
         }
     }
 
 protected:
     explicit FenceManager(VideoCore::RasterizerInterface& rasterizer_, Tegra::GPU& gpu_,
-                          TTextureCache& texture_cache_, TTBufferCache& buffer_cache_,
+                          TTextureCache& texture_cache_, TBufferCache& buffer_cache_,
                           TQueryCache& query_cache_)
         : rasterizer{rasterizer_}, gpu{gpu_}, syncpoint_manager{gpu.Host1x().GetSyncpointManager()},
-          texture_cache{texture_cache_}, buffer_cache{buffer_cache_}, query_cache{query_cache_} {}
+          texture_cache{texture_cache_}, buffer_cache{buffer_cache_}, query_cache{query_cache_} {
+        if constexpr (can_async_check) {
+            fence_thread =
+                std::jthread([this](std::stop_token token) { ReleaseThreadFunc(token); });
+        }
+    }
 
-    virtual ~FenceManager() = default;
+    virtual ~FenceManager() {
+        if constexpr (can_async_check) {
+            fence_thread.request_stop();
+            cv.notify_all();
+            fence_thread.join();
+        }
+    }
 
     /// Creates a Fence Interface, does not create a backend fence if 'is_stubbed' is
     /// true
@@ -104,15 +133,20 @@ protected:
     Tegra::GPU& gpu;
     Tegra::Host1x::SyncpointManager& syncpoint_manager;
     TTextureCache& texture_cache;
-    TTBufferCache& buffer_cache;
+    TBufferCache& buffer_cache;
     TQueryCache& query_cache;
 
 private:
+    template <bool force_wait>
     void TryReleasePendingFences() {
         while (!fences.empty()) {
             TFence& current_fence = fences.front();
             if (ShouldWait() && !IsFenceSignaled(current_fence)) {
-                return;
+                if constexpr (force_wait) {
+                    WaitFence(current_fence);
+                } else {
+                    return;
+                }
             }
             PopAsyncFlushes();
             auto operations = std::move(pending_operations.front());
@@ -120,7 +154,49 @@ private:
             for (auto& operation : operations) {
                 operation();
             }
-            PopFence();
+            {
+                std::unique_lock lock(ring_guard);
+                delayed_destruction_ring.Push(std::move(current_fence));
+            }
+            fences.pop();
+        }
+    }
+
+    void ReleaseThreadFunc(std::stop_token stop_token) {
+        std::string name = "GPUFencingThread";
+        MicroProfileOnThreadCreate(name.c_str());
+
+        // Cleanup
+        SCOPE_EXIT({ MicroProfileOnThreadExit(); });
+
+        Common::SetCurrentThreadName(name.c_str());
+        Common::SetCurrentThreadPriority(Common::ThreadPriority::High);
+
+        TFence current_fence;
+        std::deque<std::function<void()>> current_operations;
+        while (!stop_token.stop_requested()) {
+            {
+                std::unique_lock lock(guard);
+                cv.wait(lock, [&] { return stop_token.stop_requested() || !fences.empty(); });
+                if (stop_token.stop_requested()) [[unlikely]] {
+                    return;
+                }
+                current_fence = std::move(fences.front());
+                current_operations = std::move(pending_operations.front());
+                fences.pop();
+                pending_operations.pop_front();
+            }
+            if (!current_fence->IsStubbed()) {
+                WaitFence(current_fence);
+            }
+            PopAsyncFlushes();
+            for (auto& operation : current_operations) {
+                operation();
+            }
+            {
+                std::unique_lock lock(ring_guard);
+                delayed_destruction_ring.Push(std::move(current_fence));
+            }
         }
     }
 
@@ -154,18 +230,15 @@ private:
         query_cache.CommitAsyncFlushes();
     }
 
-    void PopFence() {
-        delayed_destruction_ring.Push(std::move(fences.front()));
-        fences.pop();
-    }
-
-    void CommitOperations() {
-        pending_operations.emplace_back(std::move(uncommitted_operations));
-    }
-
     std::queue<TFence> fences;
     std::deque<std::function<void()>> uncommitted_operations;
     std::deque<std::deque<std::function<void()>>> pending_operations;
+
+    std::mutex guard;
+    std::mutex ring_guard;
+    std::condition_variable cv;
+
+    std::jthread fence_thread;
 
     DelayedDestructionRing<TFence, 6> delayed_destruction_ring;
 };

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -215,6 +216,9 @@ private:
 
     std::vector<u64> big_page_continuous;
     std::vector<std::pair<VAddr, std::size_t>> page_stash{};
+    std::vector<std::pair<VAddr, std::size_t>> page_stash2{};
+
+    mutable std::mutex guard;
 
     static constexpr size_t continuous_bits = 64;
 

--- a/src/video_core/query_cache.h
+++ b/src/video_core/query_cache.h
@@ -173,15 +173,18 @@ public:
     }
 
     void CommitAsyncFlushes() {
+        std::unique_lock lock{mutex};
         committed_flushes.push_back(uncommitted_flushes);
         uncommitted_flushes.reset();
     }
 
     bool HasUncommittedFlushes() const {
+        std::unique_lock lock{mutex};
         return uncommitted_flushes != nullptr;
     }
 
     bool ShouldWaitAsyncFlushes() const {
+        std::unique_lock lock{mutex};
         if (committed_flushes.empty()) {
             return false;
         }
@@ -189,6 +192,7 @@ public:
     }
 
     void PopAsyncFlushes() {
+        std::unique_lock lock{mutex};
         if (committed_flushes.empty()) {
             return;
         }
@@ -265,7 +269,7 @@ private:
 
     VideoCore::RasterizerInterface& rasterizer;
 
-    std::recursive_mutex mutex;
+    mutable std::recursive_mutex mutex;
 
     std::unordered_map<u64, std::vector<CachedQuery>> cached_queries;
 

--- a/src/video_core/renderer_opengl/gl_fence_manager.h
+++ b/src/video_core/renderer_opengl/gl_fence_manager.h
@@ -30,7 +30,17 @@ private:
 };
 
 using Fence = std::shared_ptr<GLInnerFence>;
-using GenericFenceManager = VideoCommon::FenceManager<Fence, TextureCache, BufferCache, QueryCache>;
+
+struct FenceManagerParams {
+    using FenceType = Fence;
+    using BufferCacheType = BufferCache;
+    using TextureCacheType = TextureCache;
+    using QueryCacheType = QueryCache;
+
+    static constexpr bool HAS_ASYNC_CHECK = false;
+};
+
+using GenericFenceManager = VideoCommon::FenceManager<FenceManagerParams>;
 
 class FenceManagerOpenGL final : public GenericFenceManager {
 public:

--- a/src/video_core/renderer_opengl/gl_query_cache.h
+++ b/src/video_core/renderer_opengl/gl_query_cache.h
@@ -28,7 +28,7 @@ using CounterStream = VideoCommon::CounterStreamBase<QueryCache, HostCounter>;
 class QueryCache final
     : public VideoCommon::QueryCacheBase<QueryCache, CachedQuery, CounterStream, HostCounter> {
 public:
-    explicit QueryCache(RasterizerOpenGL& rasterizer_);
+    explicit QueryCache(RasterizerOpenGL& rasterizer_, Core::Memory::Memory& cpu_memory_);
     ~QueryCache();
 
     OGLQuery AllocateQuery(VideoCore::QueryType type);
@@ -51,7 +51,7 @@ public:
     void EndQuery();
 
 private:
-    u64 BlockingQuery() const override;
+    u64 BlockingQuery(bool async = false) const override;
 
     QueryCache& cache;
     const VideoCore::QueryType type;
@@ -70,7 +70,7 @@ public:
     CachedQuery(const CachedQuery&) = delete;
     CachedQuery& operator=(const CachedQuery&) = delete;
 
-    void Flush() override;
+    u64 Flush(bool async = false) override;
 
 private:
     QueryCache* cache;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -63,7 +63,7 @@ RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& emu_window_, Tegra
       buffer_cache(*this, cpu_memory_, buffer_cache_runtime),
       shader_cache(*this, emu_window_, device, texture_cache, buffer_cache, program_manager,
                    state_tracker, gpu.ShaderNotify()),
-      query_cache(*this), accelerate_dma(buffer_cache, texture_cache),
+      query_cache(*this, cpu_memory_), accelerate_dma(buffer_cache, texture_cache),
       fence_manager(*this, gpu, texture_cache, buffer_cache, query_cache),
       blit_image(program_manager_) {}
 

--- a/src/video_core/renderer_vulkan/vk_fence_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_fence_manager.cpp
@@ -10,7 +10,6 @@
 #include "video_core/renderer_vulkan/vk_texture_cache.h"
 #include "video_core/vulkan_common/vulkan_device.h"
 
-
 namespace Vulkan {
 
 InnerFence::InnerFence(Scheduler& scheduler_, bool is_stubbed_)

--- a/src/video_core/renderer_vulkan/vk_fence_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_fence_manager.cpp
@@ -5,9 +5,11 @@
 
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_fence_manager.h"
+#include "video_core/renderer_vulkan/vk_query_cache.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_texture_cache.h"
 #include "video_core/vulkan_common/vulkan_device.h"
+
 
 namespace Vulkan {
 

--- a/src/video_core/renderer_vulkan/vk_fence_manager.h
+++ b/src/video_core/renderer_vulkan/vk_fence_manager.h
@@ -40,7 +40,16 @@ private:
 };
 using Fence = std::shared_ptr<InnerFence>;
 
-using GenericFenceManager = VideoCommon::FenceManager<Fence, TextureCache, BufferCache, QueryCache>;
+struct FenceManagerParams {
+    using FenceType = Fence;
+    using BufferCacheType = BufferCache;
+    using TextureCacheType = TextureCache;
+    using QueryCacheType = QueryCache;
+
+    static constexpr bool HAS_ASYNC_CHECK = true;
+};
+
+using GenericFenceManager = VideoCommon::FenceManager<FenceManagerParams>;
 
 class FenceManager final : public GenericFenceManager {
 public:

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -98,8 +98,9 @@ HostCounter::HostCounter(QueryCache& cache_, std::shared_ptr<HostCounter> depend
       query{cache_.AllocateQuery(type_)}, tick{cache_.GetScheduler().CurrentTick()} {
     const vk::Device* logical = &cache.GetDevice().GetLogical();
     cache.GetScheduler().Record([logical, query = query](vk::CommandBuffer cmdbuf) {
+        const bool use_precise = Settings::IsGPULevelHigh();
         logical->ResetQueryPool(query.first, query.second, 1);
-        cmdbuf.BeginQuery(query.first, query.second, VK_QUERY_CONTROL_PRECISE_BIT);
+        cmdbuf.BeginQuery(query.first, query.second, use_precise ? VK_QUERY_CONTROL_PRECISE_BIT : 0);
     });
 }
 

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -66,9 +66,10 @@ void QueryPool::Reserve(std::pair<VkQueryPool, u32> query) {
     }
 }
 
-QueryCache::QueryCache(VideoCore::RasterizerInterface& rasterizer_, const Device& device_,
+QueryCache::QueryCache(VideoCore::RasterizerInterface& rasterizer_,
+                       Core::Memory::Memory& cpu_memory_, const Device& device_,
                        Scheduler& scheduler_)
-    : QueryCacheBase{rasterizer_}, device{device_}, scheduler{scheduler_},
+    : QueryCacheBase{rasterizer_, cpu_memory_}, device{device_}, scheduler{scheduler_},
       query_pools{
           QueryPool{device_, scheduler_, QueryType::SamplesPassed},
       } {}
@@ -100,7 +101,8 @@ HostCounter::HostCounter(QueryCache& cache_, std::shared_ptr<HostCounter> depend
     cache.GetScheduler().Record([logical, query = query](vk::CommandBuffer cmdbuf) {
         const bool use_precise = Settings::IsGPULevelHigh();
         logical->ResetQueryPool(query.first, query.second, 1);
-        cmdbuf.BeginQuery(query.first, query.second, use_precise ? VK_QUERY_CONTROL_PRECISE_BIT : 0);
+        cmdbuf.BeginQuery(query.first, query.second,
+                          use_precise ? VK_QUERY_CONTROL_PRECISE_BIT : 0);
     });
 }
 
@@ -113,8 +115,10 @@ void HostCounter::EndQuery() {
         [query = query](vk::CommandBuffer cmdbuf) { cmdbuf.EndQuery(query.first, query.second); });
 }
 
-u64 HostCounter::BlockingQuery() const {
-    cache.GetScheduler().Wait(tick);
+u64 HostCounter::BlockingQuery(bool async) const {
+    if (!async) {
+        cache.GetScheduler().Wait(tick);
+    }
     u64 data;
     const VkResult query_result = cache.GetDevice().GetLogical().GetQueryResults(
         query.first, query.second, 1, sizeof(data), &data, sizeof(data),

--- a/src/video_core/renderer_vulkan/vk_query_cache.h
+++ b/src/video_core/renderer_vulkan/vk_query_cache.h
@@ -52,7 +52,8 @@ private:
 class QueryCache final
     : public VideoCommon::QueryCacheBase<QueryCache, CachedQuery, CounterStream, HostCounter> {
 public:
-    explicit QueryCache(VideoCore::RasterizerInterface& rasterizer_, const Device& device_,
+    explicit QueryCache(VideoCore::RasterizerInterface& rasterizer_,
+                        Core::Memory::Memory& cpu_memory_, const Device& device_,
                         Scheduler& scheduler_);
     ~QueryCache();
 
@@ -83,7 +84,7 @@ public:
     void EndQuery();
 
 private:
-    u64 BlockingQuery() const override;
+    u64 BlockingQuery(bool async = false) const override;
 
     QueryCache& cache;
     const VideoCore::QueryType type;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -172,7 +172,8 @@ RasterizerVulkan::RasterizerVulkan(Core::Frontend::EmuWindow& emu_window_, Tegra
       buffer_cache(*this, cpu_memory_, buffer_cache_runtime),
       pipeline_cache(*this, device, scheduler, descriptor_pool, update_descriptor_queue,
                      render_pass_cache, buffer_cache, texture_cache, gpu.ShaderNotify()),
-      query_cache{*this, cpu_memory_, device, scheduler}, accelerate_dma(buffer_cache, texture_cache, scheduler),
+      query_cache{*this, cpu_memory_, device, scheduler},
+      accelerate_dma(buffer_cache, texture_cache, scheduler),
       fence_manager(*this, gpu, texture_cache, buffer_cache, query_cache, device, scheduler),
       wfi_event(device.GetLogical().CreateEvent()) {
     scheduler.SetQueryCache(query_cache);
@@ -675,7 +676,8 @@ bool RasterizerVulkan::AccelerateConditionalRendering() {
     const GPUVAddr condition_address{maxwell3d->regs.render_enable.Address()};
     Maxwell::ReportSemaphore::Compare cmp;
     if (gpu_memory->IsMemoryDirty(condition_address, sizeof(cmp),
-                                  VideoCommon::CacheType::BufferCache | VideoCommon::CacheType::QueryCache)) {
+                                  VideoCommon::CacheType::BufferCache |
+                                      VideoCommon::CacheType::QueryCache)) {
         return true;
     }
     return false;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -172,7 +172,7 @@ RasterizerVulkan::RasterizerVulkan(Core::Frontend::EmuWindow& emu_window_, Tegra
       buffer_cache(*this, cpu_memory_, buffer_cache_runtime),
       pipeline_cache(*this, device, scheduler, descriptor_pool, update_descriptor_queue,
                      render_pass_cache, buffer_cache, texture_cache, gpu.ShaderNotify()),
-      query_cache{*this, device, scheduler}, accelerate_dma(buffer_cache, texture_cache, scheduler),
+      query_cache{*this, cpu_memory_, device, scheduler}, accelerate_dma(buffer_cache, texture_cache, scheduler),
       fence_manager(*this, gpu, texture_cache, buffer_cache, query_cache, device, scheduler),
       wfi_event(device.GetLogical().CreateEvent()) {
     scheduler.SetQueryCache(query_cache);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -675,7 +675,7 @@ bool RasterizerVulkan::AccelerateConditionalRendering() {
     const GPUVAddr condition_address{maxwell3d->regs.render_enable.Address()};
     Maxwell::ReportSemaphore::Compare cmp;
     if (gpu_memory->IsMemoryDirty(condition_address, sizeof(cmp),
-                                  VideoCommon::CacheType::BufferCache)) {
+                                  VideoCommon::CacheType::BufferCache | VideoCommon::CacheType::QueryCache)) {
         return true;
     }
     return false;


### PR DESCRIPTION
This pull requests aims to do 3 things:

1st Allow verification of fencing and writing of async downloads in a separate thread.
2nd Restructure the way accuracy is handled. Normal accuracy will now skip host-guest fence syncing and won't download on host conditional rendering.
3rd Rework Query Cache async downloads to be more consistent.

as a result when paired with the buffer cache revamp and Faster DMA:

- Performance greatly improves in many games with Normal accuracy.
- Splatoon 2's ink now works perfectly in AMD. (Splatoon 2 requires High accuracy).
