### PR TITLE
time: implement ContinuousAdjustmentTimePoint

### DIFF
--- a/src/core/hle/service/time/clock_types.h
+++ b/src/core/hle/service/time/clock_types.h
@@ -59,6 +59,18 @@ static_assert(sizeof(SystemClockContext) == 0x20, "SystemClockContext is incorre
 static_assert(std::is_trivially_copyable_v<SystemClockContext>,
               "SystemClockContext must be trivially copyable");
 
+struct ContinuousAdjustmentTimePoint {
+    s64 measurement_offset;
+    s64 diff_scale;
+    u32 shift_amount;
+    s64 lower;
+    s64 upper;
+    Common::UUID clock_source_id;
+};
+static_assert(sizeof(ContinuousAdjustmentTimePoint) == 0x38);
+static_assert(std::is_trivially_copyable_v<ContinuousAdjustmentTimePoint>,
+              "ContinuousAdjustmentTimePoint must be trivially copyable");
+
 /// https://switchbrew.org/wiki/Glue_services#TimeSpanType
 struct TimeSpanType {
     s64 nanoseconds{};

--- a/src/core/hle/service/time/time_sharedmemory.h
+++ b/src/core/hle/service/time/time_sharedmemory.h
@@ -65,14 +65,15 @@ public:
         LockFreeAtomicType<Clock::SystemClockContext> standard_local_system_clock_context;
         LockFreeAtomicType<Clock::SystemClockContext> standard_network_system_clock_context;
         LockFreeAtomicType<bool> is_standard_user_system_clock_automatic_correction_enabled;
-        u32 format_version;
+        LockFreeAtomicType<Clock::ContinuousAdjustmentTimePoint> continuous_adjustment_timepoint;
     };
     static_assert(offsetof(Format, standard_steady_clock_timepoint) == 0x0);
     static_assert(offsetof(Format, standard_local_system_clock_context) == 0x38);
     static_assert(offsetof(Format, standard_network_system_clock_context) == 0x80);
     static_assert(offsetof(Format, is_standard_user_system_clock_automatic_correction_enabled) ==
                   0xc8);
-    static_assert(sizeof(Format) == 0xd8, "Format is an invalid size");
+    static_assert(offsetof(Format, continuous_adjustment_timepoint) == 0xd0);
+    static_assert(sizeof(Format) == 0x148, "Format is an invalid size");
 
     void SetupStandardSteadyClock(const Common::UUID& clock_source_id,
                                   Clock::TimeSpanType current_time_point);


### PR DESCRIPTION
This adds a new structure into the time shared memory which has some nice upgrades compared to before:
- Allows computing the current time in ns
- Automatically adjusts for clock skew
- Uses the same clock source as the steady clock

This should fix the save slot timestamps in Tears of the Kingdom. I didn't figure out how exactly the lower/upper distinction worked, or if the time skew adjustment uses the same values every single time (seems to update every 5-10 minutes). However, I did notice when making a test homebrew that everything gets set to the same value on console boot, so we'll go with that.