### PR TITLE
add hotkeys to increase/decrease speed percent

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -70,7 +70,7 @@ const std::array<int, 2> Config::default_ringcon_analogs{{
 // This must be in alphabetical order according to action name as it must have the same order as
 // UISetting::values.shortcuts, which is alphabetically ordered.
 // clang-format off
-const std::array<UISettings::Shortcut, 22> Config::default_hotkeys{{
+const std::array<UISettings::Shortcut, 24> Config::default_hotkeys{{
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Audio Mute/Unmute")),        QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("Ctrl+M"),  QStringLiteral("Home+Dpad_Right"), Qt::WindowShortcut, false}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Audio Volume Down")),        QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("-"),       QStringLiteral("Home+Dpad_Down"), Qt::ApplicationShortcut, true}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Audio Volume Up")),          QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("="),       QStringLiteral("Home+Dpad_Up"), Qt::ApplicationShortcut, true}},
@@ -85,6 +85,8 @@ const std::array<UISettings::Shortcut, 22> Config::default_hotkeys{{
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Load File")),                QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("Ctrl+O"),  QStringLiteral(""), Qt::WidgetWithChildrenShortcut, false}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Load/Remove Amiibo")),       QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("F2"),      QStringLiteral("Home+A"), Qt::WidgetWithChildrenShortcut, false}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Restart Emulation")),        QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("F6"),      QStringLiteral(""), Qt::WindowShortcut, false}},
+    {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Speed Percent Decrease")),   QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("Ctrl+-"),  QStringLiteral(""), Qt::WindowShortcut, false}},
+    {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Speed Percent Increase")),   QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("Ctrl+="),  QStringLiteral(""), Qt::WindowShortcut, false}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Stop Emulation")),           QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("F5"),      QStringLiteral(""), Qt::WindowShortcut, false}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "TAS Record")),               QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("Ctrl+F7"), QStringLiteral(""), Qt::ApplicationShortcut, false}},
     {QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "TAS Reset")),                QStringLiteral(QT_TRANSLATE_NOOP("Hotkeys", "Main Window")), {QStringLiteral("Ctrl+F6"), QStringLiteral(""), Qt::ApplicationShortcut, false}},

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -47,7 +47,7 @@ public:
         default_mouse_buttons;
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardKeys> default_keyboard_keys;
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardMods> default_keyboard_mods;
-    static const std::array<UISettings::Shortcut, 22> default_hotkeys;
+    static const std::array<UISettings::Shortcut, 24> default_hotkeys;
 
     static constexpr UISettings::Theme default_theme{
 #ifdef _WIN32

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -42,7 +42,7 @@
                <string>%</string>
               </property>
               <property name="minimum">
-               <number>1</number>
+               <number>0</number>
               </property>
               <property name="maximum">
                <number>9999</number>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1247,6 +1247,8 @@ void GMainWindow::InitializeHotkeys() {
             render_window->setAttribute(Qt::WA_Hover, true);
         }
     });
+    connect_shortcut(QStringLiteral("Speed Percent Decrease"), &GMainWindow::OnDecreaseSpeed);
+    connect_shortcut(QStringLiteral("Speed Percent Increase"), &GMainWindow::OnIncreaseSpeed);
 }
 
 void GMainWindow::SetDefaultUIGeometry() {
@@ -4553,6 +4555,16 @@ void GMainWindow::OnLanguageChanged(const QString& locale) {
     ui->retranslateUi(this);
     multiplayer_state->retranslateUi();
     UpdateWindowTitle();
+}
+
+void GMainWindow::OnDecreaseSpeed() {
+    int step = 50;
+    Settings::values.speed_limit.SetValue(std::max(Settings::values.speed_limit.GetValue() - step, 0));
+}
+
+void GMainWindow::OnIncreaseSpeed() {
+    int step = 50;
+    Settings::values.speed_limit.SetValue(Settings::values.speed_limit.GetValue() + step);
 }
 
 void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -360,6 +360,8 @@ private slots:
     void OnShutdownBeginDialog();
     void OnEmulationStopped();
     void OnEmulationStopTimeExpired();
+    void OnDecreaseSpeed();
+    void OnIncreaseSpeed();
 
 private:
     QString GetGameListErrorRemoving(InstalledEntryType type) const;


### PR DESCRIPTION
Adds the hotkeys CTRL+= and CTRL+- to increase/decrease the game speed percent by a step of 50. 
Satisfies issues #9876 and #9280. Solves the same issue that PR #10324 is going for. 
Can enhance down the line for a configurable step size via config window, but I think +-50 is going to cover most current cases. 