### PR TITLE
input_common: Make amiibo scanning less demanding

### DIFF
--- a/src/input_common/helpers/joycon_protocol/joycon_types.h
+++ b/src/input_common/helpers/joycon_protocol/joycon_types.h
@@ -394,6 +394,7 @@ enum class DriverResult {
     InvalidHandle,
     NotSupported,
     Disabled,
+    Delayed,
     Unknown,
 };
 

--- a/src/input_common/helpers/joycon_protocol/nfc.h
+++ b/src/input_common/helpers/joycon_protocol/nfc.h
@@ -32,6 +32,9 @@ public:
     bool IsEnabled() const;
 
 private:
+    // Number of times the function will be delayed until it outputs valid data
+    static constexpr std::size_t AMIIBO_UPDATE_DELAY = 15;
+
     struct TagFoundData {
         u8 type;
         std::vector<u8> uuid;
@@ -39,7 +42,7 @@ private:
 
     DriverResult WaitUntilNfcIsReady();
 
-    DriverResult StartPolling(TagFoundData& data);
+    DriverResult StartPolling(TagFoundData& data, std::size_t timeout_limit = 1);
 
     DriverResult ReadTag(const TagFoundData& data);
 
@@ -56,6 +59,7 @@ private:
     NFCReadBlockCommand GetReadBlockCommand(NFCPages pages) const;
 
     bool is_enabled{};
+    std::size_t update_counter{};
 };
 
 } // namespace InputCommon::Joycon


### PR DESCRIPTION
Scanning for amiibos is a really demanding task. We don't need to scan every frame so I reduced the scan rate to 5hz and reduced the number of attempts to get valid data to 1 instead of 7.

This makes the right joycon usable while using the amiibo rune on totk. Small stutters will still happen but nothing like current master