### PR TITLE
android: Don't crash the app when selecting a zip that causes a SecurityException

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GpuDriverHelper.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GpuDriverHelper.kt
@@ -103,7 +103,11 @@ object GpuDriverHelper {
         )
 
         // Unzip the driver.
-        unzip(driverInstallationPath + DRIVER_INTERNAL_FILENAME, driverInstallationPath!!)
+        try {
+            unzip(driverInstallationPath + DRIVER_INTERNAL_FILENAME, driverInstallationPath!!)
+        } catch (e: SecurityException) {
+            return
+        }
 
         // Initialize the driver parameters.
         initializeDriverParameters(context)


### PR DESCRIPTION
Just return and the app will show an invalid driver error to the user.