### PR TITLE
vulkan_device: reserve extra memory to prevent swaps

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1009,6 +1009,8 @@ void Device::CollectPhysicalMemoryInfo() {
         device_access_memory += mem_properties.memoryHeaps[element].size;
     }
     if (!is_integrated) {
+        const u64 reserve_memory = std::min<u64>(device_access_memory / 8, 1_GiB);
+        device_access_memory -= reserve_memory;
         return;
     }
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);


### PR DESCRIPTION
Under memory pressure, the memory allocator will fall back to host memory for new allocations. If host memory is used in the render pipeline, this will cause a massive performance dip during rendering. However, since we have a garbage collector, we want the GC to trigger earlier, since collection is much faster than using host memory, and should be able to reclaim enough space to prevent needing host memory.

Helps performance loss in Tears of the Kingdom