### PR TITLE
Improve path splitting speed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ find_package(LLVM MODULE COMPONENTS Demangle)
 find_package(lz4 REQUIRED)
 find_package(nlohmann_json 3.8 REQUIRED)
 find_package(Opus 1.3 MODULE)
+find_package(range-v3 REQUIRED)
 find_package(ZLIB 1.2 REQUIRED)
 find_package(zstd 1.5 REQUIRED)
 

--- a/src/common/fs/path_util.cpp
+++ b/src/common/fs/path_util.cpp
@@ -350,17 +350,11 @@ std::string_view RemoveTrailingSlash(std::string_view path) {
 }
 
 std::vector<std::string> SplitPathComponents(std::string_view filename) {
-    std::string copy(filename);
-    std::replace(copy.begin(), copy.end(), '\\', '/');
-    std::vector<std::string> out;
-
-    std::stringstream stream(copy);
-    std::string item;
-    while (std::getline(stream, item, '/')) {
-        out.push_back(std::move(item));
+    std::vector<std::string> copied_components;
+    for (std::string_view component : filename | split_path_components_view) {
+        copied_components.emplace_back(component);
     }
-
-    return out;
+    return copied_components;
 }
 
 std::string SanitizePath(std::string_view path_, DirectorySeparator directory_separator) {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -837,7 +837,7 @@ endif()
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core network video_core)
-target_link_libraries(core PUBLIC Boost::headers PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls Opus::opus)
+target_link_libraries(core PUBLIC Boost::headers PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls Opus::opus range-v3)
 if (MINGW)
     target_link_libraries(core PRIVATE ${MSWSOCK_LIBRARY})
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,6 +24,7 @@
         "fmt",
         "lz4",
         "nlohmann-json",
+        "range-v3",
         "zlib",
         "zstd"
     ],


### PR DESCRIPTION
Creates a range closure so the components can be iterated without allocating a container.
Use the range closure to speed up `VfsDirectory::GetFileRelative`

Unfortunately the C++ standard has no direct equivalent to range-v3's `split_when_view`. If pulling range-v3 in is not okay, then building a vector of string_views like this is still relatively cheap:
```cpp
std::vector<std::string_view> SplitPathComponentsView(std::string_view filename) {
    std::vector<std::string_view> components;
    const char* component_begin = filename.data();
    const char* const end = component_begin + filename.size();
    for (const char* it = component_begin; it != end; ++it) {
        const char c = *it;
        if (c == '\\' || c == '/') [[unlikely]] {
            if (component_begin != it) {
                components.emplace_back(std::string_view{component_begin, it});
            }
            component_begin = it + 1;
        }
    }
    if (component_begin != end) {
        components.emplace_back(std::string_view{component_begin, end});
    }
    return components;
}
```
I benchmarked this by looping `CreateRomFS` for ToTK with several mods. Both the range adaptor and vector of string_view approaches doubled the speed. The range adapter is about 8% faster than making a vector of string_views.

Original
![Original](https://github.com/yuzu-emu/yuzu/assets/28246325/3d000611-79d1-4657-b5c6-240ffa4a7609)
Vector of string_view
![Vector of string_view](https://github.com/yuzu-emu/yuzu/assets/28246325/0a711d8f-75e6-4331-ba46-fc7530e383d3)
Range adaptor closure
![Range adaptor closure](https://github.com/yuzu-emu/yuzu/assets/28246325/d80ba68c-330c-443b-b1eb-4c9f0152f166)