### PR TITLE
input_common: Fix pro controller amiibo support

### DIFF
--- a/src/input_common/drivers/joycon.cpp
+++ b/src/input_common/drivers/joycon.cpp
@@ -195,8 +195,8 @@ void Joycons::RegisterNewDevice(SDL_hid_device_info* device_info) {
                 OnMotionUpdate(port, type, id, value);
             }},
             .on_ring_data = {[this](f32 ring_data) { OnRingConUpdate(ring_data); }},
-            .on_amiibo_data = {[this, port](const std::vector<u8>& amiibo_data) {
-                OnAmiiboUpdate(port, amiibo_data);
+            .on_amiibo_data = {[this, port, type](const std::vector<u8>& amiibo_data) {
+                OnAmiiboUpdate(port, type, amiibo_data);
             }},
             .on_camera_data = {[this, port](const std::vector<u8>& camera_data,
                                             Joycon::IrsResolution format) {
@@ -398,8 +398,9 @@ void Joycons::OnRingConUpdate(f32 ring_data) {
     SetAxis(identifier, 100, ring_data);
 }
 
-void Joycons::OnAmiiboUpdate(std::size_t port, const std::vector<u8>& amiibo_data) {
-    const auto identifier = GetIdentifier(port, Joycon::ControllerType::Right);
+void Joycons::OnAmiiboUpdate(std::size_t port, Joycon::ControllerType type,
+                             const std::vector<u8>& amiibo_data) {
+    const auto identifier = GetIdentifier(port, type);
     const auto nfc_state = amiibo_data.empty() ? Common::Input::NfcState::AmiiboRemoved
                                                : Common::Input::NfcState::NewAmiibo;
     SetNfc(identifier, {nfc_state, amiibo_data});

--- a/src/input_common/drivers/joycon.h
+++ b/src/input_common/drivers/joycon.h
@@ -81,7 +81,8 @@ private:
     void OnMotionUpdate(std::size_t port, Joycon::ControllerType type, int id,
                         const Joycon::MotionData& value);
     void OnRingConUpdate(f32 ring_data);
-    void OnAmiiboUpdate(std::size_t port, const std::vector<u8>& amiibo_data);
+    void OnAmiiboUpdate(std::size_t port, Joycon::ControllerType type,
+                        const std::vector<u8>& amiibo_data);
     void OnCameraUpdate(std::size_t port, const std::vector<u8>& camera_data,
                         Joycon::IrsResolution format);
 

--- a/src/input_common/helpers/joycon_protocol/common_protocol.cpp
+++ b/src/input_common/helpers/joycon_protocol/common_protocol.cpp
@@ -265,7 +265,7 @@ DriverResult JoyconCommonProtocol::SendMCUData(ReportMode report_mode, MCUSubCom
 
 DriverResult JoyconCommonProtocol::WaitSetMCUMode(ReportMode report_mode, MCUMode mode) {
     MCUCommandResponse output{};
-    constexpr std::size_t MaxTries{8};
+    constexpr std::size_t MaxTries{16};
     std::size_t tries{};
 
     do {

--- a/src/input_common/helpers/joycon_protocol/joycon_types.h
+++ b/src/input_common/helpers/joycon_protocol/joycon_types.h
@@ -577,8 +577,8 @@ static_assert(sizeof(NFCPollingCommandData) == 0x05, "NFCPollingCommandData is a
 
 struct NFCRequestState {
     NFCReadCommand command_argument;
-    u8 packet_id;
     INSERT_PADDING_BYTES(0x1);
+    u8 packet_id;
     MCUPacketFlag packet_flag;
     u8 data_length;
     union {

--- a/src/input_common/helpers/joycon_protocol/nfc.h
+++ b/src/input_common/helpers/joycon_protocol/nfc.h
@@ -42,9 +42,9 @@ private:
 
     DriverResult WaitUntilNfcIsReady();
 
-    DriverResult StartPolling(TagFoundData& data, std::size_t timeout_limit = 1);
+    DriverResult WaitUntilNfcIsPolling();
 
-    DriverResult ReadTag(const TagFoundData& data);
+    DriverResult IsTagInRange(TagFoundData& data, std::size_t timeout_limit = 1);
 
     DriverResult GetAmiiboData(std::vector<u8>& data);
 
@@ -52,7 +52,7 @@ private:
 
     DriverResult SendStopPollingRequest(MCUCommandResponse& output);
 
-    DriverResult SendStartWaitingRecieveRequest(MCUCommandResponse& output);
+    DriverResult SendNextPackageRequest(MCUCommandResponse& output, u8 packet_id);
 
     DriverResult SendReadAmiiboRequest(MCUCommandResponse& output, NFCPages ntag_pages);
 


### PR DESCRIPTION
Turns out the previous implementation worked by a miracle, is not easy to just read hex data and give it a meaning. This fixes the amiibo detection for both joycon and pro controllers.

Special thanks to byte for providing the logs and Alicia for testing.