### PR TITLE
AccelerateDMA: Fix incorrect check in Buffer<->Texture copies

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -850,15 +850,11 @@ void TextureCache<P>::PopAsyncFlushes() {
 template <class P>
 ImageId TextureCache<P>::DmaImageId(const Tegra::DMA::ImageOperand& operand, bool is_upload) {
     const ImageInfo dst_info(operand);
-    const ImageId dst_id = FindDMAImage(dst_info, operand.address);
-    if (!dst_id) {
+    const ImageId image_id = FindDMAImage(dst_info, operand.address);
+    if (!image_id) {
         return NULL_IMAGE_ID;
     }
-    auto& image = slot_images[dst_id];
-    if (False(image.flags & ImageFlagBits::GpuModified)) {
-        // No need to waste time on an image that's synced with guest
-        return NULL_IMAGE_ID;
-    }
+    auto& image = slot_images[image_id];
     if (!is_upload && !image.info.dma_downloaded) {
         // Force a full sync.
         image.info.dma_downloaded = true;
@@ -868,7 +864,7 @@ ImageId TextureCache<P>::DmaImageId(const Tegra::DMA::ImageOperand& operand, boo
     if (!base) {
         return NULL_IMAGE_ID;
     }
-    return dst_id;
+    return image_id;
 }
 
 template <class P>


### PR DESCRIPTION
This PR improves performance, which I verified on some homebrew tests I made. 
But, I don't know which titles are likely to be affected by this change.

> `// No need to waste time on an image that's synced with guest`

This comment makes me think the idea for this check was to skip downloading images that haven't been modified on the GPU, but the early return here made it so that the slower unaccelerated path was taken instead, which still downloaded the image.

The logic is also flawed because it makes the **assumption** that the destination for the DMA copy is the same address as the CPU address for the image, which is "synced with guest" and thus needs no updating.
This assumption can't really be made.