### PR TITLE
Allow fully customised controller hotkeys

### DIFF
--- a/src/yuzu/configuration/configure_hotkeys.h
+++ b/src/yuzu/configuration/configure_hotkeys.h
@@ -59,7 +59,7 @@ private:
     QStandardItemModel* model;
 
     void SetPollingResult(Core::HID::NpadButton button, bool cancel);
-    QString GetButtonName(Core::HID::NpadButton button) const;
+    QString GetButtonCombinationName(Core::HID::NpadButton button, bool home, bool capture) const;
     Core::HID::EmulatedController* controller;
     std::unique_ptr<QTimer> timeout_timer;
     std::unique_ptr<QTimer> poll_timer;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1163,7 +1163,8 @@ void GMainWindow::InitializeRecentFileMenuActions() {
     UpdateRecentFiles();
 }
 
-void GMainWindow::LinkActionShortcut(QAction* action, const QString& action_name) {
+void GMainWindow::LinkActionShortcut(QAction* action, const QString& action_name,
+                                     const bool tas_allowed) {
     static const QString main_window = QStringLiteral("Main Window");
     action->setShortcut(hotkey_registry.GetKeySequence(main_window, action_name));
     action->setShortcutContext(hotkey_registry.GetShortcutContext(main_window, action_name));
@@ -1175,7 +1176,14 @@ void GMainWindow::LinkActionShortcut(QAction* action, const QString& action_name
     const auto* controller_hotkey =
         hotkey_registry.GetControllerHotkey(main_window, action_name, controller);
     connect(
-        controller_hotkey, &ControllerShortcut::Activated, this, [action] { action->trigger(); },
+        controller_hotkey, &ControllerShortcut::Activated, this,
+        [action, tas_allowed, this] {
+            auto [tas_status, current_tas_frame, total_tas_frames] =
+                input_subsystem->GetTas()->GetStatus();
+            if (tas_allowed || tas_status == InputCommon::TasInput::TasState::Stopped) {
+                action->trigger();
+            }
+        },
         Qt::QueuedConnection);
 }
 
@@ -1192,9 +1200,9 @@ void GMainWindow::InitializeHotkeys() {
     LinkActionShortcut(ui->action_Show_Status_Bar, QStringLiteral("Toggle Status Bar"));
     LinkActionShortcut(ui->action_Fullscreen, QStringLiteral("Fullscreen"));
     LinkActionShortcut(ui->action_Capture_Screenshot, QStringLiteral("Capture Screenshot"));
-    LinkActionShortcut(ui->action_TAS_Start, QStringLiteral("TAS Start/Stop"));
-    LinkActionShortcut(ui->action_TAS_Record, QStringLiteral("TAS Record"));
-    LinkActionShortcut(ui->action_TAS_Reset, QStringLiteral("TAS Reset"));
+    LinkActionShortcut(ui->action_TAS_Start, QStringLiteral("TAS Start/Stop"), true);
+    LinkActionShortcut(ui->action_TAS_Record, QStringLiteral("TAS Record"), true);
+    LinkActionShortcut(ui->action_TAS_Reset, QStringLiteral("TAS Reset"), true);
 
     static const QString main_window = QStringLiteral("Main Window");
     const auto connect_shortcut = [&]<typename Fn>(const QString& action_name, const Fn& function) {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -214,7 +214,8 @@ public slots:
 
 private:
     /// Updates an action's shortcut and text to reflect an updated hotkey from the hotkey registry.
-    void LinkActionShortcut(QAction* action, const QString& action_name);
+    void LinkActionShortcut(QAction* action, const QString& action_name,
+                            const bool tas_allowed = false);
 
     void RegisterMetaTypes();
 


### PR DESCRIPTION
This PR moves away from prefixing `Home+` on all controller hotkey keybinds and instead allows for fully customisable mapping.


Things to note are:
- Work has gone into protecting the TAS functionality from triggering controller hotkeys.
- I moved away from a separate Home/Screenshot button, it looked like the main purpose of this was for protecting against TAS inputs which I have found a method to do without needing to single out these buttons.
- This is my first time working with C++ and I am very open that I have gaps in better ways of doing some of this work.

Unrelated to the work but there is an issue I found where you can record while in playback mode that probably deserves its own issue.

Closes  #10093.