### PR TITLE
video_core: lower memory limits again

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -30,8 +30,8 @@ BufferCache<P>::BufferCache(VideoCore::RasterizerInterface& rasterizer_,
     }
 
     const s64 device_memory = static_cast<s64>(runtime.GetDeviceLocalMemory());
-    const s64 min_spacing_expected = device_memory - 1_GiB;
-    const s64 min_spacing_critical = device_memory - 512_MiB;
+    const s64 min_spacing_expected = device_memory - 1_GiB - 512_MiB;
+    const s64 min_spacing_critical = device_memory - 1_GiB;
     const s64 mem_threshold = std::min(device_memory, TARGET_THRESHOLD);
     const s64 min_vacancy_expected = (6 * mem_threshold) / 10;
     const s64 min_vacancy_critical = (3 * mem_threshold) / 10;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -49,8 +49,8 @@ TextureCache<P>::TextureCache(Runtime& runtime_, VideoCore::RasterizerInterface&
 
     if constexpr (HAS_DEVICE_MEMORY_INFO) {
         const s64 device_memory = static_cast<s64>(runtime.GetDeviceLocalMemory());
-        const s64 min_spacing_expected = device_memory - 1_GiB;
-        const s64 min_spacing_critical = device_memory - 512_MiB;
+        const s64 min_spacing_expected = device_memory - 1_GiB - 512_MiB;
+        const s64 min_spacing_critical = device_memory - 1_GiB;
         const s64 mem_threshold = std::min(device_memory, TARGET_THRESHOLD);
         const s64 min_vacancy_expected = (6 * mem_threshold) / 10;
         const s64 min_vacancy_critical = (3 * mem_threshold) / 10;


### PR DESCRIPTION
The adjustments to device memory limits in #10422 are causing a lot of crashes and device losses in the latest mainline. Unfortunately, this also brings back a lot of the menuing delays in Tears of the Kingdom on 4GB cards, but I can't see a more optimal way to deal with this for now (BC1 recompression still avoids the worst of it).