### PR TITLE
Wait indefinitely when audio buffer queue is too big

### DIFF
--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -273,6 +273,9 @@ void SinkStream::WaitFreeSpace() {
     std::unique_lock lk{release_mutex};
     release_cv.wait_for(lk, std::chrono::milliseconds(5),
                         [this]() { return queued_buffers < max_queue_size; });
+    if (queued_buffers > max_queue_size + 3) {
+        release_cv.wait(lk, [this]() { return queued_buffers < max_queue_size; });
+    }
 }
 
 } // namespace AudioCore::Sink


### PR DESCRIPTION
This was a change sugegsted by ByLaws to stop some audio desync when the emu core gets frozen, e.g by IO on load screens. He thinks it can help with audio crackling by limiting the queue size. (copium)