### PR TITLE
qt: warn on inoperable keys

### DIFF
--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -392,6 +392,7 @@ private:
     void LoadTranslation();
     void OpenPerGameConfiguration(u64 title_id, const std::string& file_name);
     bool CheckDarkMode();
+    bool CheckSystemArchiveDecryption();
 
     QString GetTasStateDescription() const;
     bool CreateShortcut(const std::string& shortcut_path, const std::string& title,


### PR DESCRIPTION
Pops up a warning informing you that your keys can't decrypt the Mii model from your firmware dump (this has already happened to me twice when forgetting to update lockpick after a new major version)