### PR TITLE
input_common: Add property to invert an axis button

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -111,6 +111,8 @@ struct AnalogProperties {
     float offset{};
     // Invert direction of the sensor data
     bool inverted{};
+    // Invert the state if it's converted to a button
+    bool inverted_button{};
     // Press once to activate, press again to release
     bool toggle{};
 };

--- a/src/core/hid/input_converter.cpp
+++ b/src/core/hid/input_converter.cpp
@@ -54,6 +54,7 @@ Common::Input::ButtonStatus TransformToButton(const Common::Input::CallbackStatu
     case Common::Input::InputType::Analog:
         status.value = TransformToTrigger(callback).pressed.value;
         status.toggle = callback.analog_status.properties.toggle;
+        status.inverted = callback.analog_status.properties.inverted_button;
         break;
     case Common::Input::InputType::Trigger:
         status.value = TransformToTrigger(callback).pressed.value;

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -939,6 +939,7 @@ std::unique_ptr<Common::Input::InputDevice> InputFactory::CreateAnalogDevice(
         .threshold = std::clamp(params.Get("threshold", 0.5f), 0.0f, 1.0f),
         .offset = std::clamp(params.Get("offset", 0.0f), -1.0f, 1.0f),
         .inverted = params.Get("invert", "+") == "-",
+        .inverted_button = params.Get("inverted", false) != 0,
         .toggle = params.Get("toggle", false) != 0,
     };
     input_engine->PreSetController(identifier);

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -206,7 +206,7 @@ QString ConfigureInputPlayer::ButtonToText(const Common::ParamPackage& param) {
         }
         if (param.Has("axis")) {
             const QString axis = QString::fromStdString(param.Get("axis", ""));
-            return QObject::tr("%1%2Axis %3").arg(toggle, invert, axis);
+            return QObject::tr("%1%2%3Axis %4").arg(toggle, inverted, invert, axis);
         }
         if (param.Has("axis_x") && param.Has("axis_y") && param.Has("axis_z")) {
             const QString axis_x = QString::fromStdString(param.Get("axis_x", ""));
@@ -229,7 +229,7 @@ QString ConfigureInputPlayer::ButtonToText(const Common::ParamPackage& param) {
         return QObject::tr("%1%2%3Hat %4").arg(turbo, toggle, inverted, button_name);
     }
     if (param.Has("axis")) {
-        return QObject::tr("%1%2Axis %3").arg(toggle, inverted, button_name);
+        return QObject::tr("%1%2%3Axis %4").arg(toggle, inverted, invert, button_name);
     }
     if (param.Has("motion")) {
         return QObject::tr("%1%2Axis %3").arg(toggle, inverted, button_name);
@@ -407,6 +407,12 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                         context_menu.addAction(tr("Invert axis"), [&] {
                             const bool toggle_value = !(param.Get("invert", "+") == "-");
                             param.Set("invert", toggle_value ? "-" : "+");
+                            button_map[button_id]->setText(ButtonToText(param));
+                            emulated_controller->SetButtonParam(button_id, param);
+                        });
+                        context_menu.addAction(tr("Invert button"), [&] {
+                            const bool invert_value = !param.Get("inverted", false);
+                            param.Set("inverted", invert_value);
                             button_map[button_id]->setText(ButtonToText(param));
                             emulated_controller->SetButtonParam(button_id, param);
                         });


### PR DESCRIPTION
Some controller manufacturers seem to follow no standard when it comes to triggers. This allows to invert the final state of an axis button.