### PR TITLE
settings: Forcibly enable asynchronous presentation.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -98,7 +98,7 @@ PresentManager::PresentManager(Core::Frontend::EmuWindow& render_window_, const 
     : render_window{render_window_}, device{device_},
       memory_allocator{memory_allocator_}, scheduler{scheduler_}, swapchain{swapchain_},
       blit_supported{CanBlitToSwapchain(device.GetPhysical(), swapchain.GetImageViewFormat())},
-      use_present_thread{Settings::values.async_presentation.GetValue()},
+      use_present_thread{/*Settings::values.async_presentation.GetValue()*/ true},
       image_count{swapchain.GetImageCount()} {
 
     auto& dld = device.GetLogical();

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -22,13 +22,13 @@ ConfigureGraphicsAdvanced::~ConfigureGraphicsAdvanced() = default;
 void ConfigureGraphicsAdvanced::SetConfiguration() {
     const bool runtime_lock = !system.IsPoweredOn();
     ui->use_vsync->setEnabled(runtime_lock);
-    ui->async_present->setEnabled(runtime_lock);
+    // ui->async_present->setEnabled(runtime_lock);
     ui->renderer_force_max_clock->setEnabled(runtime_lock);
     ui->async_astc->setEnabled(runtime_lock);
     ui->use_asynchronous_shaders->setEnabled(runtime_lock);
     ui->anisotropic_filtering_combobox->setEnabled(runtime_lock);
 
-    ui->async_present->setChecked(Settings::values.async_presentation.GetValue());
+    // ui->async_present->setChecked(Settings::values.async_presentation.GetValue());
     ui->renderer_force_max_clock->setChecked(Settings::values.renderer_force_max_clock.GetValue());
     ui->use_vsync->setChecked(Settings::values.use_vsync.GetValue());
     ui->async_astc->setChecked(Settings::values.async_astc.GetValue());
@@ -56,8 +56,8 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
 
 void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.gpu_accuracy, ui->gpu_accuracy);
-    ConfigurationShared::ApplyPerGameSetting(&Settings::values.async_presentation,
-                                             ui->async_present, async_present);
+    // ConfigurationShared::ApplyPerGameSetting(&Settings::values.async_presentation,
+    //                                          ui->async_present, async_present);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.renderer_force_max_clock,
                                              ui->renderer_force_max_clock,
                                              renderer_force_max_clock);
@@ -94,7 +94,7 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     // Disable if not global (only happens during game)
     if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setEnabled(Settings::values.gpu_accuracy.UsingGlobal());
-        ui->async_present->setEnabled(Settings::values.async_presentation.UsingGlobal());
+        // ui->async_present->setEnabled(Settings::values.async_presentation.UsingGlobal());
         ui->renderer_force_max_clock->setEnabled(
             Settings::values.renderer_force_max_clock.UsingGlobal());
         ui->use_vsync->setEnabled(Settings::values.use_vsync.UsingGlobal());
@@ -112,8 +112,9 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         return;
     }
 
-    ConfigurationShared::SetColoredTristate(ui->async_present, Settings::values.async_presentation,
-                                            async_present);
+    // ConfigurationShared::SetColoredTristate(ui->async_present,
+    // Settings::values.async_presentation,
+    //                                         async_present);
     ConfigurationShared::SetColoredTristate(ui->renderer_force_max_clock,
                                             Settings::values.renderer_force_max_clock,
                                             renderer_force_max_clock);

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -70,13 +70,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="async_present">
-          <property name="text">
-           <string>Enable asynchronous presentation (Vulkan only)</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QCheckBox" name="renderer_force_max_clock">
           <property name="toolTip">
            <string>Runs work in the background while waiting for graphics commands to keep the GPU from lowering its clock speed.</string>


### PR DESCRIPTION
When this is disabled, many games softlock. Regression caused by #9973. This is just a do-not-merge workaround for tomorrow's mainline build. @GPUCode for proper fix.