### PR TITLE
Fix incorrect syncpt id bounds check and potential out of bounds lookup

### DIFF
--- a/src/core/hle/service/nvdrv/core/syncpoint_manager.cpp
+++ b/src/core/hle/service/nvdrv/core/syncpoint_manager.cpp
@@ -64,7 +64,7 @@ void SyncpointManager::FreeSyncpoint(u32 id) {
 }
 
 bool SyncpointManager::IsSyncpointAllocated(u32 id) const {
-    return (id <= SyncpointCount) && syncpoints[id].reserved;
+    return (id < SyncpointCount) && syncpoints[id].reserved;
 }
 
 bool SyncpointManager::HasSyncpointExpired(u32 id, u32 threshold) const {


### PR DESCRIPTION
This is a bug copied over from Skyline. I doubt this affects any games, so this is very inconsequential, but a bug I spotted nonetheless.