### PR TITLE
Log object names with debug renderer, add a GPU address to ImageViews

### DIFF
--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -108,7 +108,8 @@ bool IsASTCSupported() {
 
 [[nodiscard]] bool IsDebugToolAttached(std::span<const std::string_view> extensions) {
     const bool nsight = std::getenv("NVTX_INJECTION64_PATH") || std::getenv("NSIGHT_LAUNCHED");
-    return nsight || HasExtension(extensions, "GL_EXT_debug_tool");
+    return nsight || HasExtension(extensions, "GL_EXT_debug_tool") ||
+           Settings::values.renderer_debug.GetValue();
 }
 } // Anonymous namespace
 

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -314,7 +314,6 @@ private:
     std::unique_ptr<StorageViews> storage_views;
     GLenum internal_format = GL_NONE;
     GLuint default_handle = 0;
-    GPUVAddr gpu_addr = 0;
     u32 buffer_size = 0;
     GLuint original_texture = 0;
     int num_samples = 0;

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1584,8 +1584,9 @@ bool Image::NeedsScaleHelper() const {
 
 ImageView::ImageView(TextureCacheRuntime& runtime, const VideoCommon::ImageViewInfo& info,
                      ImageId image_id_, Image& image)
-    : VideoCommon::ImageViewBase{info, image.info, image_id_}, device{&runtime.device},
-      image_handle{image.Handle()}, samples(ConvertSampleCount(image.info.num_samples)) {
+    : VideoCommon::ImageViewBase{info, image.info, image_id_, image.gpu_addr},
+      device{&runtime.device}, image_handle{image.Handle()},
+      samples(ConvertSampleCount(image.info.num_samples)) {
     using Shader::TextureType;
 
     const VkImageAspectFlags aspect_mask = ImageViewAspectMask(info);
@@ -1631,7 +1632,7 @@ ImageView::ImageView(TextureCacheRuntime& runtime, const VideoCommon::ImageViewI
         }
         vk::ImageView handle = device->GetLogical().CreateImageView(ci);
         if (device->HasDebuggingToolAttached()) {
-            handle.SetObjectNameEXT(VideoCommon::Name(*this).c_str());
+            handle.SetObjectNameEXT(VideoCommon::Name(*this, gpu_addr).c_str());
         }
         image_views[static_cast<size_t>(tex_type)] = std::move(handle);
     };
@@ -1672,7 +1673,7 @@ ImageView::ImageView(TextureCacheRuntime& runtime, const VideoCommon::ImageViewI
 
 ImageView::ImageView(TextureCacheRuntime&, const VideoCommon::ImageInfo& info,
                      const VideoCommon::ImageViewInfo& view_info, GPUVAddr gpu_addr_)
-    : VideoCommon::ImageViewBase{info, view_info}, gpu_addr{gpu_addr_},
+    : VideoCommon::ImageViewBase{info, view_info, gpu_addr_},
       buffer_size{VideoCommon::CalculateGuestSizeInBytes(info)} {}
 
 ImageView::ImageView(TextureCacheRuntime&, const VideoCommon::NullImageViewParams& params)

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -265,7 +265,6 @@ private:
     VkImage image_handle = VK_NULL_HANDLE;
     VkImageView render_target = VK_NULL_HANDLE;
     VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT;
-    GPUVAddr gpu_addr = 0;
     u32 buffer_size = 0;
 };
 

--- a/src/video_core/texture_cache/formatter.cpp
+++ b/src/video_core/texture_cache/formatter.cpp
@@ -46,7 +46,7 @@ std::string Name(const ImageBase& image) {
     return "Invalid";
 }
 
-std::string Name(const ImageViewBase& image_view) {
+std::string Name(const ImageViewBase& image_view, GPUVAddr addr) {
     const u32 width = image_view.size.width;
     const u32 height = image_view.size.height;
     const u32 depth = image_view.size.depth;
@@ -56,23 +56,25 @@ std::string Name(const ImageViewBase& image_view) {
     const std::string level = num_levels > 1 ? fmt::format(":{}", num_levels) : "";
     switch (image_view.type) {
     case ImageViewType::e1D:
-        return fmt::format("ImageView 1D {}{}", width, level);
+        return fmt::format("ImageView 1D 0x{:X} {}{}", addr, width, level);
     case ImageViewType::e2D:
-        return fmt::format("ImageView 2D {}x{}{}", width, height, level);
+        return fmt::format("ImageView 2D 0x{:X} {}x{}{}", addr, width, height, level);
     case ImageViewType::Cube:
-        return fmt::format("ImageView Cube {}x{}{}", width, height, level);
+        return fmt::format("ImageView Cube 0x{:X} {}x{}{}", addr, width, height, level);
     case ImageViewType::e3D:
-        return fmt::format("ImageView 3D {}x{}x{}{}", width, height, depth, level);
+        return fmt::format("ImageView 3D 0x{:X} {}x{}x{}{}", addr, width, height, depth, level);
     case ImageViewType::e1DArray:
-        return fmt::format("ImageView 1DArray {}{}|{}", width, level, num_layers);
+        return fmt::format("ImageView 1DArray 0x{:X} {}{}|{}", addr, width, level, num_layers);
     case ImageViewType::e2DArray:
-        return fmt::format("ImageView 2DArray {}x{}{}|{}", width, height, level, num_layers);
+        return fmt::format("ImageView 2DArray 0x{:X} {}x{}{}|{}", addr, width, height, level,
+                           num_layers);
     case ImageViewType::CubeArray:
-        return fmt::format("ImageView CubeArray {}x{}{}|{}", width, height, level, num_layers);
+        return fmt::format("ImageView CubeArray 0x{:X} {}x{}{}|{}", addr, width, height, level,
+                           num_layers);
     case ImageViewType::Rect:
-        return fmt::format("ImageView Rect {}x{}{}", width, height, level);
+        return fmt::format("ImageView Rect 0x{:X} {}x{}{}", addr, width, height, level);
     case ImageViewType::Buffer:
-        return fmt::format("BufferView {}", width);
+        return fmt::format("BufferView 0x{:X} {}", addr, width);
     }
     return "Invalid";
 }

--- a/src/video_core/texture_cache/formatter.h
+++ b/src/video_core/texture_cache/formatter.h
@@ -274,7 +274,7 @@ struct RenderTargets;
 
 [[nodiscard]] std::string Name(const ImageBase& image);
 
-[[nodiscard]] std::string Name(const ImageViewBase& image_view);
+[[nodiscard]] std::string Name(const ImageViewBase& image_view, GPUVAddr addr);
 
 [[nodiscard]] std::string Name(const RenderTargets& render_targets);
 

--- a/src/video_core/texture_cache/image_view_base.cpp
+++ b/src/video_core/texture_cache/image_view_base.cpp
@@ -16,8 +16,8 @@
 namespace VideoCommon {
 
 ImageViewBase::ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_info,
-                             ImageId image_id_)
-    : image_id{image_id_}, format{info.format}, type{info.type}, range{info.range},
+                             ImageId image_id_, GPUVAddr addr)
+    : image_id{image_id_}, gpu_addr{addr}, format{info.format}, type{info.type}, range{info.range},
       size{
           .width = std::max(image_info.size.width >> range.base.level, 1u),
           .height = std::max(image_info.size.height >> range.base.level, 1u),
@@ -35,8 +35,8 @@ ImageViewBase::ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_i
     }
 }
 
-ImageViewBase::ImageViewBase(const ImageInfo& info, const ImageViewInfo& view_info)
-    : image_id{NULL_IMAGE_ID}, format{info.format}, type{ImageViewType::Buffer},
+ImageViewBase::ImageViewBase(const ImageInfo& info, const ImageViewInfo& view_info, GPUVAddr addr)
+    : image_id{NULL_IMAGE_ID}, gpu_addr{addr}, format{info.format}, type{ImageViewType::Buffer},
       size{
           .width = info.size.width,
           .height = 1,

--- a/src/video_core/texture_cache/image_view_base.h
+++ b/src/video_core/texture_cache/image_view_base.h
@@ -24,9 +24,9 @@ enum class ImageViewFlagBits : u16 {
 DECLARE_ENUM_FLAG_OPERATORS(ImageViewFlagBits)
 
 struct ImageViewBase {
-    explicit ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_info,
-                           ImageId image_id);
-    explicit ImageViewBase(const ImageInfo& info, const ImageViewInfo& view_info);
+    explicit ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_info, ImageId image_id,
+                           GPUVAddr addr);
+    explicit ImageViewBase(const ImageInfo& info, const ImageViewInfo& view_info, GPUVAddr addr);
     explicit ImageViewBase(const NullImageViewParams&);
 
     [[nodiscard]] bool IsBuffer() const noexcept {
@@ -34,6 +34,7 @@ struct ImageViewBase {
     }
 
     ImageId image_id{};
+    GPUVAddr gpu_addr = 0;
     PixelFormat format{};
     ImageViewType type{};
     SubresourceRange range;

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "common/common_types.h"
+#include "common/settings.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 
 // Define all features which may be used by the implementation here.
@@ -510,7 +511,7 @@ public:
 
     /// Returns true when a known debugging tool is attached.
     bool HasDebuggingToolAttached() const {
-        return has_renderdoc || has_nsight_graphics;
+        return has_renderdoc || has_nsight_graphics || Settings::values.renderer_debug.GetValue();
     }
 
     /// Returns true when the device does not properly support cube compatibility.


### PR DESCRIPTION
Validation layers have the ability to print object names if they've been assigned. Currently we only set names if RenderDoc or Nsight is being used, but we should enable it for graphics debugging as well.

This also adds the GPU address to image views, which helps for validation layers and OpenGL in RenderDoc. This is something I kept doing locally, but worth PR'ing it.

Before:
> Validation Error: [ VUID-VkWriteDescriptorSet-descriptorType-00336 ] Object 0: handle = 0xbde60e00000000c6, type = VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT; | MessageID = 0xc258ecf8 | vkPushDescriptorSetWithTemplateKHR() VkWriteDescriptorSet[1] failed update validation: Write update to Push Descriptors defined with VkDescriptorSetLayout 0xbde60e00000000c6[] binding #1 failed with error message: Attempted write update to image descriptor failed due to: ImageView (VkImageView 0x947b780000001381[]) has a non-identiy swizzle component,  r swizzle = VK_COMPONENT_SWIZZLE_R, g swizzle = VK_COMPONENT_SWIZZLE_ZERO, b swizzle = VK_COMPONENT_SWIZZLE_ZERO, a swizzle = VK_COMPONENT_SWIZZLE_ONE.. The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, the imageView member of each element of pImageInfo must have been created with the identity swizzle (https://vulkan.lunarg.com/doc/view/1.3.231.1/windows/1.3-extensions/vkspec.html#VUID-VkWriteDescriptorSet-descriptorType-00336)

After:
> Validation Error: [ VUID-VkWriteDescriptorSet-descriptorType-00336 ] Object 0: handle = 0x35ee6900000000c1, type = VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT; | MessageID = 0xc258ecf8 | vkPushDescriptorSetWithTemplateKHR() VkWriteDescriptorSet[1] failed update validation: Write update to Push Descriptors defined with VkDescriptorSetLayout 0x35ee6900000000c1[] binding #1 failed with error message: Attempted write update to image descriptor failed due to: ImageView (VkImageView 0x947b780000001381[**ImageView 2D 0x54461C000 480x270**]) has a non-identiy swizzle component,  r swizzle = VK_COMPONENT_SWIZZLE_R, g swizzle = VK_COMPONENT_SWIZZLE_ZERO, b swizzle = VK_COMPONENT_SWIZZLE_ZERO, a swizzle = VK_COMPONENT_SWIZZLE_ONE.. The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, the imageView member of each element of pImageInfo must have been created with the identity swizzle (https://vulkan.lunarg.com/doc/view/1.3.231.1/windows/1.3-extensions/vkspec.html#VUID-VkWriteDescriptorSet-descriptorType-00336)
