### PR TITLE
Use TARGET_FILE_DIR generator expression

### DIFF
--- a/.ci/scripts/windows/upload.ps1
+++ b/.ci/scripts/windows/upload.ps1
@@ -26,7 +26,11 @@ $env:BUILD_ZIP = $MSVC_BUILD_ZIP
 $env:BUILD_SYMBOLS = $MSVC_BUILD_PDB
 $env:BUILD_UPDATE = $MSVC_SEVENZIP
 
-$BUILD_DIR = ".\build\bin\Release"
+if (Test-Path -Path ".\build\bin\Release") {
+    $BUILD_DIR = ".\build\bin\Release"
+} else {
+    $BUILD_DIR = ".\build\bin\"
+}
 
 # Cleanup unneeded data in submodules
 git submodule foreach git clean -fxd

--- a/CMakeModules/CopyYuzuFFmpegDeps.cmake
+++ b/CMakeModules/CopyYuzuFFmpegDeps.cmake
@@ -3,7 +3,7 @@
 
 function(copy_yuzu_FFmpeg_deps target_dir)
     include(WindowsCopyFiles)
-    set(DLL_DEST "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/")
+    set(DLL_DEST "$<TARGET_FILE_DIR:${target_dir}>/")
     file(READ "${FFmpeg_PATH}/requirements.txt" FFmpeg_REQUIRED_DLLS)
     string(STRIP "${FFmpeg_REQUIRED_DLLS}" FFmpeg_REQUIRED_DLLS)
     windows_copy_files(${target_dir} ${FFmpeg_DLL_DIR} ${DLL_DEST} ${FFmpeg_REQUIRED_DLLS})

--- a/CMakeModules/CopyYuzuQt5Deps.cmake
+++ b/CMakeModules/CopyYuzuQt5Deps.cmake
@@ -4,7 +4,7 @@
 function(copy_yuzu_Qt5_deps target_dir)
     include(WindowsCopyFiles)
     if (MSVC)
-        set(DLL_DEST "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/")
+        set(DLL_DEST "$<TARGET_FILE_DIR:${target_dir}>/")
         set(Qt5_DLL_DIR "${Qt5_DIR}/../../../bin")
     else()
         set(DLL_DEST "${CMAKE_BINARY_DIR}/bin/")

--- a/CMakeModules/CopyYuzuSDLDeps.cmake
+++ b/CMakeModules/CopyYuzuSDLDeps.cmake
@@ -3,6 +3,6 @@
 
 function(copy_yuzu_SDL_deps target_dir)
     include(WindowsCopyFiles)
-    set(DLL_DEST "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/")
+    set(DLL_DEST "$<TARGET_FILE_DIR:${target_dir}>/")
     windows_copy_files(${target_dir} ${SDL2_DLL_DIR} ${DLL_DEST} SDL2.dll)
 endfunction(copy_yuzu_SDL_deps)

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -378,11 +378,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if (WIN32 AND QT_VERSION VERSION_GREATER_EQUAL 6)
-    if (MSVC AND NOT ${CMAKE_GENERATOR} STREQUAL "Ninja")
-        set(YUZU_EXE_DIR "${CMAKE_BINARY_DIR}/bin/$<CONFIG>")
-    else()
-        set(YUZU_EXE_DIR "${CMAKE_BINARY_DIR}/bin")
-    endif()
+    set(YUZU_EXE_DIR "$<TARGET_FILE_DIR:yuzu>")
     add_custom_command(TARGET yuzu POST_BUILD COMMAND ${WINDEPLOYQT_EXECUTABLE} "${YUZU_EXE_DIR}/yuzu.exe" --dir "${YUZU_EXE_DIR}" --libdir "${YUZU_EXE_DIR}" --plugindir "${YUZU_EXE_DIR}/plugins" --no-compiler-runtime --no-opengl-sw --no-system-d3d-compiler --no-translations --verbose 0)
 endif()
 


### PR DESCRIPTION
Use `$<TARGET_FILE_DIR:...>` where appropriate instead of trying to guess where the binary will end up.

Fixed the issue I had where the dlls weren't copied to the appropriate place on my setup (VS 2022, CMake project).

One thing is that `string(REPLACE "/" "\\\\" SOURCE_DIR ${SOURCE_DIR})` lines in `WindowsCopyFiles.cmake` are now sort of useless since generator expression is expanded after such replacement could be done, on the other hand it seems like `robocopy` doesn't care ;P