### PR TITLE
android: Use ContentResolver to get file extension

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
@@ -284,10 +284,10 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
             if (result == null)
                 return@registerForActivityResult
 
-            if (!FileUtil.hasExtension(result.toString(), "keys")) {
+            if (!FileUtil.hasExtension(result, "keys")) {
                 MessageDialogFragment.newInstance(
                     R.string.reading_keys_failure,
-                    R.string.install_keys_failure_extension_description
+                    R.string.install_prod_keys_failure_extension_description
                 ).show(supportFragmentManager, MessageDialogFragment.TAG)
                 return@registerForActivityResult
             }
@@ -379,10 +379,10 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
             if (result == null)
                 return@registerForActivityResult
 
-            if (!FileUtil.hasExtension(result.toString(), "bin")) {
+            if (!FileUtil.hasExtension(result, "bin")) {
                 MessageDialogFragment.newInstance(
                     R.string.reading_keys_failure,
-                    R.string.install_keys_failure_extension_description
+                    R.string.install_amiibo_keys_failure_extension_description
                 ).show(supportFragmentManager, MessageDialogFragment.TAG)
                 return@registerForActivityResult
             }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/FileUtil.kt
@@ -7,7 +7,9 @@ import android.content.Context
 import android.database.Cursor
 import android.net.Uri
 import android.provider.DocumentsContract
+import android.provider.OpenableColumns
 import androidx.documentfile.provider.DocumentFile
+import org.yuzu.yuzu_emu.YuzuApplication
 import org.yuzu.yuzu_emu.model.MinimalDocumentFile
 import java.io.BufferedInputStream
 import java.io.File
@@ -324,7 +326,25 @@ object FileUtil {
         }
     }
 
-    fun hasExtension(path: String, extension: String): Boolean {
-        return path.substring(path.lastIndexOf(".") + 1).contains(extension)
+    fun hasExtension(path: String, extension: String): Boolean =
+        path.substring(path.lastIndexOf(".") + 1).contains(extension)
+
+    fun hasExtension(uri: Uri, extension: String): Boolean {
+        val fileName: String?
+        val cursor = YuzuApplication.appContext.contentResolver.query(uri, null, null, null, null)
+        val nameIndex = cursor?.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        cursor?.moveToFirst()
+
+        if (nameIndex == null) {
+            return false
+        }
+
+        fileName = cursor.getString(nameIndex)
+        cursor.close()
+
+        if (fileName == null) {
+            return false
+        }
+        return fileName.substring(fileName.lastIndexOf(".") + 1).contains(extension)
     }
 }

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -65,11 +65,8 @@
     <string name="invalid_keys_file">Invalid keys file selected</string>
     <string name="install_keys_success">Keys successfully installed</string>
     <string name="reading_keys_failure">Error reading encryption keys</string>
-    <string name="install_keys_failure_extension_description">
-        1. Verify your keys have the .keys extension.\n\n
-        2. Keys must not be stored in the Downloads folder.\n\n
-        Resolve the issue(s) and try again.
-    </string>
+    <string name="install_prod_keys_failure_extension_description">Verify your keys file has a .keys extension and try again.</string>
+    <string name="install_amiibo_keys_failure_extension_description">Verify your keys file has a .bin extension and try again.</string>
     <string name="invalid_keys_error">Invalid encryption keys</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">The selected file is incorrect or corrupt. Please redump your keys.</string>


### PR DESCRIPTION
Fixes an issue where we try to resolve file extension from URIs. Sometimes the URI will not contain the file name at all and instead a string of numbers. Here we query the content resolver and guarantee that we get a file name every time.