### PR TITLE
shader_recompiler: fix copy-paste error

### DIFF
--- a/src/shader_recompiler/frontend/maxwell/translate/impl/integer_funnel_shift.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate/impl/integer_funnel_shift.cpp
@@ -30,7 +30,7 @@ void SHF(TranslatorVisitor& v, u64 insn, const IR::U32& shift, const IR::U32& hi
     union {
         u64 insn;
         BitField<0, 8, IR::Reg> dest_reg;
-        BitField<0, 8, IR::Reg> lo_bits_reg;
+        BitField<8, 8, IR::Reg> lo_bits_reg;
         BitField<37, 2, MaxShift> max_shift;
         BitField<47, 1, u64> cc;
         BitField<48, 2, u64> x_mode;


### PR DESCRIPTION
Fixes cracks between mesh patches in Tears of the Kingdom, particularly in underground areas. (No cache clear required.)
|Before|After|
|-|-|
|![0100f2c0115b6000_2023-05-26_00-35-23-537](https://github.com/yuzu-emu/yuzu/assets/9658600/45036846-4bfa-4dd2-8557-735813fbd202)|![0100f2c0115b6000_2023-05-26_00-33-57-330](https://github.com/yuzu-emu/yuzu/assets/9658600/4e9556fc-21b1-4e4f-b6f4-85c4a38025f8)|