### PR TITLE
qt: add menu item to remove cache storage

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -544,6 +544,7 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     QAction* remove_update = remove_menu->addAction(tr("Remove Installed Update"));
     QAction* remove_dlc = remove_menu->addAction(tr("Remove All Installed DLC"));
     QAction* remove_custom_config = remove_menu->addAction(tr("Remove Custom Configuration"));
+    QAction* remove_cache_storage = remove_menu->addAction(tr("Remove Cache Storage"));
     QAction* remove_gl_shader_cache = remove_menu->addAction(tr("Remove OpenGL Pipeline Cache"));
     QAction* remove_vk_shader_cache = remove_menu->addAction(tr("Remove Vulkan Pipeline Cache"));
     remove_menu->addSeparator();
@@ -613,6 +614,9 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     });
     connect(remove_custom_config, &QAction::triggered, [this, program_id, path]() {
         emit RemoveFileRequested(program_id, GameListRemoveTarget::CustomConfiguration, path);
+    });
+    connect(remove_cache_storage, &QAction::triggered, [this, program_id, path] {
+        emit RemoveFileRequested(program_id, GameListRemoveTarget::CacheStorage, path);
     });
     connect(dump_romfs, &QAction::triggered, [this, program_id, path]() {
         emit DumpRomFSRequested(program_id, path, DumpRomFSTarget::Normal);

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -45,6 +45,7 @@ enum class GameListRemoveTarget {
     VkShaderCache,
     AllShaderCache,
     CustomConfiguration,
+    CacheStorage,
 };
 
 enum class DumpRomFSTarget {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2323,6 +2323,8 @@ void GMainWindow::OnGameListRemoveFile(u64 program_id, GameListRemoveTarget targ
             return tr("Delete All Transferable Shader Caches?");
         case GameListRemoveTarget::CustomConfiguration:
             return tr("Remove Custom Game Configuration?");
+        case GameListRemoveTarget::CacheStorage:
+            return tr("Remove Cache Storage?");
         default:
             return QString{};
         }
@@ -2345,6 +2347,9 @@ void GMainWindow::OnGameListRemoveFile(u64 program_id, GameListRemoveTarget targ
         break;
     case GameListRemoveTarget::CustomConfiguration:
         RemoveCustomConfiguration(program_id, game_path);
+        break;
+    case GameListRemoveTarget::CacheStorage:
+        RemoveCacheStorage(program_id);
         break;
     }
 }
@@ -2433,6 +2438,21 @@ void GMainWindow::RemoveCustomConfiguration(u64 program_id, const std::string& g
         QMessageBox::warning(this, tr("Error Removing Custom Configuration"),
                              tr("Failed to remove the custom game configuration."));
     }
+}
+
+void GMainWindow::RemoveCacheStorage(u64 program_id) {
+    const auto nand_dir = Common::FS::GetYuzuPath(Common::FS::YuzuPath::NANDDir);
+    auto vfs_nand_dir =
+        vfs->OpenDirectory(Common::FS::PathToUTF8String(nand_dir), FileSys::Mode::Read);
+
+    const auto cache_storage_path = FileSys::SaveDataFactory::GetFullPath(
+        *system, vfs_nand_dir, FileSys::SaveDataSpaceId::NandUser,
+        FileSys::SaveDataType::CacheStorage, 0 /* program_id */, {}, 0);
+
+    const auto path = Common::FS::ConcatPathSafe(nand_dir, cache_storage_path);
+
+    // Not an error if it wasn't cleared.
+    Common::FS::RemoveDirRecursively(path);
 }
 
 void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_path,

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -370,6 +370,7 @@ private:
     void RemoveVulkanDriverPipelineCache(u64 program_id);
     void RemoveAllTransferableShaderCaches(u64 program_id);
     void RemoveCustomConfiguration(u64 program_id, const std::string& game_path);
+    void RemoveCacheStorage(u64 program_id);
     std::optional<u64> SelectRomFSDumpTarget(const FileSys::ContentProvider&, u64 program_id);
     InstallResult InstallNSPXCI(const QString& filename);
     InstallResult InstallNCA(const QString& filename);


### PR DESCRIPTION
Tears of the Kingdom stores weapon icons as PNG files in cache storage. #10418 fixed the issue with generating fused weapon icons (when async shaders are disabled -- it will never work when they are enabled), but this does not do anything to address icons already persisted in cache storage. This adds a button to quickly clear it out so that the icons can be rendered again properly.

Note that because current vfs is a meme the cache storage dir used is always for program id 0 when games open it.