### PR TITLE
Allow Fermi blit accelerate to work without images in cache

### DIFF
--- a/src/common/scratch_buffer.h
+++ b/src/common/scratch_buffer.h
@@ -23,7 +23,10 @@ public:
           buffer{Common::make_unique_for_overwrite<T[]>(initial_capacity)} {}
 
     ~ScratchBuffer() = default;
+    ScratchBuffer(const ScratchBuffer&) = delete;
+    ScratchBuffer& operator=(const ScratchBuffer&) = delete;
     ScratchBuffer(ScratchBuffer&&) = default;
+    ScratchBuffer& operator=(ScratchBuffer&&) = default;
 
     /// This will only grow the buffer's capacity if size is greater than the current capacity.
     /// The previously held data will remain intact.
@@ -85,6 +88,12 @@ public:
 
     [[nodiscard]] size_t capacity() const noexcept {
         return buffer_capacity;
+    }
+
+    void swap(ScratchBuffer& other) noexcept {
+        std::swap(last_requested_size, other.last_requested_size);
+        std::swap(buffer_capacity, other.buffer_capacity);
+        std::swap(buffer, other.buffer);
     }
 
 private:

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1469,7 +1469,7 @@ std::optional<typename TextureCache<P>::BlitImages> TextureCache<P>::GetBlitImag
         if (!copy.must_accelerate) {
             do {
                 if (!src_id && !dst_id) {
-                    return std::nullopt;
+                    break;
                 }
                 if (src_id && True(slot_images[src_id].flags & ImageFlagBits::GpuModified)) {
                     break;


### PR DESCRIPTION
Currently the accelerated blit path will return nullopt if neither src nor dst exist in the cache already, and then fall back to the software path. This PR changes that to allow it, I also replaced the vectors with scratchbuffers as they were showing up in the perf profiler as well.

Super Fowlst 2 uses Fermi blit a lot (thousands of times), and consistently fails the accelerate path, and is very very slow during menus, which this PR helps to address. It's still slow even with the accelerated path, but noticeably better. @FernandoS27 is there any reason we can't add both images to the cache and do this? Is it slower for some games? Which? We already allow it to work when *either* src or dst is in the cache, just not both.

Needs perf testing either way.

Before:
https://user-images.githubusercontent.com/34639600/235504776-679bfc0b-7363-4e7a-a5cc-f7f20d3b0a5b.mp4

After:
https://user-images.githubusercontent.com/34639600/235505189-6ece4482-9df6-4813-80f5-3ac8dedc3f87.mp4

