### PR TITLE
fs: stub cache storage

### DIFF
--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -82,9 +82,9 @@ std::string GetFutureSaveDataPath(SaveDataSpaceId space_id, SaveDataType type, u
     // Only detect account/device saves from the future location.
     switch (type) {
     case SaveDataType::SaveData:
-        return fmt::format("{}/account/{}/{:016X}/1", space_id_path, uuid.RawString(), title_id);
+        return fmt::format("{}/account/{}/{:016X}/0", space_id_path, uuid.RawString(), title_id);
     case SaveDataType::DeviceSaveData:
-        return fmt::format("{}/device/{:016X}/1", space_id_path, title_id);
+        return fmt::format("{}/device/{:016X}/0", space_id_path, title_id);
     default:
         return "";
     }

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -13,6 +13,7 @@
 #include "core/file_sys/savedata_factory.h"
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/kernel/k_transfer_memory.h"
+#include "core/hle/result.h"
 #include "core/hle/service/acc/profile_manager.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applet_ae.h"
@@ -1335,7 +1336,7 @@ IApplicationFunctions::IApplicationFunctions(Core::System& system_)
         {24, nullptr, "GetLaunchStorageInfoForDebug"},
         {25, &IApplicationFunctions::ExtendSaveData, "ExtendSaveData"},
         {26, &IApplicationFunctions::GetSaveDataSize, "GetSaveDataSize"},
-        {27, nullptr, "CreateCacheStorage"},
+        {27, &IApplicationFunctions::CreateCacheStorage, "CreateCacheStorage"},
         {28, nullptr, "GetSaveDataSizeMax"},
         {29, nullptr, "GetCacheStorageMax"},
         {30, &IApplicationFunctions::BeginBlockingHomeButtonShortAndLongPressed, "BeginBlockingHomeButtonShortAndLongPressed"},
@@ -1736,6 +1737,36 @@ void IApplicationFunctions::GetSaveDataSize(HLERequestContext& ctx) {
     rb.Push(ResultSuccess);
     rb.Push(size.normal);
     rb.Push(size.journal);
+}
+
+void IApplicationFunctions::CreateCacheStorage(HLERequestContext& ctx) {
+    struct InputParameters {
+        u16 index;
+        s64 size;
+        s64 journal_size;
+    };
+    static_assert(sizeof(InputParameters) == 24);
+
+    struct OutputParameters {
+        u32 storage_target;
+        u64 required_size;
+    };
+    static_assert(sizeof(OutputParameters) == 16);
+
+    IPC::RequestParser rp{ctx};
+    const auto params = rp.PopRaw<InputParameters>();
+
+    LOG_WARNING(Service_AM, "(STUBBED) called with index={}, size={:#x}, journal_size={:#x}",
+                params.index, params.size, params.journal_size);
+
+    const OutputParameters resp{
+        .storage_target = 1,
+        .required_size = 0,
+    };
+
+    IPC::ResponseBuilder rb{ctx, 6};
+    rb.Push(ResultSuccess);
+    rb.PushRaw(resp);
 }
 
 void IApplicationFunctions::QueryApplicationPlayStatistics(HLERequestContext& ctx) {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -333,6 +333,7 @@ private:
     void GetPseudoDeviceId(HLERequestContext& ctx);
     void ExtendSaveData(HLERequestContext& ctx);
     void GetSaveDataSize(HLERequestContext& ctx);
+    void CreateCacheStorage(HLERequestContext& ctx);
     void BeginBlockingHomeButtonShortAndLongPressed(HLERequestContext& ctx);
     void EndBlockingHomeButtonShortAndLongPressed(HLERequestContext& ctx);
     void BeginBlockingHomeButton(HLERequestContext& ctx);

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -310,8 +310,8 @@ private:
 class IFileSystem final : public ServiceFramework<IFileSystem> {
 public:
     explicit IFileSystem(Core::System& system_, FileSys::VirtualDir backend_, SizeGetter size_)
-        : ServiceFramework{system_, "IFileSystem"}, backend{std::move(backend_)},
-          size{std::move(size_)} {
+        : ServiceFramework{system_, "IFileSystem"}, backend{std::move(backend_)}, size{std::move(
+                                                                                      size_)} {
         static const FunctionInfo functions[] = {
             {0, &IFileSystem::CreateFile, "CreateFile"},
             {1, &IFileSystem::DeleteFile, "DeleteFile"},

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -24,8 +24,10 @@
 #include "core/file_sys/savedata_factory.h"
 #include "core/file_sys/system_archive/system_archive.h"
 #include "core/file_sys/vfs.h"
+#include "core/hle/result.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/filesystem/fsp_srv.h"
+#include "core/hle/service/hle_ipc.h"
 #include "core/hle/service/ipc_helpers.h"
 #include "core/reporter.h"
 
@@ -308,8 +310,8 @@ private:
 class IFileSystem final : public ServiceFramework<IFileSystem> {
 public:
     explicit IFileSystem(Core::System& system_, FileSys::VirtualDir backend_, SizeGetter size_)
-        : ServiceFramework{system_, "IFileSystem"}, backend{std::move(backend_)}, size{std::move(
-                                                                                      size_)} {
+        : ServiceFramework{system_, "IFileSystem"}, backend{std::move(backend_)},
+          size{std::move(size_)} {
         static const FunctionInfo functions[] = {
             {0, &IFileSystem::CreateFile, "CreateFile"},
             {1, &IFileSystem::DeleteFile, "DeleteFile"},
@@ -552,9 +554,9 @@ public:
         // Write the data to memory
         ctx.WriteBuffer(begin, range_size);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(ResultSuccess);
-        rb.Push<u32>(static_cast<u32>(actual_entries));
+        rb.Push<u64>(actual_entries);
     }
 
 private:
@@ -712,7 +714,7 @@ FSP_SRV::FSP_SRV(Core::System& system_)
         {59, nullptr, "WriteSaveDataFileSystemExtraData"},
         {60, nullptr, "OpenSaveDataInfoReader"},
         {61, &FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId, "OpenSaveDataInfoReaderBySaveDataSpaceId"},
-        {62, nullptr, "OpenCacheStorageList"},
+        {62, &FSP_SRV::OpenSaveDataInfoReaderOnlyCacheStorage, "OpenSaveDataInfoReaderOnlyCacheStorage"},
         {64, nullptr, "OpenSaveDataInternalStorageFileSystem"},
         {65, nullptr, "UpdateSaveDataMacForDebug"},
         {66, nullptr, "WriteSaveDataFileSystemExtraData2"},
@@ -919,6 +921,15 @@ void FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(HLERequestContext& ctx) {
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISaveDataInfoReader>(
         std::make_shared<ISaveDataInfoReader>(system, space, fsc));
+}
+
+void FSP_SRV::OpenSaveDataInfoReaderOnlyCacheStorage(HLERequestContext& ctx) {
+    LOG_WARNING(Service_FS, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(ResultSuccess);
+    rb.PushIpcInterface<ISaveDataInfoReader>(system, FileSys::SaveDataSpaceId::TemporaryStorage,
+                                             fsc);
 }
 
 void FSP_SRV::WriteSaveDataFileSystemExtraDataBySaveDataAttribute(HLERequestContext& ctx) {

--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -42,6 +42,7 @@ private:
     void OpenSaveDataFileSystem(HLERequestContext& ctx);
     void OpenReadOnlySaveDataFileSystem(HLERequestContext& ctx);
     void OpenSaveDataInfoReaderBySaveDataSpaceId(HLERequestContext& ctx);
+    void OpenSaveDataInfoReaderOnlyCacheStorage(HLERequestContext& ctx);
     void WriteSaveDataFileSystemExtraDataBySaveDataAttribute(HLERequestContext& ctx);
     void ReadSaveDataFileSystemExtraDataWithMaskBySaveDataAttribute(HLERequestContext& ctx);
     void OpenDataStorageByCurrentProcess(HLERequestContext& ctx);


### PR DESCRIPTION
Somehow, we didn't have any implementation of this, despite it existing and being used in retail games since at least 2019(?). This adds a stub implementation which always returns 0 results for cache storage, and fixes the response alignment for Read on the info reader.

Needed for Tears of the Kingdom to boot. May also fix other games that use it.