### PR TITLE
add context menu for status bar settings

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -65,6 +65,42 @@ const std::array<int, 2> Config::default_ringcon_analogs{{
     Qt::Key_D,
 }};
 
+const std::map<Settings::AntiAliasing, QString> Config::anti_aliasing_texts_map = {
+    {Settings::AntiAliasing::None, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "None"))},
+    {Settings::AntiAliasing::Fxaa, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "FXAA"))},
+    {Settings::AntiAliasing::Smaa, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "SMAA"))},
+};
+
+const std::map<Settings::ScalingFilter, QString> Config::scaling_filter_texts_map = {
+    {Settings::ScalingFilter::NearestNeighbor,
+     QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Nearest"))},
+    {Settings::ScalingFilter::Bilinear,
+     QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Bilinear"))},
+    {Settings::ScalingFilter::Bicubic, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Bicubic"))},
+    {Settings::ScalingFilter::Gaussian,
+     QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Gaussian"))},
+    {Settings::ScalingFilter::ScaleForce,
+     QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "ScaleForce"))},
+    {Settings::ScalingFilter::Fsr, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "FSR"))},
+};
+
+const std::map<bool, QString> Config::use_docked_mode_texts_map = {
+    {true, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Docked"))},
+    {false, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Handheld"))},
+};
+
+const std::map<Settings::GPUAccuracy, QString> Config::gpu_accuracy_texts_map = {
+    {Settings::GPUAccuracy::Normal, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Normal"))},
+    {Settings::GPUAccuracy::High, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "High"))},
+    {Settings::GPUAccuracy::Extreme, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Extreme"))},
+};
+
+const std::map<Settings::RendererBackend, QString> Config::renderer_backend_texts_map = {
+    {Settings::RendererBackend::Vulkan, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Vulkan"))},
+    {Settings::RendererBackend::OpenGL, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "OpenGL"))},
+    {Settings::RendererBackend::Null, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "Null"))},
+};
+
 // This shouldn't have anything except static initializers (no functions). So
 // QKeySequence(...).toString() is NOT ALLOWED HERE.
 // This must be in alphabetical order according to action name as it must have the same order as

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -49,6 +49,12 @@ public:
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardMods> default_keyboard_mods;
     static const std::array<UISettings::Shortcut, 22> default_hotkeys;
 
+    static const std::map<Settings::AntiAliasing, QString> anti_aliasing_texts_map;
+    static const std::map<Settings::ScalingFilter, QString> scaling_filter_texts_map;
+    static const std::map<bool, QString> use_docked_mode_texts_map;
+    static const std::map<Settings::GPUAccuracy, QString> gpu_accuracy_texts_map;
+    static const std::map<Settings::RendererBackend, QString> renderer_backend_texts_map;
+
     static constexpr UISettings::Theme default_theme{
 #ifdef _WIN32
         UISettings::Theme::DarkColorful


### PR DESCRIPTION
Satisfies feature request #10337

Only added context menus for filter and anti-aliasing, other options either only have 2 values or undesirable options ("Extreme" accuracy).

Only thing to note is the `repaint()` at the end of each context menu is to remove the hover CSS on the button which would otherwise be stuck with a border. Looking around this appears to be a quirk of Qt context menus and other solutions I tried were unsuccessful.