### PR TITLE
Correctly track render target index in the framebuffer for image aspects

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1864,6 +1864,7 @@ void Framebuffer::CreateFramebuffer(TextureCacheRuntime& runtime,
         num_layers = std::max(num_layers, color_buffer->range.extent.layers);
         images[num_images] = color_buffer->ImageHandle();
         image_ranges[num_images] = MakeSubresourceRange(color_buffer);
+        rt_map[index] = num_images;
         samples = color_buffer->Samples();
         ++num_images;
     }

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -334,7 +334,7 @@ public:
     }
 
     [[nodiscard]] bool HasAspectColorBit(size_t index) const noexcept {
-        return (image_ranges.at(index).aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) != 0;
+        return (image_ranges.at(rt_map[index]).aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) != 0;
     }
 
     [[nodiscard]] bool HasAspectDepthBit() const noexcept {
@@ -354,6 +354,7 @@ private:
     u32 num_images = 0;
     std::array<VkImage, 9> images{};
     std::array<VkImageSubresourceRange, 9> image_ranges{};
+    std::array<size_t, NUM_RT> rt_map{};
     bool has_depth{};
     bool has_stencil{};
 };


### PR DESCRIPTION
The framebuffer sequentially adds only valid render targets to `image_ranges`. However, for clears, we look up the image aspect by render target index, and since the framebuffer skips invalid RTs, this can lead to a mis-match between the requested clear RT and the aspect of the RT we look up.

In Tears of the Kingdom, it uses a framebuffer with colour render targets 0/1/2/4, where 3 is invalid. Our framebuffer adds these into `image_ranges` as 0/1/2/3, and then the depth gets index 4. At the start of the renderpass it tries to clear RT index 4 with a colour clear, which looks up `image_ranges[4]` in `framebuffer->HasAspectColorBit()` and returns false as that's now the depth target, and the clear is skipped entirely. This PR just adds a quick mapping between real RT index and the new framebuffer index.

This fixes the red dot on the right of the screen in Tears of the Kingdom, and all of the big graphical corruption in handheld.