### PR TITLE
yuzu: Add motion preview to controller input

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -111,6 +111,8 @@ struct AnalogProperties {
     float offset{};
     // Invert direction of the sensor data
     bool inverted{};
+    // Invert the state if it's converted to a button
+    bool inverted_button{};
     // Press once to activate, press again to release
     bool toggle{};
 };

--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -265,7 +265,7 @@ public:
         z = std::sin(roll) * temp + std::cos(roll) * z;
 
         temp = x;
-        x = std::cosf(pitch) * x + std::sin(pitch) * z;
+        x = std::cos(pitch) * x + std::sin(pitch) * z;
         z = -std::sin(pitch) * temp + std::cos(pitch) * z;
 
         temp = x;

--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -259,6 +259,20 @@ public:
         return *this;
     }
 
+    void RotateFromOrigin(float roll, float pitch, float yaw) {
+        float temp = y;
+        y = std::cos(roll) * y - std::sin(roll) * z;
+        z = std::sin(roll) * temp + std::cos(roll) * z;
+
+        temp = x;
+        x = std::cosf(pitch) * x + std::sin(pitch) * z;
+        z = -std::sin(pitch) * temp + std::cos(pitch) * z;
+
+        temp = x;
+        x = std::cos(yaw) * x - std::sin(yaw) * y;
+        y = std::sin(yaw) * temp + std::cos(yaw) * y;
+    }
+
     [[nodiscard]] constexpr T Length2() const {
         return x * x + y * y + z * z;
     }

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -376,6 +376,7 @@ void EmulatedController::ReloadInput() {
         motion.accel = emulated_motion.GetAcceleration();
         motion.gyro = emulated_motion.GetGyroscope();
         motion.rotation = emulated_motion.GetRotations();
+        motion.euler = emulated_motion.GetEulerAngles();
         motion.orientation = emulated_motion.GetOrientation();
         motion.is_at_rest = !emulated_motion.IsMoving(motion_sensitivity);
     }
@@ -976,14 +977,11 @@ void EmulatedController::SetMotion(const Common::Input::CallbackStatus& callback
     emulated.UpdateOrientation(raw_status.delta_timestamp);
     force_update_motion = raw_status.force_update;
 
-    if (is_configuring) {
-        return;
-    }
-
     auto& motion = controller.motion_state[index];
     motion.accel = emulated.GetAcceleration();
     motion.gyro = emulated.GetGyroscope();
     motion.rotation = emulated.GetRotations();
+    motion.euler = emulated.GetEulerAngles();
     motion.orientation = emulated.GetOrientation();
     motion.is_at_rest = !emulated.IsMoving(motion_sensitivity);
 }

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -106,6 +106,7 @@ struct ControllerMotion {
     Common::Vec3f accel{};
     Common::Vec3f gyro{};
     Common::Vec3f rotation{};
+    Common::Vec3f euler{};
     std::array<Common::Vec3f, 3> orientation{};
     bool is_at_rest{};
 };

--- a/src/core/hid/input_converter.cpp
+++ b/src/core/hid/input_converter.cpp
@@ -54,6 +54,7 @@ Common::Input::ButtonStatus TransformToButton(const Common::Input::CallbackStatu
     case Common::Input::InputType::Analog:
         status.value = TransformToTrigger(callback).pressed.value;
         status.toggle = callback.analog_status.properties.toggle;
+        status.inverted = callback.analog_status.properties.inverted_button;
         break;
     case Common::Input::InputType::Trigger:
         status.value = TransformToTrigger(callback).pressed.value;

--- a/src/core/hid/motion_input.h
+++ b/src/core/hid/motion_input.h
@@ -35,6 +35,7 @@ public:
     void SetAcceleration(const Common::Vec3f& acceleration);
     void SetGyroscope(const Common::Vec3f& gyroscope);
     void SetQuaternion(const Common::Quaternion<f32>& quaternion);
+    void SetEulerAngles(const Common::Vec3f& euler_angles);
     void SetGyroBias(const Common::Vec3f& bias);
     void SetGyroThreshold(f32 threshold);
 
@@ -54,6 +55,7 @@ public:
     [[nodiscard]] Common::Vec3f GetGyroBias() const;
     [[nodiscard]] Common::Vec3f GetRotations() const;
     [[nodiscard]] Common::Quaternion<f32> GetQuaternion() const;
+    [[nodiscard]] Common::Vec3f GetEulerAngles() const;
 
     [[nodiscard]] bool IsMoving(f32 sensitivity) const;
     [[nodiscard]] bool IsCalibrated(f32 sensitivity) const;

--- a/src/input_common/input_engine.cpp
+++ b/src/input_common/input_engine.cpp
@@ -58,6 +58,8 @@ void InputEngine::SetHatButton(const PadIdentifier& identifier, int button, u8 v
 }
 
 void InputEngine::SetAxis(const PadIdentifier& identifier, int axis, f32 value) {
+    value /= 2.0f;
+    value -= 0.5f;
     {
         std::scoped_lock lock{mutex};
         ControllerData& controller = controller_list.at(identifier);

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -939,6 +939,7 @@ std::unique_ptr<Common::Input::InputDevice> InputFactory::CreateAnalogDevice(
         .threshold = std::clamp(params.Get("threshold", 0.5f), 0.0f, 1.0f),
         .offset = std::clamp(params.Get("offset", 0.0f), -1.0f, 1.0f),
         .inverted = params.Get("invert", "+") == "-",
+        .inverted_button = params.Get("inverted", false) != 0,
         .toggle = params.Get("toggle", false) != 0,
     };
     input_engine->PreSetController(identifier);

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -206,7 +206,7 @@ QString ConfigureInputPlayer::ButtonToText(const Common::ParamPackage& param) {
         }
         if (param.Has("axis")) {
             const QString axis = QString::fromStdString(param.Get("axis", ""));
-            return QObject::tr("%1%2Axis %3").arg(toggle, invert, axis);
+            return QObject::tr("%1%2%3Axis %4").arg(toggle, inverted, invert, axis);
         }
         if (param.Has("axis_x") && param.Has("axis_y") && param.Has("axis_z")) {
             const QString axis_x = QString::fromStdString(param.Get("axis_x", ""));
@@ -229,7 +229,7 @@ QString ConfigureInputPlayer::ButtonToText(const Common::ParamPackage& param) {
         return QObject::tr("%1%2%3Hat %4").arg(turbo, toggle, inverted, button_name);
     }
     if (param.Has("axis")) {
-        return QObject::tr("%1%2Axis %3").arg(toggle, inverted, button_name);
+        return QObject::tr("%1%2%3Axis %4").arg(toggle, inverted, invert, button_name);
     }
     if (param.Has("motion")) {
         return QObject::tr("%1%2Axis %3").arg(toggle, inverted, button_name);
@@ -407,6 +407,12 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                         context_menu.addAction(tr("Invert axis"), [&] {
                             const bool toggle_value = !(param.Get("invert", "+") == "-");
                             param.Set("invert", toggle_value ? "-" : "+");
+                            button_map[button_id]->setText(ButtonToText(param));
+                            emulated_controller->SetButtonParam(button_id, param);
+                        });
+                        context_menu.addAction(tr("Invert button"), [&] {
+                            const bool invert_value = !param.Get("inverted", false);
+                            param.Set("inverted", invert_value);
                             button_map[button_id]->setText(ButtonToText(param));
                             emulated_controller->SetButtonParam(button_id, param);
                         });

--- a/src/yuzu/configuration/configure_input_player_widget.h
+++ b/src/yuzu/configuration/configure_input_player_widget.h
@@ -9,6 +9,7 @@
 
 #include "common/input.h"
 #include "common/settings_input.h"
+#include "common/vector_math.h"
 #include "core/hid/emulated_controller.h"
 #include "core/hid/hid_types.h"
 
@@ -193,6 +194,9 @@ private:
     void DrawSymbol(QPainter& p, QPointF center, Symbol symbol, float icon_size);
     void DrawArrow(QPainter& p, QPointF center, Direction direction, float size);
 
+    // Draw motion functions
+    void Draw3dCube(QPainter& p, QPointF center, const Common::Vec3f& euler, float size);
+
     // Draw primitive types
     template <size_t N>
     void DrawPolygon(QPainter& p, const std::array<QPointF, N>& polygon);
@@ -222,4 +226,5 @@ private:
     Core::HID::SticksValues stick_values{};
     Core::HID::TriggerValues trigger_values{};
     Core::HID::BatteryValues battery_values{};
+    Core::HID::MotionState motion_values{};
 };


### PR DESCRIPTION
Adds a little 3d cube to the preview that is linked to motion input. This helps to determine if motion has been setup properly.
![image](https://user-images.githubusercontent.com/5944268/236540909-d5d86ea5-d684-4fc9-b9c6-d945991078ce.png)
