### PR TITLE
input_common: set input thread delay of joycon to 15ms

### DIFF
--- a/src/input_common/helpers/joycon_driver.cpp
+++ b/src/input_common/helpers/joycon_driver.cpp
@@ -128,8 +128,9 @@ void JoyconDriver::InputThread(std::stop_token stop_token) {
     Common::SetCurrentThreadName("JoyconInput");
     input_thread_running = true;
 
-    // Max update rate is 5ms, ensure we are always able to read a bit faster
-    constexpr int ThreadDelay = 2;
+    // Max update rate is 5ms, but in normal the console asks Joy-Con for an update
+    // every 15ms, this can help reducing CPU pressure on some weak platform
+    constexpr int ThreadDelay = 15;
     std::vector<u8> buffer(MaxBufferSize);
 
     while (!stop_token.stop_requested()) {


### PR DESCRIPTION
According to my test, the time during between two `IsPayloadCorrect == true` would be 15ms in most of time even though we pull the data every 2ms. This causes a lot useless `status == 0` condition, which means no data received and wastes CPU cycles.

It turns out 15ms is already enough for imperceptible operation and somehow reduces lag on my platform (i5-7300hq + gtx1060 + CRS8510).

Consider that Switch console also requests data every 15ms, I believe it would be fine for us to do so.