### PR TITLE
Rework GC to be based on available card memory

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache_base.h
+++ b/src/video_core/buffer_cache/buffer_cache_base.h
@@ -57,8 +57,6 @@ MICROPROFILE_DECLARE(GPU_PrepareBuffers);
 MICROPROFILE_DECLARE(GPU_BindUploadBuffers);
 MICROPROFILE_DECLARE(GPU_DownloadMemory);
 
-using BufferId = SlotId;
-
 using VideoCore::Surface::PixelFormat;
 using namespace Common::Literals;
 
@@ -466,6 +464,9 @@ private:
 
     void MappedUploadMemory(Buffer& buffer, u64 total_size_bytes, std::span<BufferCopy> copies);
 
+    [[nodiscard]] VideoCommon::BufferCopies FullDownloadCopies(Buffer& buffer, VAddr cpu_addr,
+                                                               u64 size, bool clear = true);
+
     void DownloadBufferMemory(Buffer& buffer_id);
 
     void DownloadBufferMemory(Buffer& buffer_id, VAddr cpu_addr, u64 size);
@@ -569,6 +570,7 @@ private:
     u64 frame_tick = 0;
     u64 total_used_memory = 0;
     u64 minimum_memory = 0;
+    u64 expected_memory = 0;
     u64 critical_memory = 0;
     BufferId inline_buffer_id;
 

--- a/src/video_core/texture_cache/types.h
+++ b/src/video_core/texture_cache/types.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <boost/container/small_vector.hpp>
+
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "video_core/texture_cache/slot_vector.h"
@@ -14,6 +16,7 @@ constexpr size_t MAX_MIP_LEVELS = 14;
 
 constexpr SlotId CORRUPT_ID{0xfffffffe};
 
+using BufferId = SlotId;
 using ImageId = SlotId;
 using ImageMapId = SlotId;
 using ImageViewId = SlotId;
@@ -144,6 +147,12 @@ struct BufferCopy {
     u64 src_offset;
     u64 dst_offset;
     size_t size;
+};
+
+struct BufferCopies {
+    u64 total_size;
+    u64 largest_copy;
+    boost::container::small_vector<BufferCopy, 16> copies;
 };
 
 struct SwizzleParameters {

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -914,7 +914,7 @@ void ConvertImage(std::span<const u8> input, const ImageInfo& info, std::span<u8
     }
 }
 
-std::vector<BufferImageCopy> FullDownloadCopies(const ImageInfo& info) {
+boost::container::small_vector<BufferImageCopy, 16> FullDownloadCopies(const ImageInfo& info) {
     const Extent3D size = info.size;
     const u32 bytes_per_block = BytesPerBlock(info.format);
     if (info.type == ImageType::Linear) {
@@ -942,7 +942,7 @@ std::vector<BufferImageCopy> FullDownloadCopies(const ImageInfo& info) {
 
     u32 host_offset = 0;
 
-    std::vector<BufferImageCopy> copies(num_levels);
+    boost::container::small_vector<BufferImageCopy, 16> copies(num_levels);
     for (s32 level = 0; level < num_levels; ++level) {
         const Extent3D level_size = AdjustMipSize(size, level);
         const u32 num_blocks_per_layer = NumBlocks(level_size, tile_size);

--- a/src/video_core/texture_cache/util.h
+++ b/src/video_core/texture_cache/util.h
@@ -5,6 +5,7 @@
 
 #include <optional>
 #include <span>
+#include <boost/container/small_vector.hpp>
 
 #include "common/common_types.h"
 #include "common/scratch_buffer.h"
@@ -73,7 +74,8 @@ struct OverlapResult {
 void ConvertImage(std::span<const u8> input, const ImageInfo& info, std::span<u8> output,
                   std::span<BufferImageCopy> copies);
 
-[[nodiscard]] std::vector<BufferImageCopy> FullDownloadCopies(const ImageInfo& info);
+[[nodiscard]] boost::container::small_vector<BufferImageCopy, 16> FullDownloadCopies(
+    const ImageInfo& info);
 
 [[nodiscard]] Extent3D MipSize(Extent3D size, u32 level);
 


### PR DESCRIPTION
Currently we're using hard-coded values for the GC memory limits, but we have access to the device's heap limits already, and through the device mem info extension we know the currently-available allocateable memory too. This PR changes the GC to use the card's heap limits, hopefully making it more appropriate for low VRAM cards and high VRAM cards.

I also decided to re-work the GC logic to not call Finish() so much. In a lot of places in our code we do download -> wait -> memcpy -> download -> wait -> memcpy -> download -> wait -> memcpy. It's more preferable to just download -> download -> download -> wait -> memcpy -> memcpy -> memcpy. It just means we need some extra loops to split these sections. This is something I want to extend to other places as well after this, as it gives us the possibility to combine copies on the same images/buffers and make fewer API calls. This change is making up most of the diff here.