### PR TITLE
vulkan_common: fix incompatible property flags

### DIFF
--- a/src/video_core/vulkan_common/vulkan_memory_allocator.cpp
+++ b/src/video_core/vulkan_common/vulkan_memory_allocator.cpp
@@ -147,7 +147,7 @@ public:
 
     /// Returns whether this allocation is compatible with the arguments.
     [[nodiscard]] bool IsCompatible(VkMemoryPropertyFlags flags, u32 type_mask) const {
-        return (flags & property_flags) == property_flags && (type_mask & shifted_memory_type) != 0;
+        return (flags & property_flags) == flags && (type_mask & shifted_memory_type) != 0;
     }
 
 private:


### PR DESCRIPTION
Incredibly silly issue.

1. Under memory pressure, the allocator may mask out ~DEVICE_LOCAL from the allocation request:
    https://github.com/yuzu-emu/yuzu/blob/9c739f1506dd549df314ccef386218cdf2e5f3a8/src/video_core/vulkan_common/vulkan_memory_allocator.cpp#L278-L281
2. If the request was for DEVICE_LOCAL, this makes property_flags 0
3. This allocation might then be recycled and used for other purposes
4. The compatibility check for a recycled allocation bitwise-ands the flags argument with 0 and checks if it is equal to 0, which it will be if property_flags is 0:
    https://github.com/yuzu-emu/yuzu/blob/9c739f1506dd549df314ccef386218cdf2e5f3a8/src/video_core/vulkan_common/vulkan_memory_allocator.cpp#L148-L151
5. vkMapMemory is then called on an allocation which wasn't host visible and the driver fails it because that's invalid.

This should allow Tears of the Kingdom to boot and play without crashing on cards with less memory.

Fixes #10281
Fixes #10277
Fixes #10271
Fixes #10261
Fixes #10258
Fixes #10239
Fixes #10233