### PR TITLE
Add support for deinterlaced video playback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,7 @@ endif()
 # List of all FFmpeg components required
 set(FFmpeg_COMPONENTS
     avcodec
+    avfilter
     avutil
     swscale)
 

--- a/externals/ffmpeg/CMakeLists.txt
+++ b/externals/ffmpeg/CMakeLists.txt
@@ -131,7 +131,6 @@ if (NOT WIN32)
         COMMAND
             /bin/bash ${FFmpeg_PREFIX}/configure
                 --disable-avdevice
-                --disable-avfilter
                 --disable-avformat
                 --disable-doc
                 --disable-everything
@@ -143,6 +142,7 @@ if (NOT WIN32)
                 --enable-decoder=h264
                 --enable-decoder=vp8
                 --enable-decoder=vp9
+                --enable-filter=yadif
                 --cc="${FFmpeg_CC}"
                 --cxx="${FFmpeg_CXX}"
                 ${FFmpeg_HWACCEL_FLAGS}
@@ -199,7 +199,7 @@ if (NOT WIN32)
     endif()
 else(WIN32)
     # Use yuzu FFmpeg binaries
-    set(FFmpeg_EXT_NAME "ffmpeg-4.4")
+    set(FFmpeg_EXT_NAME "ffmpeg-5.1.3")
     set(FFmpeg_PATH "${CMAKE_BINARY_DIR}/externals/${FFmpeg_EXT_NAME}")
     download_bundled_external("ffmpeg/" ${FFmpeg_EXT_NAME} "")
     set(FFmpeg_FOUND YES)
@@ -210,6 +210,7 @@ else(WIN32)
     set(FFmpeg_LIBRARIES
     ${FFmpeg_LIBRARY_DIR}/swscale.lib
     ${FFmpeg_LIBRARY_DIR}/avcodec.lib
+    ${FFmpeg_LIBRARY_DIR}/avfilter.lib
     ${FFmpeg_LIBRARY_DIR}/avutil.lib
     CACHE PATH "Paths to FFmpeg libraries" FORCE)
     # exported variables

--- a/src/video_core/host1x/codecs/codec.h
+++ b/src/video_core/host1x/codecs/codec.h
@@ -15,6 +15,7 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
 #include <libavcodec/avcodec.h>
+#include <libavfilter/avfilter.h>
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
@@ -61,16 +62,23 @@ public:
 private:
     void InitializeAvCodecContext();
 
+    void InitializeAvFilters(AVFrame* frame);
+
     void InitializeGpuDecoder();
 
     bool CreateGpuAvDevice();
 
     bool initialized{};
+    bool filters_initialized{};
     Host1x::NvdecCommon::VideoCodec current_codec{Host1x::NvdecCommon::VideoCodec::None};
 
     const AVCodec* av_codec{nullptr};
     AVCodecContext* av_codec_ctx{nullptr};
     AVBufferRef* av_gpu_decoder{nullptr};
+
+    AVFilterContext* av_filter_src_ctx{nullptr};
+    AVFilterContext* av_filter_sink_ctx{nullptr};
+    AVFilterGraph* av_filter_graph{nullptr};
 
     Host1x::Host1x& host1x;
     const Host1x::NvdecCommon::NvdecRegisters& state;


### PR DESCRIPTION
This is a follow up to #10254 to improve the playback of cut scenes in Layton's Mystery Journey. It uses ffmpeg's yadif filter for deinterlacing.
This means that we now must enable libavfilter in ffmpeg (and update windows binaries).

Alternatively, we may hack some basic deinterlacing ourselves, similarly to how it was done in ryujinx: https://github.com/Ryujinx/Ryujinx/pull/3225, but that seems quite a bit more complicated for what essentially amounts to one and a half games that'd use this feature to my knowledge.

If anyone could tests STAR WARS Episode I Racer before and after this PR, it'd be the most welcome.