### PR TITLE
CMakeLists: Force C++20 on MSVC due to conflicts with C++23 modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ endif()
 # boost asio's concept usage doesn't play nicely with some compilers yet.
 add_definitions(-DBOOST_ASIO_DISABLE_CONCEPTS)
 if (MSVC)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++latest>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++20>)
 
     # boost still makes use of deprecated result_of.
     add_definitions(-D_HAS_DEPRECATED_RESULT_OF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ if (MSVC)
         /Zo
         /permissive-
         /EHsc
-        /std:c++latest
+        /std:c++20
         /utf-8
         /volatile:iso
         /Zc:externConstexpr
@@ -51,8 +51,10 @@ if (MSVC)
         /Zc:throwingNew
         /GT
 
+        # Modules
+        /experimental:module- # Disable module support explicitly due to conflicts with precompiled headers
+
         # External headers diagnostics
-        /experimental:external  # Enables the external headers options. This option isn't required in Visual Studio 2019 version 16.10 and later
         /external:anglebrackets # Treats all headers included by #include <header>, where the header file is enclosed in angle brackets (< >), as external headers
         /external:W0            # Sets the default warning level to 0 for external headers, effectively turning off warnings for external headers
 


### PR DESCRIPTION
The latest version of MSVC STL brings C++23 standard library modules, which conflict with precompiled headers. Disabling with /experimental:module- has no effect, so force C++20 in the meantime while we wait for module support in other compilers.