### PR TITLE
k_memory_block_manager: remove auditing calls

### DIFF
--- a/src/core/hle/kernel/k_memory_block_manager.h
+++ b/src/core/hle/kernel/k_memory_block_manager.h
@@ -144,14 +144,10 @@ private:
 
 class KScopedMemoryBlockManagerAuditor {
 public:
-    explicit KScopedMemoryBlockManagerAuditor(KMemoryBlockManager* m) : m_manager(m) {
-        ASSERT(m_manager->CheckState());
-    }
+    explicit KScopedMemoryBlockManagerAuditor(KMemoryBlockManager* m) : m_manager(m) {}
     explicit KScopedMemoryBlockManagerAuditor(KMemoryBlockManager& m)
         : KScopedMemoryBlockManagerAuditor(std::addressof(m)) {}
-    ~KScopedMemoryBlockManagerAuditor() {
-        ASSERT(m_manager->CheckState());
-    }
+    ~KScopedMemoryBlockManagerAuditor() = default;
 
 private:
     KMemoryBlockManager* m_manager;


### PR DESCRIPTION
These showed up in a profile but are not intended to be used here.