### PR TITLE
Move buffer bindings to per-channel state

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "common/microprofile.h"
+#include "video_core/buffer_cache/buffer_cache_base.h"
+#include "video_core/control/channel_state_cache.inc"
 
 namespace VideoCommon {
 
 MICROPROFILE_DEFINE(GPU_PrepareBuffers, "GPU", "Prepare buffers", MP_RGB(224, 128, 128));
 MICROPROFILE_DEFINE(GPU_BindUploadBuffers, "GPU", "Bind and upload buffers", MP_RGB(224, 128, 128));
 MICROPROFILE_DEFINE(GPU_DownloadMemory, "GPU", "Download buffers", MP_RGB(224, 128, 128));
+
+template class VideoCommon::ChannelSetupCaches<VideoCommon::BufferCacheChannelInfo>;
 
 } // namespace VideoCommon

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -117,7 +117,7 @@ BufferCacheRuntime::BufferCacheRuntime(const Device& device_)
     for (auto& stage_uniforms : fast_uniforms) {
         for (OGLBuffer& buffer : stage_uniforms) {
             buffer.Create();
-            glNamedBufferData(buffer.handle, BufferCache::DEFAULT_SKIP_CACHE_SIZE, nullptr,
+            glNamedBufferData(buffer.handle, VideoCommon::DEFAULT_SKIP_CACHE_SIZE, nullptr,
                               GL_STREAM_DRAW);
         }
     }


### PR DESCRIPTION
Buffer bindings need to be tracked per-channel, and not globally in the buffer cache. 

Dokapon Kingdom Connect boots with a sequence like:
Bind 3d channel 0, bind addr 0x1000 as uniform for vertex shader with cb index 2, draw.
Bind 3d channel 1, bind addr 0x2000 as uniform for vertex shader with cb index 2, draw.
Bind 3d channel 0, send inline const buffer data for addr 0x1000, bind cb index 2 for vertex shader, draw.

Currently, because buffers are tracked globally, the last draw ignores the channel swap, and addr 0x2000 remains the active vertex stage index 2 uniform buffer, and the inline data that was sent inbetween is ignored, leading to bad const buffer values in the uniform, since it's the wrong buffer.

By moving buffer bindings to be channel-specific, addr 0x1000 becomes the active index 2 buffer once again, and the inline cb data is applied and correct data is sent.

This PR fixes the main menu in Dokapon Kingdom Connect, and should help any other games using multiple 3d channels.