### PR TITLE
vulkan_common: disable depth clamp dynamic state for older radv

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -406,6 +406,14 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         features.extended_dynamic_state3.extendedDynamicState3ColorBlendEnable = false;
         features.extended_dynamic_state3.extendedDynamicState3ColorBlendEquation = false;
         dynamic_state3_blending = false;
+
+        const u32 version = (properties.properties.driverVersion << 3) >> 3;
+        if (version < VK_MAKE_API_VERSION(0, 23, 1, 0)) {
+            LOG_WARNING(Render_Vulkan,
+                        "RADV versions older than 23.1.0 have broken depth clamp dynamic state");
+            features.extended_dynamic_state3.extendedDynamicState3DepthClampEnable = false;
+            dynamic_state3_enables = false;
+        }
     }
     if (extensions.vertex_input_dynamic_state && is_radv) {
         // TODO(ameerj): Blacklist only offending driver versions


### PR DESCRIPTION
This [bug in radv](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/22777) causes an amusing vertex explosion during a critical gameplay moment in Tears of the Kingdom.
|Before|After|
|-|-|
|![0100f2c0115b6000_2023-05-13_00-35-00-993](https://github.com/yuzu-emu/yuzu/assets/9658600/845cac0a-79cd-4243-b032-54cb700233b2)|![0100f2c0115b6000_2023-05-13_00-30-46-691](https://github.com/yuzu-emu/yuzu/assets/9658600/7fd22552-65be-4dbb-ba88-34582b1bf7c3)|