### PR TITLE
vfs_vector: avoid n^2 lookup in layeredfs building

### DIFF
--- a/src/core/file_sys/vfs_layered.cpp
+++ b/src/core/file_sys/vfs_layered.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <algorithm>
+#include <set>
 #include <utility>
 #include "core/file_sys/vfs_layered.h"
 
@@ -58,11 +59,13 @@ std::string LayeredVfsDirectory::GetFullPath() const {
 
 std::vector<VirtualFile> LayeredVfsDirectory::GetFiles() const {
     std::vector<VirtualFile> out;
+    std::set<std::string, std::less<>> out_names;
+
     for (const auto& layer : dirs) {
         for (const auto& file : layer->GetFiles()) {
-            if (std::find_if(out.begin(), out.end(), [&file](const VirtualFile& comp) {
-                    return comp->GetName() == file->GetName();
-                }) == out.end()) {
+            auto file_name = file->GetName();
+            if (!out_names.contains(file_name)) {
+                out_names.emplace(std::move(file_name));
                 out.push_back(file);
             }
         }

--- a/src/core/file_sys/vfs_vector.cpp
+++ b/src/core/file_sys/vfs_vector.cpp
@@ -67,6 +67,23 @@ VectorVfsDirectory::VectorVfsDirectory(std::vector<VirtualFile> files_,
 
 VectorVfsDirectory::~VectorVfsDirectory() = default;
 
+VirtualFile VectorVfsDirectory::GetFile(std::string_view file_name) const {
+    if (!optimized_file_index_built) {
+        optimized_file_index.clear();
+        for (size_t i = 0; i < files.size(); i++) {
+            optimized_file_index.emplace(files[i]->GetName(), i);
+        }
+        optimized_file_index_built = true;
+    }
+
+    const auto it = optimized_file_index.find(file_name);
+    if (it != optimized_file_index.end()) {
+        return files[it->second];
+    }
+
+    return nullptr;
+}
+
 std::vector<VirtualFile> VectorVfsDirectory::GetFiles() const {
     return files;
 }
@@ -107,6 +124,7 @@ bool VectorVfsDirectory::DeleteSubdirectory(std::string_view subdir_name) {
 }
 
 bool VectorVfsDirectory::DeleteFile(std::string_view file_name) {
+    optimized_file_index_built = false;
     return FindAndRemoveVectorElement(files, file_name);
 }
 
@@ -124,6 +142,7 @@ VirtualFile VectorVfsDirectory::CreateFile(std::string_view file_name) {
 }
 
 void VectorVfsDirectory::AddFile(VirtualFile file) {
+    optimized_file_index_built = false;
     files.push_back(std::move(file));
 }
 

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -105,6 +105,7 @@ public:
                                 VirtualDir parent = nullptr);
     ~VectorVfsDirectory() override;
 
+    VirtualFile GetFile(std::string_view file_name) const override;
     std::vector<VirtualFile> GetFiles() const override;
     std::vector<VirtualDir> GetSubdirectories() const override;
     bool IsWritable() const override;
@@ -126,6 +127,9 @@ private:
 
     VirtualDir parent;
     std::string name;
+
+    mutable std::map<std::string, size_t, std::less<>> optimized_file_index;
+    mutable bool optimized_file_index_built{};
 };
 
 } // namespace FileSys


### PR DESCRIPTION
This optimization reduces the time it takes to apply a single-file romfs mod in Fire Emblem Engage from ~1.5 minutes to ~3 seconds. The performance is still not ideal, because it wastes a lot of time copying and freeing strings, but still worth doing.