### PR TITLE
Y.F.C. bring back Reactive Flushing

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -62,6 +62,7 @@ void LogSettings() {
     log_setting("Renderer_AccelerateASTC", values.accelerate_astc.GetValue());
     log_setting("Renderer_AsyncASTC", values.async_astc.GetValue());
     log_setting("Renderer_UseVsync", values.vsync_mode.GetValue());
+    log_setting("Renderer_UseReactiveFlushing", values.use_reactive_flushing.GetValue());
     log_setting("Renderer_ShaderBackend", values.shader_backend.GetValue());
     log_setting("Renderer_UseAsynchronousShaders", values.use_asynchronous_shaders.GetValue());
     log_setting("Renderer_AnisotropicFilteringLevel", values.max_anisotropy.GetValue());
@@ -223,6 +224,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.nvdec_emulation.SetGlobal(true);
     values.accelerate_astc.SetGlobal(true);
     values.async_astc.SetGlobal(true);
+    values.use_reactive_flushing.SetGlobal(true);
     values.shader_backend.SetGlobal(true);
     values.use_asynchronous_shaders.SetGlobal(true);
     values.use_fast_gpu_time.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -465,6 +465,7 @@ struct Values {
     SwitchableSetting<bool> async_astc{false, "async_astc"};
     Setting<VSyncMode, true> vsync_mode{VSyncMode::FIFO, VSyncMode::Immediate,
                                         VSyncMode::FIFORelaxed, "use_vsync"};
+    SwitchableSetting<bool> use_reactive_flushing{true, "use_reactive_flushing"};
     SwitchableSetting<ShaderBackend, true> shader_backend{ShaderBackend::GLSL, ShaderBackend::GLSL,
                                                           ShaderBackend::SPIRV, "shader_backend"};
     SwitchableSetting<bool> use_asynchronous_shaders{false, "use_asynchronous_shaders"};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -612,6 +612,10 @@ void System::PrepareReschedule(const u32 core_index) {
     impl->kernel.PrepareReschedule(core_index);
 }
 
+size_t System::GetCurrentHostThreadID() const {
+    return impl->kernel.GetCurrentHostThreadID();
+}
+
 PerfStatsResults System::GetAndResetPerfStats() {
     return impl->GetAndResetPerfStats();
 }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -222,6 +222,8 @@ public:
     /// Prepare the core emulation for a reschedule
     void PrepareReschedule(u32 core_index);
 
+    [[nodiscard]] size_t GetCurrentHostThreadID() const;
+
     /// Gets and resets core performance statistics
     [[nodiscard]] PerfStatsResults GetAndResetPerfStats();
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -20,7 +20,6 @@
 #include "video_core/gpu.h"
 #include "video_core/rasterizer_download_area.h"
 
-
 namespace Core::Memory {
 
 // Implementation class used to keep the specifics of the memory subsystem hidden
@@ -465,7 +464,8 @@ struct Memory::Impl {
         }
 
         if (Settings::IsFastmemEnabled()) {
-            const bool is_read_enable = !Settings::values.use_reactive_flushing.GetValue() || !cached;
+            const bool is_read_enable =
+                !Settings::values.use_reactive_flushing.GetValue() || !cached;
             system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
         }
 
@@ -654,9 +654,7 @@ struct Memory::Impl {
                 LOG_ERROR(HW_Memory, "Unmapped Read{} @ 0x{:016X}", sizeof(T) * 8,
                           GetInteger(vaddr));
             },
-            [&]() {
-                HandleRasterizerDownload(GetInteger(vaddr), sizeof(T));
-            });
+            [&]() { HandleRasterizerDownload(GetInteger(vaddr), sizeof(T)); });
         if (ptr) {
             std::memcpy(&result, ptr, sizeof(T));
         }
@@ -721,7 +719,8 @@ struct Memory::Impl {
         const size_t core = system.GetCurrentHostThreadID();
         auto& current_area = rasterizer_areas[core];
         const VAddr end_address = address + size;
-        if (current_area.start_address <= address && end_address <= current_area.end_address) [[likely]] {
+        if (current_area.start_address <= address && end_address <= current_area.end_address)
+            [[likely]] {
             return;
         }
         current_area = system.GPU().OnCPURead(address, size);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -465,7 +465,8 @@ struct Memory::Impl {
         }
 
         if (Settings::IsFastmemEnabled()) {
-            system.DeviceMemory().buffer.Protect(vaddr, size, !cached, !cached);
+            const bool is_read_enable = !Settings::values.use_reactive_flushing.GetValue() || !cached;
+            system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
         }
 
         // Iterate over a contiguous CPU address space, which corresponds to the specified GPU

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -13,10 +13,13 @@
 #include "common/swap.h"
 #include "core/core.h"
 #include "core/device_memory.h"
+#include "core/hardware_properties.h"
 #include "core/hle/kernel/k_page_table.h"
 #include "core/hle/kernel/k_process.h"
 #include "core/memory.h"
 #include "video_core/gpu.h"
+#include "video_core/rasterizer_download_area.h"
+
 
 namespace Core::Memory {
 
@@ -243,7 +246,7 @@ struct Memory::Impl {
             [&](const Common::ProcessAddress current_vaddr, const std::size_t copy_amount,
                 const u8* const host_ptr) {
                 if constexpr (!UNSAFE) {
-                    system.GPU().FlushRegion(GetInteger(current_vaddr), copy_amount);
+                    HandleRasterizerDownload(GetInteger(current_vaddr), copy_amount);
                 }
                 std::memcpy(dest_buffer, host_ptr, copy_amount);
             },
@@ -334,7 +337,7 @@ struct Memory::Impl {
             },
             [&](const Common::ProcessAddress current_vaddr, const std::size_t copy_amount,
                 u8* const host_ptr) {
-                system.GPU().FlushRegion(GetInteger(current_vaddr), copy_amount);
+                HandleRasterizerDownload(GetInteger(current_vaddr), copy_amount);
                 WriteBlockImpl<false>(process, dest_addr, host_ptr, copy_amount);
             },
             [&](const std::size_t copy_amount) {
@@ -373,7 +376,7 @@ struct Memory::Impl {
                                  const std::size_t block_size) {
             // dc ivac: Invalidate to point of coherency
             // GPU flush -> CPU invalidate
-            system.GPU().FlushRegion(GetInteger(current_vaddr), block_size);
+            HandleRasterizerDownload(GetInteger(current_vaddr), block_size);
         };
         return PerformCacheOperation(process, dest_addr, size, on_rasterizer);
     }
@@ -462,8 +465,7 @@ struct Memory::Impl {
         }
 
         if (Settings::IsFastmemEnabled()) {
-            const bool is_read_enable = !Settings::IsGPULevelExtreme() || !cached;
-            system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
+            system.DeviceMemory().buffer.Protect(vaddr, size, !cached, !cached);
         }
 
         // Iterate over a contiguous CPU address space, which corresponds to the specified GPU
@@ -651,7 +653,9 @@ struct Memory::Impl {
                 LOG_ERROR(HW_Memory, "Unmapped Read{} @ 0x{:016X}", sizeof(T) * 8,
                           GetInteger(vaddr));
             },
-            [&]() { system.GPU().FlushRegion(GetInteger(vaddr), sizeof(T)); });
+            [&]() {
+                HandleRasterizerDownload(GetInteger(vaddr), sizeof(T));
+            });
         if (ptr) {
             std::memcpy(&result, ptr, sizeof(T));
         }
@@ -712,7 +716,18 @@ struct Memory::Impl {
         return true;
     }
 
+    void HandleRasterizerDownload(VAddr address, size_t size) {
+        const size_t core = system.GetCurrentHostThreadID();
+        auto& current_area = rasterizer_areas[core];
+        const VAddr end_address = address + size;
+        if (current_area.start_address <= address && end_address <= current_area.end_address) [[likely]] {
+            return;
+        }
+        current_area = system.GPU().OnCPURead(address, size);
+    }
+
     Common::PageTable* current_page_table = nullptr;
+    std::array<VideoCore::RasterizerDownloadArea, Core::Hardware::NUM_CPU_CORES> rasterizer_areas{};
     Core::System& system;
 };
 

--- a/src/tests/video_core/memory_tracker.cpp
+++ b/src/tests/video_core/memory_tracker.cpp
@@ -535,12 +535,12 @@ TEST_CASE("MemoryTracker: Cached write downloads") {
     memory_track->MarkRegionAsGpuModified(c + PAGE, PAGE);
     int num = 0;
     memory_track->ForEachDownloadRangeAndClear(c, WORD, [&](u64 offset, u64 size) { ++num; });
-    REQUIRE(num == 1);
+    REQUIRE(num == 0);
     num = 0;
     memory_track->ForEachUploadRange(c, WORD, [&](u64 offset, u64 size) { ++num; });
     REQUIRE(num == 0);
     REQUIRE(!memory_track->IsRegionCpuModified(c + PAGE, PAGE));
-    REQUIRE(!memory_track->IsRegionGpuModified(c + PAGE, PAGE));
+    REQUIRE(memory_track->IsRegionGpuModified(c + PAGE, PAGE));
     memory_track->FlushCachedWrites();
     REQUIRE(memory_track->IsRegionCpuModified(c + PAGE, PAGE));
     REQUIRE(!memory_track->IsRegionGpuModified(c + PAGE, PAGE));

--- a/src/video_core/buffer_cache/buffer_base.h
+++ b/src/video_core/buffer_cache/buffer_base.h
@@ -18,6 +18,7 @@ namespace VideoCommon {
 enum class BufferFlagBits {
     Picked = 1 << 0,
     CachedWrites = 1 << 1,
+    PreemtiveDownload = 1 << 2,
 };
 DECLARE_ENUM_FLAG_OPERATORS(BufferFlagBits)
 
@@ -54,6 +55,10 @@ public:
         flags |= BufferFlagBits::Picked;
     }
 
+    void MarkPreemtiveDownload() noexcept {
+        flags |= BufferFlagBits::PreemtiveDownload;
+    }
+
     /// Unmark buffer as picked
     void Unpick() noexcept {
         flags &= ~BufferFlagBits::Picked;
@@ -82,6 +87,10 @@ public:
     /// Returns true when the buffer has pending cached writes
     [[nodiscard]] bool HasCachedWrites() const noexcept {
         return True(flags & BufferFlagBits::CachedWrites);
+    }
+
+    bool IsPreemtiveDownload() const noexcept {
+        return True(flags & BufferFlagBits::PreemtiveDownload);
     }
 
     /// Returns the base CPU address of the buffer

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -203,11 +203,8 @@ bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 am
         const VAddr new_base_address = *cpu_dest_address + diff;
         const IntervalType add_interval{new_base_address, new_base_address + size};
         tmp_intervals.push_back(add_interval);
-        if (!Settings::values.use_reactive_flushing.GetValue() ||
-            memory_tracker.IsRegionPreflushable(new_base_address, new_base_address + size)) {
-            uncommitted_ranges.add(add_interval);
-            pending_ranges.add(add_interval);
-        }
+        uncommitted_ranges.add(add_interval);
+        pending_ranges.add(add_interval);
     };
     ForEachInRangeSet(common_ranges, *cpu_src_address, amount, mirror);
     // This subtraction in this order is important for overlapping copies.
@@ -1234,10 +1231,6 @@ void BufferCache<P>::MarkWrittenBuffer(BufferId buffer_id, VAddr cpu_addr, u32 s
 
     const IntervalType base_interval{cpu_addr, cpu_addr + size};
     common_ranges.add(base_interval);
-    if (Settings::values.use_reactive_flushing.GetValue() &&
-        !memory_tracker.IsRegionPreflushable(cpu_addr, cpu_addr + size)) {
-        return;
-    }
     uncommitted_ranges.add(base_interval);
     pending_ranges.add(base_interval);
 }

--- a/src/video_core/buffer_cache/buffer_cache_base.h
+++ b/src/video_core/buffer_cache/buffer_cache_base.h
@@ -572,8 +572,6 @@ private:
     u64 critical_memory = 0;
     BufferId inline_buffer_id;
 
-    bool active_async_buffers = false;
-
     std::array<BufferId, ((1ULL << 39) >> CACHING_PAGEBITS)> page_table;
     std::vector<u8> tmp_buffer;
 };

--- a/src/video_core/buffer_cache/buffer_cache_base.h
+++ b/src/video_core/buffer_cache/buffer_cache_base.h
@@ -188,6 +188,8 @@ public:
 
     void DownloadMemory(VAddr cpu_addr, u64 size);
 
+    std::optional<VideoCore::RasterizerDownloadArea> GetFlushArea(VAddr cpu_addr, u64 size);
+
     bool InlineMemory(VAddr dest_address, size_t copy_size, std::span<const u8> inlined_buffer);
 
     void BindGraphicsUniformBuffer(size_t stage, u32 index, GPUVAddr gpu_addr, u32 size);
@@ -541,8 +543,6 @@ private:
                        std::array<std::array<u32, NUM_GRAPHICS_UNIFORM_BUFFERS>, NUM_STAGES>, Empty>
         uniform_buffer_binding_sizes{};
 
-    std::vector<BufferId> cached_write_buffer_ids;
-
     MemoryTracker memory_tracker;
     IntervalSet uncommitted_ranges;
     IntervalSet common_ranges;
@@ -575,6 +575,7 @@ private:
     bool active_async_buffers = false;
 
     std::array<BufferId, ((1ULL << 39) >> CACHING_PAGEBITS)> page_table;
+    std::vector<u8> tmp_buffer;
 };
 
 } // namespace VideoCommon

--- a/src/video_core/buffer_cache/word_manager.h
+++ b/src/video_core/buffer_cache/word_manager.h
@@ -26,6 +26,7 @@ enum class Type {
     GPU,
     CachedCPU,
     Untracked,
+    Preflushable,
 };
 
 /// Vector tracking modified pages tightly packed with small vector optimization
@@ -55,17 +56,20 @@ struct Words {
             gpu.stack.fill(0);
             cached_cpu.stack.fill(0);
             untracked.stack.fill(~u64{0});
+            preflushable.stack.fill(0);
         } else {
             // Share allocation between CPU and GPU pages and set their default values
-            u64* const alloc = new u64[num_words * 4];
+            u64* const alloc = new u64[num_words * 5];
             cpu.heap = alloc;
             gpu.heap = alloc + num_words;
             cached_cpu.heap = alloc + num_words * 2;
             untracked.heap = alloc + num_words * 3;
+            preflushable.heap = alloc + num_words * 4;
             std::fill_n(cpu.heap, num_words, ~u64{0});
             std::fill_n(gpu.heap, num_words, 0);
             std::fill_n(cached_cpu.heap, num_words, 0);
             std::fill_n(untracked.heap, num_words, ~u64{0});
+            std::fill_n(preflushable.heap, num_words, 0);
         }
         // Clean up tailing bits
         const u64 last_word_size = size_bytes % BYTES_PER_WORD;
@@ -88,13 +92,14 @@ struct Words {
         gpu = rhs.gpu;
         cached_cpu = rhs.cached_cpu;
         untracked = rhs.untracked;
+        preflushable = rhs.preflushable;
         rhs.cpu.heap = nullptr;
         return *this;
     }
 
     Words(Words&& rhs) noexcept
         : size_bytes{rhs.size_bytes}, num_words{rhs.num_words}, cpu{rhs.cpu}, gpu{rhs.gpu},
-          cached_cpu{rhs.cached_cpu}, untracked{rhs.untracked} {
+          cached_cpu{rhs.cached_cpu}, untracked{rhs.untracked}, preflushable{rhs.preflushable} {
         rhs.cpu.heap = nullptr;
     }
 
@@ -129,6 +134,8 @@ struct Words {
             return std::span<u64>(cached_cpu.Pointer(IsShort()), num_words);
         } else if constexpr (type == Type::Untracked) {
             return std::span<u64>(untracked.Pointer(IsShort()), num_words);
+        } else if constexpr (type == Type::Preflushable) {
+            return std::span<u64>(preflushable.Pointer(IsShort()), num_words);
         }
     }
 
@@ -142,6 +149,8 @@ struct Words {
             return std::span<const u64>(cached_cpu.Pointer(IsShort()), num_words);
         } else if constexpr (type == Type::Untracked) {
             return std::span<const u64>(untracked.Pointer(IsShort()), num_words);
+        } else if constexpr (type == Type::Preflushable) {
+            return std::span<const u64>(preflushable.Pointer(IsShort()), num_words);
         }
     }
 
@@ -151,6 +160,7 @@ struct Words {
     WordsArray<stack_words> gpu;
     WordsArray<stack_words> cached_cpu;
     WordsArray<stack_words> untracked;
+    WordsArray<stack_words> preflushable;
 };
 
 template <class RasterizerInterface, size_t stack_words = 1>

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -288,7 +288,7 @@ void MaxwellDMA::CopyPitchToBlockLinear() {
     write_buffer.resize_destructive(dst_size);
 
     memory_manager.ReadBlock(regs.offset_in, read_buffer.data(), src_size);
-    memory_manager.ReadBlock(regs.offset_out, write_buffer.data(), dst_size);
+    memory_manager.ReadBlockUnsafe(regs.offset_out, write_buffer.data(), dst_size);
 
     // If the input is linear and the output is tiled, swizzle the input and copy it over.
     SwizzleSubrect(write_buffer, read_buffer, bytes_per_pixel, width, height, depth, x_offset,

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -223,7 +223,7 @@ void MaxwellDMA::CopyBlockLinearToPitch() {
     write_buffer.resize_destructive(dst_size);
 
     memory_manager.ReadBlock(src_operand.address, read_buffer.data(), src_size);
-    memory_manager.ReadBlockUnsafe(dst_operand.address, write_buffer.data(), dst_size);
+    memory_manager.ReadBlock(dst_operand.address, write_buffer.data(), dst_size);
 
     UnswizzleSubrect(write_buffer, read_buffer, bytes_per_pixel, width, height, depth, x_offset,
                      src_params.origin.y, x_elements, regs.line_count, block_height, block_depth,
@@ -288,11 +288,7 @@ void MaxwellDMA::CopyPitchToBlockLinear() {
     write_buffer.resize_destructive(dst_size);
 
     memory_manager.ReadBlock(regs.offset_in, read_buffer.data(), src_size);
-    if (Settings::IsGPULevelExtreme()) {
-        memory_manager.ReadBlock(regs.offset_out, write_buffer.data(), dst_size);
-    } else {
-        memory_manager.ReadBlockUnsafe(regs.offset_out, write_buffer.data(), dst_size);
-    }
+    memory_manager.ReadBlock(regs.offset_out, write_buffer.data(), dst_size);
 
     // If the input is linear and the output is tiled, swizzle the input and copy it over.
     SwizzleSubrect(write_buffer, read_buffer, bytes_per_pixel, width, height, depth, x_offset,

--- a/src/video_core/fence_manager.h
+++ b/src/video_core/fence_manager.h
@@ -55,7 +55,12 @@ public:
 
     // Unlike other fences, this one doesn't
     void SignalOrdering() {
-        std::function<void()> do_nothing([]{});
+        std::scoped_lock lock{buffer_cache.mutex};
+        buffer_cache.AccumulateFlushes();
+    }
+
+    void SignalReference() {
+        std::function<void()> do_nothing([] {});
         SignalFence(std::move(do_nothing));
     }
 

--- a/src/video_core/fence_manager.h
+++ b/src/video_core/fence_manager.h
@@ -55,8 +55,8 @@ public:
 
     // Unlike other fences, this one doesn't
     void SignalOrdering() {
-        std::scoped_lock lock{buffer_cache.mutex};
-        buffer_cache.AccumulateFlushes();
+        std::function<void()> do_nothing([]{});
+        SignalFence(std::move(do_nothing));
     }
 
     void SyncOperation(std::function<void()>&& func) {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -10,6 +10,7 @@
 #include "core/hle/service/nvdrv/nvdata.h"
 #include "video_core/cdma_pusher.h"
 #include "video_core/framebuffer_config.h"
+#include "video_core/rasterizer_download_area.h"
 
 namespace Core {
 class System;
@@ -239,6 +240,9 @@ public:
 
     /// Swap buffers (render frame)
     void SwapBuffers(const Tegra::FramebufferConfig* framebuffer);
+
+    /// Notify rasterizer that any caches of the specified region should be flushed to Switch memory
+    [[nodiscard]] VideoCore::RasterizerDownloadArea OnCPURead(VAddr addr, u64 size);
 
     /// Notify rasterizer that any caches of the specified region should be flushed to Switch memory
     void FlushRegion(VAddr addr, u64 size);

--- a/src/video_core/query_cache.h
+++ b/src/video_core/query_cache.h
@@ -255,7 +255,6 @@ private:
                 if (!in_range(query)) {
                     continue;
                 }
-                rasterizer.UpdatePagesCachedCount(query.GetCpuAddr(), query.SizeInBytes(), -1);
                 AsyncJobId async_job_id = query.GetAsyncJob();
                 auto flush_result = query.Flush(async);
                 if (async_job_id == NULL_ASYNC_JOB_ID) {
@@ -273,7 +272,6 @@ private:
 
     /// Registers the passed parameters as cached and returns a pointer to the stored cached query.
     CachedQuery* Register(VideoCore::QueryType type, VAddr cpu_addr, u8* host_ptr, bool timestamp) {
-        rasterizer.UpdatePagesCachedCount(cpu_addr, CachedQuery::SizeInBytes(timestamp), 1);
         const u64 page = static_cast<u64>(cpu_addr) >> YUZU_PAGEBITS;
         return &cached_queries[page].emplace_back(static_cast<QueryCache&>(*this), type, cpu_addr,
                                                   host_ptr);

--- a/src/video_core/rasterizer_download_area.h
+++ b/src/video_core/rasterizer_download_area.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #pragma once
 
 #include "common/common_types.h"

--- a/src/video_core/rasterizer_download_area.h
+++ b/src/video_core/rasterizer_download_area.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "common/common_types.h"
+
+namespace VideoCore {
+
+struct RasterizerDownloadArea {
+    VAddr start_address;
+    VAddr end_address;
+    bool preemtive;
+};
+
+} // namespace VideoCore

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -12,6 +12,7 @@
 #include "video_core/cache_types.h"
 #include "video_core/engines/fermi_2d.h"
 #include "video_core/gpu.h"
+#include "video_core/rasterizer_download_area.h"
 
 namespace Tegra {
 class MemoryManager;
@@ -94,6 +95,8 @@ public:
     /// Check if the the specified memory area requires flushing to CPU Memory.
     virtual bool MustFlushRegion(VAddr addr, u64 size,
                                  VideoCommon::CacheType which = VideoCommon::CacheType::All) = 0;
+
+    virtual RasterizerDownloadArea GetFlushArea(VAddr addr, u64 size) = 0;
 
     /// Notify rasterizer that any caches of the specified region should be invalidated
     virtual void InvalidateRegion(VAddr addr, u64 size,

--- a/src/video_core/renderer_null/null_rasterizer.cpp
+++ b/src/video_core/renderer_null/null_rasterizer.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/alignment.h"
+#include "core/memory.h"
 #include "video_core/host1x/host1x.h"
 #include "video_core/memory_manager.h"
 #include "video_core/renderer_null/null_rasterizer.h"
@@ -46,6 +48,14 @@ bool RasterizerNull::MustFlushRegion(VAddr addr, u64 size, VideoCommon::CacheTyp
 }
 void RasterizerNull::InvalidateRegion(VAddr addr, u64 size, VideoCommon::CacheType) {}
 void RasterizerNull::OnCPUWrite(VAddr addr, u64 size) {}
+VideoCore::RasterizerDownloadArea RasterizerNull::GetFlushArea(VAddr addr, u64 size) {
+    VideoCore::RasterizerDownloadArea new_area{
+        .start_address = Common::AlignDown(addr, Core::Memory::YUZU_PAGESIZE),
+        .end_address = Common::AlignUp(addr + size, Core::Memory::YUZU_PAGESIZE),
+        .preemtive = true,
+    };
+    return new_area;
+}
 void RasterizerNull::InvalidateGPUCache() {}
 void RasterizerNull::UnmapMemory(VAddr addr, u64 size) {}
 void RasterizerNull::ModifyGPUMemory(size_t as_id, GPUVAddr addr, u64 size) {}

--- a/src/video_core/renderer_null/null_rasterizer.h
+++ b/src/video_core/renderer_null/null_rasterizer.h
@@ -54,6 +54,7 @@ public:
     void InvalidateRegion(VAddr addr, u64 size,
                           VideoCommon::CacheType which = VideoCommon::CacheType::All) override;
     void OnCPUWrite(VAddr addr, u64 size) override;
+    VideoCore::RasterizerDownloadArea GetFlushArea(VAddr addr, u64 size) override;
     void InvalidateGPUCache() override;
     void UnmapMemory(VAddr addr, u64 size) override;
     void ModifyGPUMemory(size_t as_id, GPUVAddr addr, u64 size) override;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1304,7 +1304,7 @@ bool AccelerateDMA::DmaBufferImageCopy(const Tegra::DMA::ImageCopy& copy_info,
                                        const Tegra::DMA::BufferOperand& buffer_operand,
                                        const Tegra::DMA::ImageOperand& image_operand) {
     std::scoped_lock lock{buffer_cache.mutex, texture_cache.mutex};
-    const auto image_id = texture_cache.DmaImageId(image_operand);
+    const auto image_id = texture_cache.DmaImageId(image_operand, IS_IMAGE_UPLOAD);
     if (image_id == VideoCommon::NULL_IMAGE_ID) {
         return false;
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -95,6 +95,7 @@ public:
                      VideoCommon::CacheType which = VideoCommon::CacheType::All) override;
     bool MustFlushRegion(VAddr addr, u64 size,
                          VideoCommon::CacheType which = VideoCommon::CacheType::All) override;
+    VideoCore::RasterizerDownloadArea GetFlushArea(VAddr addr, u64 size) override;
     void InvalidateRegion(VAddr addr, u64 size,
                           VideoCommon::CacheType which = VideoCommon::CacheType::All) override;
     void OnCPUWrite(VAddr addr, u64 size) override;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -510,13 +510,6 @@ VideoCore::RasterizerDownloadArea RasterizerVulkan::GetFlushArea(VAddr addr, u64
             return *area;
         }
     }
-    {
-        std::scoped_lock lock{buffer_cache.mutex};
-        auto area = buffer_cache.GetFlushArea(addr, size);
-        if (area) {
-            return *area;
-        }
-    }
     VideoCore::RasterizerDownloadArea new_area{
         .start_address = Common::AlignDown(addr, Core::Memory::YUZU_PAGESIZE),
         .end_address = Common::AlignUp(addr + size, Core::Memory::YUZU_PAGESIZE),

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -621,7 +621,7 @@ void RasterizerVulkan::SignalSyncPoint(u32 value) {
 }
 
 void RasterizerVulkan::SignalReference() {
-    fence_manager.SignalOrdering();
+    fence_manager.SignalReference();
 }
 
 void RasterizerVulkan::ReleaseFences() {
@@ -654,7 +654,7 @@ void RasterizerVulkan::WaitForIdle() {
         cmdbuf.SetEvent(event, flags);
         cmdbuf.WaitEvents(event, flags, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, {}, {}, {});
     });
-    SignalReference();
+    fence_manager.SignalOrdering();
 }
 
 void RasterizerVulkan::FragmentBarrier() {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -793,7 +793,7 @@ bool AccelerateDMA::DmaBufferImageCopy(const Tegra::DMA::ImageCopy& copy_info,
                                        const Tegra::DMA::BufferOperand& buffer_operand,
                                        const Tegra::DMA::ImageOperand& image_operand) {
     std::scoped_lock lock{buffer_cache.mutex, texture_cache.mutex};
-    const auto image_id = texture_cache.DmaImageId(image_operand);
+    const auto image_id = texture_cache.DmaImageId(image_operand, IS_IMAGE_UPLOAD);
     if (image_id == VideoCommon::NULL_IMAGE_ID) {
         return false;
     }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -92,6 +92,7 @@ public:
                      VideoCommon::CacheType which = VideoCommon::CacheType::All) override;
     bool MustFlushRegion(VAddr addr, u64 size,
                          VideoCommon::CacheType which = VideoCommon::CacheType::All) override;
+    VideoCore::RasterizerDownloadArea GetFlushArea(VAddr addr, u64 size) override;
     void InvalidateRegion(VAddr addr, u64 size,
                           VideoCommon::CacheType which = VideoCommon::CacheType::All) override;
     void InnerInvalidation(std::span<const std::pair<VAddr, std::size_t>> sequences) override;

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -39,6 +39,7 @@ struct ImageInfo {
     u32 tile_width_spacing = 0;
     bool rescaleable = false;
     bool downscaleable = false;
+    bool forced_flushed = false;
 };
 
 } // namespace VideoCommon

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -40,6 +40,7 @@ struct ImageInfo {
     bool rescaleable = false;
     bool downscaleable = false;
     bool forced_flushed = false;
+    bool dma_downloaded = false;
 };
 
 } // namespace VideoCommon

--- a/src/video_core/texture_cache/image_view_base.cpp
+++ b/src/video_core/texture_cache/image_view_base.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 
 #include "common/assert.h"
-#include "common/settings.h"
 #include "video_core/compatible_formats.h"
 #include "video_core/surface.h"
 #include "video_core/texture_cache/formatter.h"
@@ -26,9 +25,7 @@ ImageViewBase::ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_i
     ASSERT_MSG(VideoCore::Surface::IsViewCompatible(image_info.format, info.format, false, true),
                "Image view format {} is incompatible with image format {}", info.format,
                image_info.format);
-    const bool preemptive =
-        !Settings::values.use_reactive_flushing.GetValue() && image_info.type == ImageType::Linear;
-    if (image_info.forced_flushed || preemptive) {
+    if (image_info.forced_flushed) {
         flags |= ImageViewFlagBits::PreemtiveDownload;
     }
     if (image_info.type == ImageType::e3D && info.type != ImageViewType::e3D) {

--- a/src/video_core/texture_cache/image_view_base.cpp
+++ b/src/video_core/texture_cache/image_view_base.cpp
@@ -26,7 +26,8 @@ ImageViewBase::ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_i
     ASSERT_MSG(VideoCore::Surface::IsViewCompatible(image_info.format, info.format, false, true),
                "Image view format {} is incompatible with image format {}", info.format,
                image_info.format);
-    const bool preemptive = !Settings::values.use_reactive_flushing.GetValue() && image_info.type == ImageType::Linear;
+    const bool preemptive =
+        !Settings::values.use_reactive_flushing.GetValue() && image_info.type == ImageType::Linear;
     if (image_info.forced_flushed || preemptive) {
         flags |= ImageViewFlagBits::PreemtiveDownload;
     }

--- a/src/video_core/texture_cache/image_view_base.cpp
+++ b/src/video_core/texture_cache/image_view_base.cpp
@@ -26,8 +26,7 @@ ImageViewBase::ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_i
     ASSERT_MSG(VideoCore::Surface::IsViewCompatible(image_info.format, info.format, false, true),
                "Image view format {} is incompatible with image format {}", info.format,
                image_info.format);
-    const bool is_async = Settings::values.use_asynchronous_gpu_emulation.GetValue();
-    if (image_info.type == ImageType::Linear && is_async) {
+    if (image_info.forced_flushed) {
         flags |= ImageViewFlagBits::PreemtiveDownload;
     }
     if (image_info.type == ImageType::e3D && info.type != ImageViewType::e3D) {

--- a/src/video_core/texture_cache/image_view_base.cpp
+++ b/src/video_core/texture_cache/image_view_base.cpp
@@ -26,7 +26,8 @@ ImageViewBase::ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_i
     ASSERT_MSG(VideoCore::Surface::IsViewCompatible(image_info.format, info.format, false, true),
                "Image view format {} is incompatible with image format {}", info.format,
                image_info.format);
-    if (image_info.forced_flushed) {
+    const bool preemptive = !Settings::values.use_reactive_flushing.GetValue() && image_info.type == ImageType::Linear;
+    if (image_info.forced_flushed || preemptive) {
         flags |= ImageViewFlagBits::PreemtiveDownload;
     }
     if (image_info.type == ImageType::e3D && info.type != ImageViewType::e3D) {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1323,7 +1323,6 @@ ImageId TextureCache<P>::JoinImages(const ImageInfo& info, GPUVAddr gpu_addr, VA
             all_siblings.push_back(overlap_id);
         } else {
             bad_overlap_ids.push_back(overlap_id);
-            overlap.flags |= ImageFlagBits::BadOverlap;
         }
     };
     ForEachImageInRegion(cpu_addr, size_bytes, region_check);
@@ -1434,7 +1433,12 @@ ImageId TextureCache<P>::JoinImages(const ImageInfo& info, GPUVAddr gpu_addr, VA
         ImageBase& aliased = slot_images[aliased_id];
         aliased.overlapping_images.push_back(new_image_id);
         new_image.overlapping_images.push_back(aliased_id);
-        new_image.flags |= ImageFlagBits::BadOverlap;
+        if (aliased.info.resources.levels == 1 && aliased.overlapping_images.size() > 1) {
+            aliased.flags |= ImageFlagBits::BadOverlap;
+        }
+        if (new_image.info.resources.levels == 1 && new_image.overlapping_images.size() > 1) {
+            new_image.flags |= ImageFlagBits::BadOverlap;
+        }
     }
     RegisterImage(new_image_id);
     return new_image_id;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -811,7 +811,7 @@ void TextureCache<P>::PopAsyncFlushes() {
 }
 
 template <class P>
-ImageId TextureCache<P>::DmaImageId(const Tegra::DMA::ImageOperand& operand) {
+ImageId TextureCache<P>::DmaImageId(const Tegra::DMA::ImageOperand& operand, bool is_upload) {
     const ImageInfo dst_info(operand);
     const ImageId dst_id = FindDMAImage(dst_info, operand.address);
     if (!dst_id) {
@@ -822,7 +822,7 @@ ImageId TextureCache<P>::DmaImageId(const Tegra::DMA::ImageOperand& operand) {
         // No need to waste time on an image that's synced with guest
         return NULL_IMAGE_ID;
     }
-    if (!image.info.dma_downloaded) {
+    if (!is_upload && !image.info.dma_downloaded) {
         // Force a full sync.
         image.info.dma_downloaded = true;
         return NULL_IMAGE_ID;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -709,18 +709,43 @@ void TextureCache<P>::CommitAsyncFlushes() {
                 download_info.async_buffer_id = last_async_buffer_id;
             }
         }
+
         if (any_none_dma) {
+            bool all_pre_sync = true;
             auto download_map = runtime.DownloadStagingBuffer(total_size_bytes, true);
             for (const PendingDownload& download_info : download_ids) {
                 if (download_info.is_swizzle) {
                     Image& image = slot_images[download_info.object_id];
+                    all_pre_sync &= image.info.dma_downloaded;
+                    image.info.dma_downloaded = true;
                     const auto copies = FullDownloadCopies(image.info);
                     image.DownloadMemory(download_map, copies);
                     download_map.offset += Common::AlignUp(image.unswizzled_size_bytes, 64);
                 }
             }
-            uncommitted_async_buffers.emplace_back(download_map);
+            if (!all_pre_sync) {
+                runtime.Finish();
+                auto it = download_ids.begin();
+                while (it != download_ids.end()) {
+                    const PendingDownload& download_info = *it;
+                    if (download_info.is_swizzle) {
+                        const ImageBase& image = slot_images[download_info.object_id];
+                        const auto copies = FullDownloadCopies(image.info);
+                        download_map.offset -= Common::AlignUp(image.unswizzled_size_bytes, 64);
+                        std::span<u8> download_span =
+                            download_map.mapped_span.subspan(download_map.offset);
+                        SwizzleImage(*gpu_memory, image.gpu_addr, image.info, copies, download_span,
+                                     swizzle_data_buffer);
+                        it = download_ids.erase(it);
+                    } else {
+                        it++;
+                    }
+                }
+            } else {
+                uncommitted_async_buffers.emplace_back(download_map);
+            }
         }
+
         async_buffers.emplace_back(std::move(uncommitted_async_buffers));
         uncommitted_async_buffers.clear();
     }
@@ -820,8 +845,9 @@ ImageId TextureCache<P>::DmaImageId(const Tegra::DMA::ImageOperand& operand) {
         // No need to waste time on an image that's synced with guest
         return NULL_IMAGE_ID;
     }
-    if (!image.info.forced_flushed) {
-        image.info.forced_flushed = true;
+    if (!image.info.dma_downloaded) {
+        // Force a full sync.
+        image.info.dma_downloaded = true;
         return NULL_IMAGE_ID;
     }
     const auto base = image.TryFindBase(operand.address);

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -207,7 +207,7 @@ public:
     /// Pop asynchronous downloads
     void PopAsyncFlushes();
 
-    [[nodiscard]] ImageId DmaImageId(const Tegra::DMA::ImageOperand& operand);
+    [[nodiscard]] ImageId DmaImageId(const Tegra::DMA::ImageOperand& operand, bool is_upload);
 
     [[nodiscard]] std::pair<Image*, BufferImageCopy> DmaBufferImageCopy(
         const Tegra::DMA::ImageCopy& copy_info, const Tegra::DMA::BufferOperand& buffer_operand,

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -179,6 +179,8 @@ public:
     /// Download contents of host images to guest memory in a region
     void DownloadMemory(VAddr cpu_addr, size_t size);
 
+    std::optional<VideoCore::RasterizerDownloadArea> GetFlushArea(VAddr cpu_addr, u64 size);
+
     /// Remove images in a region
     void UnmapMemory(VAddr cpu_addr, size_t size);
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -710,6 +710,7 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.nvdec_emulation);
     ReadGlobalSetting(Settings::values.accelerate_astc);
     ReadGlobalSetting(Settings::values.async_astc);
+    ReadGlobalSetting(Settings::values.use_reactive_flushing);
     ReadGlobalSetting(Settings::values.shader_backend);
     ReadGlobalSetting(Settings::values.use_asynchronous_shaders);
     ReadGlobalSetting(Settings::values.use_fast_gpu_time);
@@ -1355,6 +1356,7 @@ void Config::SaveRendererValues() {
                  Settings::values.nvdec_emulation.UsingGlobal());
     WriteGlobalSetting(Settings::values.accelerate_astc);
     WriteGlobalSetting(Settings::values.async_astc);
+    WriteGlobalSetting(Settings::values.use_reactive_flushing);
     WriteSetting(QString::fromStdString(Settings::values.shader_backend.GetLabel()),
                  static_cast<u32>(Settings::values.shader_backend.GetValue(global)),
                  static_cast<u32>(Settings::values.shader_backend.GetDefault()),

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -21,6 +21,7 @@ ConfigureGraphicsAdvanced::~ConfigureGraphicsAdvanced() = default;
 
 void ConfigureGraphicsAdvanced::SetConfiguration() {
     const bool runtime_lock = !system.IsPoweredOn();
+    ui->use_reactive_flushing->setEnabled(runtime_lock);
     ui->async_present->setEnabled(runtime_lock);
     ui->renderer_force_max_clock->setEnabled(runtime_lock);
     ui->async_astc->setEnabled(runtime_lock);
@@ -29,6 +30,7 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
 
     ui->async_present->setChecked(Settings::values.async_presentation.GetValue());
     ui->renderer_force_max_clock->setChecked(Settings::values.renderer_force_max_clock.GetValue());
+    ui->use_reactive_flushing->setChecked(Settings::values.use_reactive_flushing.GetValue());
     ui->async_astc->setChecked(Settings::values.async_astc.GetValue());
     ui->use_asynchronous_shaders->setChecked(Settings::values.use_asynchronous_shaders.GetValue());
     ui->use_fast_gpu_time->setChecked(Settings::values.use_fast_gpu_time.GetValue());
@@ -60,6 +62,8 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
                                              renderer_force_max_clock);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                              ui->anisotropic_filtering_combobox);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_reactive_flushing,
+                                             ui->use_reactive_flushing, use_reactive_flushing);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.async_astc, ui->async_astc,
                                              async_astc);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
@@ -91,6 +95,7 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         ui->async_present->setEnabled(Settings::values.async_presentation.UsingGlobal());
         ui->renderer_force_max_clock->setEnabled(
             Settings::values.renderer_force_max_clock.UsingGlobal());
+        ui->use_reactive_flushing->setEnabled(Settings::values.use_reactive_flushing.UsingGlobal());
         ui->async_astc->setEnabled(Settings::values.async_astc.UsingGlobal());
         ui->use_asynchronous_shaders->setEnabled(
             Settings::values.use_asynchronous_shaders.UsingGlobal());
@@ -108,6 +113,8 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->renderer_force_max_clock,
                                             Settings::values.renderer_force_max_clock,
                                             renderer_force_max_clock);
+    ConfigurationShared::SetColoredTristate(
+        ui->use_reactive_flushing, Settings::values.use_reactive_flushing, use_reactive_flushing);
     ConfigurationShared::SetColoredTristate(ui->async_astc, Settings::values.async_astc,
                                             async_astc);
     ConfigurationShared::SetColoredTristate(ui->use_asynchronous_shaders,

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -40,6 +40,7 @@ private:
     ConfigurationShared::CheckState renderer_force_max_clock;
     ConfigurationShared::CheckState use_vsync;
     ConfigurationShared::CheckState async_astc;
+    ConfigurationShared::CheckState use_reactive_flushing;
     ConfigurationShared::CheckState use_asynchronous_shaders;
     ConfigurationShared::CheckState use_fast_gpu_time;
     ConfigurationShared::CheckState use_vulkan_driver_pipeline_cache;

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -97,6 +97,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="use_reactive_flushing">
+          <property name="toolTip">
+           <string>Uses reactive flushing instead of predictive flushing. Allowing a more accurate syncing of memory.</string>
+          </property>
+          <property name="text">
+           <string>Enable Reactive Flushing</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="use_asynchronous_shaders">
           <property name="toolTip">
            <string>Enables asynchronous shader compilation, which may reduce shader stutter. This feature is experimental.</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -312,6 +312,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.use_asynchronous_gpu_emulation);
     ReadSetting("Renderer", Settings::values.vsync_mode);
     ReadSetting("Renderer", Settings::values.shader_backend);
+    ReadSetting("Renderer", Settings::values.use_reactive_flushing);
     ReadSetting("Renderer", Settings::values.use_asynchronous_shaders);
     ReadSetting("Renderer", Settings::values.nvdec_emulation);
     ReadSetting("Renderer", Settings::values.accelerate_astc);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -340,6 +340,10 @@ use_vsync =
 # 0: GLSL, 1 (default): GLASM, 2: SPIR-V
 shader_backend =
 
+# Uses reactive flushing instead of predictive flushing. Allowing a more accurate syncing of memory.
+# 0: Off, 1 (default): On
+use_reactive_flushing =
+
 # Whether to allow asynchronous shader building.
 # 0 (default): Off, 1: On
 use_asynchronous_shaders =


### PR DESCRIPTION
In the early stages of yuzu, it operated similarly to older emulators where if the CPU read an area that was modified by the GPU, a full sync between the host and guest GPUs would be triggered. However, this approach was too costly and was later replaced with predictive flushing. This change introduces back reactive flushing in a new way.

This fixes 
- Old regressions such as Bayonetta 2's shadows.
- Xenoblade DE Thumbnails.
- Lighting in Xenoblade games.
- Improves performance in buffer-heavy games like Monster Hunter Rise.
- Thumbnails and in-game photos in a bunch of games (like camera photos in Astral Chain and partially thumbnails in Luigi's Mansion 3)
- Vertex explosions in Pokemon Violet / Scarlet.
- Make High accuracy fully use async buffers in Vulkan, thus improving performance more in this mode.

For the time being, this is an option (enabled by default) as it costs performance in games like Xenoblade

Shadows fixed in Bayonetta 2
![image](https://user-images.githubusercontent.com/1731197/236083345-1566b2dd-28f2-4268-995c-4f8e79a9c344.png)

Camera photos fixed in Astral Chain
![image](https://user-images.githubusercontent.com/1731197/236084982-f46185c8-3c8c-45b4-9208-3ef5c134c84c.png)

Thumbnails fixed in Luigi's Mansion 3 & Xenoblade DE.
![image](https://user-images.githubusercontent.com/1731197/236085003-bce45db4-e934-4f5b-a311-caaa2e337133.png)
![image](https://user-images.githubusercontent.com/1731197/236085028-37c6f8e4-1a09-4138-9cdd-f8138a564a10.png)

Fixed lighting:
![image](https://user-images.githubusercontent.com/1731197/236182469-ec931e05-be20-4b6a-8dbe-c15bfd267a43.png)

seems to fix rendering here
![image](https://user-images.githubusercontent.com/1731197/236182274-c0970346-6a61-48aa-9370-4d8f55b9ec00.png)

Seems to fix explosions, mostly
![image](https://user-images.githubusercontent.com/1731197/236182305-d7b0acdf-8725-4f37-b4fb-a4e85a1045d4.png)

Fixes regressions in Yoshi crafted world:
![image](https://user-images.githubusercontent.com/1731197/236212495-102668d0-510f-4a3b-ab53-d668be7140b0.png)

This is one of the last 2 pieces from Y.F.C. Project. The next feature will be Query Cache overhaul and Host Conditional Rendering.
