### PR TITLE
Use normal GPU accuracy by default

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -450,7 +450,7 @@ struct Values {
     SwitchableSetting<bool> use_speed_limit{true, "use_speed_limit"};
     SwitchableSetting<u16, true> speed_limit{100, 0, 9999, "speed_limit"};
     SwitchableSetting<bool> use_disk_shader_cache{true, "use_disk_shader_cache"};
-    SwitchableSetting<GPUAccuracy, true> gpu_accuracy{GPUAccuracy::High, GPUAccuracy::Normal,
+    SwitchableSetting<GPUAccuracy, true> gpu_accuracy{GPUAccuracy::Normal, GPUAccuracy::Normal,
                                                       GPUAccuracy::Extreme, "gpu_accuracy"};
     SwitchableSetting<bool> use_asynchronous_gpu_emulation{true, "use_asynchronous_gpu_emulation"};
     SwitchableSetting<NvdecEmulation> nvdec_emulation{NvdecEmulation::GPU, "nvdec_emulation"};


### PR DESCRIPTION
Thanks to the changes made by @FernandoS27 I think it's safe to enable this. 
The list of games that render well with it outweighs the list that don't now.