### PR TITLE
android: Update settings, remove unused translations

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
@@ -26,7 +26,7 @@ enum class IntSetting(
     RENDERER_FORCE_MAX_CLOCK(
         "force_max_clock",
         Settings.SECTION_RENDERER,
-        1
+        0
     ),
     RENDERER_ASYNCHRONOUS_SHADERS(
         "use_asynchronous_shaders",

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
@@ -33,6 +33,11 @@ enum class IntSetting(
         Settings.SECTION_RENDERER,
         0
     ),
+    RENDERER_REACTIVE_FLUSHING(
+        "use_reactive_flushing",
+        Settings.SECTION_RENDERER,
+        0
+    ),
     RENDERER_DEBUG(
         "debug",
         Settings.SECTION_RENDERER,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -321,6 +321,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     IntSetting.RENDERER_ASYNCHRONOUS_SHADERS.defaultValue
                 )
             )
+            add(
+                SwitchSetting(
+                    IntSetting.RENDERER_REACTIVE_FLUSHING,
+                    R.string.renderer_reactive_flushing,
+                    R.string.renderer_reactive_flushing_description,
+                    IntSetting.RENDERER_REACTIVE_FLUSHING.key,
+                    IntSetting.RENDERER_REACTIVE_FLUSHING.defaultValue
+                )
+            )
         }
     }
 

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -235,13 +235,13 @@ void Config::ReadValues() {
     Settings::values.async_presentation =
         config->GetBoolean("Renderer", "async_presentation", true);
 
-    // Enable force_max_clock by default on Android
+    // Disable force_max_clock by default on Android
     Settings::values.renderer_force_max_clock =
-        config->GetBoolean("Renderer", "force_max_clock", true);
+        config->GetBoolean("Renderer", "force_max_clock", false);
 
     // Disable use_reactive_flushing by default on Android
     Settings::values.use_reactive_flushing =
-            config->GetBoolean("Renderer", "use_reactive_flushing", false);
+        config->GetBoolean("Renderer", "use_reactive_flushing", false);
 
     // Audio
     ReadSetting("Audio", Settings::values.sink_id);

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -239,6 +239,10 @@ void Config::ReadValues() {
     Settings::values.renderer_force_max_clock =
         config->GetBoolean("Renderer", "force_max_clock", true);
 
+    // Disable use_reactive_flushing by default on Android
+    Settings::values.use_reactive_flushing =
+            config->GetBoolean("Renderer", "use_reactive_flushing", false);
+
     // Audio
     ReadSetting("Audio", Settings::values.sink_id);
     ReadSetting("Audio", Settings::values.audio_output_device_id);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -328,6 +328,10 @@ shader_backend =
 # 0 (default): Off, 1: On
 use_asynchronous_shaders =
 
+# Uses reactive flushing instead of predictive flushing. Allowing a more accurate syncing of memory.
+# 0 (default): Off, 1: On
+use_reactive_flushing =
+
 # NVDEC emulation.
 # 0: Disabled, 1: CPU Decoding, 2 (default): GPU Decoding
 nvdec_emulation =

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -251,7 +251,7 @@ backend =
 # 0: Off, 1 (default): On
 async_presentation =
 
-# Enable graphics API debugging mode.
+# Forces the GPU to run at the maximum possible clocks (thermal constraints will still be applied).
 # 0 (default): Disabled, 1: Enabled
 force_max_clock =
 

--- a/src/android/app/src/main/res/values-de/strings.xml
+++ b/src/android/app/src/main/res/values-de/strings.xml
@@ -176,7 +176,6 @@
     <string name="installing_driver">Treiber wird installiert...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Erweiterte Einstellungen</string>
     <string name="preferences_settings">Einstellungen</string>
     <string name="preferences_general">Allgemein</string>
     <string name="preferences_system">System</string>
@@ -228,7 +227,6 @@
     <string name="performance_warning">Das Deaktivieren dieser Einstellung führt zu erheblichen Leistungsverlusten! Für ein optimales Erlebnis wird empfohlen, sie aktiviert zu lassen.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Automatisch auswählen</string>
     <string name="region_japan">Japan</string>
     <string name="region_usa">USA</string>
     <string name="region_europe">Europa</string>
@@ -301,7 +299,6 @@
     <string name="ratio_stretch">Auf Fenster anpassen</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Auto</string>
     <string name="cpu_accuracy_accurate">Akkurat</string>
     <string name="cpu_accuracy_unsafe">Unsicher</string>
     <string name="cpu_accuracy_paranoid">Paranoid (Langsam)</string>

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">Archivo de claves inválido seleccionado</string>
     <string name="install_keys_success">Claves instaladas correctamente</string>
     <string name="reading_keys_failure">Error al leer las claves de cifrado</string>
-    <string name="install_keys_failure_extension_description">
-        1. Verifique que sus claves acaben con la extensión .keys.\n\n
-        2. Las claves no deben de estar almacenadas en la carpeta Descargas.\n\n
-        Resuelva el/los problema(s) y vuelva a intentarlo.
-    </string>
     <string name="invalid_keys_error">Claves de cifrado no válidas</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">El archivo seleccionado es incorrecto o está corrupto. Vuelva a redumpear sus claves.</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">Instalando driver...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Configuración avanzada</string>
     <string name="preferences_settings">Ajustes</string>
     <string name="preferences_general">General</string>
     <string name="preferences_system">Sistema</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">¡Desactivar esta configuración reducirá significativamente el rendimiento de la emulación!  Para obtener la mejor experiencia, se recomienda dejar esta configuración habilitada.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Auto seleccionar</string>
     <string name="region_japan">Japón</string>
     <string name="region_usa">EEUU</string>
     <string name="region_europe">Europa</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">Ajustar a la ventana</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Auto</string>
     <string name="cpu_accuracy_accurate">Preciso</string>
     <string name="cpu_accuracy_unsafe">Impreciso</string>
     <string name="cpu_accuracy_paranoid">Paranoico (Lento)</string>

--- a/src/android/app/src/main/res/values-fr/strings.xml
+++ b/src/android/app/src/main/res/values-fr/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">Fichier de clés sélectionné invalide</string>
     <string name="install_keys_success">Clés installées avec succès</string>
     <string name="reading_keys_failure">Erreur lors de la lecture des clés de chiffrement</string>
-    <string name="install_keys_failure_extension_description">
-        1. Vérifiez que vos clés ont l\'extension .keys.\n\n
-        2. Les clés ne doivent pas être stockées dans le      dossier Téléchargements.\n\n
-        Résolvez le(s) problème(s) et réessayez.
-    </string>
     <string name="invalid_keys_error">Clés de chiffrement invalides</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">Le fichier sélectionné est incorrect ou corrompu. Veuillez dumper à nouveau vos clés.</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">Installation du pilote...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Paramètres avancés</string>
     <string name="preferences_settings">Paramètres</string>
     <string name="preferences_general">Général</string>
     <string name="preferences_system">Système</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">La désactivation de ce paramètre réduira considérablement les performances d\'émulation ! Pour une expérience optimale, il est recommandé de laisser ce paramètre activé.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Sélection automatique</string>
     <string name="region_japan">Japon</string>
     <string name="region_usa">É.-U.A.</string>
     <string name="region_europe">Europe</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">Étirer à la fenêtre</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Auto</string>
     <string name="cpu_accuracy_accurate">Précis</string>
     <string name="cpu_accuracy_unsafe">Risqué</string>
     <string name="cpu_accuracy_paranoid">Paranoïaque (Lent)</string>

--- a/src/android/app/src/main/res/values-it/strings.xml
+++ b/src/android/app/src/main/res/values-it/strings.xml
@@ -61,10 +61,6 @@
     <string name="invalid_keys_file">Selezionate chiavi non valide</string>
     <string name="install_keys_success">Chiavi installate correttamente</string>
     <string name="reading_keys_failure">Errore durante la lettura delle chiavi di crittografia</string>
-    <string name="install_keys_failure_extension_description">
-1. Verifica che le tue chiavi abbiano l\'estensione .keys.\n\n
-2. Le chiavi non devono essere archiviate nella cartella Download.\n\n
-Risolvi i problemi e riprova.</string>
     <string name="invalid_keys_error">Chiavi di crittografia non valide</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">Il file selezionato è incorretto o corrotto. Per favore riesegui il dump delle tue chiavi.</string>
@@ -183,7 +179,6 @@ Risolvi i problemi e riprova.</string>
     <string name="installing_driver">Installando i driver...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Impostazioni Avanzate</string>
     <string name="preferences_settings">Impostazioni</string>
     <string name="preferences_general">Generali</string>
     <string name="preferences_system">Sistema</string>
@@ -237,7 +232,6 @@ Risolvi i problemi e riprova.</string>
     <string name="performance_warning">Disattivare questa impostazione può ridurre significativamente le performance di emulazione! Per una migliore esperienza, è consigliato lasciare questa impostazione attivata.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Selezione automatica</string>
     <string name="region_japan">Giappone</string>
     <string name="region_usa">USA</string>
     <string name="region_europe">Europa</string>
@@ -310,7 +304,6 @@ Risolvi i problemi e riprova.</string>
     <string name="ratio_stretch">Allunga a finestra</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Automatico</string>
     <string name="cpu_accuracy_accurate">Accurata</string>
     <string name="cpu_accuracy_unsafe">Non sicura</string>
     <string name="cpu_accuracy_paranoid">Paranoico (Lento)</string>

--- a/src/android/app/src/main/res/values-ja/strings.xml
+++ b/src/android/app/src/main/res/values-ja/strings.xml
@@ -60,11 +60,6 @@
     <string name="invalid_keys_file">無効なキーファイルが選択されました</string>
     <string name="install_keys_success">正常にインストールされました</string>
     <string name="reading_keys_failure">暗号化キーの読み取りエラー</string>
-    <string name="install_keys_failure_extension_description">
-        1. キーの拡張子が .keys であることを確認します。\n\n
-        2. キーはダウンロードフォルダに保存しないでください。\n\n
-        問題を解決して、再度お試しください。
-    </string>
     <string name="invalid_keys_error">暗号化キーが無効です</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">選択されたファイルが不正または破損しています。キーを再ダンプしてください。</string>
@@ -183,7 +178,6 @@
     <string name="installing_driver">インストール中…</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">詳細設定</string>
     <string name="preferences_settings">設定</string>
     <string name="preferences_general">全般</string>
     <string name="preferences_system">システム</string>
@@ -236,7 +230,6 @@
     <string name="performance_warning">この設定をオフにすると、エミュレーションのパフォーマンスが著しく低下します！最高の体験を得るためには、この設定を有効にしておくことをお勧めします。</string>
 
     <!-- Region Names -->
-    <string name="region_auto">自動選択</string>
     <string name="region_japan">日本</string>
     <string name="region_usa">アメリカ</string>
     <string name="region_europe">ヨーロッパ</string>
@@ -309,7 +302,6 @@
     <string name="ratio_stretch">ウィンドウに合わせる</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">自動</string>
     <string name="cpu_accuracy_accurate">正確</string>
     <string name="cpu_accuracy_unsafe">不安定</string>
     <string name="cpu_accuracy_paranoid">パラノイド (低速)</string>

--- a/src/android/app/src/main/res/values-ko/strings.xml
+++ b/src/android/app/src/main/res/values-ko/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">잘못된 keys 파일 선택</string>
     <string name="install_keys_success">keys가 성공적으로 설치됨</string>
     <string name="reading_keys_failure">암호화 keys 읽기 오류</string>
-    <string name="install_keys_failure_extension_description">
-1. keys의 확장자가 .keys인지 확인하세요.\n\n
-2. keys는 다운로드 폴더에 저장하면 안 됩니다.\n\n
-문제를 해결하고 다시 시도하세요.
-</string>
     <string name="invalid_keys_error">잘못된 암호화 keys</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">선택한 파일이 잘못되었거나 손상되었습니다. keys를 다시 덤프하세요.</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">드라이버 설치 중...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">고급 설정</string>
     <string name="preferences_settings">설정</string>
     <string name="preferences_general">일반</string>
     <string name="preferences_system">시스템</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">이 설정을 끄면 에뮬레이션 성능이 크게 저하됩니다! 최상의 환경을 위해 이 설정을 활성화된 상태로 두는 것이 좋습니다.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">자동 선택</string>
     <string name="region_japan">일본</string>
     <string name="region_usa">미국</string>
     <string name="region_europe">유럽</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">창에 맞게 늘림</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">자동</string>
     <string name="cpu_accuracy_accurate">정확함</string>
     <string name="cpu_accuracy_unsafe">안전하지 않음</string>
     <string name="cpu_accuracy_paranoid">편집증 (느림)</string>

--- a/src/android/app/src/main/res/values-nb/strings.xml
+++ b/src/android/app/src/main/res/values-nb/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">Ugyldig nøkkelfil valgt</string>
     <string name="install_keys_success">Nøkler vellykket installert</string>
     <string name="reading_keys_failure">Feil ved lesing av krypteringsnøkler</string>
-    <string name="install_keys_failure_extension_description">
-        1. Kontroller at nøklene har filtypen .keys.\n\n
-        2. Nøkler må ikke lagres i nedlastingsmappen.\n\n
-        Løs problemet/problemene og prøv igjen.
-    </string>
     <string name="invalid_keys_error">Ugyldige krypteringsnøkler</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">Den valgte filen er feil eller ødelagt. Vennligst dump nøklene på nytt.</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">Installerer driver...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Avanserte innstillinger</string>
     <string name="preferences_settings">Innstillinger</string>
     <string name="preferences_general">Generelt</string>
     <string name="preferences_system">System</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">Hvis du slår av denne innstillingen, reduseres emuleringsytelsen betydelig! Vi anbefaler at du lar denne innstillingen være aktivert for å få den beste opplevelsen.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Automatisk valg</string>
     <string name="region_japan">Japan</string>
     <string name="region_usa">USA</string>
     <string name="region_europe">Europa</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">Strekk til Vindu</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Auto</string>
     <string name="cpu_accuracy_accurate">Nøyaktig</string>
     <string name="cpu_accuracy_unsafe">Utrygt</string>
     <string name="cpu_accuracy_paranoid">Paranoid (Langsom)</string>

--- a/src/android/app/src/main/res/values-pl/strings.xml
+++ b/src/android/app/src/main/res/values-pl/strings.xml
@@ -61,10 +61,6 @@
     <string name="invalid_keys_file">Wybrano niepoprawne klucze</string>
     <string name="install_keys_success">Klucze zainstalowane pomyślnie</string>
     <string name="reading_keys_failure">Błąd podczas odczytu kluczy</string>
-    <string name="install_keys_failure_extension_description">
-1. Upewnij się że klucze mają rozszerzenie .keys. \n\n
-2. Klucze nie mogą znajdować się w folderze Pobrane. \n\n
-Rozwiąż te problemy (oba) i spróbuj ponownie.</string>
     <string name="invalid_keys_error">Niepoprawne klucze</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">Wybrany plik jest niepoprawny lub uszkodzony. Zrzuć ponownie swoje klucze.</string>
@@ -183,7 +179,6 @@ Rozwiąż te problemy (oba) i spróbuj ponownie.</string>
     <string name="installing_driver">Instalowanie sterownika...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Zaawansowane</string>
     <string name="preferences_settings">Ustawienia</string>
     <string name="preferences_general">Ogólne</string>
     <string name="preferences_system">System</string>
@@ -237,7 +232,6 @@ Rozwiąż te problemy (oba) i spróbuj ponownie.</string>
     <string name="performance_warning">Wyłączenie tej opcji znacząco ograniczy wydajność! Dla najlepszego doświadczenia, zaleca się zostawienie tej opcji włączonej.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Auto-wybór</string>
     <string name="region_japan">Japonia</string>
     <string name="region_usa">USA</string>
     <string name="region_europe">Europa</string>
@@ -310,7 +304,6 @@ Rozwiąż te problemy (oba) i spróbuj ponownie.</string>
     <string name="ratio_stretch">Rozciągnij do Okna</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Automatyczny</string>
     <string name="cpu_accuracy_accurate">Dokładny</string>
     <string name="cpu_accuracy_unsafe">Niebezpieczny</string>
     <string name="cpu_accuracy_paranoid">Paranoid (Wolny)</string>

--- a/src/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/src/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">Ficheiro de chaves inválido</string>
     <string name="install_keys_success">Chaves instaladas com sucesso</string>
     <string name="reading_keys_failure">Erro ao ler chaves de encriptação</string>
-    <string name="install_keys_failure_extension_description">
-        1. Verifica se as tuas chaves têm a extensão .keys.\n\n
-        2. As Chaves não podem estar gravadas na pasta Transferências.\n\n
-        Resolve esta(s) questões e tenta novamente.
-    </string>
     <string name="invalid_keys_error">Chaves de encriptação inválidas</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">O ficheiro selecionado está corrompido. Por favor recarrega as tuas chaves.</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">A instalar o Driver...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Configurações avançadas</string>
     <string name="preferences_settings">Configurações</string>
     <string name="preferences_general">Geral</string>
     <string name="preferences_system">Sistema</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">Desligar esta configuração irá reduzir a performance da emulação significantemente! Para a melhor experiência é recomendado que deixes esta configuração ativada.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Auto seleção</string>
     <string name="region_japan">Japão</string>
     <string name="region_usa">EUA</string>
     <string name="region_europe">Europa</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">Esticar para a janela</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Automático</string>
     <string name="cpu_accuracy_accurate">Preciso</string>
     <string name="cpu_accuracy_unsafe">Não seguro</string>
     <string name="cpu_accuracy_paranoid">Paranoid (Lento)</string>

--- a/src/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/src/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">Ficheiro de chaves inválido</string>
     <string name="install_keys_success">Chaves instaladas com sucesso</string>
     <string name="reading_keys_failure">Erro ao ler chaves de encriptação</string>
-    <string name="install_keys_failure_extension_description">
-        1. Verifica se as tuas chaves têm a extensão .keys.\n\n
-        2. As Chaves não podem estar gravadas na pasta Transferências.\n\n
-        Resolve esta(s) questões e tenta novamente.
-    </string>
     <string name="invalid_keys_error">Chaves de encriptação inválidas</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">O ficheiro selecionado está corrompido. Por favor recarrega as tuas chaves.</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">A instalar o Driver...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Configurações avançadas</string>
     <string name="preferences_settings">Configurações</string>
     <string name="preferences_general">Geral</string>
     <string name="preferences_system">Sistema</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">Desligar esta configuração irá reduzir a performance da emulação significantemente! Para a melhor experiência é recomendado que deixes esta configuração ativada.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Autosseleção</string>
     <string name="region_japan">Japão</string>
     <string name="region_usa">EUA</string>
     <string name="region_europe">Europa</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">Esticar à Janela</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Automático</string>
     <string name="cpu_accuracy_accurate">Preciso</string>
     <string name="cpu_accuracy_unsafe">Inseguro</string>
     <string name="cpu_accuracy_paranoid">Paranoid (Lento)</string>

--- a/src/android/app/src/main/res/values-ru/strings.xml
+++ b/src/android/app/src/main/res/values-ru/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">Выбран неверный файл ключей</string>
     <string name="install_keys_success">Ключи успешно установлены</string>
     <string name="reading_keys_failure">Ошибка при чтении ключей шифрования</string>
-    <string name="install_keys_failure_extension_description">
-        1. Убедитесь, что ваши ключи имеют расширение .keys\n\n
-        2. Ключи не должны находиться в папке Downloads.\n\n
-        Исправьте проблему(-ы) и повторите попытку.
-    </string>
     <string name="invalid_keys_error">Неверные ключи шифрования</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">Выбранный файл неверен или поврежден. Пожалуйста, пере-дампите ваши ключи.</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">Установка драйвера...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Расширенные настройки</string>
     <string name="preferences_settings">Настройки</string>
     <string name="preferences_general">Общие</string>
     <string name="preferences_system">Система</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">Отключение этой настройки значительно снизит производительность эмуляции! Для достижения наилучших результатов рекомендуется оставить эту настройку включенной.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Авто-выбор</string>
     <string name="region_japan">Япония</string>
     <string name="region_usa">США</string>
     <string name="region_europe">Европа</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">Растянуть до окна</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Авто</string>
     <string name="cpu_accuracy_accurate">Точно</string>
     <string name="cpu_accuracy_unsafe">Небезопасно</string>
     <string name="cpu_accuracy_paranoid">Параноик (медленно)</string>

--- a/src/android/app/src/main/res/values-uk/strings.xml
+++ b/src/android/app/src/main/res/values-uk/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">Вибрано неправильний файл ключів</string>
     <string name="install_keys_success">Ключі успішно встановлено</string>
     <string name="reading_keys_failure">Помилка під час зчитування ключів шифрування</string>
-    <string name="install_keys_failure_extension_description">
-        1. Переконайтеся, що ваші ключі мають розширення .keys\n\n
-        2. Ключі не повинні знаходитися в папці Downloads.\n\n
-        Виправте проблему(-и) та спробуйте ще раз.
-    </string>
     <string name="invalid_keys_error">Невірні ключі шифрування</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">Обраний файл невірний або пошкоджений. Будь ласка, пере-дампіть ваші ключі.</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">Встановлення драйвера...</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">Розширені налаштування</string>
     <string name="preferences_settings">Налаштування</string>
     <string name="preferences_general">Загальні</string>
     <string name="preferences_system">Система</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">Вимкнення цього налаштування значно знизить продуктивність емуляції! Для досягнення найкращих результатів рекомендується залишити це налаштування увімкненим.</string>
 
     <!-- Region Names -->
-    <string name="region_auto">Авто-вибір</string>
     <string name="region_japan">Японія</string>
     <string name="region_usa">США</string>
     <string name="region_europe">Європа</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">Розтягнути до вікна</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">Авто</string>
     <string name="cpu_accuracy_accurate">Точно</string>
     <string name="cpu_accuracy_unsafe">Небезпечно</string>
     <string name="cpu_accuracy_paranoid">Параноїк (повільно)</string>

--- a/src/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">选择的密钥文件无效</string>
     <string name="install_keys_success">密钥文件已成功安装</string>
     <string name="reading_keys_failure">读取加密密钥时出错</string>
-    <string name="install_keys_failure_extension_description">
-        1. 验证您的密钥文件是否具有 .keys 扩展名。\n\n
-        2. 密钥文件不能放置于 Downloads 文件夹。\n\n
-        解决问题并再试一次。
-    </string>
     <string name="invalid_keys_error">无效的加密密钥</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">选择的密钥文件不正确或已损坏。请重新转储密钥文件。</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">正在安装驱动程序…</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">高级选项</string>
     <string name="preferences_settings">设置</string>
     <string name="preferences_general">通用</string>
     <string name="preferences_system">系统</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">关闭此项会显著降低模拟性能！建议您将此项保持为启用状态。</string>
 
     <!-- Region Names -->
-    <string name="region_auto">自动选择</string>
     <string name="region_japan">日本</string>
     <string name="region_usa">美国</string>
     <string name="region_europe">欧洲</string>
@@ -311,7 +304,6 @@
     <string name="ratio_stretch">拉伸窗口</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">自动</string>
     <string name="cpu_accuracy_accurate">高精度</string>
     <string name="cpu_accuracy_unsafe">低精度</string>
     <string name="cpu_accuracy_paranoid">偏执模式 (慢速)</string>

--- a/src/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -61,11 +61,6 @@
     <string name="invalid_keys_file">無效的金鑰檔案已選取</string>
     <string name="install_keys_success">金鑰已成功安裝</string>
     <string name="reading_keys_failure">讀取加密金鑰時出現錯誤</string>
-    <string name="install_keys_failure_extension_description">
-        1. 驗證您的金鑰是否具有 .keys 副檔名。\n\n
-        2. 金鑰不能儲存於 Downloads 資料夾。\n\n
-        解決問題並再試一次。
-    </string>
     <string name="invalid_keys_error">無效的加密金鑰</string>
     <string name="dumping_keys_quickstart_link">https://yuzu-emu.org/help/quickstart/#dumping-decryption-keys</string>
     <string name="install_keys_failure_description">選取的檔案不正確或已損毀，請重新傾印您的金鑰。</string>
@@ -184,7 +179,6 @@
     <string name="installing_driver">正在安裝驅動程式…</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_advanced_settings">進階設定</string>
     <string name="preferences_settings">設定</string>
     <string name="preferences_general">一般</string>
     <string name="preferences_system">系統</string>
@@ -238,7 +232,6 @@
     <string name="performance_warning">關閉此設定會顯著降低模擬效能！如需最佳體驗，建議您將此設定保持為啟用狀態。</string>
 
     <!-- Region Names -->
-    <string name="region_auto">自動選取</string>
     <string name="region_japan">日本</string>
     <string name="region_usa">美國</string>
     <string name="region_europe">歐洲</string>
@@ -311,8 +304,6 @@
     <string name="ratio_stretch">延伸視窗</string>
 
     <!-- CPU Accuracy -->
-    <string name="cpu_accuracy_auto">自動</string>
-    <string name="cpu_accuracy_accurate">高精度</string>
     <string name="cpu_accuracy_unsafe">低精度</string>
     <string name="cpu_accuracy_paranoid">不合理 (慢)</string>
 

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -169,6 +169,8 @@
     <string name="renderer_force_max_clock_description">Forces the GPU to run at the maximum possible clocks (thermal constraints will still be applied).</string>
     <string name="renderer_asynchronous_shaders">Use asynchronous shaders</string>
     <string name="renderer_asynchronous_shaders_description">Compiles shaders asynchronously, reducing stutter but may introduce glitches.</string>
+    <string name="renderer_reactive_flushing">Use reactive flushing</string>
+    <string name="renderer_reactive_flushing_description">Improves rendering accuracy in some games at the cost of performance.</string>
     <string name="renderer_debug">Graphics debugging</string>
     <string name="renderer_debug_description">Sets the graphics API to a slow debugging mode.</string>
     <string name="use_disk_shader_cache">Disk shader cache</string>


### PR DESCRIPTION
* Disables force_max_clocks by default due to thermal throttling on most devices.
* Adds use_reactive_flushing as a setting and disables it by default to improve performance.
* Removes deleted translations that were causing a build break.