### PR TITLE
yuzu-sdl,audio_core: Remove antiquated warning ignore

### DIFF
--- a/src/audio_core/sink/sdl2_sink.cpp
+++ b/src/audio_core/sink/sdl2_sink.cpp
@@ -3,22 +3,13 @@
 
 #include <span>
 #include <vector>
+#include <SDL.h>
 
 #include "audio_core/common/common.h"
 #include "audio_core/sink/sdl2_sink.h"
 #include "audio_core/sink/sink_stream.h"
 #include "common/logging/log.h"
 #include "core/core.h"
-
-// Ignore -Wimplicit-fallthrough due to https://github.com/libsdl-org/SDL/issues/4307
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-#include <SDL.h>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 namespace AudioCore::Sink {
 /**

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -4,18 +4,8 @@
 #include <memory>
 #include <optional>
 #include <sstream>
-
-// Ignore -Wimplicit-fallthrough due to https://github.com/libsdl-org/SDL/issues/4307
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-#include <SDL.h>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
 #include <INIReader.h>
+#include <SDL.h>
 #include "common/fs/file.h"
 #include "common/fs/fs.h"
 #include "common/fs/path_util.h"


### PR DESCRIPTION
Issue was fixed a long time ago, both by SDL2 and in yuzu by including SDL2 as a system library.

Partially reverts f973274 (the other files seemed to have been cleaned up by now).