### PR TITLE
CMakeLists: Enable more checks on Clang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ else()
         $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-private-field>
         $<$<CXX_COMPILER_ID:Clang>:-Werror=shadow-uncaptured-local>
         $<$<CXX_COMPILER_ID:Clang>:-Werror=implicit-fallthrough>
+        $<$<CXX_COMPILER_ID:Clang>:-Werror=type-limits>
         $<$<CXX_COMPILER_ID:AppleClang>:-Wno-braced-scalar-init>
         $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-private-field>
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,8 @@ else()
 
         $<$<CXX_COMPILER_ID:Clang>:-Wno-braced-scalar-init>
         $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-private-field>
+        $<$<CXX_COMPILER_ID:Clang>:-Werror=shadow-uncaptured-local>
+        $<$<CXX_COMPILER_ID:Clang>:-Werror=implicit-fallthrough>
         $<$<CXX_COMPILER_ID:AppleClang>:-Wno-braced-scalar-init>
         $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-private-field>
     )


### PR DESCRIPTION
Enables shadow-uncaptured-locals, type-limits and implicit-fallthrough for Clang. implicit-fallthrough is not enabled by default in -Wall or -Wextra, and shadow-uncaptured-local doesn't seem to be enabled by default by -Wshadow, even though GCC has both of these by their respective cases.

Exposed by CI on #10125 

Clang's shadow-all seems to enable checks more than GCC's shadow, and raises more warnings than GCC does as-is. Choosing not to enable that for now.