### PR TITLE
Update README.md to remove Skyline license exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,3 @@ If you wish to support us a different way, please join our [Discord](https://dis
 ## License
 
 yuzu is licensed under the GPLv3 (or any later version). Refer to the [LICENSE.txt](https://github.com/yuzu-emu/yuzu/blob/master/LICENSE.txt) file.
-
-The [Skyline-Emulator Team](https://github.com/skyline-emu/skyline) may choose to use the code from these contributors under the GPL-3.0-or-later OR MPL-2.0: [FernandoS27](https://github.com/FernandoS27), [lioncash](https://github.com/lioncash), [bunnei](https://github.com/bunnei), [ReinUsesLisp](https://github.com/ReinUsesLisp), [Morph1984](https://github.com/Morph1984), [ogniK5377](https://github.com/ogniK5377), [german77](https://github.com/german77), [ameerj](https://github.com/ameerj), [Kelebek1](https://github.com/Kelebek1) and [lat9nq](https://github.com/lat9nq)


### PR DESCRIPTION
With Skyline disbanded, we're removing the blanket license exception to avoid any confusion with unofficial forks relicensing components of yuzu. Future license exceptions will be handled on a case-by-case basis.