### PR TITLE
service: nfc: Accuracy fixes

### DIFF
--- a/src/core/hle/service/nfc/common/amiibo_crypto.h
+++ b/src/core/hle/service/nfc/common/amiibo_crypto.h
@@ -24,10 +24,8 @@ using DrgbOutput = std::array<u8, 0x20>;
 struct HashSeed {
     u16_be magic;
     std::array<u8, 0xE> padding;
-    NFC::UniqueSerialNumber uid_1;
-    u8 nintendo_id_1;
-    NFC::UniqueSerialNumber uid_2;
-    u8 nintendo_id_2;
+    TagUuid uid_1;
+    TagUuid uid_2;
     std::array<u8, 0x20> keygen_salt;
 };
 static_assert(sizeof(HashSeed) == 0x40, "HashSeed is an invalid size");
@@ -68,9 +66,6 @@ NTAG215File NfcDataToEncodedData(const EncryptedNTAG215File& nfc_data);
 
 /// Converts from encoded file format to encrypted file format
 EncryptedNTAG215File EncodedDataToNfcData(const NTAG215File& encoded_data);
-
-/// Returns password needed to allow write access to protected memory
-u32 GetTagPassword(const TagUuid& uuid);
 
 // Generates Seed needed for key derivation
 HashSeed GetSeed(const NTAG215File& data);

--- a/src/core/hle/service/nfc/common/device.h
+++ b/src/core/hle/service/nfc/common/device.h
@@ -86,9 +86,14 @@ public:
     Result GetAll(NFP::NfpData& data) const;
     Result SetAll(const NFP::NfpData& data);
     Result BreakTag(NFP::BreakType break_type);
-    Result HasBackup(const NFC::UniqueSerialNumber& uid) const;
-    Result ReadBackupData(const NFC::UniqueSerialNumber& uid, std::span<u8> data) const;
-    Result WriteBackupData(const NFC::UniqueSerialNumber& uid, std::span<const u8> data);
+    Result HasBackup(const UniqueSerialNumber& uid, std::size_t uuid_size) const;
+    Result HasBackup(const NFP::TagUuid& tag_uid) const;
+    Result ReadBackupData(const UniqueSerialNumber& uid, std::size_t uuid_size,
+                          std::span<u8> data) const;
+    Result ReadBackupData(const NFP::TagUuid& tag_uid, std::span<u8> data) const;
+    Result WriteBackupData(const UniqueSerialNumber& uid, std::size_t uuid_size,
+                           std::span<const u8> data);
+    Result WriteBackupData(const NFP::TagUuid& tag_uid, std::span<const u8> data);
     Result WriteNtf(std::span<const u8> data);
 
     u64 GetHandle() const;

--- a/src/core/hle/service/nfc/common/device_manager.cpp
+++ b/src/core/hle/service/nfc/common/device_manager.cpp
@@ -550,7 +550,7 @@ Result DeviceManager::ReadBackupData(u64 device_handle, std::span<u8> data) cons
     }
 
     if (result.IsSuccess()) {
-        result = device->ReadBackupData(tag_info.uuid, data);
+        result = device->ReadBackupData(tag_info.uuid, tag_info.uuid_length, data);
         result = VerifyDeviceResult(device, result);
     }
 
@@ -569,7 +569,7 @@ Result DeviceManager::WriteBackupData(u64 device_handle, std::span<const u8> dat
     }
 
     if (result.IsSuccess()) {
-        result = device->WriteBackupData(tag_info.uuid, data);
+        result = device->WriteBackupData(tag_info.uuid, tag_info.uuid_length, data);
         result = VerifyDeviceResult(device, result);
     }
 

--- a/src/core/hle/service/nfc/mifare_result.h
+++ b/src/core/hle/service/nfc/mifare_result.h
@@ -12,6 +12,6 @@ constexpr Result ResultInvalidArgument(ErrorModule::NFCMifare, 65);
 constexpr Result ResultWrongDeviceState(ErrorModule::NFCMifare, 73);
 constexpr Result ResultNfcDisabled(ErrorModule::NFCMifare, 80);
 constexpr Result ResultTagRemoved(ErrorModule::NFCMifare, 97);
-constexpr Result ResultReadError(ErrorModule::NFCMifare, 288);
+constexpr Result ResultNotAMifare(ErrorModule::NFCMifare, 288);
 
 } // namespace Service::NFC::Mifare

--- a/src/core/hle/service/nfc/nfc_interface.cpp
+++ b/src/core/hle/service/nfc/nfc_interface.cpp
@@ -142,9 +142,13 @@ void NfcInterface::AttachAvailabilityChangeEvent(HLERequestContext& ctx) {
 void NfcInterface::StartDetection(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto device_handle{rp.Pop<u64>()};
-    const auto tag_protocol{rp.PopEnum<NfcProtocol>()};
-    LOG_INFO(Service_NFC, "called, device_handle={}, nfp_protocol={}", device_handle, tag_protocol);
+    auto tag_protocol{NfcProtocol::All};
 
+    if (backend_type == BackendType::Nfc) {
+        tag_protocol = rp.PopEnum<NfcProtocol>();
+    }
+
+    LOG_INFO(Service_NFC, "called, device_handle={}, nfp_protocol={}", device_handle, tag_protocol);
     auto result = GetManager()->StartDetection(device_handle, tag_protocol);
     result = TranslateResultToServiceError(result);
 

--- a/src/core/hle/service/nfc/nfc_interface.cpp
+++ b/src/core/hle/service/nfc/nfc_interface.cpp
@@ -355,7 +355,7 @@ Result NfcInterface::TranslateResultToNfp(Result result) const {
     if (result == ResultApplicationAreaExist) {
         return NFP::ResultApplicationAreaExist;
     }
-    if (result == ResultNotAnAmiibo) {
+    if (result == ResultInvalidTagType) {
         return NFP::ResultNotAnAmiibo;
     }
     if (result == ResultUnableToAccessBackupFile) {
@@ -380,6 +380,9 @@ Result NfcInterface::TranslateResultToMifare(Result result) const {
     }
     if (result == ResultTagRemoved) {
         return Mifare::ResultTagRemoved;
+    }
+    if (result == ResultInvalidTagType) {
+        return Mifare::ResultNotAMifare;
     }
     LOG_WARNING(Service_NFC, "Result conversion not handled");
     return result;

--- a/src/core/hle/service/nfc/nfc_result.h
+++ b/src/core/hle/service/nfc/nfc_result.h
@@ -24,7 +24,8 @@ constexpr Result ResultCorruptedDataWithBackup(ErrorModule::NFC, 136);
 constexpr Result ResultCorruptedData(ErrorModule::NFC, 144);
 constexpr Result ResultWrongApplicationAreaId(ErrorModule::NFC, 152);
 constexpr Result ResultApplicationAreaExist(ErrorModule::NFC, 168);
-constexpr Result ResultNotAnAmiibo(ErrorModule::NFC, 178);
+constexpr Result ResultInvalidTagType(ErrorModule::NFC, 178);
 constexpr Result ResultBackupPathAlreadyExist(ErrorModule::NFC, 216);
+constexpr Result ResultMifareError288(ErrorModule::NFC, 288);
 
 } // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc_types.h
+++ b/src/core/hle/service/nfc/nfc_types.h
@@ -35,21 +35,27 @@ enum class State : u32 {
 
 // This is nn::nfc::TagType
 enum class TagType : u32 {
-    None,
-    Type1, // ISO14443A RW 96-2k bytes 106kbit/s
-    Type2, // ISO14443A RW/RO 540 bytes 106kbit/s
-    Type3, // Sony FeliCa RW/RO 2k bytes 212kbit/s
-    Type4, // ISO14443A RW/RO 4k-32k bytes 424kbit/s
-    Type5, // ISO15693 RW/RO 540 bytes 106kbit/s
+    None = 0,
+    Type1 = 1U << 0,  // ISO14443A RW. Topaz
+    Type2 = 1U << 1,  // ISO14443A RW. Ultralight, NTAGX, ST25TN
+    Type3 = 1U << 2,  // ISO14443A RW/RO. Sony FeliCa
+    Type4A = 1U << 3, // ISO14443A RW/RO. DESFire
+    Type4B = 1U << 4, // ISO14443B RW/RO. DESFire
+    Type5 = 1U << 5,  // ISO15693 RW/RO. SLI, SLIX, ST25TV
+    Mifare = 1U << 6, // Mifare classic. Skylanders
+    All = 0xFFFFFFFF,
 };
 
 enum class PackedTagType : u8 {
-    None,
-    Type1, // ISO14443A RW 96-2k bytes 106kbit/s
-    Type2, // ISO14443A RW/RO 540 bytes 106kbit/s
-    Type3, // Sony FeliCa RW/RO 2k bytes 212kbit/s
-    Type4, // ISO14443A RW/RO 4k-32k bytes 424kbit/s
-    Type5, // ISO15693 RW/RO 540 bytes 106kbit/s
+    None = 0,
+    Type1 = 1U << 0,  // ISO14443A RW. Topaz
+    Type2 = 1U << 1,  // ISO14443A RW. Ultralight, NTAGX, ST25TN
+    Type3 = 1U << 2,  // ISO14443A RW/RO. Sony FeliCa
+    Type4A = 1U << 3, // ISO14443A RW/RO. DESFire
+    Type4B = 1U << 4, // ISO14443B RW/RO. DESFire
+    Type5 = 1U << 5,  // ISO15693 RW/RO. SLI, SLIX, ST25TV
+    Mifare = 1U << 6, // Mifare classic. Skylanders
+    All = 0xFF,
 };
 
 // This is nn::nfc::NfcProtocol
@@ -69,8 +75,7 @@ enum class TestWaveType : u32 {
     Unknown,
 };
 
-using UniqueSerialNumber = std::array<u8, 7>;
-using UniqueSerialNumberExtension = std::array<u8, 3>;
+using UniqueSerialNumber = std::array<u8, 10>;
 
 // This is nn::nfc::DeviceHandle
 using DeviceHandle = u64;
@@ -78,7 +83,6 @@ using DeviceHandle = u64;
 // This is nn::nfc::TagInfo
 struct TagInfo {
     UniqueSerialNumber uuid;
-    UniqueSerialNumberExtension uuid_extension;
     u8 uuid_length;
     INSERT_PADDING_BYTES(0x15);
     NfcProtocol protocol;

--- a/src/core/hle/service/nfc/nfc_types.h
+++ b/src/core/hle/service/nfc/nfc_types.h
@@ -59,14 +59,11 @@ enum class PackedTagType : u8 {
 };
 
 // This is nn::nfc::NfcProtocol
-// Verify this enum. It might be completely wrong default protocol is 0x48
 enum class NfcProtocol : u32 {
     None,
     TypeA = 1U << 0, // ISO14443A
     TypeB = 1U << 1, // ISO14443B
     TypeF = 1U << 2, // Sony FeliCa
-    Unknown1 = 1U << 3,
-    Unknown2 = 1U << 5,
     All = 0xFFFFFFFFU,
 };
 


### PR DESCRIPTION
Adds proper checks to ReadMifare and fixes GetTagInfo output to match switch. Might fix the skylander bug where each time the file was loaded it was detected as a different toy.