### PR TITLE
catch2: update to 3.3.1

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -49,7 +49,7 @@
     "overrides": [
         {
             "name": "catch2",
-            "version": "3.0.1"
+            "version": "3.3.1"
         },
         {
             "name": "fmt",


### PR DESCRIPTION
Fixes compile error with gcc 13