### PR TITLE
Fix read access violation after 2 hours of gameplay in PMD: RTDX

### DIFF
--- a/src/common/address_space.inc
+++ b/src/common/address_space.inc
@@ -72,7 +72,7 @@ MAP_MEMBER(void)::MapLocked(VaType virt, PaType phys, VaType size, ExtraBlockInf
                 }
             }()};
 
-            if (block_end_predecessor->virt >= virt) {
+            if (block_end_predecessor != blocks.begin() && block_end_predecessor->virt >= virt) {
                 // If this block's start would be overlapped by the map then reuse it as a tail
                 // block
                 block_end_predecessor->virt = virt_end;


### PR DESCRIPTION
fixes #10168 
potentially also fixes #10126

OP from the support thread linked in the first issue here. Now I may not exactly be the most qualified person to work on this, but yesterday a Twitch chatter who claims to work at Google took a look at my issue and seems to be "almost certain" that this should fix the issue. Apparently, due to company policy, they are not allowed to contribute to emulators.

Tried out the fix today, and for the first time ever I was able to play through the entire game up to the credits in a single sitting without a crash. Can't really explain much of this myself, but apparently devs of this should be able to "immediately understand" the change.