### PR TITLE
Combine vertex/transform feedback buffer binding into a single call

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache_base.h
+++ b/src/video_core/buffer_cache/buffer_cache_base.h
@@ -105,6 +105,15 @@ static constexpr Binding NULL_BINDING{
     .buffer_id = NULL_BUFFER_ID,
 };
 
+struct HostBindings {
+    boost::container::small_vector<void*, NUM_VERTEX_BUFFERS> buffers;
+    boost::container::small_vector<u64, NUM_VERTEX_BUFFERS> offsets;
+    boost::container::small_vector<u64, NUM_VERTEX_BUFFERS> sizes;
+    boost::container::small_vector<u64, NUM_VERTEX_BUFFERS> strides;
+    u32 min_index{NUM_VERTEX_BUFFERS};
+    u32 max_index{0};
+};
+
 class BufferCacheChannelInfo : public ChannelInfo {
 public:
     BufferCacheChannelInfo() = delete;
@@ -518,8 +527,6 @@ private:
     void DownloadBufferMemory(Buffer& buffer_id, VAddr cpu_addr, u64 size);
 
     void DeleteBuffer(BufferId buffer_id, bool do_not_mark = false);
-
-    void NotifyBufferDeletion();
 
     [[nodiscard]] Binding StorageBufferBinding(GPUVAddr ssbo_addr, u32 cbuf_index,
                                                bool is_written) const;

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -232,6 +232,15 @@ void BufferCacheRuntime::BindVertexBuffer(u32 index, Buffer& buffer, u32 offset,
     }
 }
 
+void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings& bindings) {
+    for (u32 index = 0; index < bindings.buffers.size(); index++) {
+        BindVertexBuffer(
+            bindings.min_index + index, *reinterpret_cast<Buffer*>(bindings.buffers[index]),
+            static_cast<u32>(bindings.offsets[index]), static_cast<u32>(bindings.sizes[index]),
+            static_cast<u32>(bindings.strides[index]));
+    }
+}
+
 void BufferCacheRuntime::BindUniformBuffer(size_t stage, u32 binding_index, Buffer& buffer,
                                            u32 offset, u32 size) {
     if (use_assembly_shaders) {
@@ -318,6 +327,15 @@ void BufferCacheRuntime::BindTransformFeedbackBuffer(u32 index, Buffer& buffer, 
                                                      u32 size) {
     glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer.Handle(),
                       static_cast<GLintptr>(offset), static_cast<GLsizeiptr>(size));
+}
+
+void BufferCacheRuntime::BindTransformFeedbackBuffers(VideoCommon::HostBindings& bindings) {
+    for (u32 index = 0; index < bindings.buffers.size(); index++) {
+        glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, index,
+                          reinterpret_cast<Buffer*>(bindings.buffers[index])->Handle(),
+                          static_cast<GLintptr>(bindings.offsets[index]),
+                          static_cast<GLsizeiptr>(bindings.sizes[index]));
+    }
 }
 
 void BufferCacheRuntime::BindTextureBuffer(Buffer& buffer, u32 offset, u32 size,

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -7,7 +7,7 @@
 #include <span>
 
 #include "common/common_types.h"
-#include "video_core/buffer_cache/buffer_cache.h"
+#include "video_core/buffer_cache/buffer_cache_base.h"
 #include "video_core/buffer_cache/memory_tracker_base.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_device.h"
@@ -87,6 +87,7 @@ public:
     void BindIndexBuffer(Buffer& buffer, u32 offset, u32 size);
 
     void BindVertexBuffer(u32 index, Buffer& buffer, u32 offset, u32 size, u32 stride);
+    void BindVertexBuffers(VideoCommon::HostBindings& bindings);
 
     void BindUniformBuffer(size_t stage, u32 binding_index, Buffer& buffer, u32 offset, u32 size);
 
@@ -99,6 +100,7 @@ public:
                                   bool is_written);
 
     void BindTransformFeedbackBuffer(u32 index, Buffer& buffer, u32 offset, u32 size);
+    void BindTransformFeedbackBuffers(VideoCommon::HostBindings& bindings);
 
     void BindTextureBuffer(Buffer& buffer, u32 offset, u32 size,
                            VideoCore::Surface::PixelFormat format);

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -18,6 +18,7 @@ namespace Vulkan {
 class Device;
 class DescriptorPool;
 class Scheduler;
+struct HostVertexBinding;
 
 class BufferCacheRuntime;
 
@@ -96,8 +97,10 @@ public:
     void BindQuadIndexBuffer(PrimitiveTopology topology, u32 first, u32 count);
 
     void BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset, u32 size, u32 stride);
+    void BindVertexBuffers(VideoCommon::HostBindings& bindings);
 
     void BindTransformFeedbackBuffer(u32 index, VkBuffer buffer, u32 offset, u32 size);
+    void BindTransformFeedbackBuffers(VideoCommon::HostBindings& bindings);
 
     std::span<u8> BindMappedUniformBuffer([[maybe_unused]] size_t stage,
                                           [[maybe_unused]] u32 binding_index, u32 size) {


### PR DESCRIPTION
Currently we bind every vertex and transform feedback buffer individually, which can lead to over a thousand extra API calls per frame. This PR combines them into a temp data structure and binds them at once instead. On buffer deletion, index and vertex buffers are also made conditional and specific, rather than invalidating the index and all vertex buffers every time any buffer is deleted.