### PR TITLE
Limit device access memory for integrated devices to 4 GB

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1034,7 +1034,7 @@ void Device::CollectPhysicalMemoryInfo() {
     }
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);
     device_access_memory = static_cast<u64>(std::max<s64>(
-        std::min<s64>(available_memory - 8_GiB, 4_GiB), static_cast<s64>(local_memory)));
+        std::min<s64>(available_memory - 8_GiB, 4_GiB), std::min<s64>(local_memory, 4_GiB)));
 }
 
 void Device::CollectToolingInfo() {


### PR DESCRIPTION
Hardly limiting the device access memory to 4 GB for integrated vulkan devices here. Vulkan seems to detect the Steam Deck's APU as integrated device. This limit works for the Steam Deck in order not to go above 4 GB VRAM usage any more (above this value the likelihood to crash when the RAM exceeds 12 GB as well raises).

But there will be perhaps a detection mechanism necessary for detecting the real memory limit for integrated vulkan devices. Those likely might have small limits anyway, but what about integrated GPUs on machines with > 16 GB RAM, aka larger amounts ?

This might fix #10407 and similar issue reports.

Tested on my steam deck and VRAM usage stayed below 4 GB, even when jumping down the gloomy depths. But it can become  a bit slow when swapping starts, tho.

Note, this is just a simple idea on how to approach this. There may be better solutions around.