### PR TITLE
Add a codespell exception for kotlin OptIn

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,4 @@
 
 [codespell]
 skip = ./.git,./build,./dist,./Doxyfile,./externals,./LICENSES
-ignore-words-list = aci,allright,ba,deques,froms,hda,inout,lod,masia,nam,nax,nd,pullrequests,pullrequest,te,transfered,unstall,uscaled,zink
+ignore-words-list = aci,allright,ba,deques,froms,hda,inout,lod,masia,nam,nax,nd,optin,pullrequests,pullrequest,te,transfered,unstall,uscaled,zink


### PR DESCRIPTION
https://github.com/yuzu-emu/yuzu/pull/10691 broke your verification because codespell thinks OptIn is a typo for option. That's why it was marked as failed, despite being perfectly fine.