### PR TITLE
vk_pipeline_cache: Skip compute pipelines on Intel proprietary drivers

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -696,6 +696,13 @@ std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline(
 std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline(
     ShaderPools& pools, const ComputePipelineCacheKey& key, Shader::Environment& env,
     PipelineStatistics* statistics, bool build_in_parallel) try {
+    // TODO: Remove this when Intel fixes their shader compiler.
+    //       https://github.com/IGCIT/Intel-GPU-Community-Issue-Tracker-IGCIT/issues/159
+    if (device.GetDriverID() == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS) {
+        LOG_ERROR(Render_Vulkan, "Skipping 0x{:016x}", key.Hash());
+        return nullptr;
+    }
+
     LOG_INFO(Render_Vulkan, "0x{:016x}", key.Hash());
 
     Shader::Maxwell::Flow::CFG cfg{env, pools.flow_block, env.StartAddress()};


### PR DESCRIPTION
Intel's SPIR-V shader compiler is broken. For now, skip compiling any compute pipelines until they fix this issue.
This is not a perfect workaround, as there are a small subset of non-compute pipelines that still cause it to crash, but this should cover the majority of crashes.
It is unfortunate that even with a test case reported 6 months ago the issue has not been fixed in favor of fixing "[the most popular games and apps](https://github.com/IGCIT/Intel-GPU-Community-Issue-Tracker-IGCIT/issues/159#issuecomment-1527618555)".
Intel, you can do better than this.