### PR TITLE
Texture Cache Util: Fix block depth adjustment on slices.

### DIFF
--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -123,7 +123,9 @@ template <u32 GOB_EXTENT>
     return {
         .width = AdjustMipBlockSize<GOB_SIZE_X>(num_tiles.width, block_size.width, level),
         .height = AdjustMipBlockSize<GOB_SIZE_Y>(num_tiles.height, block_size.height, level),
-        .depth = AdjustMipBlockSize<GOB_SIZE_Z>(num_tiles.depth, block_size.depth, level),
+        .depth = level == 0
+                     ? block_size.depth
+                     : AdjustMipBlockSize<GOB_SIZE_Z>(num_tiles.depth, block_size.depth, level),
     };
 }
 
@@ -165,6 +167,13 @@ template <u32 GOB_EXTENT>
 }
 
 [[nodiscard]] constexpr Extent3D TileShift(const LevelInfo& info, u32 level) {
+    if (level == 0) {
+        return Extent3D{
+            .width = info.block.width,
+            .height = info.block.height,
+            .depth = info.block.depth,
+        };
+    }
     const Extent3D blocks = NumLevelBlocks(info, level);
     return Extent3D{
         .width = AdjustTileSize(info.block.width, GOB_SIZE_X, blocks.width),
@@ -1288,7 +1297,9 @@ u32 MapSizeBytes(const ImageBase& image) {
 
 static_assert(CalculateLevelSize(LevelInfo{{1920, 1080, 1}, {0, 2, 0}, {1, 1}, 2, 0}, 0) ==
               0x7f8000);
-static_assert(CalculateLevelSize(LevelInfo{{32, 32, 1}, {0, 0, 4}, {1, 1}, 4, 0}, 0) == 0x4000);
+static_assert(CalculateLevelSize(LevelInfo{{32, 32, 1}, {0, 0, 4}, {1, 1}, 4, 0}, 0) == 0x40000);
+
+static_assert(CalculateLevelSize(LevelInfo{{128, 8, 1}, {0, 4, 0}, {1, 1}, 4, 0}, 0) == 0x40000);
 
 static_assert(CalculateLevelOffset(PixelFormat::R8_SINT, {1920, 1080, 1}, {0, 2, 0}, 0, 7) ==
               0x2afc00);


### PR DESCRIPTION
This fixes gloom being broken in Zelda TotK on low VRAM GPUs.

Thanks to @Kelebek1 and @liamwhite for debugging it.