### PR TITLE
externals: Update to fmt 10 and add format_as formatter for BitField

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 # Enforce the search mode of non-required packages for better and shorter failure messages
 find_package(Boost 1.79.0 REQUIRED context)
 find_package(enet 1.3 MODULE)
-find_package(fmt 9 REQUIRED)
+find_package(fmt 10 REQUIRED)
 find_package(inih 52 MODULE COMPONENTS INIReader)
 find_package(LLVM MODULE COMPONENTS Demangle)
 find_package(lz4 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 # Enforce the search mode of non-required packages for better and shorter failure messages
 find_package(Boost 1.79.0 REQUIRED context)
 find_package(enet 1.3 MODULE)
-find_package(fmt 10 REQUIRED)
+find_package(fmt 9 REQUIRED)
 find_package(inih 52 MODULE COMPONENTS INIReader)
 find_package(LLVM MODULE COMPONENTS Demangle)
 find_package(lz4 REQUIRED)

--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -188,3 +188,8 @@ private:
 
 template <std::size_t Position, std::size_t Bits, typename T>
 using BitFieldBE = BitField<Position, Bits, T, BETag>;
+
+template <std::size_t Position, std::size_t Bits, typename T, typename EndianTag = LETag>
+inline auto format_as(BitField<Position, Bits, T, EndianTag> bitfield) {
+    return bitfield.Value();
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "yuzu",
-    "builtin-baseline": "acc3bcf76b84ae5041c86ab55fe138ae7b8255c7",
+    "builtin-baseline": "656fcc6ab2b05c6d999b7eaca717027ac3738f71",
     "version": "1.0",
     "dependencies": [
         "boost-algorithm",
@@ -53,7 +53,7 @@
         },
         {
             "name": "fmt",
-            "version": "9.0.0"
+            "version": "10.0.0"
         }
     ]
 }


### PR DESCRIPTION
Implicit conversions are now disallowed in fmt 10. Use format_as to convert to the underlying type.