### PR TITLE
Fix buffer overlap checking skipping a page for stream score right expand

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1262,7 +1262,7 @@ typename BufferCache<P>::OverlapResult BufferCache<P>::ResolveOverlaps(VAddr cpu
         const VAddr overlap_cpu_addr = overlap.CpuAddr();
         const bool expands_left = overlap_cpu_addr < begin;
         if (expands_left) {
-            cpu_addr = begin = overlap_cpu_addr;
+            begin = overlap_cpu_addr;
         }
         const VAddr overlap_end = overlap_cpu_addr + overlap.SizeBytes();
         const bool expands_right = overlap_end > end;
@@ -1276,7 +1276,7 @@ typename BufferCache<P>::OverlapResult BufferCache<P>::ResolveOverlaps(VAddr cpu
             has_stream_leap = true;
             if (expands_right) {
                 begin -= CACHING_PAGESIZE * 256;
-                cpu_addr = begin;
+                cpu_addr = begin - CACHING_PAGESIZE;
             }
             if (expands_left) {
                 end += CACHING_PAGESIZE * 256;
@@ -1299,7 +1299,7 @@ void BufferCache<P>::JoinOverlap(BufferId new_buffer_id, BufferId overlap_id,
     if (accumulate_stream_score) {
         new_buffer.IncreaseStreamScore(overlap.StreamScore() + 1);
     }
-    boost::container::small_vector<BufferCopy, 1> copies;
+    boost::container::small_vector<BufferCopy, 10> copies;
     const size_t dst_base_offset = overlap.CpuAddr() - new_buffer.CpuAddr();
     copies.push_back(BufferCopy{
         .src_offset = 0,


### PR DESCRIPTION
When expanding a stream buffer backwards, we set the begin to a big backwards address, but then immediately increment cpu_addr by 1 page, so it ends up that we potentially have 1 page at the start of the new buffer range that is not added to overlap_ids.

The previous cpu_addr assignment shouldn't be necessary either, since the buffers are merging intervals, there cannot be another buffer between half way inside a buffer, and the beginning of that same buffer, so moving cpu_addr backwards just means checking the exact same buffer's pages again up until the point we were previously at.