### PR TITLE
Wait for the terminate event before destroying a system instance

### DIFF
--- a/src/audio_core/renderer/system.cpp
+++ b/src/audio_core/renderer/system.cpp
@@ -436,10 +436,7 @@ void System::Stop() {
     }
 
     if (execution_mode == ExecutionMode::Auto) {
-        // Should wait for the system to terminate here, but core timing (should have) already
-        // stopped, so this isn't needed. Find a way to make this definite.
-
-        // terminate_event.Wait();
+        terminate_event.Wait();
     }
 }
 


### PR DESCRIPTION
Without this, the DSP can still be active with a command list, using memory from a System which is being destroyed. The terminate event here ensures that doesn't happen. I had to remove it before due to relying on CoreTiming to signal it, but CoreTiming stops before services are shut down, which meant it would never signal and deadlock on shutdown.

ByLaws removed the reliance on CoreTiming, so this should be fine now, and remove the use after free.