### PR TITLE
input_common: Redesign mouse->stick panning for better responsiveness

### DIFF
--- a/src/yuzu/configuration/configure_input_advanced.ui
+++ b/src/yuzu/configuration/configure_input_advanced.ui
@@ -2764,14 +2764,11 @@
                        <property name="alignment">
                          <set>Qt::AlignCenter</set>
                        </property>
-                       <property name="suffix">
-                         <string>%</string>
-                       </property>
                        <property name="minimum">
                          <number>1</number>
                        </property>
                        <property name="maximum">
-                         <number>100</number>
+                         <number>10000</number>
                        </property>
                        <property name="value">
                          <number>100</number>


### PR DESCRIPTION
Previously, the mouse processing code had some issues that reduced mouse control quality. No matter how you configured it or how you used the mouse, it was impossible to be able to make both fine inputs and maximum inputs to the control stick with the same configuration, as inputs were clamped to the range, and *outputs* were multiplied by the sensitivity setting. It was also impossible to make brief inputs, as two built-in exponential moving average filters in the mouse driver caused any mouse inputs, no matter how brief, to continue to produce stick outputs for several hundred milliseconds before dissipating.

This commit is an attempt to address those issues. With this commit, an entirely different model of processing inputs is used. Instead of applying the sensitivity to the stick output, this commit applies the sensitivity at the beginning of processing to the mouse input. Next, inputs from the mouse are accumulated into a buffer variable. When the stick is updated, stick output is clamped to the range of the stick, and that value is subtracted from the input buffer. Any *excess* motion still remaining in the buffer gets decayed exponentially (similar to one of the exponential moving averages before). This gives a good compromise between responsiveness (brief mouse movement causes a brief stick response) and inertia (large mouse movement which exceeds the stick's instantaneous dynamic range causes stick movement that persists for a short time afterwards, mimicking inertia). Finally, to improve the linearity of the response, the stick motion is square-rooted to amplify small movements.

This commit changes the semantics of the sensitivity option. It's no longer a percent, and "100(%)" no longer means anything special, so the input configuration UI has been changed to allow values up to 10,000 instead of being limited to 100. The changes to the filtration also affect the sensitivity. There are some magic constants in the code to try to keep the sensitivity about the same with a given value, but it's not exact, and users are encouraged to play around with it again on the new code.

These changes have only been tested in TotK, but they improve aiming with bows, the scope, and hand abilities dramatically. It also improves the ability to carefully select items in the quick menus.