### PR TITLE
renderer_vulkan: separate guest and host compute descriptor queues

### DIFF
--- a/src/video_core/renderer_vulkan/pipeline_helper.h
+++ b/src/video_core/renderer_vulkan/pipeline_helper.h
@@ -176,7 +176,7 @@ public:
 };
 
 inline void PushImageDescriptors(TextureCache& texture_cache,
-                                 UpdateDescriptorQueue& update_descriptor_queue,
+                                 GuestDescriptorQueue& guest_descriptor_queue,
                                  const Shader::Info& info, RescalingPushConstant& rescaling,
                                  const VkSampler*& samplers,
                                  const VideoCommon::ImageViewInOut*& views) {
@@ -190,7 +190,7 @@ inline void PushImageDescriptors(TextureCache& texture_cache,
             const VkSampler sampler{*(samplers++)};
             ImageView& image_view{texture_cache.GetImageView(image_view_id)};
             const VkImageView vk_image_view{image_view.Handle(desc.type)};
-            update_descriptor_queue.AddSampledImage(vk_image_view, sampler);
+            guest_descriptor_queue.AddSampledImage(vk_image_view, sampler);
             rescaling.PushTexture(texture_cache.IsRescaling(image_view));
         }
     }
@@ -201,7 +201,7 @@ inline void PushImageDescriptors(TextureCache& texture_cache,
                 texture_cache.MarkModification(image_view.image_id);
             }
             const VkImageView vk_image_view{image_view.StorageView(desc.type, desc.format)};
-            update_descriptor_queue.AddImage(vk_image_view);
+            guest_descriptor_queue.AddImage(vk_image_view);
             rescaling.PushImage(texture_cache.IsRescaling(image_view));
         }
     }

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -298,12 +298,14 @@ private:
 
 BufferCacheRuntime::BufferCacheRuntime(const Device& device_, MemoryAllocator& memory_allocator_,
                                        Scheduler& scheduler_, StagingBufferPool& staging_pool_,
-                                       UpdateDescriptorQueue& update_descriptor_queue_,
+                                       GuestDescriptorQueue& guest_descriptor_queue_,
+                                       ComputePassDescriptorQueue& compute_pass_descriptor_queue,
                                        DescriptorPool& descriptor_pool)
     : device{device_}, memory_allocator{memory_allocator_}, scheduler{scheduler_},
-      staging_pool{staging_pool_}, update_descriptor_queue{update_descriptor_queue_},
-      uint8_pass(device, scheduler, descriptor_pool, staging_pool, update_descriptor_queue),
-      quad_index_pass(device, scheduler, descriptor_pool, staging_pool, update_descriptor_queue) {
+      staging_pool{staging_pool_}, guest_descriptor_queue{guest_descriptor_queue_},
+      uint8_pass(device, scheduler, descriptor_pool, staging_pool, compute_pass_descriptor_queue),
+      quad_index_pass(device, scheduler, descriptor_pool, staging_pool,
+                      compute_pass_descriptor_queue) {
     quad_array_index_buffer = std::make_shared<QuadArrayIndexBuffer>(device_, memory_allocator_,
                                                                      scheduler_, staging_pool_);
     quad_strip_index_buffer = std::make_shared<QuadStripIndexBuffer>(device_, memory_allocator_,

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -63,7 +63,8 @@ class BufferCacheRuntime {
 public:
     explicit BufferCacheRuntime(const Device& device_, MemoryAllocator& memory_manager_,
                                 Scheduler& scheduler_, StagingBufferPool& staging_pool_,
-                                UpdateDescriptorQueue& update_descriptor_queue_,
+                                GuestDescriptorQueue& guest_descriptor_queue,
+                                ComputePassDescriptorQueue& compute_pass_descriptor_queue,
                                 DescriptorPool& descriptor_pool);
 
     void Finish();
@@ -116,12 +117,12 @@ public:
 
     void BindTextureBuffer(Buffer& buffer, u32 offset, u32 size,
                            VideoCore::Surface::PixelFormat format) {
-        update_descriptor_queue.AddTexelBuffer(buffer.View(offset, size, format));
+        guest_descriptor_queue.AddTexelBuffer(buffer.View(offset, size, format));
     }
 
 private:
     void BindBuffer(VkBuffer buffer, u32 offset, u32 size) {
-        update_descriptor_queue.AddBuffer(buffer, offset, size);
+        guest_descriptor_queue.AddBuffer(buffer, offset, size);
     }
 
     void ReserveNullBuffer();
@@ -130,7 +131,7 @@ private:
     MemoryAllocator& memory_allocator;
     Scheduler& scheduler;
     StagingBufferPool& staging_pool;
-    UpdateDescriptorQueue& update_descriptor_queue;
+    GuestDescriptorQueue& guest_descriptor_queue;
 
     std::shared_ptr<QuadArrayIndexBuffer> quad_array_index_buffer;
     std::shared_ptr<QuadStripIndexBuffer> quad_strip_index_buffer;

--- a/src/video_core/renderer_vulkan/vk_compute_pass.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.h
@@ -9,6 +9,7 @@
 #include "common/common_types.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_vulkan/vk_descriptor_pool.h"
+#include "video_core/renderer_vulkan/vk_update_descriptor.h"
 #include "video_core/vulkan_common/vulkan_memory_allocator.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 
@@ -21,7 +22,6 @@ namespace Vulkan {
 class Device;
 class StagingBufferPool;
 class Scheduler;
-class UpdateDescriptorQueue;
 class Image;
 struct StagingBufferRef;
 
@@ -50,7 +50,7 @@ class Uint8Pass final : public ComputePass {
 public:
     explicit Uint8Pass(const Device& device_, Scheduler& scheduler_,
                        DescriptorPool& descriptor_pool_, StagingBufferPool& staging_buffer_pool_,
-                       UpdateDescriptorQueue& update_descriptor_queue_);
+                       ComputePassDescriptorQueue& compute_pass_descriptor_queue_);
     ~Uint8Pass();
 
     /// Assemble uint8 indices into an uint16 index buffer
@@ -61,7 +61,7 @@ public:
 private:
     Scheduler& scheduler;
     StagingBufferPool& staging_buffer_pool;
-    UpdateDescriptorQueue& update_descriptor_queue;
+    ComputePassDescriptorQueue& compute_pass_descriptor_queue;
 };
 
 class QuadIndexedPass final : public ComputePass {
@@ -69,7 +69,7 @@ public:
     explicit QuadIndexedPass(const Device& device_, Scheduler& scheduler_,
                              DescriptorPool& descriptor_pool_,
                              StagingBufferPool& staging_buffer_pool_,
-                             UpdateDescriptorQueue& update_descriptor_queue_);
+                             ComputePassDescriptorQueue& compute_pass_descriptor_queue_);
     ~QuadIndexedPass();
 
     std::pair<VkBuffer, VkDeviceSize> Assemble(
@@ -79,7 +79,7 @@ public:
 private:
     Scheduler& scheduler;
     StagingBufferPool& staging_buffer_pool;
-    UpdateDescriptorQueue& update_descriptor_queue;
+    ComputePassDescriptorQueue& compute_pass_descriptor_queue;
 };
 
 class ASTCDecoderPass final : public ComputePass {
@@ -87,7 +87,7 @@ public:
     explicit ASTCDecoderPass(const Device& device_, Scheduler& scheduler_,
                              DescriptorPool& descriptor_pool_,
                              StagingBufferPool& staging_buffer_pool_,
-                             UpdateDescriptorQueue& update_descriptor_queue_,
+                             ComputePassDescriptorQueue& compute_pass_descriptor_queue_,
                              MemoryAllocator& memory_allocator_);
     ~ASTCDecoderPass();
 
@@ -97,7 +97,7 @@ public:
 private:
     Scheduler& scheduler;
     StagingBufferPool& staging_buffer_pool;
-    UpdateDescriptorQueue& update_descriptor_queue;
+    ComputePassDescriptorQueue& compute_pass_descriptor_queue;
     MemoryAllocator& memory_allocator;
 };
 

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.h
@@ -30,7 +30,7 @@ class ComputePipeline {
 public:
     explicit ComputePipeline(const Device& device, vk::PipelineCache& pipeline_cache,
                              DescriptorPool& descriptor_pool,
-                             UpdateDescriptorQueue& update_descriptor_queue,
+                             GuestDescriptorQueue& guest_descriptor_queue,
                              Common::ThreadWorker* thread_worker,
                              PipelineStatistics* pipeline_statistics,
                              VideoCore::ShaderNotify* shader_notify, const Shader::Info& info,
@@ -48,7 +48,7 @@ public:
 private:
     const Device& device;
     vk::PipelineCache& pipeline_cache;
-    UpdateDescriptorQueue& update_descriptor_queue;
+    GuestDescriptorQueue& guest_descriptor_queue;
     Shader::Info info;
 
     VideoCommon::ComputeUniformBufferSizes uniform_buffer_sizes{};

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -64,7 +64,6 @@ class RenderPassCache;
 class RescalingPushConstant;
 class RenderAreaPushConstant;
 class Scheduler;
-class UpdateDescriptorQueue;
 
 class GraphicsPipeline {
     static constexpr size_t NUM_STAGES = Tegra::Engines::Maxwell3D::Regs::MaxShaderStage;
@@ -74,7 +73,7 @@ public:
         Scheduler& scheduler, BufferCache& buffer_cache, TextureCache& texture_cache,
         vk::PipelineCache& pipeline_cache, VideoCore::ShaderNotify* shader_notify,
         const Device& device, DescriptorPool& descriptor_pool,
-        UpdateDescriptorQueue& update_descriptor_queue, Common::ThreadWorker* worker_thread,
+        GuestDescriptorQueue& guest_descriptor_queue, Common::ThreadWorker* worker_thread,
         PipelineStatistics* pipeline_statistics, RenderPassCache& render_pass_cache,
         const GraphicsPipelineCacheKey& key, std::array<vk::ShaderModule, NUM_STAGES> stages,
         const std::array<const Shader::Info*, NUM_STAGES>& infos);
@@ -133,7 +132,7 @@ private:
     BufferCache& buffer_cache;
     vk::PipelineCache& pipeline_cache;
     Scheduler& scheduler;
-    UpdateDescriptorQueue& update_descriptor_queue;
+    GuestDescriptorQueue& guest_descriptor_queue;
 
     void (*configure_func)(GraphicsPipeline*, bool){};
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -277,11 +277,11 @@ bool GraphicsPipelineCacheKey::operator==(const GraphicsPipelineCacheKey& rhs) c
 
 PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device_,
                              Scheduler& scheduler_, DescriptorPool& descriptor_pool_,
-                             UpdateDescriptorQueue& update_descriptor_queue_,
+                             GuestDescriptorQueue& guest_descriptor_queue_,
                              RenderPassCache& render_pass_cache_, BufferCache& buffer_cache_,
                              TextureCache& texture_cache_, VideoCore::ShaderNotify& shader_notify_)
     : VideoCommon::ShaderCache{rasterizer_}, device{device_}, scheduler{scheduler_},
-      descriptor_pool{descriptor_pool_}, update_descriptor_queue{update_descriptor_queue_},
+      descriptor_pool{descriptor_pool_}, guest_descriptor_queue{guest_descriptor_queue_},
       render_pass_cache{render_pass_cache_}, buffer_cache{buffer_cache_},
       texture_cache{texture_cache_}, shader_notify{shader_notify_},
       use_asynchronous_shaders{Settings::values.use_asynchronous_shaders.GetValue()},
@@ -643,7 +643,7 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
     Common::ThreadWorker* const thread_worker{build_in_parallel ? &workers : nullptr};
     return std::make_unique<GraphicsPipeline>(
         scheduler, buffer_cache, texture_cache, vulkan_pipeline_cache, &shader_notify, device,
-        descriptor_pool, update_descriptor_queue, thread_worker, statistics, render_pass_cache, key,
+        descriptor_pool, guest_descriptor_queue, thread_worker, statistics, render_pass_cache, key,
         std::move(modules), infos);
 
 } catch (const Shader::Exception& exception) {
@@ -722,7 +722,7 @@ std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline(
     }
     Common::ThreadWorker* const thread_worker{build_in_parallel ? &workers : nullptr};
     return std::make_unique<ComputePipeline>(device, vulkan_pipeline_cache, descriptor_pool,
-                                             update_descriptor_queue, thread_worker, statistics,
+                                             guest_descriptor_queue, thread_worker, statistics,
                                              &shader_notify, program.info, std::move(spv_module));
 
 } catch (const Shader::Exception& exception) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -82,7 +82,6 @@ class PipelineStatistics;
 class RasterizerVulkan;
 class RenderPassCache;
 class Scheduler;
-class UpdateDescriptorQueue;
 
 using VideoCommon::ShaderInfo;
 
@@ -102,7 +101,7 @@ class PipelineCache : public VideoCommon::ShaderCache {
 public:
     explicit PipelineCache(RasterizerVulkan& rasterizer, const Device& device, Scheduler& scheduler,
                            DescriptorPool& descriptor_pool,
-                           UpdateDescriptorQueue& update_descriptor_queue,
+                           GuestDescriptorQueue& guest_descriptor_queue,
                            RenderPassCache& render_pass_cache, BufferCache& buffer_cache,
                            TextureCache& texture_cache, VideoCore::ShaderNotify& shader_notify_);
     ~PipelineCache();
@@ -144,7 +143,7 @@ private:
     const Device& device;
     Scheduler& scheduler;
     DescriptorPool& descriptor_pool;
-    UpdateDescriptorQueue& update_descriptor_queue;
+    GuestDescriptorQueue& guest_descriptor_queue;
     RenderPassCache& render_pass_cache;
     BufferCache& buffer_cache;
     TextureCache& texture_cache;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -184,7 +184,8 @@ private:
 
     StagingBufferPool staging_pool;
     DescriptorPool descriptor_pool;
-    UpdateDescriptorQueue update_descriptor_queue;
+    GuestDescriptorQueue guest_descriptor_queue;
+    ComputePassDescriptorQueue compute_pass_descriptor_queue;
     BlitImageHelper blit_image;
     RenderPassCache render_pass_cache;
 

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -798,13 +798,13 @@ TextureCacheRuntime::TextureCacheRuntime(const Device& device_, Scheduler& sched
                                          BlitImageHelper& blit_image_helper_,
                                          RenderPassCache& render_pass_cache_,
                                          DescriptorPool& descriptor_pool,
-                                         UpdateDescriptorQueue& update_descriptor_queue)
+                                         ComputePassDescriptorQueue& compute_pass_descriptor_queue)
     : device{device_}, scheduler{scheduler_}, memory_allocator{memory_allocator_},
       staging_buffer_pool{staging_buffer_pool_}, blit_image_helper{blit_image_helper_},
       render_pass_cache{render_pass_cache_}, resolution{Settings::values.resolution_info} {
     if (Settings::values.accelerate_astc) {
         astc_decoder_pass.emplace(device, scheduler, descriptor_pool, staging_buffer_pool,
-                                  update_descriptor_queue, memory_allocator);
+                                  compute_pass_descriptor_queue, memory_allocator);
     }
 }
 

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -34,7 +34,6 @@ class ImageView;
 class Framebuffer;
 class RenderPassCache;
 class StagingBufferPool;
-class UpdateDescriptorQueue;
 class Scheduler;
 
 class TextureCacheRuntime {
@@ -45,7 +44,7 @@ public:
                                  BlitImageHelper& blit_image_helper_,
                                  RenderPassCache& render_pass_cache_,
                                  DescriptorPool& descriptor_pool,
-                                 UpdateDescriptorQueue& update_descriptor_queue);
+                                 ComputePassDescriptorQueue& compute_pass_descriptor_queue);
 
     void Finish();
 

--- a/src/video_core/renderer_vulkan/vk_update_descriptor.h
+++ b/src/video_core/renderer_vulkan/vk_update_descriptor.h
@@ -32,7 +32,7 @@ class UpdateDescriptorQueue final {
     // This should be plenty for the vast majority of cases. Most desktop platforms only
     // provide up to 3 swapchain images.
     static constexpr size_t FRAMES_IN_FLIGHT = 5;
-    static constexpr size_t FRAME_PAYLOAD_SIZE = 0x10000;
+    static constexpr size_t FRAME_PAYLOAD_SIZE = 0x20000;
     static constexpr size_t PAYLOAD_SIZE = FRAME_PAYLOAD_SIZE * FRAMES_IN_FLIGHT;
 
 public:
@@ -85,5 +85,9 @@ private:
     const DescriptorUpdateEntry* upload_start = nullptr;
     std::array<DescriptorUpdateEntry, PAYLOAD_SIZE> payload;
 };
+
+// TODO: should these be separate classes instead?
+using GuestDescriptorQueue = UpdateDescriptorQueue;
+using ComputePassDescriptorQueue = UpdateDescriptorQueue;
 
 } // namespace Vulkan


### PR DESCRIPTION
This PR separates the update descriptor queues for synchronous compute passes and guest pipelines. This way, they each have their own separate spaces for descriptor set data, and will not interfere with each other during descriptor set updates.

Due to an oversight in how the compute passes were designed, we often ended up binding the pipeline for compute-shader data conversion concurrently with the binding for a guest pipeline. In the best case, this broke the guest pipeline state; in the worst case, it crashed the driver due to the update template not matching up with the update data.

This should fix a bunch of random crashes in games which need to do synchronous compute conversion work (Xenoblade, LM3, Astral Chain, Bayonetta 3, etc.). It should also fix many crashes in validation layers in all of these games.