### PR TITLE
android: Declare languages in locales_config.xml

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         android:hasFragileUserData="true"
         android:supportsRtl="true"
         android:isGame="true"
+        android:localeConfig="@xml/locales_config"
         android:banner="@drawable/tv_banner"
         android:extractNativeLibs="true"
         android:fullBackupContent="@xml/data_extraction_rules"

--- a/src/android/app/src/main/res/xml/locales_config.xml
+++ b/src/android/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" /> <!-- English (default) -->
+    <locale android:name="de" /> <!-- German -->
+    <locale android:name="es" /> <!-- Spanish -->
+    <locale android:name="fr" /> <!-- French -->
+    <locale android:name="it" /> <!-- Italian -->
+    <locale android:name="ja" /> <!-- Japanese -->
+    <locale android:name="nb" /> <!-- Norwegian Bokmal -->
+    <locale android:name="pl" /> <!-- Polish -->
+    <locale android:name="pt-rBR" /> <!-- Portuguese (Brazil) -->
+    <locale android:name="pt-RPT" /> <!-- Portuguese (Portugal) -->
+    <locale android:name="ru" /> <!-- Russian -->
+    <locale android:name="uk" /> <!-- Ukranian -->
+    <locale android:name="zh-rCN" /> <!-- Chinese (China) -->
+    <locale android:name="zh-rTW" /> <!-- Chinese (Taiwan) -->
+</locale-config>


### PR DESCRIPTION
This is required to make per-app language swithcing possible on Android 13.