### PR TITLE
buffer_cache_base: Specify buffer type in HostBindings

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -715,7 +715,7 @@ void BufferCache<P>::BindHostIndexBuffer() {
 
 template <class P>
 void BufferCache<P>::BindHostVertexBuffers() {
-    HostBindings host_bindings;
+    HostBindings<typename P::Buffer> host_bindings;
     bool any_valid{false};
     auto& flags = maxwell3d->dirty.flags;
     for (u32 index = 0; index < NUM_VERTEX_BUFFERS; ++index) {
@@ -741,7 +741,7 @@ void BufferCache<P>::BindHostVertexBuffers() {
             const u32 stride = maxwell3d->regs.vertex_streams[index].stride;
             const u32 offset = buffer.Offset(binding.cpu_addr);
 
-            host_bindings.buffers.push_back(reinterpret_cast<void*>(&buffer));
+            host_bindings.buffers.push_back(&buffer);
             host_bindings.offsets.push_back(offset);
             host_bindings.sizes.push_back(binding.size);
             host_bindings.strides.push_back(stride);
@@ -900,7 +900,7 @@ void BufferCache<P>::BindHostTransformFeedbackBuffers() {
     if (maxwell3d->regs.transform_feedback_enabled == 0) {
         return;
     }
-    HostBindings host_bindings;
+    HostBindings<typename P::Buffer> host_bindings;
     for (u32 index = 0; index < NUM_TRANSFORM_FEEDBACK_BUFFERS; ++index) {
         const Binding& binding = channel_state->transform_feedback_buffers[index];
         if (maxwell3d->regs.transform_feedback.controls[index].varying_count == 0 &&
@@ -913,7 +913,7 @@ void BufferCache<P>::BindHostTransformFeedbackBuffers() {
         SynchronizeBuffer(buffer, binding.cpu_addr, size);
 
         const u32 offset = buffer.Offset(binding.cpu_addr);
-        host_bindings.buffers.push_back(reinterpret_cast<void*>(&buffer));
+        host_bindings.buffers.push_back(&buffer);
         host_bindings.offsets.push_back(offset);
         host_bindings.sizes.push_back(binding.size);
     }

--- a/src/video_core/buffer_cache/buffer_cache_base.h
+++ b/src/video_core/buffer_cache/buffer_cache_base.h
@@ -105,8 +105,9 @@ static constexpr Binding NULL_BINDING{
     .buffer_id = NULL_BUFFER_ID,
 };
 
+template <typename Buffer>
 struct HostBindings {
-    boost::container::small_vector<void*, NUM_VERTEX_BUFFERS> buffers;
+    boost::container::small_vector<Buffer*, NUM_VERTEX_BUFFERS> buffers;
     boost::container::small_vector<u64, NUM_VERTEX_BUFFERS> offsets;
     boost::container::small_vector<u64, NUM_VERTEX_BUFFERS> sizes;
     boost::container::small_vector<u64, NUM_VERTEX_BUFFERS> strides;

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -232,12 +232,12 @@ void BufferCacheRuntime::BindVertexBuffer(u32 index, Buffer& buffer, u32 offset,
     }
 }
 
-void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings& bindings) {
-    for (u32 index = 0; index < bindings.buffers.size(); index++) {
-        BindVertexBuffer(
-            bindings.min_index + index, *reinterpret_cast<Buffer*>(bindings.buffers[index]),
-            static_cast<u32>(bindings.offsets[index]), static_cast<u32>(bindings.sizes[index]),
-            static_cast<u32>(bindings.strides[index]));
+void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bindings) {
+    for (u32 index = 0; index < bindings.buffers.size(); ++index) {
+        BindVertexBuffer(bindings.min_index + index, *bindings.buffers[index],
+                         static_cast<u32>(bindings.offsets[index]),
+                         static_cast<u32>(bindings.sizes[index]),
+                         static_cast<u32>(bindings.strides[index]));
     }
 }
 
@@ -329,10 +329,9 @@ void BufferCacheRuntime::BindTransformFeedbackBuffer(u32 index, Buffer& buffer, 
                       static_cast<GLintptr>(offset), static_cast<GLsizeiptr>(size));
 }
 
-void BufferCacheRuntime::BindTransformFeedbackBuffers(VideoCommon::HostBindings& bindings) {
-    for (u32 index = 0; index < bindings.buffers.size(); index++) {
-        glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, index,
-                          reinterpret_cast<Buffer*>(bindings.buffers[index])->Handle(),
+void BufferCacheRuntime::BindTransformFeedbackBuffers(VideoCommon::HostBindings<Buffer>& bindings) {
+    for (u32 index = 0; index < bindings.buffers.size(); ++index) {
+        glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, index, bindings.buffers[index]->Handle(),
                           static_cast<GLintptr>(bindings.offsets[index]),
                           static_cast<GLsizeiptr>(bindings.sizes[index]));
     }

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -87,7 +87,8 @@ public:
     void BindIndexBuffer(Buffer& buffer, u32 offset, u32 size);
 
     void BindVertexBuffer(u32 index, Buffer& buffer, u32 offset, u32 size, u32 stride);
-    void BindVertexBuffers(VideoCommon::HostBindings& bindings);
+
+    void BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bindings);
 
     void BindUniformBuffer(size_t stage, u32 binding_index, Buffer& buffer, u32 offset, u32 size);
 
@@ -100,7 +101,8 @@ public:
                                   bool is_written);
 
     void BindTransformFeedbackBuffer(u32 index, Buffer& buffer, u32 offset, u32 size);
-    void BindTransformFeedbackBuffers(VideoCommon::HostBindings& bindings);
+
+    void BindTransformFeedbackBuffers(VideoCommon::HostBindings<Buffer>& bindings);
 
     void BindTextureBuffer(Buffer& buffer, u32 offset, u32 size,
                            VideoCore::Surface::PixelFormat format);

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -501,11 +501,10 @@ void BufferCacheRuntime::BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset
     }
 }
 
-void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings& bindings) {
+void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bindings) {
     boost::container::small_vector<VkBuffer, 32> buffer_handles;
-    for (u32 index = 0; index < bindings.buffers.size(); index++) {
-        auto& buffer = *reinterpret_cast<Buffer*>(bindings.buffers[index]);
-        auto handle = buffer.Handle();
+    for (u32 index = 0; index < bindings.buffers.size(); ++index) {
+        auto handle = bindings.buffers[index]->Handle();
         if (handle == VK_NULL_HANDLE) {
             bindings.offsets[index] = 0;
             bindings.sizes[index] = VK_WHOLE_SIZE;
@@ -521,16 +520,13 @@ void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings& bindings) 
                           buffer_handles = buffer_handles](vk::CommandBuffer cmdbuf) {
             cmdbuf.BindVertexBuffers2EXT(
                 bindings.min_index, bindings.max_index - bindings.min_index, buffer_handles.data(),
-                reinterpret_cast<const VkDeviceSize*>(bindings.offsets.data()),
-                reinterpret_cast<const VkDeviceSize*>(bindings.sizes.data()),
-                reinterpret_cast<const VkDeviceSize*>(bindings.strides.data()));
+                bindings.offsets.data(), bindings.sizes.data(), bindings.strides.data());
         });
     } else {
         scheduler.Record([bindings = bindings,
                           buffer_handles = buffer_handles](vk::CommandBuffer cmdbuf) {
-            cmdbuf.BindVertexBuffers(
-                bindings.min_index, bindings.max_index - bindings.min_index, buffer_handles.data(),
-                reinterpret_cast<const VkDeviceSize*>(bindings.offsets.data()));
+            cmdbuf.BindVertexBuffers(bindings.min_index, bindings.max_index - bindings.min_index,
+                                     buffer_handles.data(), bindings.offsets.data());
         });
     }
 }
@@ -556,22 +552,20 @@ void BufferCacheRuntime::BindTransformFeedbackBuffer(u32 index, VkBuffer buffer,
     });
 }
 
-void BufferCacheRuntime::BindTransformFeedbackBuffers(VideoCommon::HostBindings& bindings) {
+void BufferCacheRuntime::BindTransformFeedbackBuffers(VideoCommon::HostBindings<Buffer>& bindings) {
     if (!device.IsExtTransformFeedbackSupported()) {
         // Already logged in the rasterizer
         return;
     }
     boost::container::small_vector<VkBuffer, 4> buffer_handles;
-    for (u32 index = 0; index < bindings.buffers.size(); index++) {
-        auto& buffer = *reinterpret_cast<Buffer*>(bindings.buffers[index]);
-        buffer_handles.push_back(buffer.Handle());
+    for (u32 index = 0; index < bindings.buffers.size(); ++index) {
+        buffer_handles.push_back(bindings.buffers[index]->Handle());
     }
     scheduler.Record(
         [bindings = bindings, buffer_handles = buffer_handles](vk::CommandBuffer cmdbuf) {
-            cmdbuf.BindTransformFeedbackBuffersEXT(
-                0, static_cast<u32>(buffer_handles.size()), buffer_handles.data(),
-                reinterpret_cast<const VkDeviceSize*>(bindings.offsets.data()),
-                reinterpret_cast<const VkDeviceSize*>(bindings.sizes.data()));
+            cmdbuf.BindTransformFeedbackBuffersEXT(0, static_cast<u32>(buffer_handles.size()),
+                                                   buffer_handles.data(), bindings.offsets.data(),
+                                                   bindings.sizes.data());
         });
 }
 

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -97,10 +97,12 @@ public:
     void BindQuadIndexBuffer(PrimitiveTopology topology, u32 first, u32 count);
 
     void BindVertexBuffer(u32 index, VkBuffer buffer, u32 offset, u32 size, u32 stride);
-    void BindVertexBuffers(VideoCommon::HostBindings& bindings);
+
+    void BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bindings);
 
     void BindTransformFeedbackBuffer(u32 index, VkBuffer buffer, u32 offset, u32 size);
-    void BindTransformFeedbackBuffers(VideoCommon::HostBindings& bindings);
+
+    void BindTransformFeedbackBuffers(VideoCommon::HostBindings<Buffer>& bindings);
 
     std::span<u8> BindMappedUniformBuffer([[maybe_unused]] size_t stage,
                                           [[maybe_unused]] u32 binding_index, u32 size) {


### PR DESCRIPTION
Avoid reinterpret-casting from void pointer since the type is already known at compile time.