### PR TITLE
video_core: add ASTC recompression

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -139,3 +139,7 @@ if (NOT TARGET LLVM::Demangle)
     target_sources(demangle PRIVATE demangle/ItaniumDemangle.cpp)
     add_library(LLVM::Demangle ALIAS demangle)
 endif()
+
+add_library(stb STATIC)
+target_include_directories(stb PUBLIC ./stb)
+target_sources(stb PRIVATE stb/stb_dxt.cpp)

--- a/externals/stb/stb_dxt.cpp
+++ b/externals/stb/stb_dxt.cpp
@@ -1,0 +1,765 @@
+// SPDX-FileCopyrightText: fabian "ryg" giesen
+// SPDX-License-Identifier: MIT
+
+// stb_dxt.h - v1.12 - DXT1/DXT5 compressor
+
+#include <stb_dxt.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#if !defined(STBD_FABS)
+#include <math.h>
+#endif
+
+#ifndef STBD_FABS
+#define STBD_FABS(x) fabs(x)
+#endif
+
+static const unsigned char stb__OMatch5[256][2] = {
+    {0, 0},   {0, 0},   {0, 1},   {0, 1},   {1, 0},   {1, 0},   {1, 0},   {1, 1},   {1, 1},
+    {1, 1},   {1, 2},   {0, 4},   {2, 1},   {2, 1},   {2, 1},   {2, 2},   {2, 2},   {2, 2},
+    {2, 3},   {1, 5},   {3, 2},   {3, 2},   {4, 0},   {3, 3},   {3, 3},   {3, 3},   {3, 4},
+    {3, 4},   {3, 4},   {3, 5},   {4, 3},   {4, 3},   {5, 2},   {4, 4},   {4, 4},   {4, 5},
+    {4, 5},   {5, 4},   {5, 4},   {5, 4},   {6, 3},   {5, 5},   {5, 5},   {5, 6},   {4, 8},
+    {6, 5},   {6, 5},   {6, 5},   {6, 6},   {6, 6},   {6, 6},   {6, 7},   {5, 9},   {7, 6},
+    {7, 6},   {8, 4},   {7, 7},   {7, 7},   {7, 7},   {7, 8},   {7, 8},   {7, 8},   {7, 9},
+    {8, 7},   {8, 7},   {9, 6},   {8, 8},   {8, 8},   {8, 9},   {8, 9},   {9, 8},   {9, 8},
+    {9, 8},   {10, 7},  {9, 9},   {9, 9},   {9, 10},  {8, 12},  {10, 9},  {10, 9},  {10, 9},
+    {10, 10}, {10, 10}, {10, 10}, {10, 11}, {9, 13},  {11, 10}, {11, 10}, {12, 8},  {11, 11},
+    {11, 11}, {11, 11}, {11, 12}, {11, 12}, {11, 12}, {11, 13}, {12, 11}, {12, 11}, {13, 10},
+    {12, 12}, {12, 12}, {12, 13}, {12, 13}, {13, 12}, {13, 12}, {13, 12}, {14, 11}, {13, 13},
+    {13, 13}, {13, 14}, {12, 16}, {14, 13}, {14, 13}, {14, 13}, {14, 14}, {14, 14}, {14, 14},
+    {14, 15}, {13, 17}, {15, 14}, {15, 14}, {16, 12}, {15, 15}, {15, 15}, {15, 15}, {15, 16},
+    {15, 16}, {15, 16}, {15, 17}, {16, 15}, {16, 15}, {17, 14}, {16, 16}, {16, 16}, {16, 17},
+    {16, 17}, {17, 16}, {17, 16}, {17, 16}, {18, 15}, {17, 17}, {17, 17}, {17, 18}, {16, 20},
+    {18, 17}, {18, 17}, {18, 17}, {18, 18}, {18, 18}, {18, 18}, {18, 19}, {17, 21}, {19, 18},
+    {19, 18}, {20, 16}, {19, 19}, {19, 19}, {19, 19}, {19, 20}, {19, 20}, {19, 20}, {19, 21},
+    {20, 19}, {20, 19}, {21, 18}, {20, 20}, {20, 20}, {20, 21}, {20, 21}, {21, 20}, {21, 20},
+    {21, 20}, {22, 19}, {21, 21}, {21, 21}, {21, 22}, {20, 24}, {22, 21}, {22, 21}, {22, 21},
+    {22, 22}, {22, 22}, {22, 22}, {22, 23}, {21, 25}, {23, 22}, {23, 22}, {24, 20}, {23, 23},
+    {23, 23}, {23, 23}, {23, 24}, {23, 24}, {23, 24}, {23, 25}, {24, 23}, {24, 23}, {25, 22},
+    {24, 24}, {24, 24}, {24, 25}, {24, 25}, {25, 24}, {25, 24}, {25, 24}, {26, 23}, {25, 25},
+    {25, 25}, {25, 26}, {24, 28}, {26, 25}, {26, 25}, {26, 25}, {26, 26}, {26, 26}, {26, 26},
+    {26, 27}, {25, 29}, {27, 26}, {27, 26}, {28, 24}, {27, 27}, {27, 27}, {27, 27}, {27, 28},
+    {27, 28}, {27, 28}, {27, 29}, {28, 27}, {28, 27}, {29, 26}, {28, 28}, {28, 28}, {28, 29},
+    {28, 29}, {29, 28}, {29, 28}, {29, 28}, {30, 27}, {29, 29}, {29, 29}, {29, 30}, {29, 30},
+    {30, 29}, {30, 29}, {30, 29}, {30, 30}, {30, 30}, {30, 30}, {30, 31}, {30, 31}, {31, 30},
+    {31, 30}, {31, 30}, {31, 31}, {31, 31},
+};
+static const unsigned char stb__OMatch6[256][2] = {
+    {0, 0},   {0, 1},   {1, 0},   {1, 1},   {1, 1},   {1, 2},   {2, 1},   {2, 2},   {2, 2},
+    {2, 3},   {3, 2},   {3, 3},   {3, 3},   {3, 4},   {4, 3},   {4, 4},   {4, 4},   {4, 5},
+    {5, 4},   {5, 5},   {5, 5},   {5, 6},   {6, 5},   {6, 6},   {6, 6},   {6, 7},   {7, 6},
+    {7, 7},   {7, 7},   {7, 8},   {8, 7},   {8, 8},   {8, 8},   {8, 9},   {9, 8},   {9, 9},
+    {9, 9},   {9, 10},  {10, 9},  {10, 10}, {10, 10}, {10, 11}, {11, 10}, {8, 16},  {11, 11},
+    {11, 12}, {12, 11}, {9, 17},  {12, 12}, {12, 13}, {13, 12}, {11, 16}, {13, 13}, {13, 14},
+    {14, 13}, {12, 17}, {14, 14}, {14, 15}, {15, 14}, {14, 16}, {15, 15}, {15, 16}, {16, 14},
+    {16, 15}, {17, 14}, {16, 16}, {16, 17}, {17, 16}, {18, 15}, {17, 17}, {17, 18}, {18, 17},
+    {20, 14}, {18, 18}, {18, 19}, {19, 18}, {21, 15}, {19, 19}, {19, 20}, {20, 19}, {20, 20},
+    {20, 20}, {20, 21}, {21, 20}, {21, 21}, {21, 21}, {21, 22}, {22, 21}, {22, 22}, {22, 22},
+    {22, 23}, {23, 22}, {23, 23}, {23, 23}, {23, 24}, {24, 23}, {24, 24}, {24, 24}, {24, 25},
+    {25, 24}, {25, 25}, {25, 25}, {25, 26}, {26, 25}, {26, 26}, {26, 26}, {26, 27}, {27, 26},
+    {24, 32}, {27, 27}, {27, 28}, {28, 27}, {25, 33}, {28, 28}, {28, 29}, {29, 28}, {27, 32},
+    {29, 29}, {29, 30}, {30, 29}, {28, 33}, {30, 30}, {30, 31}, {31, 30}, {30, 32}, {31, 31},
+    {31, 32}, {32, 30}, {32, 31}, {33, 30}, {32, 32}, {32, 33}, {33, 32}, {34, 31}, {33, 33},
+    {33, 34}, {34, 33}, {36, 30}, {34, 34}, {34, 35}, {35, 34}, {37, 31}, {35, 35}, {35, 36},
+    {36, 35}, {36, 36}, {36, 36}, {36, 37}, {37, 36}, {37, 37}, {37, 37}, {37, 38}, {38, 37},
+    {38, 38}, {38, 38}, {38, 39}, {39, 38}, {39, 39}, {39, 39}, {39, 40}, {40, 39}, {40, 40},
+    {40, 40}, {40, 41}, {41, 40}, {41, 41}, {41, 41}, {41, 42}, {42, 41}, {42, 42}, {42, 42},
+    {42, 43}, {43, 42}, {40, 48}, {43, 43}, {43, 44}, {44, 43}, {41, 49}, {44, 44}, {44, 45},
+    {45, 44}, {43, 48}, {45, 45}, {45, 46}, {46, 45}, {44, 49}, {46, 46}, {46, 47}, {47, 46},
+    {46, 48}, {47, 47}, {47, 48}, {48, 46}, {48, 47}, {49, 46}, {48, 48}, {48, 49}, {49, 48},
+    {50, 47}, {49, 49}, {49, 50}, {50, 49}, {52, 46}, {50, 50}, {50, 51}, {51, 50}, {53, 47},
+    {51, 51}, {51, 52}, {52, 51}, {52, 52}, {52, 52}, {52, 53}, {53, 52}, {53, 53}, {53, 53},
+    {53, 54}, {54, 53}, {54, 54}, {54, 54}, {54, 55}, {55, 54}, {55, 55}, {55, 55}, {55, 56},
+    {56, 55}, {56, 56}, {56, 56}, {56, 57}, {57, 56}, {57, 57}, {57, 57}, {57, 58}, {58, 57},
+    {58, 58}, {58, 58}, {58, 59}, {59, 58}, {59, 59}, {59, 59}, {59, 60}, {60, 59}, {60, 60},
+    {60, 60}, {60, 61}, {61, 60}, {61, 61}, {61, 61}, {61, 62}, {62, 61}, {62, 62}, {62, 62},
+    {62, 63}, {63, 62}, {63, 63}, {63, 63},
+};
+
+static int stb__Mul8Bit(int a, int b) {
+    int t = a * b + 128;
+    return (t + (t >> 8)) >> 8;
+}
+
+static void stb__From16Bit(unsigned char* out, unsigned short v) {
+    int rv = (v & 0xf800) >> 11;
+    int gv = (v & 0x07e0) >> 5;
+    int bv = (v & 0x001f) >> 0;
+
+    // expand to 8 bits via bit replication
+    out[0] = static_cast<unsigned char>((rv * 33) >> 2);
+    out[1] = static_cast<unsigned char>((gv * 65) >> 4);
+    out[2] = static_cast<unsigned char>((bv * 33) >> 2);
+    out[3] = 0;
+}
+
+static unsigned short stb__As16Bit(int r, int g, int b) {
+    return (unsigned short)((stb__Mul8Bit(r, 31) << 11) + (stb__Mul8Bit(g, 63) << 5) +
+                            stb__Mul8Bit(b, 31));
+}
+
+// linear interpolation at 1/3 point between a and b, using desired rounding
+// type
+static int stb__Lerp13(int a, int b) {
+#ifdef STB_DXT_USE_ROUNDING_BIAS
+    // with rounding bias
+    return a + stb__Mul8Bit(b - a, 0x55);
+#else
+    // without rounding bias
+    // replace "/ 3" by "* 0xaaab) >> 17" if your compiler sucks or you really
+    // need every ounce of speed.
+    return (2 * a + b) / 3;
+#endif
+}
+
+// linear interpolation at 1/2 point between a and b
+static int stb__Lerp12(int a, int b) {
+    return (a + b) / 2;
+}
+
+// lerp RGB color
+static void stb__Lerp13RGB(unsigned char* out, unsigned char* p1, unsigned char* p2) {
+    out[0] = (unsigned char)stb__Lerp13(p1[0], p2[0]);
+    out[1] = (unsigned char)stb__Lerp13(p1[1], p2[1]);
+    out[2] = (unsigned char)stb__Lerp13(p1[2], p2[2]);
+}
+
+static void stb__Lerp12RGB(unsigned char* out, unsigned char* p1, unsigned char* p2) {
+    out[0] = (unsigned char)stb__Lerp12(p1[0], p2[0]);
+    out[1] = (unsigned char)stb__Lerp12(p1[1], p2[1]);
+    out[2] = (unsigned char)stb__Lerp12(p1[2], p2[2]);
+}
+
+/****************************************************************************/
+
+static void stb__Eval4Colors(unsigned char* color, unsigned short c0, unsigned short c1) {
+    stb__From16Bit(color + 0, c0);
+    stb__From16Bit(color + 4, c1);
+    stb__Lerp13RGB(color + 8, color + 0, color + 4);
+    stb__Lerp13RGB(color + 12, color + 4, color + 0);
+}
+
+static void stb__Eval3Colors(unsigned char* color, unsigned short c0, unsigned short c1) {
+    stb__From16Bit(color + 0, c0);
+    stb__From16Bit(color + 4, c1);
+    stb__Lerp12RGB(color + 8, color + 0, color + 4);
+}
+
+// The color matching function
+static unsigned int stb__MatchColorsBlock(unsigned char* block, unsigned char* color) {
+    unsigned int mask = 0;
+    int dirr = color[0 * 4 + 0] - color[1 * 4 + 0];
+    int dirg = color[0 * 4 + 1] - color[1 * 4 + 1];
+    int dirb = color[0 * 4 + 2] - color[1 * 4 + 2];
+    int dots[16];
+    int stops[4];
+    int i;
+    int c0Point, halfPoint, c3Point;
+
+    for (i = 0; i < 16; i++)
+        dots[i] = block[i * 4 + 0] * dirr + block[i * 4 + 1] * dirg + block[i * 4 + 2] * dirb;
+
+    for (i = 0; i < 4; i++)
+        stops[i] = color[i * 4 + 0] * dirr + color[i * 4 + 1] * dirg + color[i * 4 + 2] * dirb;
+
+    // think of the colors as arranged on a line; project point onto that line,
+    // then choose next color out of available ones. we compute the crossover
+    // points for "best color in top half"/"best in bottom half" and then the same
+    // inside that subinterval.
+    //
+    // relying on this 1d approximation isn't always optimal in terms of euclidean
+    // distance, but it's very close and a lot faster.
+    // http://cbloomrants.blogspot.com/2008/12/12-08-08-dxtc-summary.html
+
+    c0Point = (stops[1] + stops[3]);
+    halfPoint = (stops[3] + stops[2]);
+    c3Point = (stops[2] + stops[0]);
+
+    for (i = 15; i >= 0; i--) {
+        int dot = dots[i] * 2;
+        mask <<= 2;
+
+        if (dot < halfPoint)
+            mask |= (dot < c0Point) ? 1 : 3;
+        else
+            mask |= (dot < c3Point) ? 2 : 0;
+    }
+
+    return mask;
+}
+
+static unsigned int stb__MatchColorsAlphaBlock(unsigned char* block, unsigned char* color) {
+    unsigned int mask = 0;
+    int dirr = color[0 * 4 + 0] - color[1 * 4 + 0];
+    int dirg = color[0 * 4 + 1] - color[1 * 4 + 1];
+    int dirb = color[0 * 4 + 2] - color[1 * 4 + 2];
+    int dots[16];
+    int stops[3];
+    int i;
+    int c0Point, c2Point;
+
+    for (i = 0; i < 16; i++)
+        dots[i] = block[i * 4 + 0] * dirr + block[i * 4 + 1] * dirg + block[i * 4 + 2] * dirb;
+
+    for (i = 0; i < 3; i++)
+        stops[i] = color[i * 4 + 0] * dirr + color[i * 4 + 1] * dirg + color[i * 4 + 2] * dirb;
+
+    c0Point = (stops[1] + stops[2]);
+    c2Point = (stops[2] + stops[0]);
+
+    for (i = 15; i >= 0; i--) {
+        int dot = dots[i] * 2;
+        mask <<= 2;
+
+        if (block[i * 4 + 3] == 0)
+            mask |= 3;
+        else if (dot < c2Point)
+            mask |= (dot < c0Point) ? 0 : 2;
+        else
+            mask |= (dot < c0Point) ? 1 : 0;
+    }
+
+    return mask;
+}
+
+static void stb__ReorderColors(unsigned short* pmax16, unsigned short* pmin16) {
+    if (*pmin16 < *pmax16) {
+        unsigned short t = *pmin16;
+        *pmin16 = *pmax16;
+        *pmax16 = t;
+    }
+}
+
+static void stb__FinalizeColors(unsigned short* pmax16, unsigned short* pmin16,
+                                unsigned int* pmask) {
+    if (*pmax16 < *pmin16) {
+        unsigned short t = *pmin16;
+        *pmin16 = *pmax16;
+        *pmax16 = t;
+        *pmask ^= 0x55555555;
+    }
+}
+
+// The color optimization function. (Clever code, part 1)
+static void stb__OptimizeColorsBlock(unsigned char* block, unsigned short* pmax16,
+                                     unsigned short* pmin16) {
+    int mind, maxd;
+    unsigned char *minp, *maxp;
+    double magn;
+    int v_r, v_g, v_b;
+    static const int nIterPower = 4;
+    float covf[6], vfr, vfg, vfb;
+
+    // determine color distribution
+    int cov[6];
+    int mu[3], min[3], max[3];
+    int ch, i, iter;
+
+    for (ch = 0; ch < 3; ch++) {
+        const unsigned char* bp = ((const unsigned char*)block) + ch;
+        int muv, minv, maxv;
+
+        muv = minv = maxv = bp[0];
+        for (i = 4; i < 64; i += 4) {
+            muv += bp[i];
+            if (bp[i] < minv)
+                minv = bp[i];
+            else if (bp[i] > maxv)
+                maxv = bp[i];
+        }
+
+        mu[ch] = (muv + 8) >> 4;
+        min[ch] = minv;
+        max[ch] = maxv;
+    }
+
+    // determine covariance matrix
+    for (i = 0; i < 6; i++)
+        cov[i] = 0;
+
+    for (i = 0; i < 16; i++) {
+        int r = block[i * 4 + 0] - mu[0];
+        int g = block[i * 4 + 1] - mu[1];
+        int b = block[i * 4 + 2] - mu[2];
+
+        cov[0] += r * r;
+        cov[1] += r * g;
+        cov[2] += r * b;
+        cov[3] += g * g;
+        cov[4] += g * b;
+        cov[5] += b * b;
+    }
+
+    // convert covariance matrix to float, find principal axis via power iter
+    for (i = 0; i < 6; i++)
+        covf[i] = static_cast<float>(cov[i]) / 255.0f;
+
+    vfr = (float)(max[0] - min[0]);
+    vfg = (float)(max[1] - min[1]);
+    vfb = (float)(max[2] - min[2]);
+
+    for (iter = 0; iter < nIterPower; iter++) {
+        float r = vfr * covf[0] + vfg * covf[1] + vfb * covf[2];
+        float g = vfr * covf[1] + vfg * covf[3] + vfb * covf[4];
+        float b = vfr * covf[2] + vfg * covf[4] + vfb * covf[5];
+
+        vfr = r;
+        vfg = g;
+        vfb = b;
+    }
+
+    magn = STBD_FABS(vfr);
+    if (STBD_FABS(vfg) > magn)
+        magn = STBD_FABS(vfg);
+    if (STBD_FABS(vfb) > magn)
+        magn = STBD_FABS(vfb);
+
+    if (magn < 4.0f) { // too small, default to luminance
+        v_r = 299;     // JPEG YCbCr luma coefs, scaled by 1000.
+        v_g = 587;
+        v_b = 114;
+    } else {
+        magn = 512.0 / magn;
+        v_r = (int)(vfr * magn);
+        v_g = (int)(vfg * magn);
+        v_b = (int)(vfb * magn);
+    }
+
+    minp = maxp = block;
+    mind = maxd = block[0] * v_r + block[1] * v_g + block[2] * v_b;
+    // Pick colors at extreme points
+    for (i = 1; i < 16; i++) {
+        int dot = block[i * 4 + 0] * v_r + block[i * 4 + 1] * v_g + block[i * 4 + 2] * v_b;
+
+        if (dot < mind) {
+            mind = dot;
+            minp = block + i * 4;
+        }
+
+        if (dot > maxd) {
+            maxd = dot;
+            maxp = block + i * 4;
+        }
+    }
+
+    *pmax16 = stb__As16Bit(maxp[0], maxp[1], maxp[2]);
+    *pmin16 = stb__As16Bit(minp[0], minp[1], minp[2]);
+    stb__ReorderColors(pmax16, pmin16);
+}
+
+static void stb__OptimizeColorsAlphaBlock(unsigned char* block, unsigned short* pmax16,
+                                          unsigned short* pmin16) {
+    int mind, maxd;
+    unsigned char *minp, *maxp;
+    double magn;
+    int v_r, v_g, v_b;
+    static const int nIterPower = 4;
+    float covf[6], vfr, vfg, vfb;
+
+    // determine color distribution
+    int cov[6];
+    int mu[3], min[3], max[3];
+    int ch, i, iter;
+
+    for (ch = 0; ch < 3; ch++) {
+        const unsigned char* bp = ((const unsigned char*)block) + ch;
+        int muv = 0, minv = 256, maxv = -1;
+        int num = 0;
+
+        for (i = 0; i < 64; i += 4) {
+            if (bp[3 - ch] == 0) {
+                continue;
+            }
+
+            muv += bp[i];
+            if (bp[i] < minv)
+                minv = bp[i];
+            else if (bp[i] > maxv)
+                maxv = bp[i];
+
+            num++;
+        }
+
+        mu[ch] = num > 0 ? (muv + 8) / num : 0;
+        min[ch] = minv;
+        max[ch] = maxv;
+    }
+
+    // determine covariance matrix
+    for (i = 0; i < 6; i++)
+        cov[i] = 0;
+
+    for (i = 0; i < 16; i++) {
+        if (block[i * 4 + 3] == 0) {
+            continue;
+        }
+
+        int r = block[i * 4 + 0] - mu[0];
+        int g = block[i * 4 + 1] - mu[1];
+        int b = block[i * 4 + 2] - mu[2];
+
+        cov[0] += r * r;
+        cov[1] += r * g;
+        cov[2] += r * b;
+        cov[3] += g * g;
+        cov[4] += g * b;
+        cov[5] += b * b;
+    }
+
+    // convert covariance matrix to float, find principal axis via power iter
+    for (i = 0; i < 6; i++)
+        covf[i] = static_cast<float>(cov[i]) / 255.0f;
+
+    vfr = (float)(max[0] - min[0]);
+    vfg = (float)(max[1] - min[1]);
+    vfb = (float)(max[2] - min[2]);
+
+    for (iter = 0; iter < nIterPower; iter++) {
+        float r = vfr * covf[0] + vfg * covf[1] + vfb * covf[2];
+        float g = vfr * covf[1] + vfg * covf[3] + vfb * covf[4];
+        float b = vfr * covf[2] + vfg * covf[4] + vfb * covf[5];
+
+        vfr = r;
+        vfg = g;
+        vfb = b;
+    }
+
+    magn = STBD_FABS(vfr);
+    if (STBD_FABS(vfg) > magn)
+        magn = STBD_FABS(vfg);
+    if (STBD_FABS(vfb) > magn)
+        magn = STBD_FABS(vfb);
+
+    if (magn < 4.0f) { // too small, default to luminance
+        v_r = 299;     // JPEG YCbCr luma coefs, scaled by 1000.
+        v_g = 587;
+        v_b = 114;
+    } else {
+        magn = 512.0 / magn;
+        v_r = (int)(vfr * magn);
+        v_g = (int)(vfg * magn);
+        v_b = (int)(vfb * magn);
+    }
+
+    minp = maxp = NULL;
+    mind = 0x7fffffff;
+    maxd = -0x80000000;
+
+    // Pick colors at extreme points
+    for (i = 0; i < 16; i++) {
+        if (block[i * 4 + 3] == 0) {
+            continue;
+        }
+
+        int dot = block[i * 4 + 0] * v_r + block[i * 4 + 1] * v_g + block[i * 4 + 2] * v_b;
+
+        if (dot < mind) {
+            mind = dot;
+            minp = block + i * 4;
+        }
+
+        if (dot > maxd) {
+            maxd = dot;
+            maxp = block + i * 4;
+        }
+    }
+
+    if (!maxp) {
+        // all alpha, no color
+        *pmin16 = 0xffff;
+        *pmax16 = 0;
+    } else {
+        // endpoint colors found
+        *pmax16 = stb__As16Bit(maxp[0], maxp[1], maxp[2]);
+        *pmin16 = stb__As16Bit(minp[0], minp[1], minp[2]);
+
+        if (*pmax16 == *pmin16) {
+            // modify the endpoints to indicate presence of an alpha block
+            if (*pmax16 > 0) {
+                (*pmax16)--;
+            } else {
+                (*pmin16)++;
+            }
+        }
+
+        stb__ReorderColors(pmax16, pmin16);
+    }
+}
+
+static const float stb__midpoints5[32] = {
+    0.015686f, 0.047059f, 0.078431f, 0.111765f, 0.145098f, 0.176471f, 0.207843f, 0.241176f,
+    0.274510f, 0.305882f, 0.337255f, 0.370588f, 0.403922f, 0.435294f, 0.466667f, 0.5f,
+    0.533333f, 0.564706f, 0.596078f, 0.629412f, 0.662745f, 0.694118f, 0.725490f, 0.758824f,
+    0.792157f, 0.823529f, 0.854902f, 0.888235f, 0.921569f, 0.952941f, 0.984314f, 1.0f};
+
+static const float stb__midpoints6[64] = {
+    0.007843f, 0.023529f, 0.039216f, 0.054902f, 0.070588f, 0.086275f, 0.101961f, 0.117647f,
+    0.133333f, 0.149020f, 0.164706f, 0.180392f, 0.196078f, 0.211765f, 0.227451f, 0.245098f,
+    0.262745f, 0.278431f, 0.294118f, 0.309804f, 0.325490f, 0.341176f, 0.356863f, 0.372549f,
+    0.388235f, 0.403922f, 0.419608f, 0.435294f, 0.450980f, 0.466667f, 0.482353f, 0.500000f,
+    0.517647f, 0.533333f, 0.549020f, 0.564706f, 0.580392f, 0.596078f, 0.611765f, 0.627451f,
+    0.643137f, 0.658824f, 0.674510f, 0.690196f, 0.705882f, 0.721569f, 0.737255f, 0.754902f,
+    0.772549f, 0.788235f, 0.803922f, 0.819608f, 0.835294f, 0.850980f, 0.866667f, 0.882353f,
+    0.898039f, 0.913725f, 0.929412f, 0.945098f, 0.960784f, 0.976471f, 0.992157f, 1.0f};
+
+static unsigned short stb__Quantize5(float x) {
+    unsigned short q;
+    x = x < 0 ? 0 : x > 1 ? 1 : x; // saturate
+    q = (unsigned short)(x * 31);
+    q += (x > stb__midpoints5[q]);
+    return q;
+}
+
+static unsigned short stb__Quantize6(float x) {
+    unsigned short q;
+    x = x < 0 ? 0 : x > 1 ? 1 : x; // saturate
+    q = (unsigned short)(x * 63);
+    q += (x > stb__midpoints6[q]);
+    return q;
+}
+
+// The refinement function. (Clever code, part 2)
+// Tries to optimize colors to suit block contents better.
+// (By solving a least squares system via normal equations+Cramer's rule)
+static int stb__RefineBlock(unsigned char* block, unsigned short* pmax16, unsigned short* pmin16,
+                            unsigned int mask) {
+    static const int w1Tab[4] = {3, 0, 2, 1};
+    static const int prods[4] = {0x090000, 0x000900, 0x040102, 0x010402};
+    // ^some magic to save a lot of multiplies in the accumulating loop...
+    // (precomputed products of weights for least squares system, accumulated
+    // inside one 32-bit register)
+
+    float f;
+    unsigned short oldMin, oldMax, min16, max16;
+    int i, akku = 0, xx, xy, yy;
+    int At1_r, At1_g, At1_b;
+    int At2_r, At2_g, At2_b;
+    unsigned int cm = mask;
+
+    oldMin = *pmin16;
+    oldMax = *pmax16;
+
+    if ((mask ^ (mask << 2)) < 4) // all pixels have the same index?
+    {
+        // yes, linear system would be singular; solve using optimal
+        // single-color match on average color
+        int r = 8, g = 8, b = 8;
+        for (i = 0; i < 16; ++i) {
+            r += block[i * 4 + 0];
+            g += block[i * 4 + 1];
+            b += block[i * 4 + 2];
+        }
+
+        r >>= 4;
+        g >>= 4;
+        b >>= 4;
+
+        max16 = static_cast<unsigned short>((stb__OMatch5[r][0] << 11) | (stb__OMatch6[g][0] << 5) |
+                                            stb__OMatch5[b][0]);
+        min16 = static_cast<unsigned short>((stb__OMatch5[r][1] << 11) | (stb__OMatch6[g][1] << 5) |
+                                            stb__OMatch5[b][1]);
+    } else {
+        At1_r = At1_g = At1_b = 0;
+        At2_r = At2_g = At2_b = 0;
+        for (i = 0; i < 16; ++i, cm >>= 2) {
+            int step = cm & 3;
+            int w1 = w1Tab[step];
+            int r = block[i * 4 + 0];
+            int g = block[i * 4 + 1];
+            int b = block[i * 4 + 2];
+
+            akku += prods[step];
+            At1_r += w1 * r;
+            At1_g += w1 * g;
+            At1_b += w1 * b;
+            At2_r += r;
+            At2_g += g;
+            At2_b += b;
+        }
+
+        At2_r = 3 * At2_r - At1_r;
+        At2_g = 3 * At2_g - At1_g;
+        At2_b = 3 * At2_b - At1_b;
+
+        // extract solutions and decide solvability
+        xx = akku >> 16;
+        yy = (akku >> 8) & 0xff;
+        xy = (akku >> 0) & 0xff;
+
+        f = 3.0f / 255.0f / static_cast<float>(xx * yy - xy * xy);
+
+        max16 = static_cast<unsigned short>(
+            stb__Quantize5(static_cast<float>(At1_r * yy - At2_r * xy) * f) << 11);
+        max16 |= static_cast<unsigned short>(
+            stb__Quantize6(static_cast<float>(At1_g * yy - At2_g * xy) * f) << 5);
+        max16 |= static_cast<unsigned short>(
+            stb__Quantize5(static_cast<float>(At1_b * yy - At2_b * xy) * f) << 0);
+
+        min16 = static_cast<unsigned short>(
+            stb__Quantize5(static_cast<float>(At2_r * xx - At1_r * xy) * f) << 11);
+        min16 |= static_cast<unsigned short>(
+            stb__Quantize6(static_cast<float>(At2_g * xx - At1_g * xy) * f) << 5);
+        min16 |= static_cast<unsigned short>(
+            stb__Quantize5(static_cast<float>(At2_b * xx - At1_b * xy) * f) << 0);
+    }
+
+    *pmin16 = min16;
+    *pmax16 = max16;
+    stb__ReorderColors(pmax16, pmin16);
+
+    return oldMin != min16 || oldMax != max16;
+}
+
+// Color block compression
+static void stb__CompressColorBlock(unsigned char* dest, unsigned char* block, int alpha,
+                                    int mode) {
+    unsigned int mask;
+    int i;
+    int refinecount;
+    unsigned short max16, min16;
+    unsigned char color[4 * 4];
+
+    refinecount = (mode & STB_DXT_HIGHQUAL) ? 2 : 1;
+
+    // check if block is constant
+    for (i = 1; i < 16; i++)
+        if (((unsigned int*)block)[i] != ((unsigned int*)block)[0])
+            break;
+
+    if (i == 16 && block[3] == 0 && alpha) { // constant alpha
+        mask = 0xffffffff;
+        max16 = 0;
+        min16 = 0xffff;
+    } else if (i == 16) { // constant color
+        int r = block[0], g = block[1], b = block[2];
+        mask = 0xaaaaaaaa;
+        max16 = static_cast<unsigned short>((stb__OMatch5[r][0] << 11) | (stb__OMatch6[g][0] << 5) |
+                                            stb__OMatch5[b][0]);
+        min16 = static_cast<unsigned short>((stb__OMatch5[r][1] << 11) | (stb__OMatch6[g][1] << 5) |
+                                            stb__OMatch5[b][1]);
+    } else if (alpha) {
+        stb__OptimizeColorsAlphaBlock(block, &max16, &min16);
+        stb__Eval3Colors(color, max16, min16);
+        mask = stb__MatchColorsAlphaBlock(block, color);
+    } else {
+        // first step: PCA+map along principal axis
+        stb__OptimizeColorsBlock(block, &max16, &min16);
+        if (max16 != min16) {
+            stb__Eval4Colors(color, max16, min16);
+            mask = stb__MatchColorsBlock(block, color);
+        } else
+            mask = 0;
+
+        // third step: refine (multiple times if requested)
+        for (i = 0; i < refinecount; i++) {
+            unsigned int lastmask = mask;
+
+            if (stb__RefineBlock(block, &max16, &min16, mask)) {
+                if (max16 != min16) {
+                    stb__Eval4Colors(color, max16, min16);
+                    mask = stb__MatchColorsBlock(block, color);
+                } else {
+                    mask = 0;
+                    break;
+                }
+            }
+
+            if (mask == lastmask)
+                break;
+        }
+    }
+
+    // write the color block
+    if (!alpha)
+        stb__FinalizeColors(&max16, &min16, &mask);
+
+    dest[0] = (unsigned char)(max16);
+    dest[1] = (unsigned char)(max16 >> 8);
+    dest[2] = (unsigned char)(min16);
+    dest[3] = (unsigned char)(min16 >> 8);
+    dest[4] = (unsigned char)(mask);
+    dest[5] = (unsigned char)(mask >> 8);
+    dest[6] = (unsigned char)(mask >> 16);
+    dest[7] = (unsigned char)(mask >> 24);
+}
+
+// Alpha block compression (this is easy for a change)
+static void stb__CompressAlphaBlock(unsigned char* dest, unsigned char* src, int stride) {
+    int i, dist, bias, dist4, dist2, bits, mask;
+
+    // find min/max color
+    int mn, mx;
+    mn = mx = src[0];
+
+    for (i = 1; i < 16; i++) {
+        if (src[i * stride] < mn)
+            mn = src[i * stride];
+        else if (src[i * stride] > mx)
+            mx = src[i * stride];
+    }
+
+    // encode them
+    dest[0] = (unsigned char)mx;
+    dest[1] = (unsigned char)mn;
+    dest += 2;
+
+    // determine bias and emit color indices
+    // given the choice of mx/mn, these indices are optimal:
+    // http://fgiesen.wordpress.com/2009/12/15/dxt5-alpha-block-index-determination/
+    dist = mx - mn;
+    dist4 = dist * 4;
+    dist2 = dist * 2;
+    bias = (dist < 8) ? (dist - 1) : (dist / 2 + 2);
+    bias -= mn * 7;
+    bits = 0, mask = 0;
+
+    for (i = 0; i < 16; i++) {
+        int a = src[i * stride] * 7 + bias;
+        int ind, t;
+
+        // select index. this is a "linear scale" lerp factor between 0 (val=min)
+        // and 7 (val=max).
+        t = (a >= dist4) ? -1 : 0;
+        ind = t & 4;
+        a -= dist4 & t;
+        t = (a >= dist2) ? -1 : 0;
+        ind += t & 2;
+        a -= dist2 & t;
+        ind += (a >= dist);
+
+        // turn linear scale into DXT index (0/1 are extremal pts)
+        ind = -ind & 7;
+        ind ^= (2 > ind);
+
+        // write index
+        mask |= ind << bits;
+        if ((bits += 3) >= 8) {
+            *dest++ = (unsigned char)mask;
+            mask >>= 8;
+            bits -= 8;
+        }
+    }
+}
+
+void stb_compress_bc1_block(unsigned char* dest, const unsigned char* src, int alpha, int mode) {
+    stb__CompressColorBlock(dest, (unsigned char*)src, alpha, mode);
+}
+
+void stb_compress_bc3_block(unsigned char* dest, const unsigned char* src, int mode) {
+    unsigned char data[16][4];
+    int i;
+
+    stb__CompressAlphaBlock(dest, (unsigned char*)src + 3, 4);
+    dest += 8;
+    // make a new copy of the data in which alpha is opaque,
+    // because code uses a fast test for color constancy
+    memcpy(data, src, 4 * 16);
+    for (i = 0; i < 16; ++i)
+        data[i][3] = 255;
+    src = &data[0][0];
+
+    stb__CompressColorBlock(dest, (unsigned char*)src, 0, mode);
+}

--- a/externals/stb/stb_dxt.h
+++ b/externals/stb/stb_dxt.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: fabian "ryg" giesen
+// SPDX-License-Identifier: MIT
+
+// stb_dxt.h - v1.12 - DXT1/DXT5 compressor
+
+#ifndef STB_INCLUDE_STB_DXT_H
+#define STB_INCLUDE_STB_DXT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef STB_DXT_STATIC
+#define STBDDEF static
+#else
+#define STBDDEF extern
+#endif
+
+// compression mode (bitflags)
+#define STB_DXT_NORMAL 0
+#define STB_DXT_DITHER 1 // use dithering. was always dubious, now deprecated. does nothing!
+#define STB_DXT_HIGHQUAL                                                                           \
+    2 // high quality mode, does two refinement steps instead of 1. ~30-40% slower.
+
+STBDDEF void stb_compress_bc1_block(unsigned char* dest,
+                                    const unsigned char* src_rgba_four_bytes_per_pixel, int alpha,
+                                    int mode);
+
+STBDDEF void stb_compress_bc3_block(unsigned char* dest, const unsigned char* src, int mode);
+
+#define STB_COMPRESS_DXT_BLOCK
+
+#ifdef __cplusplus
+}
+#endif
+#endif // STB_INCLUDE_STB_DXT_H

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -61,6 +61,7 @@ void LogSettings() {
     log_setting("Renderer_NvdecEmulation", values.nvdec_emulation.GetValue());
     log_setting("Renderer_AccelerateASTC", values.accelerate_astc.GetValue());
     log_setting("Renderer_AsyncASTC", values.async_astc.GetValue());
+    log_setting("Renderer_AstcRecompression", values.astc_recompression.GetValue());
     log_setting("Renderer_UseVsync", values.vsync_mode.GetValue());
     log_setting("Renderer_UseReactiveFlushing", values.use_reactive_flushing.GetValue());
     log_setting("Renderer_ShaderBackend", values.shader_backend.GetValue());
@@ -224,6 +225,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.nvdec_emulation.SetGlobal(true);
     values.accelerate_astc.SetGlobal(true);
     values.async_astc.SetGlobal(true);
+    values.astc_recompression.SetGlobal(true);
     values.use_reactive_flushing.SetGlobal(true);
     values.shader_backend.SetGlobal(true);
     values.use_asynchronous_shaders.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -90,6 +90,12 @@ enum class AntiAliasing : u32 {
     LastAA = Smaa,
 };
 
+enum class AstcRecompression : u32 {
+    Uncompressed = 0,
+    Bc1 = 1,
+    Bc3 = 2,
+};
+
 struct ResolutionScalingInfo {
     u32 up_scale{1};
     u32 down_shift{0};
@@ -473,6 +479,9 @@ struct Values {
     SwitchableSetting<bool> use_vulkan_driver_pipeline_cache{true,
                                                              "use_vulkan_driver_pipeline_cache"};
     SwitchableSetting<bool> enable_compute_pipelines{false, "enable_compute_pipelines"};
+    SwitchableSetting<AstcRecompression, true> astc_recompression{
+        AstcRecompression::Uncompressed, AstcRecompression::Uncompressed, AstcRecompression::Bc3,
+        "astc_recompression"};
 
     SwitchableSetting<u8> bg_red{0, "bg_red"};
     SwitchableSetting<u8> bg_green{0, "bg_green"};

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -246,10 +246,14 @@ add_library(video_core STATIC
     texture_cache/util.h
     textures/astc.h
     textures/astc.cpp
+    textures/bcn.cpp
+    textures/bcn.h
     textures/decoders.cpp
     textures/decoders.h
     textures/texture.cpp
     textures/texture.h
+    textures/workers.cpp
+    textures/workers.h
     transform_feedback.cpp
     transform_feedback.h
     video_core.cpp
@@ -275,7 +279,7 @@ add_library(video_core STATIC
 create_target_directory_groups(video_core)
 
 target_link_libraries(video_core PUBLIC common core)
-target_link_libraries(video_core PUBLIC glad shader_recompiler)
+target_link_libraries(video_core PUBLIC glad shader_recompiler stb)
 
 if (YUZU_USE_BUNDLED_FFMPEG AND NOT WIN32)
     add_dependencies(video_core ffmpeg-build)

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1664,7 +1664,7 @@ typename BufferCache<P>::Binding BufferCache<P>::StorageBufferBinding(GPUVAddr s
         // cbufs, which do not store the sizes adjacent to the addresses, so use the fully
         // mapped buffer size for now.
         const u32 memory_layout_size = static_cast<u32>(gpu_memory->GetMemoryLayoutSize(gpu_addr));
-        return memory_layout_size;
+        return std::min(memory_layout_size, static_cast<u32>(8_MiB));
     }();
     const std::optional<VAddr> cpu_addr = gpu_memory->GpuToCpuAddress(gpu_addr);
     if (!cpu_addr || size == 0) {

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1268,7 +1268,9 @@ Image::Image(TextureCacheRuntime& runtime_, const ImageInfo& info_, GPUVAddr gpu
     if (IsPixelFormatASTC(info.format) && !runtime->device.IsOptimalAstcSupported()) {
         if (Settings::values.async_astc.GetValue()) {
             flags |= VideoCommon::ImageFlagBits::AsynchronousDecode;
-        } else if (Settings::values.accelerate_astc.GetValue() && info.size.depth == 1) {
+        } else if (Settings::values.astc_recompression.GetValue() ==
+                       Settings::AstcRecompression::Uncompressed &&
+                   Settings::values.accelerate_astc.GetValue() && info.size.depth == 1) {
             flags |= VideoCommon::ImageFlagBits::AcceleratedUpload;
         }
         flags |= VideoCommon::ImageFlagBits::Converted;
@@ -1283,7 +1285,9 @@ Image::Image(TextureCacheRuntime& runtime_, const ImageInfo& info_, GPUVAddr gpu
         .usage = VK_IMAGE_USAGE_STORAGE_BIT,
     };
     current_image = *original_image;
-    if (IsPixelFormatASTC(info.format) && !runtime->device.IsOptimalAstcSupported()) {
+    if (IsPixelFormatASTC(info.format) && !runtime->device.IsOptimalAstcSupported() &&
+        Settings::values.astc_recompression.GetValue() ==
+            Settings::AstcRecompression::Uncompressed) {
         const auto& device = runtime->device.GetLogical();
         storage_image_views.reserve(info.resources.levels);
         for (s32 level = 0; level < info.resources.levels; ++level) {

--- a/src/video_core/textures/astc.cpp
+++ b/src/video_core/textures/astc.cpp
@@ -16,8 +16,8 @@
 #include "common/alignment.h"
 #include "common/common_types.h"
 #include "common/polyfill_ranges.h"
-#include "common/thread_worker.h"
 #include "video_core/textures/astc.h"
+#include "video_core/textures/workers.h"
 
 class InputBitStream {
 public:
@@ -1656,8 +1656,7 @@ void Decompress(std::span<const uint8_t> data, uint32_t width, uint32_t height, 
     const u32 rows = Common::DivideUp(height, block_height);
     const u32 cols = Common::DivideUp(width, block_width);
 
-    static Common::ThreadWorker workers{std::max(std::thread::hardware_concurrency(), 2U) / 2,
-                                        "ASTCDecompress"};
+    Common::ThreadWorker& workers{GetThreadWorkers()};
 
     for (u32 z = 0; z < depth; ++z) {
         const u32 depth_offset = z * height * width * 4;

--- a/src/video_core/textures/bcn.cpp
+++ b/src/video_core/textures/bcn.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <stb_dxt.h>
+#include <string.h>
+
+#include "common/alignment.h"
+#include "video_core/textures/bcn.h"
+#include "video_core/textures/workers.h"
+
+namespace Tegra::Texture::BCN {
+
+using BCNCompressor = void(u8* block_output, const u8* block_input, bool any_alpha);
+
+template <u32 BytesPerBlock, bool ThresholdAlpha = false>
+void CompressBCN(std::span<const uint8_t> data, uint32_t width, uint32_t height, uint32_t depth,
+                 std::span<uint8_t> output, BCNCompressor f) {
+    constexpr u8 alpha_threshold = 128;
+    constexpr u32 bytes_per_px = 4;
+    const u32 plane_dim = width * height;
+
+    Common::ThreadWorker& workers{GetThreadWorkers()};
+
+    for (u32 z = 0; z < depth; z++) {
+        for (u32 y = 0; y < height; y += 4) {
+            auto compress_row = [z, y, width, height, plane_dim, f, data, output]() {
+                for (u32 x = 0; x < width; x += 4) {
+                    // Gather 4x4 block of RGBA texels
+                    u8 input_colors[4][4][4];
+                    bool any_alpha = false;
+
+                    for (u32 j = 0; j < 4; j++) {
+                        for (u32 i = 0; i < 4; i++) {
+                            const size_t coord =
+                                (z * plane_dim + (y + j) * width + (x + i)) * bytes_per_px;
+
+                            if ((x + i < width) && (y + j < height)) {
+                                if constexpr (ThresholdAlpha) {
+                                    if (data[coord + 3] >= alpha_threshold) {
+                                        input_colors[j][i][0] = data[coord + 0];
+                                        input_colors[j][i][1] = data[coord + 1];
+                                        input_colors[j][i][2] = data[coord + 2];
+                                        input_colors[j][i][3] = 255;
+                                    } else {
+                                        any_alpha = true;
+                                        memset(input_colors[j][i], 0, bytes_per_px);
+                                    }
+                                } else {
+                                    memcpy(input_colors[j][i], &data[coord], bytes_per_px);
+                                }
+                            } else {
+                                memset(input_colors[j][i], 0, bytes_per_px);
+                            }
+                        }
+                    }
+
+                    const u32 bytes_per_row = BytesPerBlock * Common::DivideUp(width, 4U);
+                    const u32 bytes_per_plane = bytes_per_row * Common::DivideUp(height, 4U);
+                    f(output.data() + z * bytes_per_plane + (y / 4) * bytes_per_row +
+                          (x / 4) * BytesPerBlock,
+                      reinterpret_cast<u8*>(input_colors), any_alpha);
+                }
+            };
+            workers.QueueWork(std::move(compress_row));
+        }
+        workers.WaitForRequests();
+    }
+}
+
+void CompressBC1(std::span<const uint8_t> data, uint32_t width, uint32_t height, uint32_t depth,
+                 std::span<uint8_t> output) {
+    CompressBCN<8, true>(data, width, height, depth, output,
+                         [](u8* block_output, const u8* block_input, bool any_alpha) {
+                             stb_compress_bc1_block(block_output, block_input, any_alpha,
+                                                    STB_DXT_NORMAL);
+                         });
+}
+
+void CompressBC3(std::span<const uint8_t> data, uint32_t width, uint32_t height, uint32_t depth,
+                 std::span<uint8_t> output) {
+    CompressBCN<16, false>(data, width, height, depth, output,
+                           [](u8* block_output, const u8* block_input, bool any_alpha) {
+                               stb_compress_bc3_block(block_output, block_input, STB_DXT_NORMAL);
+                           });
+}
+
+} // namespace Tegra::Texture::BCN

--- a/src/video_core/textures/bcn.h
+++ b/src/video_core/textures/bcn.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <span>
+#include <stdint.h>
+
+namespace Tegra::Texture::BCN {
+
+void CompressBC1(std::span<const uint8_t> data, uint32_t width, uint32_t height, uint32_t depth,
+                 std::span<uint8_t> output);
+
+void CompressBC3(std::span<const uint8_t> data, uint32_t width, uint32_t height, uint32_t depth,
+                 std::span<uint8_t> output);
+
+} // namespace Tegra::Texture::BCN

--- a/src/video_core/textures/workers.cpp
+++ b/src/video_core/textures/workers.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "video_core/textures/workers.h"
+
+namespace Tegra::Texture {
+
+Common::ThreadWorker& GetThreadWorkers() {
+    static Common::ThreadWorker workers{std::max(std::thread::hardware_concurrency(), 2U) / 2,
+                                        "ImageTranscode"};
+
+    return workers;
+}
+
+} // namespace Tegra::Texture

--- a/src/video_core/textures/workers.h
+++ b/src/video_core/textures/workers.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/thread_worker.h"
+
+namespace Tegra::Texture {
+
+Common::ThreadWorker& GetThreadWorkers();
+
+}

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1001,6 +1001,11 @@ u64 Device::GetDeviceMemoryUsage() const {
 }
 
 void Device::CollectPhysicalMemoryInfo() {
+    // Account for resolution scaling in memory limits
+    const size_t normal_memory = 6_GiB;
+    const size_t scaler_memory = 1_GiB * Settings::values.resolution_info.ScaleUp(1);
+
+    // Calculate limits using memory budget
     VkPhysicalDeviceMemoryBudgetPropertiesEXT budget{};
     budget.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT;
     const auto mem_info =
@@ -1030,6 +1035,7 @@ void Device::CollectPhysicalMemoryInfo() {
     if (!is_integrated) {
         const u64 reserve_memory = std::min<u64>(device_access_memory / 8, 1_GiB);
         device_access_memory -= reserve_memory;
+        device_access_memory = std::min<u64>(device_access_memory, normal_memory + scaler_memory);
         return;
     }
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -711,6 +711,7 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.nvdec_emulation);
     ReadGlobalSetting(Settings::values.accelerate_astc);
     ReadGlobalSetting(Settings::values.async_astc);
+    ReadGlobalSetting(Settings::values.astc_recompression);
     ReadGlobalSetting(Settings::values.use_reactive_flushing);
     ReadGlobalSetting(Settings::values.shader_backend);
     ReadGlobalSetting(Settings::values.use_asynchronous_shaders);
@@ -1359,6 +1360,10 @@ void Config::SaveRendererValues() {
                  Settings::values.nvdec_emulation.UsingGlobal());
     WriteGlobalSetting(Settings::values.accelerate_astc);
     WriteGlobalSetting(Settings::values.async_astc);
+    WriteSetting(QString::fromStdString(Settings::values.astc_recompression.GetLabel()),
+                 static_cast<u32>(Settings::values.astc_recompression.GetValue(global)),
+                 static_cast<u32>(Settings::values.astc_recompression.GetDefault()),
+                 Settings::values.astc_recompression.UsingGlobal());
     WriteGlobalSetting(Settings::values.use_reactive_flushing);
     WriteSetting(QString::fromStdString(Settings::values.shader_backend.GetLabel()),
                  static_cast<u32>(Settings::values.shader_backend.GetValue(global)),

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -208,3 +208,4 @@ Q_DECLARE_METATYPE(Settings::ScalingFilter);
 Q_DECLARE_METATYPE(Settings::AntiAliasing);
 Q_DECLARE_METATYPE(Settings::RendererBackend);
 Q_DECLARE_METATYPE(Settings::ShaderBackend);
+Q_DECLARE_METATYPE(Settings::AstcRecompression);

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -27,6 +27,7 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
     ui->async_present->setEnabled(runtime_lock);
     ui->renderer_force_max_clock->setEnabled(runtime_lock);
     ui->async_astc->setEnabled(runtime_lock);
+    ui->astc_recompression_combobox->setEnabled(runtime_lock);
     ui->use_asynchronous_shaders->setEnabled(runtime_lock);
     ui->anisotropic_filtering_combobox->setEnabled(runtime_lock);
     ui->enable_compute_pipelines_checkbox->setEnabled(runtime_lock);
@@ -47,14 +48,20 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
             static_cast<int>(Settings::values.gpu_accuracy.GetValue()));
         ui->anisotropic_filtering_combobox->setCurrentIndex(
             Settings::values.max_anisotropy.GetValue());
+        ui->astc_recompression_combobox->setCurrentIndex(
+            static_cast<int>(Settings::values.astc_recompression.GetValue()));
     } else {
         ConfigurationShared::SetPerGameSetting(ui->gpu_accuracy, &Settings::values.gpu_accuracy);
         ConfigurationShared::SetPerGameSetting(ui->anisotropic_filtering_combobox,
                                                &Settings::values.max_anisotropy);
+        ConfigurationShared::SetPerGameSetting(ui->astc_recompression_combobox,
+                                               &Settings::values.astc_recompression);
         ConfigurationShared::SetHighlight(ui->label_gpu_accuracy,
                                           !Settings::values.gpu_accuracy.UsingGlobal());
         ConfigurationShared::SetHighlight(ui->af_label,
                                           !Settings::values.max_anisotropy.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_astc_recompression,
+                                          !Settings::values.astc_recompression.UsingGlobal());
     }
 }
 
@@ -71,6 +78,8 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
                                              ui->use_reactive_flushing, use_reactive_flushing);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.async_astc, ui->async_astc,
                                              async_astc);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.astc_recompression,
+                                             ui->astc_recompression_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
                                              ui->use_asynchronous_shaders,
                                              use_asynchronous_shaders);
@@ -105,6 +114,8 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
             Settings::values.renderer_force_max_clock.UsingGlobal());
         ui->use_reactive_flushing->setEnabled(Settings::values.use_reactive_flushing.UsingGlobal());
         ui->async_astc->setEnabled(Settings::values.async_astc.UsingGlobal());
+        ui->astc_recompression_combobox->setEnabled(
+            Settings::values.astc_recompression.UsingGlobal());
         ui->use_asynchronous_shaders->setEnabled(
             Settings::values.use_asynchronous_shaders.UsingGlobal());
         ui->use_fast_gpu_time->setEnabled(Settings::values.use_fast_gpu_time.UsingGlobal());
@@ -144,6 +155,9 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->anisotropic_filtering_combobox, ui->af_label,
         static_cast<int>(Settings::values.max_anisotropy.GetValue(true)));
+    ConfigurationShared::SetColoredComboBox(
+        ui->astc_recompression_combobox, ui->label_astc_recompression,
+        static_cast<int>(Settings::values.astc_recompression.GetValue(true)));
 }
 
 void ConfigureGraphicsAdvanced::ExposeComputeOption() {

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -70,6 +70,50 @@
          </widget>
         </item>
         <item>
+         <widget class="QWidget" name="astc_recompression_layout" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <property name="leftMargin">
+              <number>0</number>
+            </property>
+            <property name="topMargin">
+              <number>0</number>
+            </property>
+            <property name="rightMargin">
+              <number>0</number>
+            </property>
+            <property name="bottomMargin">
+              <number>0</number>
+            </property>
+            <item>
+              <widget class="QLabel" name="label_astc_recompression">
+              <property name="text">
+                <string>ASTC recompression:</string>
+              </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QComboBox" name="astc_recompression_combobox">
+                <item>
+                <property name="text">
+                  <string>Uncompressed (Best quality)</string>
+                </property>
+                </item>
+                <item>
+                <property name="text">
+                  <string>BC1 (Low quality)</string>
+                </property>
+                </item>
+                <item>
+                <property name="text">
+                  <string>BC3 (Medium quality)</string>
+                </property>
+                </item>
+              </widget>
+            </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="async_present">
           <property name="text">
            <string>Enable asynchronous presentation (Vulkan only)</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -318,6 +318,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.nvdec_emulation);
     ReadSetting("Renderer", Settings::values.accelerate_astc);
     ReadSetting("Renderer", Settings::values.async_astc);
+    ReadSetting("Renderer", Settings::values.astc_recompression);
     ReadSetting("Renderer", Settings::values.use_fast_gpu_time);
     ReadSetting("Renderer", Settings::values.use_vulkan_driver_pipeline_cache);
 

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -360,6 +360,10 @@ accelerate_astc =
 # 0 (default): Off, 1: On
 async_astc =
 
+# Recompress ASTC textures to a different format.
+# 0 (default): Uncompressed, 1: BC1 (Low quality), 2: BC3: (Medium quality)
+async_astc =
+
 # Turns on the speed limiter, which will limit the emulation speed to the desired speed limit value
 # 0: Off, 1: On (default)
 use_speed_limit =


### PR DESCRIPTION
This does two things:
1. Add a setting to transcode ASTC textures into uncompressed RGBA (default, matches previous behavior), BC1 (very low quality, causes issues in many games but saves 8x memory) or BC3 (medium quality, saves 4x memory). Currently the BC1 and BC3 compressors are not GPU accelerated due to challenges in getting it wired up. BC7 may be added in the future, it was not added in time for this PR due to issues with encoding performance.
2. ~~Tunes texture cache and buffer cache memory usage and garbage collection to be more accommodating for ASTC transcoding on systems with less VRAM. This also adds a usage cap based on the resolution scale for cards with very large amounts of memory, which should help prevent slowdowns as memory is filled up.~~ Moved to #10422

When combined with texture recompression, this should make games like Tears of the Kingdom much more playable on 4GB and possibly even 2GB cards - I no longer see lag when menuing on my 560 4GB.