### PR TITLE
Re-enable SDL's `CPUinfo` subsystem

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -63,8 +63,9 @@ if (YUZU_USE_EXTERNAL_SDL2)
         # Yuzu itself needs: Atomic Audio Events Joystick Haptic Sensor Threads Timers
         # Since 2.0.18 Atomic+Threads required for HIDAPI/libusb (see https://github.com/libsdl-org/SDL/issues/5095)
         # Yuzu-cmd also needs: Video (depends on Loadso/Dlopen)
+        # CPUinfo also required for SDL Audio, at least until 2.28.0 (see https://github.com/libsdl-org/SDL/issues/7809)
         set(SDL_UNUSED_SUBSYSTEMS
-            CPUinfo File Filesystem
+            File Filesystem
             Locale Power Render)
         foreach(_SUB ${SDL_UNUSED_SUBSYSTEMS})
           string(TOUPPER ${_SUB} _OPT)


### PR DESCRIPTION
TLDR: Disabling `CPUinfo` triggers a very nasty SDL audio subsystem bug, which **utterly** breaks SDL's JACK output on Linux, so no audio when one wanted to do `SDL_AUDIODRIVER=jack bin/yuzu`. This is a workaround for that.

Below is the offending SDL code in question, if anyone is curious. Without `CPUinfo`, it thinks there is no SIMD support (so it doesn't use SIMD granule type conversion), while also thinking there is no lack of SIMD support, because for example on x86 `SDL_SSE2_INTRINSICS` is still defined (so `NEED_SCALAR_CONVERTER_FALLBACKS` isn't set, so it doesn't use the fallback granule type conversion functions either), thus all the `SDL_Convert_x_to_y` functions are null and there is no way for other parts of SDL's audio subsystem to work properly:

https://github.com/libsdl-org/SDL/blob/4e0f94ea7d58d4a1aac624421d73110232df3efd/src/audio/SDL_audiotypecvt.c#L939C1-L978