### PR TITLE
service: nfc: Remove encryption key requirement

### DIFF
--- a/src/core/hle/service/nfc/common/amiibo_crypto.cpp
+++ b/src/core/hle/service/nfc/common/amiibo_crypto.cpp
@@ -52,9 +52,6 @@ bool IsAmiiboValid(const EncryptedNTAG215File& ntag_file) {
     if (ntag_file.compability_container != 0xEEFF10F1U) {
         return false;
     }
-    if (amiibo_data.constant_value != 0xA5) {
-        return false;
-    }
     if (amiibo_data.model_info.tag_type != NFC::PackedTagType::Type2) {
         return false;
     }

--- a/src/core/hle/service/nfc/common/device.h
+++ b/src/core/hle/service/nfc/common/device.h
@@ -110,6 +110,8 @@ private:
     void UpdateSettingsCrc();
     void UpdateRegisterInfoCrc();
 
+    void BuildAmiiboWithoutKeys();
+
     bool is_controller_set{};
     int callback_key;
     const Core::HID::NpadIdType npad_id;
@@ -128,6 +130,7 @@ private:
     bool is_data_moddified{};
     bool is_app_area_open{};
     bool is_plain_amiibo{};
+    bool is_write_protected{};
     NFP::MountTarget mount_target{NFP::MountTarget::None};
 
     NFP::NTAG215File tag_data{};


### PR DESCRIPTION
Adds fallbacks for lack of keys. Any game will be able to load a valid amiibo dump it just won't be able to write any data.