### PR TITLE
video_core: tune garbage collection aggressiveness

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -30,8 +30,8 @@ BufferCache<P>::BufferCache(VideoCore::RasterizerInterface& rasterizer_,
     }
 
     const s64 device_memory = static_cast<s64>(runtime.GetDeviceLocalMemory());
-    const s64 min_spacing_expected = device_memory - 1_GiB - 512_MiB;
-    const s64 min_spacing_critical = device_memory - 1_GiB;
+    const s64 min_spacing_expected = device_memory - 1_GiB;
+    const s64 min_spacing_critical = device_memory - 512_MiB;
     const s64 mem_threshold = std::min(device_memory, TARGET_THRESHOLD);
     const s64 min_vacancy_expected = (6 * mem_threshold) / 10;
     const s64 min_vacancy_critical = (3 * mem_threshold) / 10;


### PR DESCRIPTION
This contains the garbage collection changes which were previously included in #10398. These are being split out due to issues reported with device losses with the GC tweaks - the recompression option itself should not be causing any issues.