### PR TITLE
Configurable RAM to VRAM percentage setting for integrated devices

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -238,8 +238,8 @@ void RestoreGlobalState(bool is_powered_on) {
     values.bg_green.SetGlobal(true);
     values.bg_blue.SetGlobal(true);
     values.enable_compute_pipelines.SetGlobal(true);
-    values.use_vram_percentage(true);
-    values.vram_percentage(25);
+    values.use_vram_percentage.SetGlobal(true);
+    values.vram_percentage.SetGlobal(true);
 
     // System
     values.language_index.SetGlobal(true);

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -257,7 +257,7 @@ void RestoreGlobalState(bool is_powered_on) {
 
 // this function only makes sense with integrated devices
 
-u64 RamPercentToBytes(u8 percent) {
+u64 RamPercentageToBytes(u8 percent) {
     // total RAM in bytes
     u64 total_ram = Common::GetMemInfo().TotalPhysicalMemory;
 

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -7,6 +7,7 @@
 #include "common/fs/path_util.h"
 #include "common/logging/log.h"
 #include "common/settings.h"
+#include "common/memory_detect.h"
 
 namespace Settings {
 
@@ -67,6 +68,8 @@ void LogSettings() {
     log_setting("Renderer_ShaderBackend", values.shader_backend.GetValue());
     log_setting("Renderer_UseAsynchronousShaders", values.use_asynchronous_shaders.GetValue());
     log_setting("Renderer_AnisotropicFilteringLevel", values.max_anisotropy.GetValue());
+    log_setting("Renderer_UseVRAMPercentage", values.use_vram_percentage.GetValue());
+    log_setting("Renderer_VRAMPercentage", values.vram_percentage.GetValue());
     log_setting("Audio_OutputEngine", values.sink_id.GetValue());
     log_setting("Audio_OutputDevice", values.audio_output_device_id.GetValue());
     log_setting("Audio_InputDevice", values.audio_input_device_id.GetValue());
@@ -235,6 +238,8 @@ void RestoreGlobalState(bool is_powered_on) {
     values.bg_green.SetGlobal(true);
     values.bg_blue.SetGlobal(true);
     values.enable_compute_pipelines.SetGlobal(true);
+    values.use_vram_percentage(true);
+    values.vram_percentage(25);
 
     // System
     values.language_index.SetGlobal(true);
@@ -248,6 +253,25 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_docked_mode.SetGlobal(true);
     values.vibration_enabled.SetGlobal(true);
     values.motion_enabled.SetGlobal(true);
+}
+
+// this function only makes sense with integrated devices
+
+u64 RAM_Percent_to_Byte(u8 percent) {
+    // total RAM in byte
+    u64 total_ram = Common::GetMemInfo().TotalPhysicalMemory;
+
+    // clamp percentage between 10 and 90, so we dont run out of either RAM or VRAM
+    if (percent < 10) {
+        percent = 10;
+    }
+
+    if (percent > 90) {
+        percent = 90;
+    }
+
+    // percentage of total RAM in byte
+    return (total_ram * percent) / 100;
 }
 
 } // namespace Settings

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -257,8 +257,8 @@ void RestoreGlobalState(bool is_powered_on) {
 
 // this function only makes sense with integrated devices
 
-u64 RamPercentToByte(u8 percent) {
-    // total RAM in byte
+u64 RamPercentToBytes(u8 percent) {
+    // total RAM in bytes
     u64 total_ram = Common::GetMemInfo().TotalPhysicalMemory;
 
     // clamp percentage between 10 and 90, so we dont run out of either RAM or VRAM

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -6,8 +6,8 @@
 #include "common/assert.h"
 #include "common/fs/path_util.h"
 #include "common/logging/log.h"
-#include "common/settings.h"
 #include "common/memory_detect.h"
+#include "common/settings.h"
 
 namespace Settings {
 
@@ -257,7 +257,7 @@ void RestoreGlobalState(bool is_powered_on) {
 
 // this function only makes sense with integrated devices
 
-u64 RAM_Percent_to_Byte(u8 percent) {
+u64 RamPercentToByte(u8 percent) {
     // total RAM in byte
     u64 total_ram = Common::GetMemInfo().TotalPhysicalMemory;
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -615,6 +615,6 @@ void UpdateRescalingInfo();
 // Restore the global state of all applicable settings in the Values struct
 void RestoreGlobalState(bool is_powered_on);
 
-u64 RamPercentToBytes(u8 percent);
+u64 RamPercentageToBytes(u8 percent);
 
 } // namespace Settings

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -487,7 +487,7 @@ struct Values {
     SwitchableSetting<u8> bg_green{0, "bg_green"};
     SwitchableSetting<u8> bg_blue{0, "bg_blue"};
 
-    SwitchableSetting<bool, true> use_vram_percentage{true, "use_vram_percentage"};
+    SwitchableSetting<bool> use_vram_percentage{true, "use_vram_percentage"};
     SwitchableSetting<u8, true> vram_percentage{25, 10, 90, "vram_percentage"};
 
     // System
@@ -614,5 +614,7 @@ void UpdateRescalingInfo();
 
 // Restore the global state of all applicable settings in the Values struct
 void RestoreGlobalState(bool is_powered_on);
+
+u64 RAM_Percent_to_Byte(u8 percent);
 
 } // namespace Settings

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -487,6 +487,9 @@ struct Values {
     SwitchableSetting<u8> bg_green{0, "bg_green"};
     SwitchableSetting<u8> bg_blue{0, "bg_blue"};
 
+    SwitchableSetting<bool, true> use_vram_percentage{true, "use_vram_percentage"};
+    SwitchableSetting<u8, true> vram_percentage{25, 10, 90, "vram_percentage"};
+
     // System
     SwitchableSetting<std::optional<u32>> rng_seed{std::optional<u32>(), "rng_seed"};
     Setting<std::string> device_name{"Yuzu", "device_name"};

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -615,6 +615,6 @@ void UpdateRescalingInfo();
 // Restore the global state of all applicable settings in the Values struct
 void RestoreGlobalState(bool is_powered_on);
 
-u64 RAM_Percent_to_Byte(u8 percent);
+u64 RamPercentToBytes(u8 percent);
 
 } // namespace Settings

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -142,7 +142,7 @@ BufferCacheRuntime::BufferCacheRuntime(const Device& device_)
 
 u64 BufferCacheRuntime::GetDeviceMemoryUsage() const {
     if (device.CanReportMemoryUsage()) {
-        return device_access_memory - device.GetCurrentDedicatedVideoMemory();
+        return device.GetTotalDedicatedVideoMemory() - device.GetCurrentDedicatedVideoMemory();
     }
     return 2_GiB;
 }

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -134,7 +134,7 @@ BufferCacheRuntime::BufferCacheRuntime(const Device& device_)
 
     device_access_memory = [this]() -> u64 {
         if (device.CanReportMemoryUsage()) {
-            return device.GetCurrentDedicatedVideoMemory() + 512_MiB;
+            return device.GetTotalDedicatedVideoMemory();
         }
         return 2_GiB; // Return minimum requirements
     }();

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -292,9 +292,8 @@ u64 Device::GetTotalDedicatedVideoMemory() const {
 
     if (Settings::values.use_vram_percentage.GetValue()) {
         u8 percent = Settings::values.vram_percentage.GetValue();
-        return Settings::RAM_Percent_to_Byte(percent);
-    }
-    else {
+        return Settings::RamPercentToByte(percent);
+    } else {
         // this is according to both former settings in the gl_buffer_cache
         // and gl_texture_cache, regarding device_access_memory
         return static_cast<u64>(tot_avail_mem_kb) * 1_KiB + 512_MiB;

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -292,7 +292,7 @@ u64 Device::GetTotalDedicatedVideoMemory() const {
 
     if (Settings::values.use_vram_percentage.GetValue()) {
         u8 percent = Settings::values.vram_percentage.GetValue();
-        return Settings::RamPercentToByte(percent);
+        return Settings::RamPercentToBytes(percent);
     } else {
         // this is according to both former settings in the gl_buffer_cache
         // and gl_texture_cache, regarding device_access_memory

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -300,7 +300,6 @@ u64 Device::GetTotalDedicatedVideoMemory() const {
     }
 }
 
-
 u64 Device::GetCurrentDedicatedVideoMemory() const {
     GLint cur_avail_mem_kb = 0;
     // this should report the currently available video memory

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -289,10 +289,16 @@ u64 Device::GetTotalDedicatedVideoMemory() const {
     // this should report the correct size of the VRAM, on integrated devices it shows the size of
     // the UMA Framebuffer
     glGetIntegerv(GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX, &tot_avail_mem_kb);
-    // LOG_INFO(Render_OpenGL, "total VRAM: {} GB", tot_avail_mem_kb / f64{1_MiB});
-    f64 percent = Settings::values.vram_percentage.GetValue();
-    u64 vram = Settings::RAM_Percent_to_Byte(percent);
-    return static_cast<u64>(tot_avail_mem_kb) * 1_KiB + vram;
+
+    if (Settings::values.use_vram_percentage.GetValue()) {
+        u8 percent = Settings::values.vram_percentage.GetValue();
+        return Settings::RAM_Percent_to_Byte(percent);
+    }
+    else {
+        // this is according to both former settings in the gl_buffer_cache
+        // and gl_texture_cache, regarding device_access_memory
+        return static_cast<u64>(tot_avail_mem_kb) * 1_KiB + 512_MiB;
+    }
 }
 
 
@@ -300,7 +306,6 @@ u64 Device::GetCurrentDedicatedVideoMemory() const {
     GLint cur_avail_mem_kb = 0;
     // this should report the currently available video memory
     glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &cur_avail_mem_kb);
-    // LOG_INFO(Render_OpenGL, "current VRAM: {} GB", cur_avail_mem_kb / f64{1_MiB});
     return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
 }
 

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -292,7 +292,7 @@ u64 Device::GetTotalDedicatedVideoMemory() const {
 
     if (Settings::values.use_vram_percentage.GetValue()) {
         u8 percent = Settings::values.vram_percentage.GetValue();
-        return Settings::RamPercentToBytes(percent);
+        return Settings::RamPercentageToBytes(percent);
     } else {
         // this is according to both former settings in the gl_buffer_cache
         // and gl_texture_cache, regarding device_access_memory

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -284,9 +284,23 @@ void main() {
 })");
 }
 
+u64 Device::GetTotalDedicatedVideoMemory() const {
+    GLint tot_avail_mem_kb = 0;
+    // this should report the correct size of the VRAM, on integrated devices it shows the size of
+    // the UMA Framebuffer
+    glGetIntegerv(GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX, &tot_avail_mem_kb);
+    // LOG_INFO(Render_OpenGL, "total VRAM: {} GB", tot_avail_mem_kb / f64{1_MiB});
+    f64 percent = Settings::values.vram_percentage.GetValue();
+    u64 vram = Settings::RAM_Percent_to_Byte(percent);
+    return static_cast<u64>(tot_avail_mem_kb) * 1_KiB + vram;
+}
+
+
 u64 Device::GetCurrentDedicatedVideoMemory() const {
     GLint cur_avail_mem_kb = 0;
-    glGetIntegerv(GL_GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX, &cur_avail_mem_kb);
+    // this should report the currently available video memory
+    glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &cur_avail_mem_kb);
+    // LOG_INFO(Render_OpenGL, "current VRAM: {} GB", cur_avail_mem_kb / f64{1_MiB});
     return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
 }
 

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -22,6 +22,8 @@ public:
 
     [[nodiscard]] std::string GetVendorName() const;
 
+    u64 GetTotalDedicatedVideoMemory() const;
+
     u64 GetCurrentDedicatedVideoMemory() const;
 
     u32 GetMaxUniformBuffers(Shader::Stage stage) const noexcept {

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -568,7 +568,7 @@ ImageBufferMap TextureCacheRuntime::DownloadStagingBuffer(size_t size) {
 
 u64 TextureCacheRuntime::GetDeviceMemoryUsage() const {
     if (device.CanReportMemoryUsage()) {
-        return device_access_memory - device.GetCurrentDedicatedVideoMemory();
+        return device.GetTotalDedicatedVideoMemory() - device.GetCurrentDedicatedVideoMemory();
     }
     return 2_GiB;
 }

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -546,7 +546,7 @@ TextureCacheRuntime::TextureCacheRuntime(const Device& device_, ProgramManager& 
 
     device_access_memory = [this]() -> u64 {
         if (device.CanReportMemoryUsage()) {
-            return device.GetCurrentDedicatedVideoMemory() + 512_MiB;
+            return device.GetTotalDedicatedVideoMemory();
         }
         return 2_GiB; // Return minimum requirements
     }();

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1039,9 +1039,10 @@ void Device::CollectPhysicalMemoryInfo() {
         device_access_memory = std::min<u64>(device_access_memory, normal_memory + scaler_memory);
         return;
     }
+    const u8 percent = Settings::values.vram_percentage.GetValue();
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);
     device_access_memory = static_cast<u64>(std::max<s64>(
-        std::min<s64>(available_memory - 8_GiB, 4_GiB), std::min<s64>(local_memory, 4_GiB)));
+        std::min<s64>(available_memory - 8_GiB, 4_GiB), std::min<s64>(local_memory, Settings::RAM_Percent_to_Byte(percent)));
 }
 
 void Device::CollectToolingInfo() {

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1042,7 +1042,7 @@ void Device::CollectPhysicalMemoryInfo() {
     const u8 percent = Settings::values.vram_percentage.GetValue();
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);
     const s64 limit = Settings::values.use_vram_percentage.GetValue()
-                          ? Settings::RamPercentToByte(percent)
+                          ? Settings::RamPercentToBytes(percent)
                           : 4_GiB;
     device_access_memory = static_cast<u64>(std::max<s64>(
         std::min<s64>(available_memory - 8_GiB, 4_GiB), std::min<s64>(local_memory, limit)));

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1041,8 +1041,9 @@ void Device::CollectPhysicalMemoryInfo() {
     }
     const u8 percent = Settings::values.vram_percentage.GetValue();
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);
+    const s64 limit = Settings::values.use_vram_percentage.GetValue() ? Settings::RAM_Percent_to_Byte(percent) : 4_GiB;
     device_access_memory = static_cast<u64>(std::max<s64>(
-        std::min<s64>(available_memory - 8_GiB, 4_GiB), std::min<s64>(local_memory, Settings::RAM_Percent_to_Byte(percent)));
+        std::min<s64>(available_memory - 8_GiB, 4_GiB), std::min<s64>(local_memory, limit)));
 }
 
 void Device::CollectToolingInfo() {

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1042,7 +1042,7 @@ void Device::CollectPhysicalMemoryInfo() {
     const u8 percent = Settings::values.vram_percentage.GetValue();
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);
     const s64 limit = Settings::values.use_vram_percentage.GetValue()
-                          ? Settings::RamPercentToBytes(percent)
+                          ? Settings::RamPercentageToBytes(percent)
                           : 4_GiB;
     device_access_memory = static_cast<u64>(std::max<s64>(
         std::min<s64>(available_memory - 8_GiB, 4_GiB), std::min<s64>(local_memory, limit)));

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1041,7 +1041,9 @@ void Device::CollectPhysicalMemoryInfo() {
     }
     const u8 percent = Settings::values.vram_percentage.GetValue();
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);
-    const s64 limit = Settings::values.use_vram_percentage.GetValue() ? Settings::RAM_Percent_to_Byte(percent) : 4_GiB;
+    const s64 limit = Settings::values.use_vram_percentage.GetValue()
+                          ? Settings::RamPercentToByte(percent)
+                          : 4_GiB;
     device_access_memory = static_cast<u64>(std::max<s64>(
         std::min<s64>(available_memory - 8_GiB, 4_GiB), std::min<s64>(local_memory, limit)));
 }

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -757,6 +757,8 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.bg_red);
     ReadGlobalSetting(Settings::values.bg_green);
     ReadGlobalSetting(Settings::values.bg_blue);
+    ReadGlobalSetting(Settings::values.use_vram_percentage);
+    ReadGlobalSetting(Settings::values.vram_percentage);
 
     if (global) {
         Settings::values.vsync_mode.SetValue(static_cast<Settings::VSyncMode>(
@@ -1412,6 +1414,8 @@ void Config::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.bg_red);
     WriteGlobalSetting(Settings::values.bg_green);
     WriteGlobalSetting(Settings::values.bg_blue);
+    WriteGlobalSetting(Settings::values.use_vram_percentage);
+    WriteGlobalSetting(Settings::values.vram_percentage);
 
     if (global) {
         WriteSetting(QString::fromStdString(Settings::values.vsync_mode.GetLabel()),

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -180,8 +180,9 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         ui->use_vram_percentage, Settings::values.use_vram_percentage, use_vram_percentage);
 
     connect(ui->use_vram_percentage, &QCheckBox::clicked, ui->vram_percentage, [this]() {
-        ui->vram_percentage->setEnabled(ui->use_vram_percentage->isChecked() &&
-                                    (use_vram_percentage != ConfigurationShared::CheckState::Global));
+        ui->vram_percentage->setEnabled(
+            ui->use_vram_percentage->isChecked() &&
+            (use_vram_percentage != ConfigurationShared::CheckState::Global));
     });
 }
 

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -46,14 +46,15 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
     ui->use_vram_percentage->setChecked(Settings::values.use_vram_percentage.GetValue());
 
     if (Settings::IsConfiguringGlobal()) {
-        ui->vram_percentage->setEnabled(Settings::values.use_vram_percentage.GetValue() && runtime_lock);
-    } else {
         ui->vram_percentage->setEnabled(Settings::values.use_vram_percentage.GetValue() &&
-                                    use_vram_percentage != ConfigurationShared::CheckState::Global && runtime_lock);
+                                        runtime_lock);
+    } else {
+        ui->vram_percentage->setEnabled(
+            Settings::values.use_vram_percentage.GetValue() &&
+            use_vram_percentage != ConfigurationShared::CheckState::Global && runtime_lock);
     }
 
     ui->vram_percentage->setValue(Settings::values.vram_percentage.GetValue());
-
 
     if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setCurrentIndex(
@@ -74,7 +75,8 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
                                           !Settings::values.max_anisotropy.UsingGlobal());
         ConfigurationShared::SetHighlight(ui->label_astc_recompression,
                                           !Settings::values.astc_recompression.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->vram_percentage, !Settings::values.vram_percentage.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->vram_percentage,
+                                          !Settings::values.vram_percentage.UsingGlobal());
     }
 }
 
@@ -105,8 +107,7 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
                                              ui->enable_compute_pipelines_checkbox,
                                              enable_compute_pipelines);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vram_percentage,
-                                             ui->use_vram_percentage,
-                                             use_vram_percentage);
+                                             ui->use_vram_percentage, use_vram_percentage);
     Settings::values.vram_percentage.SetValue(ui->vram_percentage->value());
 }
 
@@ -175,9 +176,8 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->astc_recompression_combobox, ui->label_astc_recompression,
         static_cast<int>(Settings::values.astc_recompression.GetValue(true)));
-    ConfigurationShared::SetColoredTristate(ui->use_vram_percentage,
-                                            Settings::values.use_vram_percentage,
-                                            use_vram_percentage);
+    ConfigurationShared::SetColoredTristate(
+        ui->use_vram_percentage, Settings::values.use_vram_percentage, use_vram_percentage);
 
     connect(ui->use_vram_percentage, &QCheckBox::clicked, ui->vram_percentage, [this]() {
         ui->vram_percentage->setEnabled(ui->use_vram_percentage->isChecked() &&

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -42,6 +42,9 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
         Settings::values.use_vulkan_driver_pipeline_cache.GetValue());
     ui->enable_compute_pipelines_checkbox->setChecked(
         Settings::values.enable_compute_pipelines.GetValue());
+    ui->use_vram_percentage->setChecked(Settings::values.use_vram_percentage.GetValue());
+    ui->vram_percentage->setVisible(Settings::values.use_vram_percentage.GetValue());
+
 
     if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setCurrentIndex(
@@ -91,6 +94,12 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.enable_compute_pipelines,
                                              ui->enable_compute_pipelines_checkbox,
                                              enable_compute_pipelines);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vram_percentage,
+                                             ui->use_vram_percentage,
+                                             use_vram_percentage);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.vram_percentage,
+                                             ui->vram_percentage,
+                                             vram_percentage);
 }
 
 void ConfigureGraphicsAdvanced::changeEvent(QEvent* event) {
@@ -158,6 +167,12 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->astc_recompression_combobox, ui->label_astc_recompression,
         static_cast<int>(Settings::values.astc_recompression.GetValue(true)));
+    ConfigurationShared::SetColoredTristate(ui->use_vram_percentage,
+                                            Settings::values.use_vram_percentage,
+                                            use_vram_percentage);
+    ConfigurationShared::SetColoredTristate(ui->vram_percentage,
+                                            Settings::values.vram_percentage,
+                                            vram_percentage);
 }
 
 void ConfigureGraphicsAdvanced::ExposeComputeOption() {

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -47,6 +47,7 @@ private:
     ConfigurationShared::CheckState use_fast_gpu_time;
     ConfigurationShared::CheckState use_vulkan_driver_pipeline_cache;
     ConfigurationShared::CheckState enable_compute_pipelines;
+    ConfigurationShared::CheckState use_vram_percentage;
 
     const Core::System& system;
 };

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -247,14 +247,19 @@ Compute pipelines are always enabled on all other drivers.</string>
              </item>
             </widget>
            </item>
-           <item>
-            <widget class="QCheckBox" name="use_vram_percentage">
-             <property name="toolTip">
-              <string>Assign the given percentage of the total shared RAM as VRAM</string>
-             </property>
-             <property name="text">
-              <string>Assign RAM percentage as VRAM (Integrated devices only)</string>
-             </property>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_vram">
+          <item>
+           <widget class="QCheckBox" name="use_vram_percentage">
+            <property name="toolTip">
+             <string>Assign the given % of the total shared RAM as VRAM</string>
+            </property>
+            <property name="text">
+             <string>Assign % of RAM as VRAM (Integrated devices only)</string>
+            </property>
             </widget>
            </item>
            <item>
@@ -265,7 +270,7 @@ Compute pipelines are always enabled on all other drivers.</string>
              <property name="minimum">
               <number>10</number>
              </property>
-              <property name="maximum">
+             <property name="maximum">
               <number>90</number>
              </property>
              <property name="value">
@@ -274,13 +279,12 @@ Compute pipelines are always enabled on all other drivers.</string>
             </widget>
            </item>
           </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </item>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </item>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -247,6 +247,32 @@ Compute pipelines are always enabled on all other drivers.</string>
              </item>
             </widget>
            </item>
+           <item>
+            <widget class="QCheckBox" name="use_vram_percentage">
+             <property name="toolTip">
+              <string>Assign the given percentage of the total shared RAM as VRAM</string>
+             </property>
+             <property name="text">
+              <string>Assign RAM percentage as VRAM (Integrated devices only)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="vram_percentage">
+             <property name="suffix">
+              <string>%</string>
+             </property>
+             <property name="minimum">
+              <number>10</number>
+             </property>
+              <property name="maximum">
+              <number>90</number>
+             </property>
+             <property name="value">
+              <number>25</number>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>


### PR DESCRIPTION
This shall allow to specify a certain percentage of RAM to use as VRAM on integrated / shared devices.
Ideally this can help tuning the garbage collector to prevent out of memory crashes.
On the other hand a too aggressive memory limitation may indeed affect rendering negatively
I did experience this on the steam deck for example. Graphical glitches may be caused in low memory
situations.
Note: there is still no proper detection yet for being actually on an integrated device. It is just a rough idea on maybe how to possibly tune the garbage collection a bit. This should affect both OpenGL and Vulkan renderers.
The default values at the moment are VRAM percentage setting is enabled and is set to 25% of the total RAM. Note on steam deck the total RAM is reported as 11.5 GB with UMA Buffer size at 4 GB, and 14.5 GB with UMA Buffer size at 1 GB.
Using for example 40% for VRAM seemed for now(!) to fix even the recall animation issue, but this all needs further testing.
Once good hardcoded defaults are found, this may be obsolete again.