### PR TITLE
vulkan: disable turbo when debugging tool is attached

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -617,7 +617,9 @@ bool Device::ShouldBoostClocks() const {
 
     const bool is_steam_deck = vendor_id == 0x1002 && device_id == 0x163F;
 
-    return validated_driver && !is_steam_deck;
+    const bool is_debugging = this->HasDebuggingToolAttached();
+
+    return validated_driver && !is_steam_deck && !is_debugging;
 }
 
 bool Device::GetSuitability(bool requires_swapchain) {


### PR DESCRIPTION
Most Vulkan tools can't handle having multiple devices created.