### PR TITLE
yuzu/applets/qt_profile_select: connect double-click to accept()

### DIFF
--- a/src/yuzu/applets/qt_profile_select.cpp
+++ b/src/yuzu/applets/qt_profile_select.cpp
@@ -95,6 +95,7 @@ QtProfileSelectionDialog::QtProfileSelectionDialog(
     scroll_area->setLayout(layout);
 
     connect(tree_view, &QTreeView::clicked, this, &QtProfileSelectionDialog::SelectUser);
+    connect(tree_view, &QTreeView::doubleClicked, this, &QtProfileSelectionDialog::accept);
     connect(controller_navigation, &ControllerNavigation::TriggerKeyboardEvent,
             [this](Qt::Key key) {
                 if (!this->isActiveWindow()) {


### PR DESCRIPTION
**In the profile selection window:**
*(enabled if the option "Prompt for user on game boot" is checked)*

Allow the user to start the game by double-clicking a profile to avoid having to additionally click the OK button. This avoids an unnecessary "step" to the start of the game...

Fixes https://github.com/yuzu-emu/yuzu/issues/10185.