### PR TITLE
Fix address space allocator slow path to avoid OOB

### DIFF
--- a/src/common/address_space.inc
+++ b/src/common/address_space.inc
@@ -336,7 +336,7 @@ ALLOC_MEMBER(VaType)::Allocate(VaType size) {
             ASSERT_MSG(false, "Unexpected allocator state!");
         }
 
-        auto search_predecessor{this->blocks.begin()};
+        auto search_predecessor{std::next(this->blocks.begin())};
         auto search_successor{std::next(search_predecessor)};
 
         while (search_successor != this->blocks.end() &&


### PR DESCRIPTION
One more update for this file: https://github.com/skyline-emu/skyline/commit/12c88babd0a8599425007a1c02a74bd4639e4600

Everything else seems identical to Skyline now.