### PR TITLE
Return the amount of dedicated VRAM under OpenGL

### DIFF
--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -286,7 +286,8 @@ void main() {
 
 u64 Device::GetCurrentDedicatedVideoMemory() const {
     GLint cur_avail_mem_kb = 0;
-    // this should report the correct size of the VRAM, on integrated devices it shows the size of the UMA Framebuffer
+    // this should report the correct size of the VRAM, on integrated devices it shows the size of
+    // the UMA Framebuffer
     glGetIntegerv(GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX, &cur_avail_mem_kb);
     return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
 }

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -286,7 +286,8 @@ void main() {
 
 u64 Device::GetCurrentDedicatedVideoMemory() const {
     GLint cur_avail_mem_kb = 0;
-    glGetIntegerv(GL_GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX, &cur_avail_mem_kb);
+    // this should report the correct size of the VRAM, on integrated devices it shows the size of the UMA Framebuffer
+    glGetIntegerv(GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX, &cur_avail_mem_kb);
     return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
 }
 


### PR DESCRIPTION
This is an attempt to prevent overflowing the actual VRAM on lower-end integrated devices. The former query returned a significantly higher value, for example it was above 8 GB on a steam deck, which has only a maximum UMA Framebuffer size of 4 GB. This can be set in the BIOS.