### PR TITLE
video_core: don't garbage collect during configuration

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -139,7 +139,6 @@ void TextureCache<P>::TickFrame() {
     TickAsyncDecode();
 
     runtime.TickFrame();
-    critical_gc = 0;
     ++frame_tick;
 
     if constexpr (IMPLEMENTS_ASYNC_DOWNLOADS) {
@@ -1885,10 +1884,6 @@ void TextureCache<P>::RegisterImage(ImageId image_id) {
         tentative_size = EstimatedDecompressedSize(tentative_size, image.info.format);
     }
     total_used_memory += Common::AlignUp(tentative_size, 1024);
-    if (total_used_memory > critical_memory && critical_gc < GC_EMERGENCY_COUNTS) {
-        RunGarbageCollector();
-        critical_gc++;
-    }
     image.lru_index = lru_cache.Insert(image_id, frame_tick);
 
     ForEachGPUPage(image.gpu_addr, image.guest_size_bytes, [this, image_id](u64 page) {

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -427,7 +427,6 @@ private:
     u64 minimum_memory;
     u64 expected_memory;
     u64 critical_memory;
-    size_t critical_gc;
 
     struct BufferDownload {
         GPUVAddr address;


### PR DESCRIPTION
This is definitely causing device losses. Fixes #10447