### PR TITLE
Localize game icons

### DIFF
--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -23,8 +23,8 @@ const std::array<const char*, 16> LANGUAGE_NAMES{{
     "Portuguese",
     "Russian",
     "Korean",
-    "Taiwanese",
-    "Chinese",
+    "TraditionalChinese",
+    "SimplifiedChinese",
     "BrazilianPortuguese",
 }};
 
@@ -45,17 +45,17 @@ constexpr std::array<Language, 18> language_to_codes = {{
     Language::German,
     Language::Italian,
     Language::Spanish,
-    Language::Chinese,
+    Language::SimplifiedChinese,
     Language::Korean,
     Language::Dutch,
     Language::Portuguese,
     Language::Russian,
-    Language::Taiwanese,
+    Language::TraditionalChinese,
     Language::BritishEnglish,
     Language::CanadianFrench,
     Language::LatinAmericanSpanish,
-    Language::Chinese,
-    Language::Taiwanese,
+    Language::SimplifiedChinese,
+    Language::TraditionalChinese,
     Language::BrazilianPortuguese,
 }};
 

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -84,8 +84,8 @@ enum class Language : u8 {
     Portuguese = 10,
     Russian = 11,
     Korean = 12,
-    Taiwanese = 13,
-    Chinese = 14,
+    TraditionalChinese = 13,
+    SimplifiedChinese = 14,
     BrazilianPortuguese = 15,
 
     Default = 255,

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -647,7 +647,7 @@ PatchManager::Metadata PatchManager::ParseControlNCA(const NCA& nca) const {
             if (language_index < FileSys::LANGUAGE_NAMES.size()) {
                 priority_language_names[i] = FileSys::LANGUAGE_NAMES[language_index];
             } else {
-                // Not a catastrophy, unlikely to happen
+                // Not a catastrophe, unlikely to happen
                 LOG_WARNING(Loader, "Invalid language index {}", language_index);
             }
         }

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -24,6 +24,8 @@
 #include "core/file_sys/vfs_layered.h"
 #include "core/file_sys/vfs_vector.h"
 #include "core/hle/service/filesystem/filesystem.h"
+#include "core/hle/service/ns/language.h"
+#include "core/hle/service/set/set.h"
 #include "core/loader/loader.h"
 #include "core/loader/nso.h"
 #include "core/memory/cheat_engine.h"
@@ -623,8 +625,37 @@ PatchManager::Metadata PatchManager::ParseControlNCA(const NCA& nca) const {
 
     auto nacp = nacp_file == nullptr ? nullptr : std::make_unique<NACP>(nacp_file);
 
+    // Get language code from settings
+    const auto language_code =
+        Service::Set::GetLanguageCodeFromIndex(Settings::values.language_index.GetValue());
+
+    // Convert to application language and get priority list
+    const auto application_language =
+        Service::NS::ConvertToApplicationLanguage(language_code)
+            .value_or(Service::NS::ApplicationLanguage::AmericanEnglish);
+    const auto language_priority_list =
+        Service::NS::GetApplicationLanguagePriorityList(application_language);
+
+    // Convert to language names
+    auto priority_language_names = FileSys::LANGUAGE_NAMES; // Copy
+    if (language_priority_list) {
+        for (size_t i = 0; i < priority_language_names.size(); ++i) {
+            // Relies on FileSys::LANGUAGE_NAMES being in the same order as
+            // Service::NS::ApplicationLanguage
+            const auto language_index = static_cast<u8>(language_priority_list->at(i));
+
+            if (language_index < FileSys::LANGUAGE_NAMES.size()) {
+                priority_language_names[i] = FileSys::LANGUAGE_NAMES[language_index];
+            } else {
+                // Not a catastrophy, unlikely to happen
+                LOG_WARNING(Loader, "Invalid language index {}", language_index);
+            }
+        }
+    }
+
+    // Get first matching icon
     VirtualFile icon_file;
-    for (const auto& language : FileSys::LANGUAGE_NAMES) {
+    for (const auto& language : priority_language_names) {
         icon_file = extracted->GetFile(std::string("icon_").append(language).append(".dat"));
         if (icon_file != nullptr) {
             break;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3491,6 +3491,7 @@ void GMainWindow::ResetWindowSize1080() {
 void GMainWindow::OnConfigure() {
     const auto old_theme = UISettings::values.theme;
     const bool old_discord_presence = UISettings::values.enable_discord_presence.GetValue();
+    const auto old_language_index = Settings::values.language_index.GetValue();
 
     Settings::SetConfiguringGlobal(true);
     ConfigureDialog configure_dialog(this, hotkey_registry, input_subsystem.get(), *system,
@@ -3559,7 +3560,7 @@ void GMainWindow::OnConfigure() {
     emit UpdateThemedIcons();
 
     const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
-    if (reload) {
+    if (reload || Settings::values.language_index.GetValue() != old_language_index) {
         game_list->PopulateAsync(UISettings::values.game_dirs);
     }
 


### PR DESCRIPTION
Some games provide different icons for different languages but the old behavior has been to pick the first available icon in an arbitrary order. These commits fix that.

I have not changed how the icons are selected by [core/loader/deconstructed_rom_directory.cpp](https://github.com/yuzu-emu/yuzu/blob/58c54aecb6a80e8f8efeae9ae84871fd543dee53/src/core/loader/deconstructed_rom_directory.cpp#L32) but that doesn't affect the UI.

(Re-uses a bit of code from [core/hle/service/ns/ns.cpp:410](https://github.com/yuzu-emu/yuzu/blob/58c54aecb6a80e8f8efeae9ae84871fd543dee53/src/core/hle/service/ns/ns.cpp#L410) by @SciresM)