### PR TITLE
service: nfc: Add backup support

### DIFF
--- a/src/common/fs/fs_paths.h
+++ b/src/common/fs/fs_paths.h
@@ -10,6 +10,7 @@
 
 // Sub-directories contained within a yuzu data directory
 
+#define AMIIBO_DIR "amiibo"
 #define CACHE_DIR "cache"
 #define CONFIG_DIR "config"
 #define DUMP_DIR "dump"

--- a/src/common/fs/path_util.cpp
+++ b/src/common/fs/path_util.cpp
@@ -114,6 +114,7 @@ public:
 #endif
 
         GenerateYuzuPath(YuzuPath::YuzuDir, yuzu_path);
+        GenerateYuzuPath(YuzuPath::AmiiboDir, yuzu_path / AMIIBO_DIR);
         GenerateYuzuPath(YuzuPath::CacheDir, yuzu_path_cache);
         GenerateYuzuPath(YuzuPath::ConfigDir, yuzu_path_config);
         GenerateYuzuPath(YuzuPath::DumpDir, yuzu_path / DUMP_DIR);

--- a/src/common/fs/path_util.h
+++ b/src/common/fs/path_util.h
@@ -12,6 +12,7 @@ namespace Common::FS {
 
 enum class YuzuPath {
     YuzuDir,        // Where yuzu stores its data.
+    AmiiboDir,      // Where Amiibo backups are stored.
     CacheDir,       // Where cached filesystem data is stored.
     ConfigDir,      // Where config files are stored.
     DumpDir,        // Where dumped data is stored.

--- a/src/core/hle/service/nfc/common/device.h
+++ b/src/core/hle/service/nfc/common/device.h
@@ -86,8 +86,9 @@ public:
     Result GetAll(NFP::NfpData& data) const;
     Result SetAll(const NFP::NfpData& data);
     Result BreakTag(NFP::BreakType break_type);
-    Result ReadBackupData(std::span<u8> data) const;
-    Result WriteBackupData(std::span<const u8> data);
+    Result HasBackup(const NFC::UniqueSerialNumber& uid) const;
+    Result ReadBackupData(const NFC::UniqueSerialNumber& uid, std::span<u8> data) const;
+    Result WriteBackupData(const NFC::UniqueSerialNumber& uid, std::span<const u8> data);
     Result WriteNtf(std::span<const u8> data);
 
     u64 GetHandle() const;
@@ -103,14 +104,15 @@ private:
     void CloseNfcTag();
 
     NFP::AmiiboName GetAmiiboName(const NFP::AmiiboSettings& settings) const;
-    void SetAmiiboName(NFP::AmiiboSettings& settings, const NFP::AmiiboName& amiibo_name);
+    void SetAmiiboName(NFP::AmiiboSettings& settings, const NFP::AmiiboName& amiibo_name) const;
     NFP::AmiiboDate GetAmiiboDate(s64 posix_time) const;
     u64 GetCurrentPosixTime() const;
     u64 RemoveVersionByte(u64 application_id) const;
     void UpdateSettingsCrc();
     void UpdateRegisterInfoCrc();
 
-    void BuildAmiiboWithoutKeys();
+    void BuildAmiiboWithoutKeys(NFP::NTAG215File& stubbed_tag_data,
+                                const NFP::EncryptedNTAG215File& encrypted_file) const;
 
     bool is_controller_set{};
     int callback_key;

--- a/src/core/hle/service/nfc/common/device_manager.cpp
+++ b/src/core/hle/service/nfc/common/device_manager.cpp
@@ -543,9 +543,14 @@ Result DeviceManager::ReadBackupData(u64 device_handle, std::span<u8> data) cons
 
     std::shared_ptr<NfcDevice> device = nullptr;
     auto result = GetDeviceHandle(device_handle, device);
+    NFC::TagInfo tag_info{};
 
     if (result.IsSuccess()) {
-        result = device->ReadBackupData(data);
+        result = device->GetTagInfo(tag_info, false);
+    }
+
+    if (result.IsSuccess()) {
+        result = device->ReadBackupData(tag_info.uuid, data);
         result = VerifyDeviceResult(device, result);
     }
 
@@ -557,9 +562,14 @@ Result DeviceManager::WriteBackupData(u64 device_handle, std::span<const u8> dat
 
     std::shared_ptr<NfcDevice> device = nullptr;
     auto result = GetDeviceHandle(device_handle, device);
+    NFC::TagInfo tag_info{};
 
     if (result.IsSuccess()) {
-        result = device->WriteBackupData(data);
+        result = device->GetTagInfo(tag_info, false);
+    }
+
+    if (result.IsSuccess()) {
+        result = device->WriteBackupData(tag_info.uuid, data);
         result = VerifyDeviceResult(device, result);
     }
 

--- a/src/core/hle/service/nfc/nfc_interface.cpp
+++ b/src/core/hle/service/nfc/nfc_interface.cpp
@@ -302,7 +302,7 @@ Result NfcInterface::TranslateResultToServiceError(Result result) const {
         return TranslateResultToNfp(result);
     }
     default:
-        if (result != ResultUnknown216) {
+        if (result != ResultBackupPathAlreadyExist) {
             return result;
         }
         return ResultUnknown74;
@@ -343,6 +343,9 @@ Result NfcInterface::TranslateResultToNfp(Result result) const {
     if (result == ResultApplicationAreaIsNotInitialized) {
         return NFP::ResultApplicationAreaIsNotInitialized;
     }
+    if (result == ResultCorruptedDataWithBackup) {
+        return NFP::ResultCorruptedDataWithBackup;
+    }
     if (result == ResultCorruptedData) {
         return NFP::ResultCorruptedData;
     }
@@ -354,6 +357,9 @@ Result NfcInterface::TranslateResultToNfp(Result result) const {
     }
     if (result == ResultNotAnAmiibo) {
         return NFP::ResultNotAnAmiibo;
+    }
+    if (result == ResultUnableToAccessBackupFile) {
+        return NFP::ResultUnableToAccessBackupFile;
     }
     LOG_WARNING(Service_NFC, "Result conversion not handled");
     return result;

--- a/src/core/hle/service/nfc/nfc_result.h
+++ b/src/core/hle/service/nfc/nfc_result.h
@@ -9,20 +9,22 @@ namespace Service::NFC {
 
 constexpr Result ResultDeviceNotFound(ErrorModule::NFC, 64);
 constexpr Result ResultInvalidArgument(ErrorModule::NFC, 65);
-constexpr Result ResultWrongApplicationAreaSize(ErrorModule::NFP, 68);
+constexpr Result ResultWrongApplicationAreaSize(ErrorModule::NFC, 68);
 constexpr Result ResultWrongDeviceState(ErrorModule::NFC, 73);
 constexpr Result ResultUnknown74(ErrorModule::NFC, 74);
 constexpr Result ResultUnknown76(ErrorModule::NFC, 76);
 constexpr Result ResultNfcNotInitialized(ErrorModule::NFC, 77);
 constexpr Result ResultNfcDisabled(ErrorModule::NFC, 80);
-constexpr Result ResultWriteAmiiboFailed(ErrorModule::NFP, 88);
+constexpr Result ResultWriteAmiiboFailed(ErrorModule::NFC, 88);
 constexpr Result ResultTagRemoved(ErrorModule::NFC, 97);
-constexpr Result ResultRegistrationIsNotInitialized(ErrorModule::NFP, 120);
-constexpr Result ResultApplicationAreaIsNotInitialized(ErrorModule::NFP, 128);
-constexpr Result ResultCorruptedData(ErrorModule::NFP, 144);
-constexpr Result ResultWrongApplicationAreaId(ErrorModule::NFP, 152);
-constexpr Result ResultApplicationAreaExist(ErrorModule::NFP, 168);
-constexpr Result ResultNotAnAmiibo(ErrorModule::NFP, 178);
-constexpr Result ResultUnknown216(ErrorModule::NFC, 216);
+constexpr Result ResultUnableToAccessBackupFile(ErrorModule::NFC, 113);
+constexpr Result ResultRegistrationIsNotInitialized(ErrorModule::NFC, 120);
+constexpr Result ResultApplicationAreaIsNotInitialized(ErrorModule::NFC, 128);
+constexpr Result ResultCorruptedDataWithBackup(ErrorModule::NFC, 136);
+constexpr Result ResultCorruptedData(ErrorModule::NFC, 144);
+constexpr Result ResultWrongApplicationAreaId(ErrorModule::NFC, 152);
+constexpr Result ResultApplicationAreaExist(ErrorModule::NFC, 168);
+constexpr Result ResultNotAnAmiibo(ErrorModule::NFC, 178);
+constexpr Result ResultBackupPathAlreadyExist(ErrorModule::NFC, 216);
 
 } // namespace Service::NFC

--- a/src/core/hle/service/nfp/nfp_interface.cpp
+++ b/src/core/hle/service/nfp/nfp_interface.cpp
@@ -126,7 +126,7 @@ void Interface::Flush(HLERequestContext& ctx) {
 void Interface::Restore(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
-    LOG_WARNING(Service_NFP, "(STUBBED) called, device_handle={}", device_handle);
+    LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
 
     auto result = GetManager()->Restore(device_handle);
     result = TranslateResultToServiceError(result);
@@ -394,7 +394,7 @@ void Interface::BreakTag(HLERequestContext& ctx) {
 void Interface::ReadBackupData(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
-    LOG_WARNING(Service_NFP, "(STUBBED) called, device_handle={}", device_handle);
+    LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
 
     std::vector<u8> backup_data{};
     auto result = GetManager()->ReadBackupData(device_handle, backup_data);
@@ -412,7 +412,7 @@ void Interface::WriteBackupData(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
     const auto backup_data_buffer{ctx.ReadBuffer()};
-    LOG_WARNING(Service_NFP, "(STUBBED) called, device_handle={}", device_handle);
+    LOG_INFO(Service_NFP, "called, device_handle={}", device_handle);
 
     auto result = GetManager()->WriteBackupData(device_handle, backup_data_buffer);
     result = TranslateResultToServiceError(result);

--- a/src/core/hle/service/nfp/nfp_result.h
+++ b/src/core/hle/service/nfp/nfp_result.h
@@ -17,9 +17,11 @@ constexpr Result ResultWriteAmiiboFailed(ErrorModule::NFP, 88);
 constexpr Result ResultTagRemoved(ErrorModule::NFP, 97);
 constexpr Result ResultRegistrationIsNotInitialized(ErrorModule::NFP, 120);
 constexpr Result ResultApplicationAreaIsNotInitialized(ErrorModule::NFP, 128);
+constexpr Result ResultCorruptedDataWithBackup(ErrorModule::NFP, 136);
 constexpr Result ResultCorruptedData(ErrorModule::NFP, 144);
 constexpr Result ResultWrongApplicationAreaId(ErrorModule::NFP, 152);
 constexpr Result ResultApplicationAreaExist(ErrorModule::NFP, 168);
 constexpr Result ResultNotAnAmiibo(ErrorModule::NFP, 178);
+constexpr Result ResultUnableToAccessBackupFile(ErrorModule::NFP, 200);
 
 } // namespace Service::NFP


### PR DESCRIPTION
Since writing to amiibos with Joy-Con is now supported, all we need is backup support for amiibo data, just like on the Switch. This pull request will create a backup every time a valid amiibo is loaded or saved. The game will be able to detect the backup and restore it accordingly, fixing any corrupted amiibo tags.

As amiibo data is stored, you can use Yuzu to dump your amiibo bin from a Joy-Con or Pro Controller. You can find all the amiibo files in `%appdata%/amiibo/backup`.