### PR TITLE
android: Add proper homebrew check

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
@@ -223,6 +223,8 @@ object NativeLibrary {
 
     external fun getCompany(filename: String): String
 
+    external fun isHomebrew(filename: String): Boolean
+
     external fun setAppDirectory(directory: String)
 
     external fun initializeGpuDriver(

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/SearchFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/SearchFragment.kt
@@ -127,13 +127,7 @@ class SearchFragment : Fragment() {
                 }
             }
 
-            R.id.chip_homebrew -> {
-                baseList.filter {
-                    Log.error("Guh - ${it.path}")
-                    FileUtil.hasExtension(it.path, "nro")
-                            || FileUtil.hasExtension(it.path, "nso")
-                }
-            }
+            R.id.chip_homebrew -> baseList.filter { it.isHomebrew }
 
             R.id.chip_retail -> baseList.filter {
                 FileUtil.hasExtension(it.path, "xci")

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/Game.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/Game.kt
@@ -16,7 +16,8 @@ class Game(
     val regions: String,
     val path: String,
     val gameId: String,
-    val company: String
+    val company: String,
+    val isHomebrew: Boolean
 ) : Parcelable {
     val keyAddedToLibraryTime get() = "${gameId}_AddedToLibraryTime"
     val keyLastPlayedTime get() = "${gameId}_LastPlayed"
@@ -31,6 +32,7 @@ class Game(
                 && path == other.path
                 && gameId == other.gameId
                 && company == other.company
+                && isHomebrew == other.isHomebrew
     }
 
     companion object {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/GamesViewModel.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/GamesViewModel.kt
@@ -13,6 +13,8 @@ import androidx.preference.PreferenceManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.yuzu.yuzu_emu.NativeLibrary
@@ -20,6 +22,7 @@ import org.yuzu.yuzu_emu.YuzuApplication
 import org.yuzu.yuzu_emu.utils.GameHelper
 import java.util.Locale
 
+@OptIn(ExperimentalSerializationApi::class)
 class GamesViewModel : ViewModel() {
     private val _games = MutableLiveData<List<Game>>(emptyList())
     val games: LiveData<List<Game>> get() = _games
@@ -49,7 +52,13 @@ class GamesViewModel : ViewModel() {
         if (storedGames!!.isNotEmpty()) {
             val deserializedGames = mutableSetOf<Game>()
             storedGames.forEach {
-                val game: Game = Json.decodeFromString(it)
+                val game: Game
+                try {
+                    game = Json.decodeFromString(it)
+                } catch (e: MissingFieldException) {
+                    return@forEach
+                }
+
                 val gameExists =
                     DocumentFile.fromSingleUri(YuzuApplication.appContext, Uri.parse(game.path))
                         ?.exists()

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameHelper.kt
@@ -6,7 +6,6 @@ package org.yuzu.yuzu_emu.utils
 import android.content.SharedPreferences
 import android.net.Uri
 import androidx.preference.PreferenceManager
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.yuzu.yuzu_emu.NativeLibrary
@@ -83,7 +82,8 @@ object GameHelper {
             NativeLibrary.getRegions(filePath),
             filePath,
             gameId,
-            NativeLibrary.getCompany(filePath)
+            NativeLibrary.getCompany(filePath),
+            NativeLibrary.isHomebrew(filePath)
         )
 
         val addedTime = preferences.getLong(newGame.keyAddedToLibraryTime, 0L)

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -33,7 +33,8 @@ static_assert(sizeof(NroSegmentHeader) == 0x8, "NroSegmentHeader has incorrect s
 struct NroHeader {
     INSERT_PADDING_BYTES(0x4);
     u32_le module_header_offset;
-    INSERT_PADDING_BYTES(0x8);
+    u32 magic_ext1;
+    u32 magic_ext2;
     u32_le magic;
     INSERT_PADDING_BYTES(0x4);
     u32_le file_size;
@@ -122,6 +123,16 @@ FileType AppLoader_NRO::IdentifyType(const FileSys::VirtualFile& nro_file) {
         return FileType::NRO;
     }
     return FileType::Error;
+}
+
+bool AppLoader_NRO::IsHomebrew() {
+    // Read NSO header
+    NroHeader nro_header{};
+    if (sizeof(NroHeader) != file->ReadObject(&nro_header)) {
+        return false;
+    }
+    return nro_header.magic_ext1 == Common::MakeMagic('H', 'O', 'M', 'E') &&
+           nro_header.magic_ext2 == Common::MakeMagic('B', 'R', 'E', 'W');
 }
 
 static constexpr u32 PageAlignSize(u32 size) {

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -38,6 +38,8 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& nro_file);
 
+    bool IsHomebrew();
+
     FileType GetFileType() const override {
         return IdentifyType(file);
     }


### PR DESCRIPTION
Instead of just using the .nro extension to guess whether a game is homebrew or not, check for "HOMEBREW" in the header of the file.