### PR TITLE
android: Use autoVersion when gradle property is set

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import android.annotation.SuppressLint
+import org.jetbrains.kotlin.konan.properties.Properties
 
 plugins {
     id("com.android.application")
@@ -57,8 +58,21 @@ android {
         applicationId = "org.yuzu.yuzu_emu"
         minSdk = 30
         targetSdk = 33
-        versionCode = 1
         versionName = getGitVersion()
+
+        // If you want to use autoVersion for the versionCode, create a property in local.properties
+        // named "autoVersioned" and set it to "true"
+        val properties = Properties()
+        val versionProperty = try {
+            properties.load(project.rootProject.file("local.properties").inputStream())
+            properties.getProperty("autoVersioned") ?: ""
+        } catch (e: Exception) { "" }
+
+        versionCode = if (versionProperty == "true") {
+            autoVersion
+        } else {
+            1
+        }
 
         ndk {
             @SuppressLint("ChromeOsAbiSupport")


### PR DESCRIPTION
Instead of fiddling with detecting gradle build types or environment variables, you can set an `autoVersioned` property to "true" in your `local.properties` file and get the appropriate `autoVersion` versionCode. Otherwise the versionCode will be 1 just like before.