### PR TITLE
core: hid: Allow to calibrate gyro sensor

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -688,6 +688,12 @@ void EmulatedController::SetMotionParam(std::size_t index, Common::ParamPackage 
     ReloadInput();
 }
 
+void EmulatedController::StartMotionCalibration() {
+    for (ControllerMotionInfo& motion : controller.motion_values) {
+        motion.emulated.Calibrate();
+    }
+}
+
 void EmulatedController::SetButton(const Common::Input::CallbackStatus& callback, std::size_t index,
                                    Common::UUID uuid) {
     if (index >= controller.button_values.size()) {

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -290,6 +290,9 @@ public:
      */
     void SetMotionParam(std::size_t index, Common::ParamPackage param);
 
+    /// Auto calibrates the current motion devices
+    void StartMotionCalibration();
+
     /// Returns the latest button status from the controller with parameters
     ButtonValues GetButtonsValues() const;
 

--- a/src/core/hid/motion_input.h
+++ b/src/core/hid/motion_input.h
@@ -23,6 +23,8 @@ public:
     static constexpr float GyroMaxValue = 5.0f;
     static constexpr float AccelMaxValue = 7.0f;
 
+    static constexpr std::size_t CalibrationSamples = 300;
+
     explicit MotionInput();
 
     MotionInput(const MotionInput&) = default;
@@ -49,6 +51,8 @@ public:
     void UpdateRotation(u64 elapsed_time);
     void UpdateOrientation(u64 elapsed_time);
 
+    void Calibrate();
+
     [[nodiscard]] std::array<Common::Vec3f, 3> GetOrientation() const;
     [[nodiscard]] Common::Vec3f GetAcceleration() const;
     [[nodiscard]] Common::Vec3f GetGyroscope() const;
@@ -61,6 +65,7 @@ public:
     [[nodiscard]] bool IsCalibrated(f32 sensitivity) const;
 
 private:
+    void StopCalibration();
     void ResetOrientation();
     void SetOrientationFromAccelerometer();
 
@@ -103,6 +108,12 @@ private:
 
     // Use accelerometer values to calculate position
     bool only_accelerometer = true;
+
+    // When enabled it will aggressively adjust for gyro drift
+    bool calibration_mode = false;
+
+    // Used to auto disable calibration mode
+    std::size_t calibration_counter = 0;
 };
 
 } // namespace Core::HID

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -479,6 +479,9 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                             param.Set("threshold", new_threshold / 1000.0f);
                             emulated_controller->SetMotionParam(motion_id, param);
                         });
+                        context_menu.addAction(tr("Calibrate sensor"), [&] {
+                            emulated_controller->StartMotionCalibration();
+                        });
                     }
                     context_menu.exec(motion_map[motion_id]->mapToGlobal(menu_location));
                 });

--- a/src/yuzu/configuration/configure_input_player_widget.cpp
+++ b/src/yuzu/configuration/configure_input_player_widget.cpp
@@ -582,9 +582,9 @@ void PlayerControlPreview::DrawDualController(QPainter& p, const QPointF center)
         using namespace Settings::NativeMotion;
         p.setPen(colors.outline);
         p.setBrush(colors.transparent);
-        Draw3dCube(p, center + QPointF(-180, -5),
+        Draw3dCube(p, center + QPointF(-180, 90),
                    motion_values[Settings::NativeMotion::MotionLeft].euler, 20.0f);
-        Draw3dCube(p, center + QPointF(180, -5),
+        Draw3dCube(p, center + QPointF(180, 90),
                    motion_values[Settings::NativeMotion::MotionRight].euler, 20.0f);
     }
 
@@ -2926,14 +2926,14 @@ void PlayerControlPreview::DrawArrow(QPainter& p, const QPointF center, const Di
 void PlayerControlPreview::Draw3dCube(QPainter& p, QPointF center, const Common::Vec3f& euler,
                                       float size) {
     std::array<Common::Vec3f, 8> cube{
-        Common::Vec3f{-1, -1, -1},
-        {-1, 1, -1},
-        {1, 1, -1},
-        {1, -1, -1},
-        {-1, -1, 1},
-        {-1, 1, 1},
-        {1, 1, 1},
-        {1, -1, 1},
+        Common::Vec3f{-0.7f, -1, -0.5f},
+        {-0.7f, 1, -0.5f},
+        {0.7f, 1, -0.5f},
+        {0.7f, -1, -0.5f},
+        {-0.7f, -1, 0.5f},
+        {-0.7f, 1, 0.5f},
+        {0.7f, 1, 0.5f},
+        {0.7f, -1, 0.5f},
     };
 
     for (Common::Vec3f& point : cube) {


### PR DESCRIPTION
Allows to calibrate motion to eliminate motion drift. This can be done multiple times until the cube stops spinning. I also moved the cube for dual joycon since it was overlapping with battery symbols and made the cube with a shape of a joycon so it's easier to distinguish the current orientation.
![image](https://user-images.githubusercontent.com/5944268/236894859-9ece0469-1c09-48e4-bc78-10c53cd6743f.png)
