### PR TITLE
input_common: Redesign mouse panning

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -524,9 +524,16 @@ struct Values {
     Setting<bool> tas_loop{false, "tas_loop"};
 
     Setting<bool> mouse_panning{false, "mouse_panning"};
-    Setting<u8, true> mouse_panning_sensitivity{50, 1, 100, "mouse_panning_sensitivity"};
-    Setting<bool> mouse_enabled{false, "mouse_enabled"};
+    Setting<u8, true> mouse_panning_x_sensitivity{50, 1, 100, "mouse_panning_x_sensitivity"};
+    Setting<u8, true> mouse_panning_y_sensitivity{50, 1, 100, "mouse_panning_y_sensitivity"};
+    Setting<u8, true> mouse_panning_deadzone_x_counterweight{
+        0, 0, 100, "mouse_panning_deadzone_x_counterweight"};
+    Setting<u8, true> mouse_panning_deadzone_y_counterweight{
+        0, 0, 100, "mouse_panning_deadzone_y_counterweight"};
+    Setting<u8, true> mouse_panning_decay_strength{22, 0, 100, "mouse_panning_decay_strength"};
+    Setting<u8, true> mouse_panning_min_decay{5, 0, 100, "mouse_panning_min_decay"};
 
+    Setting<bool> mouse_enabled{false, "mouse_enabled"};
     Setting<bool> emulate_analog_keyboard{false, "emulate_analog_keyboard"};
     Setting<bool> keyboard_enabled{false, "keyboard_enabled"};
 

--- a/src/input_common/drivers/mouse.h
+++ b/src/input_common/drivers/mouse.h
@@ -98,7 +98,6 @@ private:
     void UpdateThread(std::stop_token stop_token);
     void UpdateStickInput();
     void UpdateMotionInput();
-    void StopPanning();
 
     Common::Input::ButtonNames GetUIButtonName(const Common::ParamPackage& params) const;
 
@@ -108,7 +107,6 @@ private:
     Common::Vec3<float> last_motion_change;
     Common::Vec2<int> wheel_position;
     bool button_pressed;
-    int mouse_panning_timeout{};
     std::jthread update_thread;
 };
 

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -98,6 +98,9 @@ add_executable(yuzu
     configuration/configure_input_profile_dialog.cpp
     configuration/configure_input_profile_dialog.h
     configuration/configure_input_profile_dialog.ui
+    configuration/configure_mouse_panning.cpp
+    configuration/configure_mouse_panning.h
+    configuration/configure_mouse_panning.ui
     configuration/configure_motion_touch.cpp
     configuration/configure_motion_touch.h
     configuration/configure_motion_touch.ui

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -351,6 +351,10 @@ void Config::ReadPlayerValue(std::size_t player_index) {
             player_motions = default_param;
         }
     }
+
+    if (player_index == 0) {
+        ReadMousePanningValues();
+    }
 }
 
 void Config::ReadDebugValues() {
@@ -471,6 +475,7 @@ void Config::ReadControlValues() {
     ReadKeyboardValues();
     ReadMouseValues();
     ReadTouchscreenValues();
+    ReadMousePanningValues();
     ReadMotionTouchValues();
     ReadHidbusValues();
     ReadIrCameraValues();
@@ -481,8 +486,6 @@ void Config::ReadControlValues() {
     Settings::values.enable_raw_input = false;
 #endif
     ReadBasicSetting(Settings::values.emulate_analog_keyboard);
-    Settings::values.mouse_panning = false;
-    ReadBasicSetting(Settings::values.mouse_panning_sensitivity);
     ReadBasicSetting(Settings::values.enable_joycon_driver);
     ReadBasicSetting(Settings::values.enable_procon_driver);
     ReadBasicSetting(Settings::values.random_amiibo_id);
@@ -494,6 +497,16 @@ void Config::ReadControlValues() {
     ReadBasicSetting(Settings::values.controller_navigation);
 
     qt_config->endGroup();
+}
+
+void Config::ReadMousePanningValues() {
+    ReadBasicSetting(Settings::values.mouse_panning);
+    ReadBasicSetting(Settings::values.mouse_panning_x_sensitivity);
+    ReadBasicSetting(Settings::values.mouse_panning_y_sensitivity);
+    ReadBasicSetting(Settings::values.mouse_panning_deadzone_x_counterweight);
+    ReadBasicSetting(Settings::values.mouse_panning_deadzone_y_counterweight);
+    ReadBasicSetting(Settings::values.mouse_panning_decay_strength);
+    ReadBasicSetting(Settings::values.mouse_panning_min_decay);
 }
 
 void Config::ReadMotionTouchValues() {
@@ -1063,6 +1076,10 @@ void Config::SavePlayerValue(std::size_t player_index) {
                      QString::fromStdString(player.motions[i]),
                      QString::fromStdString(default_param));
     }
+
+    if (player_index == 0) {
+        SaveMousePanningValues();
+    }
 }
 
 void Config::SaveDebugValues() {
@@ -1097,6 +1114,16 @@ void Config::SaveTouchscreenValues() {
     WriteSetting(QStringLiteral("touchscreen_angle"), touchscreen.rotation_angle, 0);
     WriteSetting(QStringLiteral("touchscreen_diameter_x"), touchscreen.diameter_x, 15);
     WriteSetting(QStringLiteral("touchscreen_diameter_y"), touchscreen.diameter_y, 15);
+}
+
+void Config::SaveMousePanningValues() {
+    // Don't overwrite values.mouse_panning
+    WriteBasicSetting(Settings::values.mouse_panning_x_sensitivity);
+    WriteBasicSetting(Settings::values.mouse_panning_y_sensitivity);
+    WriteBasicSetting(Settings::values.mouse_panning_deadzone_x_counterweight);
+    WriteBasicSetting(Settings::values.mouse_panning_deadzone_y_counterweight);
+    WriteBasicSetting(Settings::values.mouse_panning_decay_strength);
+    WriteBasicSetting(Settings::values.mouse_panning_min_decay);
 }
 
 void Config::SaveMotionTouchValues() {
@@ -1185,6 +1212,7 @@ void Config::SaveControlValues() {
     SaveDebugValues();
     SaveMouseValues();
     SaveTouchscreenValues();
+    SaveMousePanningValues();
     SaveMotionTouchValues();
     SaveHidbusValues();
     SaveIrCameraValues();
@@ -1199,7 +1227,6 @@ void Config::SaveControlValues() {
     WriteBasicSetting(Settings::values.random_amiibo_id);
     WriteBasicSetting(Settings::values.keyboard_enabled);
     WriteBasicSetting(Settings::values.emulate_analog_keyboard);
-    WriteBasicSetting(Settings::values.mouse_panning_sensitivity);
     WriteBasicSetting(Settings::values.controller_navigation);
 
     WriteBasicSetting(Settings::values.tas_enable);

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -74,6 +74,7 @@ private:
     void ReadKeyboardValues();
     void ReadMouseValues();
     void ReadTouchscreenValues();
+    void ReadMousePanningValues();
     void ReadMotionTouchValues();
     void ReadHidbusValues();
     void ReadIrCameraValues();
@@ -104,6 +105,7 @@ private:
     void SaveDebugValues();
     void SaveMouseValues();
     void SaveTouchscreenValues();
+    void SaveMousePanningValues();
     void SaveMotionTouchValues();
     void SaveHidbusValues();
     void SaveIrCameraValues();

--- a/src/yuzu/configuration/configure_input_advanced.cpp
+++ b/src/yuzu/configuration/configure_input_advanced.cpp
@@ -129,9 +129,6 @@ void ConfigureInputAdvanced::ApplyConfiguration() {
     Settings::values.mouse_enabled = ui->mouse_enabled->isChecked();
     Settings::values.keyboard_enabled = ui->keyboard_enabled->isChecked();
     Settings::values.emulate_analog_keyboard = ui->emulate_analog_keyboard->isChecked();
-    Settings::values.mouse_panning = ui->mouse_panning->isChecked();
-    Settings::values.mouse_panning_sensitivity =
-        static_cast<float>(ui->mouse_panning_sensitivity->value());
     Settings::values.touchscreen.enabled = ui->touchscreen_enabled->isChecked();
     Settings::values.enable_raw_input = ui->enable_raw_input->isChecked();
     Settings::values.enable_udp_controller = ui->enable_udp_controller->isChecked();
@@ -167,8 +164,6 @@ void ConfigureInputAdvanced::LoadConfiguration() {
     ui->mouse_enabled->setChecked(Settings::values.mouse_enabled.GetValue());
     ui->keyboard_enabled->setChecked(Settings::values.keyboard_enabled.GetValue());
     ui->emulate_analog_keyboard->setChecked(Settings::values.emulate_analog_keyboard.GetValue());
-    ui->mouse_panning->setChecked(Settings::values.mouse_panning.GetValue());
-    ui->mouse_panning_sensitivity->setValue(Settings::values.mouse_panning_sensitivity.GetValue());
     ui->touchscreen_enabled->setChecked(Settings::values.touchscreen.enabled);
     ui->enable_raw_input->setChecked(Settings::values.enable_raw_input.GetValue());
     ui->enable_udp_controller->setChecked(Settings::values.enable_udp_controller.GetValue());
@@ -197,8 +192,6 @@ void ConfigureInputAdvanced::RetranslateUI() {
 void ConfigureInputAdvanced::UpdateUIEnabled() {
     ui->debug_configure->setEnabled(ui->debug_enabled->isChecked());
     ui->touchscreen_advanced->setEnabled(ui->touchscreen_enabled->isChecked());
-    ui->mouse_panning->setEnabled(!ui->mouse_enabled->isChecked());
-    ui->mouse_panning_sensitivity->setEnabled(!ui->mouse_enabled->isChecked());
     ui->ring_controller_configure->setEnabled(ui->enable_ring_controller->isChecked());
 #if QT_VERSION > QT_VERSION_CHECK(6, 0, 0) || !defined(YUZU_USE_QT_MULTIMEDIA)
     ui->enable_ir_sensor->setEnabled(false);

--- a/src/yuzu/configuration/configure_input_advanced.ui
+++ b/src/yuzu/configuration/configure_input_advanced.ui
@@ -2744,48 +2744,13 @@
                      </widget>
                    </item>
                    <item row="8" column="0">
-                     <widget class="QCheckBox" name="mouse_panning">
-                       <property name="minimumSize">
-                         <size>
-                           <width>0</width>
-                           <height>23</height>
-                         </size>
-                       </property>
-                       <property name="text">
-                         <string>Enable mouse panning</string>
-                       </property>
-                     </widget>
-                   </item>
-                   <item row="8" column="2">
-                     <widget class="QSpinBox" name="mouse_panning_sensitivity">
-                       <property name="toolTip">
-                         <string>Mouse sensitivity</string>
-                       </property>
-                       <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                       </property>
-                       <property name="suffix">
-                         <string>%</string>
-                       </property>
-                       <property name="minimum">
-                         <number>1</number>
-                       </property>
-                       <property name="maximum">
-                         <number>100</number>
-                       </property>
-                       <property name="value">
-                         <number>100</number>
-                       </property>
-                     </widget>
-                   </item>
-                   <item row="9" column="0">
                      <widget class="QLabel" name="motion_touch">
                        <property name="text">
                          <string>Motion / Touch</string>
                        </property>
                      </widget>
                    </item>
-                   <item row="9" column="2">
+                   <item row="8" column="2">
                      <widget class="QPushButton" name="buttonMotionTouch">
                        <property name="text">
                          <string>Configure</string>

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -23,6 +23,7 @@
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_input_player.h"
 #include "yuzu/configuration/configure_input_player_widget.h"
+#include "yuzu/configuration/configure_mouse_panning.h"
 #include "yuzu/configuration/input_profiles.h"
 #include "yuzu/util/limitable_input_dialog.h"
 
@@ -709,6 +710,21 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
             param.Set("modifier_scale", slider_value / 100.0f);
             emulated_controller->SetStickParam(analog_id, param);
         });
+    }
+
+    if (player_index_ == 0) {
+        connect(ui->mousePanningButton, &QPushButton::clicked, [this, input_subsystem_] {
+            const auto right_stick_param =
+                emulated_controller->GetStickParam(Settings::NativeAnalog::RStick);
+            ConfigureMousePanning dialog(this, input_subsystem_,
+                                         right_stick_param.Get("deadzone", 0.0f),
+                                         right_stick_param.Get("range", 1.0f));
+            if (dialog.exec() == QDialog::Accepted) {
+                dialog.ApplyConfiguration();
+            }
+        });
+    } else {
+        ui->mousePanningWidget->hide();
     }
 
     // Player Connected checkbox

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -3048,6 +3048,102 @@
                 </item>
                </layout>
               </item>
+              <item>
+               <widget class="QWidget" name="mousePanningWidget" native="true">
+                <layout class="QHBoxLayout" name="mousePanningHorizontalLayout">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>3</number>
+                 </property>
+                 <item>
+                  <spacer name="mousePanningHorizontalSpacerLeft">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="mousePanningGroup">
+                   <property name="title">
+                    <string>Mouse panning</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                   <layout class="QVBoxLayout" name="mousePanningVerticalLayout">
+                    <property name="spacing">
+                     <number>3</number>
+                    </property>
+                    <property name="leftMargin">
+                     <number>3</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>3</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>3</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>3</number>
+                    </property>
+                    <item>
+                     <widget class="QPushButton" name="mousePanningButton">
+                      <property name="minimumSize">
+                       <size>
+                        <width>68</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>68</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="styleSheet">
+                       <string notr="true">min-width: 68px;</string>
+                      </property>
+                      <property name="text">
+                       <string>Configure</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="mousePanningHorizontalSpacerRight">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>

--- a/src/yuzu/configuration/configure_mouse_panning.cpp
+++ b/src/yuzu/configuration/configure_mouse_panning.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <QCloseEvent>
+
+#include "common/settings.h"
+#include "ui_configure_mouse_panning.h"
+#include "yuzu/configuration/configure_mouse_panning.h"
+
+ConfigureMousePanning::ConfigureMousePanning(QWidget* parent,
+                                             InputCommon::InputSubsystem* input_subsystem_,
+                                             float right_stick_deadzone, float right_stick_range)
+    : QDialog(parent), input_subsystem{input_subsystem_},
+      ui(std::make_unique<Ui::ConfigureMousePanning>()) {
+    ui->setupUi(this);
+    SetConfiguration(right_stick_deadzone, right_stick_range);
+    ConnectEvents();
+}
+
+ConfigureMousePanning::~ConfigureMousePanning() = default;
+
+void ConfigureMousePanning::closeEvent(QCloseEvent* event) {
+    event->accept();
+}
+
+void ConfigureMousePanning::SetConfiguration(float right_stick_deadzone, float right_stick_range) {
+    ui->enable->setChecked(Settings::values.mouse_panning.GetValue());
+    ui->x_sensitivity->setValue(Settings::values.mouse_panning_x_sensitivity.GetValue());
+    ui->y_sensitivity->setValue(Settings::values.mouse_panning_y_sensitivity.GetValue());
+    ui->deadzone_x_counterweight->setValue(
+        Settings::values.mouse_panning_deadzone_x_counterweight.GetValue());
+    ui->deadzone_y_counterweight->setValue(
+        Settings::values.mouse_panning_deadzone_y_counterweight.GetValue());
+    ui->decay_strength->setValue(Settings::values.mouse_panning_decay_strength.GetValue());
+    ui->min_decay->setValue(Settings::values.mouse_panning_min_decay.GetValue());
+
+    if (right_stick_deadzone > 0.0f || right_stick_range != 1.0f) {
+        ui->warning_label->setText(QString::fromStdString(
+            "Mouse panning works better with a deadzone of 0% and a range of 100%.\n"
+            "Current values are " +
+            std::to_string(static_cast<int>(right_stick_deadzone * 100.0f)) + "% and " +
+            std::to_string(static_cast<int>(right_stick_range * 100.0f)) + "% respectively."));
+    } else {
+        ui->warning_label->hide();
+    }
+}
+
+void ConfigureMousePanning::SetDefaultConfiguration() {
+    ui->x_sensitivity->setValue(Settings::values.mouse_panning_x_sensitivity.GetDefault());
+    ui->y_sensitivity->setValue(Settings::values.mouse_panning_y_sensitivity.GetDefault());
+    ui->deadzone_x_counterweight->setValue(
+        Settings::values.mouse_panning_deadzone_x_counterweight.GetDefault());
+    ui->deadzone_y_counterweight->setValue(
+        Settings::values.mouse_panning_deadzone_y_counterweight.GetDefault());
+    ui->decay_strength->setValue(Settings::values.mouse_panning_decay_strength.GetDefault());
+    ui->min_decay->setValue(Settings::values.mouse_panning_min_decay.GetDefault());
+}
+
+void ConfigureMousePanning::ConnectEvents() {
+    connect(ui->default_button, &QPushButton::clicked, this,
+            &ConfigureMousePanning::SetDefaultConfiguration);
+    connect(ui->button_box, &QDialogButtonBox::accepted, this,
+            &ConfigureMousePanning::ApplyConfiguration);
+    connect(ui->button_box, &QDialogButtonBox::rejected, this, [this] { reject(); });
+}
+
+void ConfigureMousePanning::ApplyConfiguration() {
+    Settings::values.mouse_panning = ui->enable->isChecked();
+    Settings::values.mouse_panning_x_sensitivity = static_cast<float>(ui->x_sensitivity->value());
+    Settings::values.mouse_panning_y_sensitivity = static_cast<float>(ui->y_sensitivity->value());
+    Settings::values.mouse_panning_deadzone_x_counterweight =
+        static_cast<float>(ui->deadzone_x_counterweight->value());
+    Settings::values.mouse_panning_deadzone_y_counterweight =
+        static_cast<float>(ui->deadzone_y_counterweight->value());
+    Settings::values.mouse_panning_decay_strength = static_cast<float>(ui->decay_strength->value());
+    Settings::values.mouse_panning_min_decay = static_cast<float>(ui->min_decay->value());
+
+    accept();
+}

--- a/src/yuzu/configuration/configure_mouse_panning.h
+++ b/src/yuzu/configuration/configure_mouse_panning.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <memory>
+#include <QDialog>
+
+namespace InputCommon {
+class InputSubsystem;
+}
+
+namespace Ui {
+class ConfigureMousePanning;
+}
+
+class ConfigureMousePanning : public QDialog {
+    Q_OBJECT
+public:
+    explicit ConfigureMousePanning(QWidget* parent, InputCommon::InputSubsystem* input_subsystem_,
+                                   float right_stick_deadzone, float right_stick_range);
+    ~ConfigureMousePanning() override;
+
+public slots:
+    void ApplyConfiguration();
+
+private:
+    void closeEvent(QCloseEvent* event) override;
+    void SetConfiguration(float right_stick_deadzone, float right_stick_range);
+    void SetDefaultConfiguration();
+    void ConnectEvents();
+
+    InputCommon::InputSubsystem* input_subsystem;
+    std::unique_ptr<Ui::ConfigureMousePanning> ui;
+};

--- a/src/yuzu/configuration/configure_mouse_panning.ui
+++ b/src/yuzu/configuration/configure_mouse_panning.ui
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureMousePanning</class>
+ <widget class="QDialog" name="configure_mouse_panning">
+  <property name="windowTitle">
+   <string>Configure mouse panning</string>
+  </property>
+  <layout class="QVBoxLayout">
+   <item>
+    <widget class="QCheckBox" name="enable">
+     <property name="text">
+      <string>Enable</string>
+     </property>
+     <property name="toolTip">
+      <string>Can be toggled via a hotkey</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QGroupBox" name="sensitivity_box">
+       <property name="title">
+        <string>Sensitivity</string>
+       </property>
+       <layout class="QGridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="x_sensitivity_label">
+          <property name="text">
+           <string>Horizontal</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="x_sensitivity">
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>50</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="y_sensitivity_label">
+          <property name="text">
+           <string>Vertical</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="y_sensitivity">
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>50</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="deadzone_counterweight_box">
+       <property name="title">
+        <string>Deadzone counterweight</string>
+       </property>
+       <property name="toolTip">
+        <string>Counteracts a game's built-in deadzone</string>
+       </property>
+       <layout class="QGridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="deadzone_x_counterweight_label">
+          <property name="text">
+           <string>Horizontal</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="deadzone_x_counterweight">
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="deadzone_y_counterweight_label">
+          <property name="text">
+           <string>Vertical</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="deadzone_y_counterweight">
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="decay_box">
+       <property name="title">
+        <string>Stick decay</string>
+       </property>
+       <layout class="QGridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="decay_strength_label">
+          <property name="text">
+           <string>Strength</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="decay_strength">
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>22</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="min_decay_label">
+          <property name="text">
+           <string>Minimum</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="min_decay">
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>5</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="warning_label">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QPushButton" name="default_button">
+       <property name="text">
+        <string>Default</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -140,9 +140,29 @@ udp_input_servers =
 # 0 (default): Off, 1: On
 mouse_panning =
 
-# Set mouse sensitivity.
-# Default: 1.0
-mouse_panning_sensitivity =
+# Set mouse panning horizontal sensitivity.
+# Default: 50.0
+mouse_panning_x_sensitivity =
+
+# Set mouse panning vertical sensitivity.
+# Default: 50.0
+mouse_panning_y_sensitivity =
+
+# Set mouse panning deadzone horizontal counterweight.
+# Default: 0.0
+mouse_panning_deadzone_x_counterweight =
+
+# Set mouse panning deadzone vertical counterweight.
+# Default: 0.0
+mouse_panning_deadzone_y_counterweight =
+
+# Set mouse panning stick decay strength.
+# Default: 22.0
+mouse_panning_decay_strength =
+
+# Set mouse panning stick minimum decay.
+# Default: 5.0
+mouse_panning_minimum_decay =
 
 # Emulate an analog control stick from keyboard inputs.
 # 0 (default): Disabled, 1: Enabled


### PR DESCRIPTION
I wanted to give a try at fixing the issues raised by #10420 (whose author is away for some months and can't update the PR), and I ended up with a somewhat more conservative solution.

Attempts to fix the following issues:

1. Sensitivity setting affecting the stick's range, making either the max value unreachable or min value too high if not set to 50%.
Fixed by applying the sensitivity on the mouse input alone, before any clamping.

2. Very small movements being impossible to perform.
Fixed by removing the line that sets the mouse event's length to a minimum of 3. Testing shows that it is rarely higher than 1 even with a low mouse polling rate, so setting it to 3 meant some details were lost.

3. Stick "resistance" feeling inconsistent.
This is more subjective. The buffer decay is applied in both `Move` (9% per mouse event) and `UpdateStickInput` (4% per update tick). Comment says "Average mouse movements" but this is really just a double exponential decay that depends not just on the buffer's current value and how much time has passed (for example I think a high polling rate mouse meant a stronger decay).
Fixed by applying it in `UpdateStickInput` only.

4. Slow stick recentering time causing slippery (high end inertia) movements.
`mouse_panning_timeout` was used to recenter a stick after a certain amount of update with no user input, but a high value resulted in slippery movements and a low one tended to make the stick recenter too easily during slow movements (killing any build-up). This can be fixed by changing the decay function and make the recenter time from a high length must faster without affecting the time it takes to recenter from a short length too much. The following graph shows the decay (Y) applied to `last_mouse_change` on each update based on the stick length (X). (Update: was slightly tweaked to be less aggressive)
![chart](https://github.com/yuzu-emu/yuzu/assets/1279721/873ed67a-8396-4cc9-8bc7-1ce7b1a7c1fa)

5. Lack of configurability.
Only the sensitivity could be configured, and globally.
The stick's decay strength and minimum amount can now be configured to fit the user preference. Another setting was added to help counteract against a game's built-in deadzone. This last setting and sensitivity were split for both X and Y axis. Because the user may want to have different settings between games, the configure button was moved from the advanced widget to the first player input widget, and values are saved in the profiles.

6. https://github.com/yuzu-emu/yuzu/issues/10481
Implemented what was suggested. The enable setting is no longer saved but is still read (effectively a read-only setting).

This still isn't perfect by any mean:
- Qt's mouse event appears to lack granularity, but I don't think we have much choice.
- The update interval is somewhat slow (10ms) so buffer decay is never going to feel very smooth.
- Buffer decay is tied to the update interval so it can't be changed without making it either slower or faster.
- Probably as a consequence of above, slippery movement currently cannot be completely prevented without introducing various issues.