### PR TITLE
Fix a potentially uninitialized local variable warning causing a build error

### DIFF
--- a/src/common/uuid.cpp
+++ b/src/common/uuid.cpp
@@ -48,7 +48,7 @@ std::array<u8, 0x10> ConstructFromRawString(std::string_view raw_string) {
 }
 
 std::array<u8, 0x10> ConstructFromFormattedString(std::string_view formatted_string) {
-    std::array<u8, 0x10> uuid;
+    std::array<u8, 0x10> uuid{};
 
     size_t i = 0;
 


### PR DESCRIPTION
Fixes a warning causing a code generation error when building with profile-guided optimizations.
I was experimenting with building a faster yuzu tuned for my specific setup and decided to use Microsoft toolchain's [Profile-guided optimizations](https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/profile-guided-optimizations.md). While doing so I found out that `warning C4701: potentially uninitialized local variable 'uuid' used` at `yuzu\src\common\uuid.cpp(115)` caused code generation error. That error occured while building an instrumented yuzu version. Without profile-guided optimizations no errors occur.

Software and hardware context:
- Microsoft Visual Studio 2022 Community (64-bit) Version 17.6.2
- Microsoft C/C++ Optimizing Compiler Version 19.36.32532 for x64
- Windows SDK version: 10.0.22000.0
- CPU: Ryzen 5 2600 which supports AVX2

Steps that led me to the error:
1. Checkout commit `9c6fc44a5904bfb158a08407958954ac101a6aaf`.
2. Add the following MSVC compile options to `yuzu/src/CMakeLists.txt` file in a corresponding code section after `/GT` and before `/experimental:module-` flags
```cmake
        /Oi
        /GL
        /fp:fast
        /arch:AVX2
```
3. Inside `yuzu/build` folder run command `cmake .. -G "Visual Studio 17 2022" -A x64 -DYUZU_TESTS=OFF -DYUZU_ENABLE_LTO=ON`.
4. Open solution `yuzu/build/yuzu.sln` in Visual Studio 17 2022.
5. Change solution configuration to `Release`.
6. Go to `Properties` of `yuzu` project inside Visual Studio.
7. Go to `Linker`, and then `Command Line` tab.
8. Add options `/LTCG` and `/FASTGENPROFILE` to `Additional Options` section.
9. Run `Build` on `yuzu` project.

Last few lines of a build output:
```
11>   Creating library C:/coding/yuzu/build/src/yuzu/Release/yuzu.lib and object C:/coding/yuzu/build/src/yuzu/Release/yuzu.exp
11>Generating code
11>C:\coding\yuzu\src\common\uuid.cpp(115): error C2220: the following warning is treated as an error
11>C:\coding\yuzu\src\common\uuid.cpp(115): warning C4701: potentially uninitialized local variable 'uuid' used
11>LINK : fatal error LNK1257: code generation failed
11>Done building project "yuzu.vcxproj" -- FAILED.
========== Build: 10 succeeded, 1 failed, 16 up-to-date, 0 skipped ==========
========== Build started at 4:08 AM and took 03:19,780 minutes ==========
```

After fixing the warning it starts to compile
```
3>Done building project "yuzu.vcxproj".
========== Build: 3 succeeded, 0 failed, 24 up-to-date, 0 skipped ==========
========== Build started at 4:15 AM and took 01:10,523 minutes ==========
```