### PR TITLE
Only use SDL wakelock on Linux

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -483,6 +483,10 @@ void SDLDriver::CloseJoysticks() {
 }
 
 SDLDriver::SDLDriver(std::string input_engine_) : InputEngine(std::move(input_engine_)) {
+    // Set our application name. Currently passed to DBus by SDL and visible to the user through
+    // their desktop environment.
+    SDL_SetHint(SDL_HINT_APP_NAME, "yuzu");
+
     if (!Settings::values.enable_raw_input) {
         // Disable raw input. When enabled this setting causes SDL to die when a web applet opens
         SDL_SetHint(SDL_HINT_JOYSTICK_RAWINPUT, "0");

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -504,8 +504,6 @@ private:
 #ifdef __unix__
     QSocketNotifier* sig_interrupt_notifier;
     static std::array<int, 3> sig_interrupt_fds;
-
-    QDBusObjectPath wake_lock{};
 #endif
 
 protected:


### PR DESCRIPTION
Closes #10674.

SDL has internally fixed shenanigans related to wakelocking through DBus from inside sandboxes from around August 2022, so we can now remove the workaround we used since 2021.