### PR TITLE
Add support for VK_KHR_image_format_list

### DIFF
--- a/src/video_core/compatible_formats.cpp
+++ b/src/video_core/compatible_formats.cpp
@@ -272,6 +272,9 @@ constexpr Table MakeNonNativeBgrCopyTable() {
 
 bool IsViewCompatible(PixelFormat format_a, PixelFormat format_b, bool broken_views,
                       bool native_bgr) {
+    if (format_a == format_b) {
+        return true;
+    }
     if (broken_views) {
         // If format views are broken, only accept formats that are identical.
         return format_a == format_b;
@@ -282,6 +285,9 @@ bool IsViewCompatible(PixelFormat format_a, PixelFormat format_b, bool broken_vi
 }
 
 bool IsCopyCompatible(PixelFormat format_a, PixelFormat format_b, bool native_bgr) {
+    if (format_a == format_b) {
+        return true;
+    }
     static constexpr Table BGR_TABLE = MakeNativeBgrCopyTable();
     static constexpr Table NO_BGR_TABLE = MakeNonNativeBgrCopyTable();
     return IsSupported(native_bgr ? BGR_TABLE : NO_BGR_TABLE, format_a, format_b);

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -826,9 +826,8 @@ TextureCacheRuntime::TextureCacheRuntime(const Device& device_, Scheduler& sched
     }
     for (size_t index_a = 0; index_a < VideoCore::Surface::MaxPixelFormat; index_a++) {
         const auto image_format = static_cast<PixelFormat>(index_a);
-        const auto type_a = VideoCore::Surface::GetFormatType(image_format);
-        if (type_a != SurfaceType::ColorTexture) {
-            continue;
+        if (IsPixelFormatASTC(image_format) && !device.IsOptimalAstcSupported()) {
+            view_formats[index_a].push_back(VK_FORMAT_A8B8G8R8_UNORM_PACK32);
         }
         for (size_t index_b = 0; index_b < VideoCore::Surface::MaxPixelFormat; index_b++) {
             const auto view_format = static_cast<PixelFormat>(index_b);

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -103,6 +103,10 @@ public:
 
     [[nodiscard]] VkBuffer GetTemporaryBuffer(size_t needed_size);
 
+    std::span<const VkFormat> ViewFormats(PixelFormat format) {
+        return view_formats[static_cast<std::size_t>(format)];
+    }
+
     void BarrierFeedbackLoop();
 
     const Device& device;
@@ -113,6 +117,7 @@ public:
     RenderPassCache& render_pass_cache;
     std::optional<ASTCDecoderPass> astc_decoder_pass;
     const Settings::ResolutionScalingInfo& resolution;
+    std::array<std::vector<VkFormat>, VideoCore::Surface::MaxPixelFormat> view_formats;
 
     static constexpr size_t indexing_slots = 8 * sizeof(size_t);
     std::array<vk::Buffer, indexing_slots> buffers{};

--- a/src/video_core/texture_cache/types.h
+++ b/src/video_core/texture_cache/types.h
@@ -54,7 +54,6 @@ enum class RelaxedOptions : u32 {
     Format = 1 << 1,
     Samples = 1 << 2,
     ForceBrokenViews = 1 << 3,
-    FormatBpp = 1 << 4,
 };
 DECLARE_ENUM_FLAG_OPERATORS(RelaxedOptions)
 

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -1201,8 +1201,7 @@ std::optional<SubresourceBase> FindSubresource(const ImageInfo& candidate, const
         // Format checking is relaxed, but we still have to check for matching bytes per block.
         // This avoids creating a view for blits on UE4 titles where formats with different bytes
         // per block are aliased.
-        if (BytesPerBlock(existing.format) != BytesPerBlock(candidate.format) &&
-            False(options & RelaxedOptions::FormatBpp)) {
+        if (BytesPerBlock(existing.format) != BytesPerBlock(candidate.format)) {
             return std::nullopt;
         }
     } else {
@@ -1233,11 +1232,7 @@ std::optional<SubresourceBase> FindSubresource(const ImageInfo& candidate, const
     }
     const bool strict_size = False(options & RelaxedOptions::Size);
     if (!IsBlockLinearSizeCompatible(existing, candidate, base->level, 0, strict_size)) {
-        if (False(options & RelaxedOptions::FormatBpp)) {
-            return std::nullopt;
-        } else if (!IsBlockLinearSizeCompatibleBPPRelaxed(existing, candidate, base->level, 0)) {
-            return std::nullopt;
-        }
+        return std::nullopt;
     }
     // TODO: compare block sizes
     return base;

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -77,6 +77,7 @@ VK_DEFINE_HANDLE(VmaAllocator)
     EXTENSION(KHR, SPIRV_1_4, spirv_1_4)                                                           \
     EXTENSION(KHR, SWAPCHAIN, swapchain)                                                           \
     EXTENSION(KHR, SWAPCHAIN_MUTABLE_FORMAT, swapchain_mutable_format)                             \
+    EXTENSION(KHR, IMAGE_FORMAT_LIST, image_format_list)                                           \
     EXTENSION(NV, DEVICE_DIAGNOSTICS_CONFIG, device_diagnostics_config)                            \
     EXTENSION(NV, GEOMETRY_SHADER_PASSTHROUGH, geometry_shader_passthrough)                        \
     EXTENSION(NV, VIEWPORT_ARRAY2, viewport_array2)                                                \
@@ -406,6 +407,11 @@ public:
     /// Returns true if the device supports VK_KHR_workgroup_memory_explicit_layout.
     bool IsKhrWorkgroupMemoryExplicitLayoutSupported() const {
         return extensions.workgroup_memory_explicit_layout;
+    }
+
+    /// Returns true if the device supports VK_KHR_image_format_list.
+    bool IsKhrImageFormatListSupported() const {
+        return extensions.image_format_list || instance_version >= VK_API_VERSION_1_2;
     }
 
     /// Returns true if the device supports VK_EXT_primitive_topology_list_restart.


### PR DESCRIPTION
Attempts to limit the impact of setting the mutable flag for every image. Depth/stencil images no longer require the mutable flag as vulkan doesn't seem to support mutable views for these formats. If supported, the image format list extension is also used to limit the compatible formats. I've also removed the FormatBpp relaxed flag, cause I could not find a place where it was being set