### PR TITLE
Add a 5ms tiemout to the DSP processing wait

### DIFF
--- a/src/audio_core/renderer/adsp/audio_renderer.cpp
+++ b/src/audio_core/renderer/adsp/audio_renderer.cpp
@@ -154,6 +154,11 @@ void AudioRenderer::ThreadFunc() {
             return;
 
         case RenderMessage::AudioRenderer_Render: {
+            if (system.IsShuttingDown()) [[unlikely]] {
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                mailbox->ADSPSendMessage(RenderMessage::AudioRenderer_RenderResponse);
+                continue;
+            }
             std::array<bool, MaxRendererSessions> buffers_reset{};
             std::array<u64, MaxRendererSessions> render_times_taken{};
             const auto start_time{system.CoreTiming().GetClockTicks()};

--- a/src/audio_core/renderer/system_manager.h
+++ b/src/audio_core/renderer/system_manager.h
@@ -66,13 +66,7 @@ private:
     /**
      * Main thread responsible for command generation.
      */
-    void ThreadFunc();
-
-    enum class StreamState {
-        Filling,
-        Steady,
-        Draining,
-    };
+    void ThreadFunc(std::stop_token stop_token);
 
     /// Core system
     Core::System& core;
@@ -90,8 +84,6 @@ private:
     ADSP::ADSP& adsp;
     /// AudioRenderer mailbox for communication
     ADSP::AudioRenderer_Mailbox* mailbox{};
-    /// Atomic for main thread to wait on
-    std::atomic<bool> update{};
 };
 
 } // namespace AudioCore::AudioRenderer

--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -271,8 +271,8 @@ u64 SinkStream::GetExpectedPlayedSampleCount() {
 
 void SinkStream::WaitFreeSpace() {
     std::unique_lock lk{release_mutex};
-    release_cv.wait(
-        lk, [this]() { return queued_buffers < max_queue_size || system.IsShuttingDown(); });
+    release_cv.wait_for(lk, std::chrono::milliseconds(5),
+                        [this]() { return queued_buffers < max_queue_size; });
 }
 
 } // namespace AudioCore::Sink


### PR DESCRIPTION
So far I haven't been able to understand how the DSP limits itself and runs with a consistent timing. From my RE, the best thing I could find was a semaphore wait on the DSP itself when it tries to reserve 240 samples in a mix queue before processing. ByLaws used that to implement his changes here, and it's a nice idea and generally works, however it relies on the host audio callback to function, and no one's system will run at 5ms. 10ms callbacks are the standard and most common I've seen, but that means the DSP essentially runs 2 times instantly, every 10ms, rather than a smooth once every 5ms.

The DSP is responsible for updating some state, such as how many samples a wavebuffer has processed, which is sent back to the game on RequestUpdate service calls, which the game then may or may not use. The DSP callback being half speed (or slower) and then instantly running 2 or 3 times is causing issues with the state given back to games which rely on it.

This PR reverts just that part of ByLaws' audio core changes, and fixes the slow audio on Super Mario Odyssey's electric wires.

Closes #10158 
Closes #10040 