### PR TITLE
yuzu-qt: Load Vulkan device info at startup

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -210,6 +210,8 @@ add_executable(yuzu
     util/url_request_interceptor.h
     util/util.cpp
     util/util.h
+    vk_device_info.cpp
+    vk_device_info.h
     compatdb.cpp
     compatdb.h
     yuzu.qrc

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -6,6 +6,7 @@
 #include "common/settings.h"
 #include "core/core.h"
 #include "ui_configure.h"
+#include "vk_device_info.h"
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_audio.h"
 #include "yuzu/configuration/configure_cpu.h"
@@ -28,6 +29,7 @@
 
 ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry_,
                                  InputCommon::InputSubsystem* input_subsystem,
+                                 std::vector<VkDeviceInfo::Record>& vk_device_records,
                                  Core::System& system_, bool enable_web_config)
     : QDialog(parent), ui{std::make_unique<Ui::ConfigureDialog>()},
       registry(registry_), system{system_}, audio_tab{std::make_unique<ConfigureAudio>(system_,
@@ -38,7 +40,8 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry_,
       general_tab{std::make_unique<ConfigureGeneral>(system_, this)},
       graphics_advanced_tab{std::make_unique<ConfigureGraphicsAdvanced>(system_, this)},
       graphics_tab{std::make_unique<ConfigureGraphics>(
-          system_, [&]() { graphics_advanced_tab->ExposeComputeOption(); }, this)},
+          system_, vk_device_records, [&]() { graphics_advanced_tab->ExposeComputeOption(); },
+          this)},
       hotkeys_tab{std::make_unique<ConfigureHotkeys>(system_.HIDCore(), this)},
       input_tab{std::make_unique<ConfigureInput>(system_, this)},
       network_tab{std::make_unique<ConfigureNetwork>(system_, this)},

--- a/src/yuzu/configuration/configure_dialog.h
+++ b/src/yuzu/configuration/configure_dialog.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 #include <QDialog>
+#include "yuzu/vk_device_info.h"
 
 namespace Core {
 class System;
@@ -40,8 +42,9 @@ class ConfigureDialog : public QDialog {
 
 public:
     explicit ConfigureDialog(QWidget* parent, HotkeyRegistry& registry_,
-                             InputCommon::InputSubsystem* input_subsystem, Core::System& system_,
-                             bool enable_web_config = true);
+                             InputCommon::InputSubsystem* input_subsystem,
+                             std::vector<VkDeviceInfo::Record>& vk_device_records,
+                             Core::System& system_, bool enable_web_config = true);
     ~ConfigureDialog() override;
 
     void ApplyConfiguration();

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -12,6 +12,7 @@
 #include <qobjectdefs.h>
 #include <vulkan/vulkan_core.h>
 #include "common/common_types.h"
+#include "vk_device_info.h"
 
 class QEvent;
 class QObject;
@@ -39,6 +40,7 @@ class ConfigureGraphics : public QWidget {
 
 public:
     explicit ConfigureGraphics(const Core::System& system_,
+                               std::vector<VkDeviceInfo::Record>& records,
                                const std::function<void()>& expose_compute_option_,
                                QWidget* parent = nullptr);
     ~ConfigureGraphics() override;
@@ -77,6 +79,7 @@ private:
     ConfigurationShared::CheckState use_disk_shader_cache;
     ConfigurationShared::CheckState use_asynchronous_gpu_emulation;
 
+    std::vector<VkDeviceInfo::Record>& records;
     std::vector<QString> vulkan_devices;
     std::vector<std::vector<VkPresentModeKHR>> device_present_modes;
     std::vector<VkPresentModeKHR>

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -34,8 +35,10 @@
 #include "yuzu/configuration/configure_system.h"
 #include "yuzu/uisettings.h"
 #include "yuzu/util/util.h"
+#include "yuzu/vk_device_info.h"
 
 ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::string& file_name,
+                                   std::vector<VkDeviceInfo::Record>& vk_device_records,
                                    Core::System& system_)
     : QDialog(parent),
       ui(std::make_unique<Ui::ConfigurePerGame>()), title_id{title_id_}, system{system_} {
@@ -50,7 +53,7 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::st
     general_tab = std::make_unique<ConfigureGeneral>(system_, this);
     graphics_advanced_tab = std::make_unique<ConfigureGraphicsAdvanced>(system_, this);
     graphics_tab = std::make_unique<ConfigureGraphics>(
-        system_, [&]() { graphics_advanced_tab->ExposeComputeOption(); }, this);
+        system_, vk_device_records, [&]() { graphics_advanced_tab->ExposeComputeOption(); }, this);
     input_tab = std::make_unique<ConfigureInputPerGame>(system_, game_config.get(), this);
     system_tab = std::make_unique<ConfigureSystem>(system_, this);
 

--- a/src/yuzu/configuration/configure_per_game.h
+++ b/src/yuzu/configuration/configure_per_game.h
@@ -5,11 +5,13 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <QDialog>
 #include <QList>
 
 #include "core/file_sys/vfs_types.h"
+#include "vk_device_info.h"
 #include "yuzu/configuration/config.h"
 
 namespace Core {
@@ -45,6 +47,7 @@ class ConfigurePerGame : public QDialog {
 public:
     // Cannot use std::filesystem::path due to https://bugreports.qt.io/browse/QTBUG-73263
     explicit ConfigurePerGame(QWidget* parent, u64 title_id_, const std::string& file_name,
+                              std::vector<VkDeviceInfo::Record>& vk_device_records,
                               Core::System& system_);
     ~ConfigurePerGame() override;
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -147,6 +147,7 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #include "yuzu/startup_checks.h"
 #include "yuzu/uisettings.h"
 #include "yuzu/util/clickable_label.h"
+#include "yuzu/vk_device_info.h"
 
 #ifdef YUZU_DBGHELP
 #include "yuzu/mini_dump.h"
@@ -440,6 +441,8 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
 
         renderer_status_button->setDisabled(true);
         renderer_status_button->setChecked(false);
+    } else {
+        VkDeviceInfo::PopulateRecords(vk_device_records, this->window()->windowHandle());
     }
 
 #if defined(HAVE_SDL2) && !defined(_WIN32)
@@ -3493,7 +3496,8 @@ void GMainWindow::OnConfigure() {
     const bool old_discord_presence = UISettings::values.enable_discord_presence.GetValue();
 
     Settings::SetConfiguringGlobal(true);
-    ConfigureDialog configure_dialog(this, hotkey_registry, input_subsystem.get(), *system,
+    ConfigureDialog configure_dialog(this, hotkey_registry, input_subsystem.get(),
+                                     vk_device_records, *system,
                                      !multiplayer_state->IsHostingPublicRoom());
     connect(&configure_dialog, &ConfigureDialog::LanguageChanged, this,
             &GMainWindow::OnLanguageChanged);
@@ -3764,7 +3768,7 @@ void GMainWindow::OpenPerGameConfiguration(u64 title_id, const std::string& file
     const auto v_file = Core::GetGameFileFromPath(vfs, file_name);
 
     Settings::SetConfiguringGlobal(false);
-    ConfigurePerGame dialog(this, title_id, file_name, *system);
+    ConfigurePerGame dialog(this, title_id, file_name, vk_device_records, *system);
     dialog.LoadFromFile(v_file);
     const auto result = dialog.exec();
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -118,6 +118,10 @@ enum class ReinitializeKeyBehavior {
     Warning,
 };
 
+namespace VkDeviceInfo {
+class Record;
+}
+
 class GMainWindow : public QMainWindow {
     Q_OBJECT
 
@@ -417,6 +421,8 @@ private:
     OverlayDialog* shutdown_dialog{};
 
     GameListPlaceholder* game_list_placeholder;
+
+    std::vector<VkDeviceInfo::Record> vk_device_records;
 
     // Status bar elements
     QLabel* message_label = nullptr;

--- a/src/yuzu/vk_device_info.cpp
+++ b/src/yuzu/vk_device_info.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #include "video_core/vulkan_common/vulkan_device.h"
 
 #include <vector>

--- a/src/yuzu/vk_device_info.cpp
+++ b/src/yuzu/vk_device_info.cpp
@@ -1,0 +1,53 @@
+#include "video_core/vulkan_common/vulkan_device.h"
+
+#include <vector>
+#include "common/dynamic_library.h"
+#include "video_core/vulkan_common/vulkan_instance.h"
+#include "video_core/vulkan_common/vulkan_library.h"
+#include "video_core/vulkan_common/vulkan_surface.h"
+#include "video_core/vulkan_common/vulkan_wrapper.h"
+#include "yuzu/qt_common.h"
+#include "yuzu/vk_device_info.h"
+
+namespace VkDeviceInfo {
+Record::Record(std::string_view name_, const std::vector<VkPresentModeKHR>& vsync_modes_,
+               bool is_intel_proprietary_)
+    : name{name_}, vsync_support{vsync_modes_}, is_intel_proprietary{is_intel_proprietary_} {}
+
+Record::~Record() = default;
+
+void PopulateRecords(std::vector<Record>& records, QWindow* window) try {
+    using namespace Vulkan;
+
+    auto wsi = QtCommon::GetWindowSystemInfo(window);
+
+    vk::InstanceDispatch dld;
+    const auto library = OpenLibrary();
+    const vk::Instance instance = CreateInstance(*library, dld, VK_API_VERSION_1_1, wsi.type);
+    const std::vector<VkPhysicalDevice> physical_devices = instance.EnumeratePhysicalDevices();
+    vk::SurfaceKHR surface = CreateSurface(instance, wsi);
+
+    records.clear();
+    records.reserve(physical_devices.size());
+    for (const VkPhysicalDevice device : physical_devices) {
+        const auto physical_device = vk::PhysicalDevice(device, dld);
+        const std::string name = physical_device.GetProperties().deviceName;
+        const std::vector<VkPresentModeKHR> present_modes =
+            physical_device.GetSurfacePresentModesKHR(*surface);
+
+        VkPhysicalDeviceDriverProperties driver_properties{};
+        driver_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
+        driver_properties.pNext = nullptr;
+        VkPhysicalDeviceProperties2 properties{};
+        properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+        properties.pNext = &driver_properties;
+        dld.vkGetPhysicalDeviceProperties2(physical_device, &properties);
+
+        records.push_back(VkDeviceInfo::Record(name, present_modes,
+                                               driver_properties.driverID ==
+                                                   VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS));
+    }
+} catch (const Vulkan::vk::Exception& exception) {
+    LOG_ERROR(Frontend, "Failed to enumerate devices with error: {}", exception.what());
+}
+} // namespace VkDeviceInfo

--- a/src/yuzu/vk_device_info.cpp
+++ b/src/yuzu/vk_device_info.cpp
@@ -1,16 +1,18 @@
 // SPDX-FileCopyrightText: 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "video_core/vulkan_common/vulkan_device.h"
-
+#include <utility>
 #include <vector>
 #include "common/dynamic_library.h"
+#include "common/logging/log.h"
 #include "video_core/vulkan_common/vulkan_instance.h"
 #include "video_core/vulkan_common/vulkan_library.h"
 #include "video_core/vulkan_common/vulkan_surface.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 #include "yuzu/qt_common.h"
 #include "yuzu/vk_device_info.h"
+
+class QWindow;
 
 namespace VkDeviceInfo {
 Record::Record(std::string_view name_, const std::vector<VkPresentModeKHR>& vsync_modes_,

--- a/src/yuzu/vk_device_info.h
+++ b/src/yuzu/vk_device_info.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #pragma once
 
 #include <string>

--- a/src/yuzu/vk_device_info.h
+++ b/src/yuzu/vk_device_info.h
@@ -3,10 +3,16 @@
 
 #pragma once
 
+#include <algorithm>
+#include <iterator>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
+#include "common/common_types.h"
 #include "vulkan/vulkan_core.h"
+
+class QWindow;
 
 namespace Settings {
 enum class VSyncMode : u32;

--- a/src/yuzu/vk_device_info.h
+++ b/src/yuzu/vk_device_info.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include "vulkan/vulkan_core.h"
+
+namespace Settings {
+enum class VSyncMode : u32;
+}
+// #include "common/settings.h"
+
+namespace VkDeviceInfo {
+// Short class to record Vulkan driver information for configuration purposes
+class Record {
+public:
+    explicit Record(std::string_view name, const std::vector<VkPresentModeKHR>& vsync_modes,
+                    bool is_intel_proprietary);
+    ~Record();
+
+    const std::string name;
+    const std::vector<VkPresentModeKHR> vsync_support;
+    const bool is_intel_proprietary;
+};
+
+void PopulateRecords(std::vector<Record>& records, QWindow* window);
+} // namespace VkDeviceInfo


### PR DESCRIPTION
Loading it when the configuration opens now incurs a noticeable delay (as a result of #10125). We also don't need to rediscover the same data repeatedly each time the configuration opens.

Moves Vulkan device info discovery to yuzu's startup as opposed to the configure_graphics constructor.