### PR TITLE
Remove fast path stream buffer for Vulkan

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -778,11 +778,12 @@ void BufferCache<P>::BindHostGraphicsUniformBuffer(size_t stage, u32 index, u32 
     const u32 size = std::min(binding.size, (*uniform_buffer_sizes)[stage][index]);
     Buffer& buffer = slot_buffers[binding.buffer_id];
     TouchBuffer(buffer, binding.buffer_id);
-    const bool use_fast_buffer = binding.buffer_id != NULL_BUFFER_ID &&
-                                 size <= uniform_buffer_skip_cache_size &&
-                                 !memory_tracker.IsRegionGpuModified(cpu_addr, size);
-    if (use_fast_buffer) {
-        if constexpr (IS_OPENGL) {
+
+    if constexpr (IS_OPENGL) {
+        const bool use_fast_buffer = binding.buffer_id != NULL_BUFFER_ID &&
+                                     size <= uniform_buffer_skip_cache_size &&
+                                     !memory_tracker.IsRegionGpuModified(cpu_addr, size);
+        if (use_fast_buffer) {
             if (runtime.HasFastBufferSubData()) {
                 // Fast path for Nvidia
                 const bool should_fast_bind =
@@ -796,18 +797,18 @@ void BufferCache<P>::BindHostGraphicsUniformBuffer(size_t stage, u32 index, u32 
                 }
                 const auto span = ImmediateBufferWithData(cpu_addr, size);
                 runtime.PushFastUniformBuffer(stage, binding_index, span);
-                return;
+            } else {
+                fast_bound_uniform_buffers[stage] |= 1U << binding_index;
+                uniform_buffer_binding_sizes[stage][binding_index] = size;
+                // Stream buffer path to avoid stalling on non-Nvidia drivers
+                const std::span<u8> span =
+                    runtime.BindMappedUniformBuffer(stage, binding_index, size);
+                cpu_memory.ReadBlockUnsafe(cpu_addr, span.data(), size);
             }
+            return;
         }
-        if constexpr (IS_OPENGL) {
-            fast_bound_uniform_buffers[stage] |= 1U << binding_index;
-            uniform_buffer_binding_sizes[stage][binding_index] = size;
-        }
-        // Stream buffer path to avoid stalling on non-Nvidia drivers or Vulkan
-        const std::span<u8> span = runtime.BindMappedUniformBuffer(stage, binding_index, size);
-        cpu_memory.ReadBlockUnsafe(cpu_addr, span.data(), size);
-        return;
     }
+
     // Classic cached path
     const bool sync_cached = SynchronizeBuffer(buffer, cpu_addr, size);
     if (sync_cached) {


### PR DESCRIPTION
I've looked at the code here and can't see any glaring issues with it, but there's some bug with it when the same piece of memory switches from fast to non-fast and visa versa. The performance loss from disabling this should be negligable. 

If anyone wants to investigate more, please do. Repro I'm using is the Crossroads of Destiny cutscene in XC2. Last cutscene for Chapter 1, just as Mets starts firing the cannons at Seiryuu right near the end of the scene. Some printing around this fast path code for the buffer with CpuAddr 0x2097471000 will show the issue.

In the bad frames, this buffer is used, and gets regularly copied to from the stream buffer during the cloud draws: 
![image](https://user-images.githubusercontent.com/34639600/233869097-e772481e-4eb4-45d8-9660-de18a59e98af.png)
Whereas in the good frames (when the clouds are drawn), all input uniform buffers use the Stream Buffer, with no copies:
![image](https://user-images.githubusercontent.com/34639600/233869137-46db89cb-f0ea-4209-8074-3ed2a9fd1c2e.png)

Disabling the fast path fixes the cloud flickering in XC2, but worth testing the performance. Closes #9688

EDIT: This is exposing bugs in our buffer cache, so marking as a draft for now. Even though this causes visual issues, they're not caused by this PR, the code I'm removing is just hiding them. The stream buffer forcibly reading from guest memory regardless of cpu/gpu modification state, and skipping all cached writes etc, seems to be what's hiding it.