### PR TITLE
qt_common: unbreak build on BSDs

### DIFF
--- a/src/yuzu/qt_common.cpp
+++ b/src/yuzu/qt_common.cpp
@@ -8,7 +8,7 @@
 #include "core/frontend/emu_window.h"
 #include "yuzu/qt_common.h"
 
-#ifdef __linux__
+#if !defined(WIN32) && !defined(__APPLE__)
 #include <qpa/qplatformnativeinterface.h>
 #endif
 


### PR DESCRIPTION
Regressed by #10125. Found on FreeBSD. Affects both Qt5 and Qt6.
