### PR TITLE
Fix shader code resize to use word size rather than byte size

### DIFF
--- a/src/video_core/shader_cache.cpp
+++ b/src/video_core/shader_cache.cpp
@@ -228,14 +228,14 @@ const ShaderInfo* ShaderCache::MakeShaderInfo(GenericEnvironment& env, VAddr cpu
     auto info = std::make_unique<ShaderInfo>();
     if (const std::optional<u64> cached_hash{env.Analyze()}) {
         info->unique_hash = *cached_hash;
-        info->size_bytes = env.CachedSize();
+        info->size_bytes = env.CachedSizeBytes();
     } else {
         // Slow path, not really hit on commercial games
         // Build a control flow graph to get the real shader size
         Shader::ObjectPool<Shader::Maxwell::Flow::Block> flow_block;
         Shader::Maxwell::Flow::CFG cfg{env, flow_block, env.StartAddress()};
         info->unique_hash = env.CalculateHash();
-        info->size_bytes = env.ReadSize();
+        info->size_bytes = env.ReadSizeBytes();
     }
     const size_t size_bytes{info->size_bytes};
     const ShaderInfo* const result{info.get()};

--- a/src/video_core/shader_environment.h
+++ b/src/video_core/shader_environment.h
@@ -48,9 +48,11 @@ public:
 
     void SetCachedSize(size_t size_bytes);
 
-    [[nodiscard]] size_t CachedSize() const noexcept;
+    [[nodiscard]] size_t CachedSizeWords() const noexcept;
 
-    [[nodiscard]] size_t ReadSize() const noexcept;
+    [[nodiscard]] size_t CachedSizeBytes() const noexcept;
+
+    [[nodiscard]] size_t ReadSizeBytes() const noexcept;
 
     [[nodiscard]] bool CanBeSerialized() const noexcept;
 


### PR DESCRIPTION
SetCachedSize is returning the size in bytes of the shader code, and using that to resize the u64 code array. Everywhere else I saw currently wants the byte size, but I figured adding a word size function can't hurt, rather than changing the callsite. This fixes the code array being 8 times larger than it should be, and why our shader dumps have always been so huge.