### PR TITLE
Add short "-u" option for yuzu_cmd.

### DIFF
--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
     };
 
     while (optind < argc) {
-        int arg = getopt_long(argc, argv, "g:fhvp::c:", long_options, &option_index);
+        int arg = getopt_long(argc, argv, "g:fhvp::c:u:", long_options, &option_index);
         if (arg != -1) {
             switch (static_cast<char>(arg)) {
             case 'c':


### PR DESCRIPTION
The -u short option was documented but not implemented in yuzu_cmd. The same long option --user worked before.