### PR TITLE
service: hid: Use span instead of vector reference

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -979,8 +979,8 @@ void Controller_NPad::VibrateController(
 }
 
 void Controller_NPad::VibrateControllers(
-    const std::vector<Core::HID::VibrationDeviceHandle>& vibration_device_handles,
-    const std::vector<Core::HID::VibrationValue>& vibration_values) {
+    std::span<const Core::HID::VibrationDeviceHandle> vibration_device_handles,
+    std::span<const Core::HID::VibrationValue> vibration_values) {
     if (!Settings::values.vibration_enabled.GetValue() && !permit_vibration_session_enabled) {
         return;
     }

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -112,8 +112,8 @@ public:
                            const Core::HID::VibrationValue& vibration_value);
 
     void VibrateControllers(
-        const std::vector<Core::HID::VibrationDeviceHandle>& vibration_device_handles,
-        const std::vector<Core::HID::VibrationValue>& vibration_values);
+        std::span<const Core::HID::VibrationDeviceHandle> vibration_device_handles,
+        std::span<const Core::HID::VibrationValue> vibration_values);
 
     Core::HID::VibrationValue GetLastVibration(
         const Core::HID::VibrationDeviceHandle& vibration_device_handle) const;


### PR DESCRIPTION
Prefer span rather than vector references.