### PR TITLE
android: Adjust various warnings

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/HomeSettingsFragment.kt
@@ -99,7 +99,7 @@ class HomeSettingsFragment : Fragment() {
                 R.drawable.ic_add
             ) { mainActivity.getGamesDirectory.launch(Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).data) },
             HomeSetting(
-                R.string.import_export_saves,
+                R.string.manage_save_data,
                 R.string.import_export_saves_description,
                 R.drawable.ic_save
             ) { ImportExportSavesFragment().show(parentFragmentManager, ImportExportSavesFragment.TAG) },

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/ImportExportSavesFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/ImportExportSavesFragment.kt
@@ -68,19 +68,21 @@ class ImportExportSavesFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return if (savesFolderRoot == "") {
             MaterialAlertDialogBuilder(requireContext())
-                .setTitle(R.string.import_export_saves)
+                .setTitle(R.string.manage_save_data)
                 .setMessage(R.string.import_export_saves_no_profile)
                 .setPositiveButton(android.R.string.ok, null)
                 .show()
         } else {
             MaterialAlertDialogBuilder(requireContext())
-                .setTitle(R.string.import_export_saves)
-                .setPositiveButton(R.string.export_saves) { _, _ ->
+                .setTitle(R.string.manage_save_data)
+                .setMessage(R.string.manage_save_data_description)
+                .setNegativeButton(R.string.export_saves) { _, _ ->
                     exportSave()
                 }
-                .setNeutralButton(R.string.import_saves) { _, _ ->
+                .setPositiveButton(R.string.import_saves) { _, _ ->
                     documentPicker.launch(arrayOf("application/zip"))
                 }
+                .setNeutralButton(android.R.string.cancel, null)
                 .show()
         }
     }
@@ -95,7 +97,10 @@ class ImportExportSavesFragment : DialogFragment() {
             tempFolder.mkdirs()
             val saveFolder = File(savesFolderRoot)
             val outputZipFile = File(
-                tempFolder, "yuzu saves - ${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))}.zip"
+                tempFolder,
+                "yuzu saves - ${
+                    LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+                }.zip"
             )
             outputZipFile.createNewFile()
             ZipOutputStream(BufferedOutputStream(FileOutputStream(outputZipFile))).use { zos ->
@@ -206,11 +211,10 @@ class ImportExportSavesFragment : DialogFragment() {
 
                 withContext(Dispatchers.Main) {
                     if (!validZip) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.save_file_invalid_zip_structure),
-                            Toast.LENGTH_LONG
-                        ).show()
+                        MessageDialogFragment.newInstance(
+                            R.string.save_file_invalid_zip_structure,
+                            R.string.save_file_invalid_zip_structure_description
+                        ).show(childFragmentManager, MessageDialogFragment.TAG)
                         return@withContext
                     }
                     Toast.makeText(

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/MessageDialogFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/MessageDialogFragment.kt
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.yuzu.yuzu_emu.fragments
+
+import android.app.Dialog
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.yuzu.yuzu_emu.R
+
+class MessageDialogFragment : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val titleId = requireArguments().getInt(TITLE)
+        val descriptionId = requireArguments().getInt(DESCRIPTION)
+        val helpLinkId = requireArguments().getInt(HELP_LINK)
+
+        val dialog = MaterialAlertDialogBuilder(requireContext())
+            .setPositiveButton(R.string.close, null)
+            .setTitle(titleId)
+            .setMessage(descriptionId)
+
+        if (helpLinkId != 0) {
+            dialog.setNeutralButton(R.string.learn_more) { _, _ ->
+                openLink(getString(helpLinkId))
+            }
+        }
+
+        return dialog.show()
+    }
+
+    private fun openLink(link: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link))
+        startActivity(intent)
+    }
+
+    companion object {
+        const val TAG = "MessageDialogFragment"
+
+        private const val TITLE = "Title"
+        private const val DESCRIPTION = "Description"
+        private const val HELP_LINK = "Link"
+
+        fun newInstance(
+            titleId: Int,
+            descriptionId: Int,
+            helpLinkId: Int = 0
+        ): MessageDialogFragment {
+            val dialog = MessageDialogFragment()
+            val bundle = Bundle()
+            bundle.apply {
+                putInt(TITLE, titleId)
+                putInt(DESCRIPTION, descriptionId)
+                putInt(HELP_LINK, helpLinkId)
+            }
+            dialog.arguments = bundle
+            return dialog
+        }
+    }
+}

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
@@ -37,6 +37,7 @@ import org.yuzu.yuzu_emu.databinding.DialogProgressBarBinding
 import org.yuzu.yuzu_emu.features.settings.model.Settings
 import org.yuzu.yuzu_emu.features.settings.ui.SettingsActivity
 import org.yuzu.yuzu_emu.features.settings.utils.SettingsFile
+import org.yuzu.yuzu_emu.fragments.MessageDialogFragment
 import org.yuzu.yuzu_emu.model.GamesViewModel
 import org.yuzu.yuzu_emu.model.HomeViewModel
 import org.yuzu.yuzu_emu.utils.*
@@ -251,11 +252,9 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
             if (result == null)
                 return@registerForActivityResult
 
-            val takeFlags =
-                Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION
             contentResolver.takePersistableUriPermission(
                 result,
-                takeFlags
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
             )
 
             // When a new directory is picked, we currently will reset the existing games
@@ -279,19 +278,16 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 return@registerForActivityResult
 
             if (!FileUtil.hasExtension(result.toString(), "keys")) {
-                Toast.makeText(
-                    applicationContext,
-                    R.string.invalid_keys_file,
-                    Toast.LENGTH_SHORT
-                ).show()
+                MessageDialogFragment.newInstance(
+                    R.string.reading_keys_failure,
+                    R.string.install_keys_failure_extension_description
+                ).show(supportFragmentManager, MessageDialogFragment.TAG)
                 return@registerForActivityResult
             }
 
-            val takeFlags =
-                Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION
             contentResolver.takePersistableUriPermission(
                 result,
-                takeFlags
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
             )
 
             val dstPath = DirectoryInitialization.userDirectory + "/keys/"
@@ -310,11 +306,11 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                     ).show()
                     gamesViewModel.reloadGames(true)
                 } else {
-                    Toast.makeText(
-                        applicationContext,
-                        R.string.install_keys_failure,
-                        Toast.LENGTH_LONG
-                    ).show()
+                    MessageDialogFragment.newInstance(
+                        R.string.invalid_keys_error,
+                        R.string.install_keys_failure_description,
+                        R.string.dumping_keys_quickstart_link
+                    ).show(supportFragmentManager, MessageDialogFragment.TAG)
                 }
             }
         }
@@ -325,19 +321,16 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 return@registerForActivityResult
 
             if (!FileUtil.hasExtension(result.toString(), "bin")) {
-                Toast.makeText(
-                    applicationContext,
-                    R.string.invalid_keys_file,
-                    Toast.LENGTH_SHORT
-                ).show()
+                MessageDialogFragment.newInstance(
+                    R.string.reading_keys_failure,
+                    R.string.install_keys_failure_extension_description
+                ).show(supportFragmentManager, MessageDialogFragment.TAG)
                 return@registerForActivityResult
             }
 
-            val takeFlags =
-                Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION
             contentResolver.takePersistableUriPermission(
                 result,
-                takeFlags
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
             )
 
             val dstPath = DirectoryInitialization.userDirectory + "/keys/"
@@ -355,11 +348,11 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                         Toast.LENGTH_SHORT
                     ).show()
                 } else {
-                    Toast.makeText(
-                        applicationContext,
-                        R.string.install_amiibo_keys_failure,
-                        Toast.LENGTH_LONG
-                    ).show()
+                    MessageDialogFragment.newInstance(
+                        R.string.invalid_keys_error,
+                        R.string.install_keys_failure_description,
+                        R.string.dumping_keys_quickstart_link
+                    ).show(supportFragmentManager, MessageDialogFragment.TAG)
                 }
             }
         }

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -222,7 +222,7 @@
     <string name="emulation_touch_overlay_edit">Edit Overlay</string>
     <string name="emulation_pause">Pause Emulation</string>
     <string name="emulation_unpause">Unpause Emulation</string>
-    <string name="emulation_input_overlay">Input Overlay</string>
+    <string name="emulation_input_overlay">Overlay Options</string>
     <string name="emulation_game_loading">Game loading…</string>
 
     <string name="load_settings">Loading Settings…</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -64,8 +64,15 @@
     <string name="install_amiibo_keys_description">Required to use Amiibo in game</string>
     <string name="invalid_keys_file">Invalid keys file selected</string>
     <string name="install_keys_success">Keys successfully installed</string>
-    <string name="install_keys_failure">Keys file (prod.keys) is invalid</string>
-    <string name="install_amiibo_keys_failure">Keys file (key_retail.bin) is invalid</string>
+    <string name="reading_keys_failure">Error reading encryption keys</string>
+    <string name="install_keys_failure_extension_description">
+        1. Verify your keys have the .keys extension.\n\n
+        2. Keys must not be stored in the Downloads folder.\n\n
+        Resolve the issue(s) and try again.
+    </string>
+    <string name="invalid_keys_error">Invalid encryption keys</string>
+    <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
+    <string name="install_keys_failure_description">The selected file is incorrect or corrupt. Please redump your keys.</string>
     <string name="install_gpu_driver">Install GPU driver</string>
     <string name="install_gpu_driver_description">Install alternative drivers for potentially better performance or accuracy</string>
     <string name="advanced_settings">Advanced settings</string>
@@ -164,6 +171,8 @@
     <string name="reset_all_settings">Reset all settings?</string>
     <string name="reset_all_settings_description">All Advanced Settings will be reset to their default configuration. This can not be undone.</string>
     <string name="settings_reset">Settings reset</string>
+    <string name="close">Close</string>
+    <string name="learn_more">Learn More</string>
 
     <!-- GPU driver installation -->
     <string name="select_gpu_driver">Select GPU driver</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -87,11 +87,13 @@
     <string name="no_file_manager">No file manager found</string>
     <string name="notification_no_directory_link">Could not open yuzu directory</string>
     <string name="notification_no_directory_link_description">Please locate the user folder with the file manager\'s side panel manually.</string>
-    <string name="import_export_saves">Import/export saves</string>
+    <string name="manage_save_data">Manage save data</string>
+    <string name="manage_save_data_description">Save data found. Please select an option below.</string>
     <string name="import_export_saves_description">Import or export save files</string>
-    <string name="import_export_saves_no_profile">No user profile found. Please launch a game first and retry.</string>
-    <string name="save_file_imported_success">Save files were imported successfully</string>
-    <string name="save_file_invalid_zip_structure">Invalid save directory structure: The first subfolder name must be the title ID of the game.</string>
+    <string name="import_export_saves_no_profile">No save data found. Please launch a game and retry.</string>
+    <string name="save_file_imported_success">Imported successfully</string>
+    <string name="save_file_invalid_zip_structure">Invalid save directory structure</string>
+    <string name="save_file_invalid_zip_structure_description">The first subfolder name must be the title ID of the game.</string>
     <string name="import_saves">Import</string>
     <string name="export_saves">Export</string>
 


### PR DESCRIPTION
Change "Input Overlay" to "Overlay Options"

Adjust wording around the import/export saves dialog.

Add new warnings for users that fail to install keys due to issues with different directories.