### PR TITLE
android: Improve Gradle build configuration

### DIFF
--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -9,8 +9,9 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms512m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+kotlin.parallel.tasks.in.project=true
 android.defaults.buildfeatures.buildconfig=true


### PR DESCRIPTION
org.gradle.jvmargs=
-Xms512m  <- Set the IDE to start with 512m allocated. 
-XX:MaxMetaspaceSize=512m <- Convert the MaxPermSize to new option 
-XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 (previous options)

android.useAndroidX=true

kotlin.code.style=official

kotlin.parallel.tasks.in.project=true <- parallel compilation tasks in the same project

android.defaults.buildfeatures.buildconfig=true