### PR TITLE
nvnflinger: fix Parcel serialization

### DIFF
--- a/src/core/hle/service/nvnflinger/buffer_queue_producer.cpp
+++ b/src/core/hle/service/nvnflinger/buffer_queue_producer.cpp
@@ -855,7 +855,7 @@ void BufferQueueProducer::Transact(HLERequestContext& ctx, TransactionId code, u
         status = DequeueBuffer(&slot, &fence, is_async, width, height, pixel_format, usage);
 
         parcel_out.Write(slot);
-        parcel_out.WriteObject(&fence);
+        parcel_out.WriteFlattenedObject(&fence);
         break;
     }
     case TransactionId::RequestBuffer: {
@@ -865,7 +865,7 @@ void BufferQueueProducer::Transact(HLERequestContext& ctx, TransactionId code, u
 
         status = RequestBuffer(slot, &buf);
 
-        parcel_out.WriteObject(buf);
+        parcel_out.WriteFlattenedObject(buf);
         break;
     }
     case TransactionId::QueueBuffer: {

--- a/src/core/hle/service/nvnflinger/buffer_queue_producer.cpp
+++ b/src/core/hle/service/nvnflinger/buffer_queue_producer.cpp
@@ -793,6 +793,7 @@ Status BufferQueueProducer::SetPreallocatedBuffer(s32 slot,
     std::scoped_lock lock{core->mutex};
 
     slots[slot] = {};
+    slots[slot].fence = Fence::NoFence();
     slots[slot].graphic_buffer = buffer;
     slots[slot].frame_number = 0;
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -64,8 +64,8 @@ public:
 private:
     const u32 magic = 2;
     const u32 process_id = 1;
-    const u32 id;
-    INSERT_PADDING_WORDS(3);
+    const u64 id;
+    INSERT_PADDING_WORDS(2);
     std::array<u8, 8> dispdrv = {'d', 'i', 's', 'p', 'd', 'r', 'v', '\0'};
     INSERT_PADDING_WORDS(2);
 };
@@ -608,7 +608,9 @@ private:
             return;
         }
 
-        const auto parcel = android::OutputParcel{NativeWindow{*buffer_queue_id}};
+        android::OutputParcel parcel;
+        parcel.WriteInterface(NativeWindow{*buffer_queue_id});
+
         const auto buffer_size = ctx.WriteBuffer(parcel.Serialize());
 
         IPC::ResponseBuilder rb{ctx, 4};
@@ -654,7 +656,9 @@ private:
             return;
         }
 
-        const auto parcel = android::OutputParcel{NativeWindow{*buffer_queue_id}};
+        android::OutputParcel parcel;
+        parcel.WriteInterface(NativeWindow{*buffer_queue_id});
+
         const auto buffer_size = ctx.WriteBuffer(parcel.Serialize());
 
         IPC::ResponseBuilder rb{ctx, 6};


### PR DESCRIPTION
We were consistently serializing the Binder responses wrong in ways that games didn't seem to care about until now. This PR aligns the serialization with what Android actually does, where flattened objects and marshalled IBinders are stored in separate regions in the parcel, and the size of the objects array is not always 4.

The producer slot fence being wrong on the first frame was another thing that jumped out at me, since Android requires that the fence object is never null.

Needed for Tears of the Kingdom to boot.