### PR TITLE
android: Fix ci builds with Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
       - name: Set up cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
The configuration requires 17, but the default in Actions is an older version