### PR TITLE
input_common: Add experimental motion to button

### DIFF
--- a/src/core/hid/input_converter.cpp
+++ b/src/core/hid/input_converter.cpp
@@ -61,6 +61,9 @@ Common::Input::ButtonStatus TransformToButton(const Common::Input::CallbackStatu
     case Common::Input::InputType::Button:
         status = callback.button_status;
         break;
+    case Common::Input::InputType::Motion:
+        status.value = std::abs(callback.motion_status.gyro.x.raw_value) > 1.0f;
+        break;
     default:
         LOG_ERROR(Input, "Conversion from type {} to button not implemented", callback.type);
         break;
@@ -225,6 +228,10 @@ Common::Input::TriggerStatus TransformToTrigger(const Common::Input::CallbackSta
     case Common::Input::InputType::Trigger:
         status = callback.trigger_status;
         calculate_button_value = false;
+        break;
+    case Common::Input::InputType::Motion:
+        status.analog.properties.range = 1.0f;
+        raw_value = callback.motion_status.accel.x.raw_value;
         break;
     default:
         LOG_ERROR(Input, "Conversion from type {} to trigger not implemented", callback.type);

--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -82,6 +82,9 @@ void MappingFactory::RegisterButton(const MappingData& data) {
         new_input.Set("axis", data.index);
         new_input.Set("threshold", 0.5f);
         break;
+    case EngineInputType::Motion:
+        new_input.Set("motion", data.index);
+        break;
     default:
         return;
     }


### PR DESCRIPTION
This is a little experiment from an user request. I still need to polish my ideas to allow individual motion axis and most likely motion to stick input.

For now you can map motion to any button and trigger it with a shake.