### PR TITLE
settings: Add option to change shader directory

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -74,6 +74,7 @@ void LogSettings() {
     log_path("DataStorage_LoadDir", Common::FS::GetYuzuPath(Common::FS::YuzuPath::LoadDir));
     log_path("DataStorage_NANDDir", Common::FS::GetYuzuPath(Common::FS::YuzuPath::NANDDir));
     log_path("DataStorage_SDMCDir", Common::FS::GetYuzuPath(Common::FS::YuzuPath::SDMCDir));
+    log_path("DataStorage_ShaderDir", Common::FS::GetYuzuPath(Common::FS::YuzuPath::ShaderDir));
     log_setting("Debugging_ProgramArgs", values.program_args.GetValue());
     log_setting("Debugging_GDBStub", values.use_gdbstub.GetValue());
     log_setting("Input_EnableMotion", values.motion_enabled.GetValue());

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -521,6 +521,13 @@ void Config::ReadDataStorageValues() {
             .toString()
             .toStdString());
     FS::SetYuzuPath(
+        FS::YuzuPath::ShaderDir,
+        qt_config
+            ->value(QStringLiteral("shader_directory"),
+                    QString::fromStdString(FS::GetYuzuPathString(FS::YuzuPath::ShaderDir)))
+            .toString()
+            .toStdString());
+    FS::SetYuzuPath(
         FS::YuzuPath::LoadDir,
         qt_config
             ->value(QStringLiteral("load_directory"),
@@ -1176,6 +1183,9 @@ void Config::SaveDataStorageValues() {
     WriteSetting(QStringLiteral("sdmc_directory"),
                  QString::fromStdString(FS::GetYuzuPathString(FS::YuzuPath::SDMCDir)),
                  QString::fromStdString(FS::GetYuzuPathString(FS::YuzuPath::SDMCDir)));
+    WriteSetting(QStringLiteral("shader_directory"),
+                 QString::fromStdString(FS::GetYuzuPathString(FS::YuzuPath::ShaderDir)),
+                 QString::fromStdString(FS::GetYuzuPathString(FS::YuzuPath::ShaderDir)));
     WriteSetting(QStringLiteral("load_directory"),
                  QString::fromStdString(FS::GetYuzuPathString(FS::YuzuPath::LoadDir)),
                  QString::fromStdString(FS::GetYuzuPathString(FS::YuzuPath::LoadDir)));

--- a/src/yuzu/configuration/configure_filesystem.cpp
+++ b/src/yuzu/configuration/configure_filesystem.cpp
@@ -19,6 +19,8 @@ ConfigureFilesystem::ConfigureFilesystem(QWidget* parent)
             [this] { SetDirectory(DirectoryTarget::NAND, ui->nand_directory_edit); });
     connect(ui->sdmc_directory_button, &QToolButton::pressed, this,
             [this] { SetDirectory(DirectoryTarget::SD, ui->sdmc_directory_edit); });
+    connect(ui->shader_directory_button, &QToolButton::pressed, this,
+            [this] { SetDirectory(DirectoryTarget::Shader, ui->shader_directory_edit); });
     connect(ui->gamecard_path_button, &QToolButton::pressed, this,
             [this] { SetDirectory(DirectoryTarget::Gamecard, ui->gamecard_path_edit); });
     connect(ui->dump_path_button, &QToolButton::pressed, this,
@@ -50,6 +52,8 @@ void ConfigureFilesystem::SetConfiguration() {
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::NANDDir)));
     ui->sdmc_directory_edit->setText(
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::SDMCDir)));
+    ui->shader_directory_edit->setText(
+        QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::ShaderDir)));
     ui->gamecard_path_edit->setText(
         QString::fromStdString(Settings::values.gamecard_path.GetValue()));
     ui->dump_path_edit->setText(
@@ -72,6 +76,8 @@ void ConfigureFilesystem::ApplyConfiguration() {
                             ui->nand_directory_edit->text().toStdString());
     Common::FS::SetYuzuPath(Common::FS::YuzuPath::SDMCDir,
                             ui->sdmc_directory_edit->text().toStdString());
+    Common::FS::SetYuzuPath(Common::FS::YuzuPath::ShaderDir,
+                            ui->shader_directory_edit->text().toStdString());
     Common::FS::SetYuzuPath(Common::FS::YuzuPath::DumpDir,
                             ui->dump_path_edit->text().toStdString());
     Common::FS::SetYuzuPath(Common::FS::YuzuPath::LoadDir,
@@ -94,6 +100,9 @@ void ConfigureFilesystem::SetDirectory(DirectoryTarget target, QLineEdit* edit) 
         break;
     case DirectoryTarget::SD:
         caption = tr("Select Emulated SD Directory...");
+        break;
+    case DirectoryTarget::Shader:
+        caption = tr("Select Shader Directory...");
         break;
     case DirectoryTarget::Gamecard:
         caption = tr("Select Gamecard Path...");

--- a/src/yuzu/configuration/configure_filesystem.h
+++ b/src/yuzu/configuration/configure_filesystem.h
@@ -30,6 +30,7 @@ private:
     enum class DirectoryTarget {
         NAND,
         SD,
+        Shader,
         Gamecard,
         Dump,
         Load,

--- a/src/yuzu/configuration/configure_filesystem.ui
+++ b/src/yuzu/configuration/configure_filesystem.ui
@@ -25,40 +25,6 @@
         <string>Storage Directories</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>NAND</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="3">
-         <widget class="QToolButton" name="nand_directory_button">
-          <property name="text">
-           <string>...</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLineEdit" name="nand_directory_edit"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLineEdit" name="sdmc_directory_edit"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>SD Card</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QToolButton" name="sdmc_directory_button">
-          <property name="text">
-           <string>...</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <spacer name="horizontalSpacer">
           <property name="orientation">
@@ -74,6 +40,57 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>NAND</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>SD Card</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLineEdit" name="sdmc_directory_edit"/>
+        </item>
+        <item row="1" column="3">
+         <widget class="QToolButton" name="sdmc_directory_button">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QToolButton" name="nand_directory_button">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLineEdit" name="nand_directory_edit"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Shaders</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QLineEdit" name="shader_directory_edit"/>
+        </item>
+        <item row="2" column="3">
+         <widget class="QToolButton" name="shader_directory_button">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
This adds an option under Emulation -> Configure -> System -> Filesystem to allow users to specify their own shader directory if they want.

This closes #10166 