### PR TITLE
Allow vertical scrolling in input configuration

### DIFF
--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <thread>
+#include <QScrollArea>
 
 #include "core/core.h"
 #include "core/hid/emulated_controller.h"
@@ -112,7 +113,13 @@ void ConfigureInput::Initialize(InputCommon::InputSubsystem* input_subsystem,
 
     for (std::size_t i = 0; i < player_tabs.size(); ++i) {
         player_tabs[i]->setLayout(new QHBoxLayout(player_tabs[i]));
-        player_tabs[i]->layout()->addWidget(player_controllers[i]);
+
+        auto scroll_area = new QScrollArea(player_tabs[i]);
+        player_tabs[i]->layout()->addWidget(scroll_area);
+        scroll_area->setWidget(player_controllers[i]);
+        scroll_area->setWidgetResizable(true);
+        scroll_area->setFrameShape(QFrame::Shape::NoFrame);
+
         connect(player_controllers[i], &ConfigureInputPlayer::Connected, [&, i](bool is_connected) {
             // Ensures that the controllers are always connected in sequential order
             if (is_connected) {

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -1327,22 +1327,28 @@
                      </property>
                     </widget>
                    </item>
-                    <item>
-                      <widget class="QSlider" name="sliderZLThreshold">
-                        <property name="maximumSize">
-                          <size>
-                            <width>70</width>
-                            <height>15</height>
-                          </size>
-                        </property>
-                        <property name="maximum">
-                          <number>100</number>
-                        </property>
-                        <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                        </property>
-                      </widget>
-                    </item>
+                   <item>
+                    <widget class="QSlider" name="sliderZLThreshold">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>70</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                     <property name="maximum">
+                      <number>100</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </widget>
                 </item>
@@ -1774,22 +1780,28 @@
                      </property>
                     </widget>
                    </item>
-                    <item>
-                      <widget class="QSlider" name="sliderZRThreshold">
-                        <property name="maximumSize">
-                          <size>
-                            <width>70</width>
-                            <height>15</height>
-                          </size>
-                        </property>
-                        <property name="maximum">
-                          <number>100</number>
-                        </property>
-                        <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                        </property>
-                      </widget>
-                    </item>
+                   <item>
+                    <widget class="QSlider" name="sliderZRThreshold">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>70</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                     <property name="maximum">
+                      <number>100</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </widget>
                 </item>

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -10,6 +10,18 @@
     <height>487</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Ignored" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>743</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Configure Input</string>
   </property>


### PR DESCRIPTION
On screens that are limited in height (like the Steam Deck) some parts of the input configuration window are cut off. This includes the motion control configuration, which is a little annoying as you can't easily "resize" a portable device:

![image](https://github.com/yuzu-emu/yuzu/assets/54911369/21bca31c-e563-4c85-85e9-3de52add9412)

I originally got around this by changing the screen orientation, but I think we could probably improve this through the UI. So now, if the screen cannot fit the input configuration it will start scrolling:

![image](https://github.com/yuzu-emu/yuzu/assets/54911369/5852aea4-bb18-43fb-bcc7-e30a16dca9e2)

Note that the vertical scrollbar should disappear when the window is the minimum size or bigger, so this wouldn't affect users with large desktop screens. I also disabled the frame rendering, so there is a frame-inside-frame nonsense going on.

Also a bonus I set a minimum size for the two ZR/ZL sliders near the top, because on certain themes like KDE Plasma's Breeze the handles are _huge_ and got cut off.

The controller input bottom panel also gets shoved into the bottom. Should I instead pin that at the bottom, as I think that's what it was originally meant to do?