### PR TITLE
vk_blit_screen: use higher bit depth for fxaa

### DIFF
--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -1159,7 +1159,7 @@ void BlitScreen::CreateRawImages(const Tegra::FramebufferConfig& framebuffer) {
             .pNext = nullptr,
             .flags = 0,
             .imageType = VK_IMAGE_TYPE_2D,
-            .format = GetFormat(framebuffer),
+            .format = used_on_framebuffer ? VK_FORMAT_R16G16B16A16_SFLOAT : GetFormat(framebuffer),
             .extent =
                 {
                     .width = (up_scale * framebuffer.width) >> down_shift,
@@ -1180,14 +1180,14 @@ void BlitScreen::CreateRawImages(const Tegra::FramebufferConfig& framebuffer) {
     const auto create_commit = [&](vk::Image& image) {
         return memory_allocator.Commit(image, MemoryUsage::DeviceLocal);
     };
-    const auto create_image_view = [&](vk::Image& image) {
+    const auto create_image_view = [&](vk::Image& image, bool used_on_framebuffer = false) {
         return device.GetLogical().CreateImageView(VkImageViewCreateInfo{
             .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
             .pNext = nullptr,
             .flags = 0,
             .image = *image,
             .viewType = VK_IMAGE_VIEW_TYPE_2D,
-            .format = GetFormat(framebuffer),
+            .format = used_on_framebuffer ? VK_FORMAT_R16G16B16A16_SFLOAT : GetFormat(framebuffer),
             .components =
                 {
                     .r = VK_COMPONENT_SWIZZLE_IDENTITY,
@@ -1217,7 +1217,7 @@ void BlitScreen::CreateRawImages(const Tegra::FramebufferConfig& framebuffer) {
     const u32 down_shift = Settings::values.resolution_info.down_shift;
     aa_image = create_image(true, up_scale, down_shift);
     aa_commit = create_commit(aa_image);
-    aa_image_view = create_image_view(aa_image);
+    aa_image_view = create_image_view(aa_image, true);
     VkExtent2D size{
         .width = (up_scale * framebuffer.width) >> down_shift,
         .height = (up_scale * framebuffer.height) >> down_shift,


### PR DESCRIPTION
Fixes annoying color banding when using FXAA
|Before|After|
|-|-|
|![01007ef00011e000_2023-06-08_11-32-27-066](https://github.com/yuzu-emu/yuzu/assets/9658600/1944db0c-15cc-45ad-a595-811044b3e3cb)|![01007ef00011e000_2023-06-08_11-29-47-002](https://github.com/yuzu-emu/yuzu/assets/9658600/e67da3c7-5134-4c3e-9bf4-42f7d5d5fb84)|