### PR TITLE
bootmanager: remove stop_token header

### DIFF
--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <stop_token>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Fixes #10193 (build on, you guessed it, Apple Clang)
