### PR TITLE
Use the rendertarget format of the correct RT rather than the first valid

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -349,25 +349,12 @@ void RasterizerVulkan::Clear(u32 layer_count) {
 
     const u32 color_attachment = regs.clear_surface.RT;
     if (use_color && framebuffer->HasAspectColorBit(color_attachment)) {
-        VkClearValue clear_value;
-        bool is_integer = false;
-        bool is_signed = false;
-        size_t int_size = 8;
-        for (std::size_t i = 0; i < Tegra::Engines::Maxwell3D::Regs::NumRenderTargets; ++i) {
-            const auto& this_rt = regs.rt[i];
-            if (this_rt.Address() == 0) {
-                continue;
-            }
-            if (this_rt.format == Tegra::RenderTargetFormat::NONE) {
-                continue;
-            }
-            const auto format =
-                VideoCore::Surface::PixelFormatFromRenderTargetFormat(this_rt.format);
-            is_integer = IsPixelFormatInteger(format);
-            is_signed = IsPixelFormatSignedInteger(format);
-            int_size = PixelComponentSizeBitsInteger(format);
-            break;
-        }
+        const auto format =
+            VideoCore::Surface::PixelFormatFromRenderTargetFormat(regs.rt[color_attachment].format);
+        bool is_integer = IsPixelFormatInteger(format);
+        bool is_signed = IsPixelFormatSignedInteger(format);
+        size_t int_size = PixelComponentSizeBitsInteger(format);
+        VkClearValue clear_value{};
         if (!is_integer) {
             std::memcpy(clear_value.color.float32, regs.clear_color.data(),
                         regs.clear_color.size() * sizeof(f32));


### PR DESCRIPTION
This code currently doesn't make much sense. We know which RT we're clearing from the clear_surface.RT register. For some reason we're iterating through all RTs and then taking the first valid one to define the format for the clear colour. No one seems to know why or what this is for, so let's remove it.