### PR TITLE
vfs: add vfs_cached for romfs build

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -106,6 +106,8 @@ add_library(core STATIC
     file_sys/system_archive/time_zone_binary.h
     file_sys/vfs.cpp
     file_sys/vfs.h
+    file_sys/vfs_cached.cpp
+    file_sys/vfs_cached.h
     file_sys/vfs_concat.cpp
     file_sys/vfs_concat.h
     file_sys/vfs_layered.cpp

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -21,6 +21,7 @@
 #include "core/file_sys/patch_manager.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/file_sys/romfs.h"
+#include "core/file_sys/vfs_cached.h"
 #include "core/file_sys/vfs_layered.h"
 #include "core/file_sys/vfs_vector.h"
 #include "core/hle/service/filesystem/filesystem.h"
@@ -380,11 +381,11 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
 
         auto romfs_dir = FindSubdirectoryCaseless(subdir, "romfs");
         if (romfs_dir != nullptr)
-            layers.push_back(std::move(romfs_dir));
+            layers.push_back(std::make_shared<CachedVfsDirectory>(romfs_dir));
 
         auto ext_dir = FindSubdirectoryCaseless(subdir, "romfs_ext");
         if (ext_dir != nullptr)
-            layers_ext.push_back(std::move(ext_dir));
+            layers_ext.push_back(std::make_shared<CachedVfsDirectory>(ext_dir));
     }
 
     // When there are no layers to apply, return early as there is no need to rebuild the RomFS

--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -9,6 +9,7 @@
 #include "core/file_sys/fsmitm_romfsbuild.h"
 #include "core/file_sys/romfs.h"
 #include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_cached.h"
 #include "core/file_sys/vfs_concat.h"
 #include "core/file_sys/vfs_offset.h"
 #include "core/file_sys/vfs_vector.h"
@@ -132,7 +133,7 @@ VirtualDir ExtractRomFS(VirtualFile file, RomFSExtractionType type) {
         out = out->GetSubdirectories().front();
     }
 
-    return out;
+    return std::make_shared<CachedVfsDirectory>(out);
 }
 
 VirtualFile CreateRomFS(VirtualDir dir, VirtualDir ext) {

--- a/src/core/file_sys/vfs_cached.cpp
+++ b/src/core/file_sys/vfs_cached.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "core/file_sys/vfs_cached.h"
+#include "core/file_sys/vfs_types.h"
+
+namespace FileSys {
+
+CachedVfsDirectory::CachedVfsDirectory(VirtualDir& source_dir)
+    : name(source_dir->GetName()), parent(source_dir->GetParentDirectory()) {
+    for (auto& dir : source_dir->GetSubdirectories()) {
+        dirs.emplace(dir->GetName(), std::make_shared<CachedVfsDirectory>(dir));
+    }
+    for (auto& file : source_dir->GetFiles()) {
+        files.emplace(file->GetName(), file);
+    }
+}
+
+CachedVfsDirectory::~CachedVfsDirectory() = default;
+
+VirtualFile CachedVfsDirectory::GetFile(std::string_view file_name) const {
+    auto it = files.find(file_name);
+    if (it != files.end()) {
+        return it->second;
+    }
+
+    return nullptr;
+}
+
+VirtualDir CachedVfsDirectory::GetSubdirectory(std::string_view dir_name) const {
+    auto it = dirs.find(dir_name);
+    if (it != dirs.end()) {
+        return it->second;
+    }
+
+    return nullptr;
+}
+
+std::vector<VirtualFile> CachedVfsDirectory::GetFiles() const {
+    std::vector<VirtualFile> out;
+    for (auto& [file_name, file] : files) {
+        out.push_back(file);
+    }
+    return out;
+}
+
+std::vector<VirtualDir> CachedVfsDirectory::GetSubdirectories() const {
+    std::vector<VirtualDir> out;
+    for (auto& [dir_name, dir] : dirs) {
+        out.push_back(dir);
+    }
+    return out;
+}
+
+std::string CachedVfsDirectory::GetName() const {
+    return name;
+}
+
+VirtualDir CachedVfsDirectory::GetParentDirectory() const {
+    return parent;
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/vfs_cached.h
+++ b/src/core/file_sys/vfs_cached.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string_view>
+#include <vector>
+#include "core/file_sys/vfs.h"
+
+namespace FileSys {
+
+class CachedVfsDirectory : public ReadOnlyVfsDirectory {
+public:
+    CachedVfsDirectory(VirtualDir& source_directory);
+
+    ~CachedVfsDirectory() override;
+    VirtualFile GetFile(std::string_view file_name) const override;
+    VirtualDir GetSubdirectory(std::string_view dir_name) const override;
+    std::vector<VirtualFile> GetFiles() const override;
+    std::vector<VirtualDir> GetSubdirectories() const override;
+    std::string GetName() const override;
+    VirtualDir GetParentDirectory() const override;
+
+private:
+    std::string name;
+    VirtualDir parent;
+    std::map<std::string, VirtualDir, std::less<>> dirs;
+    std::map<std::string, VirtualFile, std::less<>> files;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/vfs_vector.cpp
+++ b/src/core/file_sys/vfs_vector.cpp
@@ -67,23 +67,6 @@ VectorVfsDirectory::VectorVfsDirectory(std::vector<VirtualFile> files_,
 
 VectorVfsDirectory::~VectorVfsDirectory() = default;
 
-VirtualFile VectorVfsDirectory::GetFile(std::string_view file_name) const {
-    if (!optimized_file_index_built) {
-        optimized_file_index.clear();
-        for (size_t i = 0; i < files.size(); i++) {
-            optimized_file_index.emplace(files[i]->GetName(), i);
-        }
-        optimized_file_index_built = true;
-    }
-
-    const auto it = optimized_file_index.find(file_name);
-    if (it != optimized_file_index.end()) {
-        return files[it->second];
-    }
-
-    return nullptr;
-}
-
 std::vector<VirtualFile> VectorVfsDirectory::GetFiles() const {
     return files;
 }
@@ -124,7 +107,6 @@ bool VectorVfsDirectory::DeleteSubdirectory(std::string_view subdir_name) {
 }
 
 bool VectorVfsDirectory::DeleteFile(std::string_view file_name) {
-    optimized_file_index_built = false;
     return FindAndRemoveVectorElement(files, file_name);
 }
 
@@ -142,7 +124,6 @@ VirtualFile VectorVfsDirectory::CreateFile(std::string_view file_name) {
 }
 
 void VectorVfsDirectory::AddFile(VirtualFile file) {
-    optimized_file_index_built = false;
     files.push_back(std::move(file));
 }
 

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -105,7 +105,6 @@ public:
                                 VirtualDir parent = nullptr);
     ~VectorVfsDirectory() override;
 
-    VirtualFile GetFile(std::string_view file_name) const override;
     std::vector<VirtualFile> GetFiles() const override;
     std::vector<VirtualDir> GetSubdirectories() const override;
     bool IsWritable() const override;
@@ -127,9 +126,6 @@ private:
 
     VirtualDir parent;
     std::string name;
-
-    mutable std::map<std::string, size_t, std::less<>> optimized_file_index;
-    mutable bool optimized_file_index_built{};
 };
 
 } // namespace FileSys


### PR DESCRIPTION
#10183 fixed an algorithmic complexity issue with loading romfs mods, but did not fix how unbelievably slow it is to make filesystem calls on Windows, and I was not testing on Windows at the time. This wraps the romfs mods directory in a memory cache, which pretty much decisively fixes romfs load time for games with tons of files, including Animal Crossing: New Horizons, Fire Emblem Engage, and Tears of the Kingdom.