### PR TITLE
externals: Fix update vcpkg to 2023.06.14

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "yuzu",
-    "builtin-baseline": "656fcc6ab2b05c6d999b7eaca717027ac3738f71",
+    "builtin-baseline": "a487471068f4cb1cbb4eeb340763cdcc0a75fd68",
     "version": "1.0",
     "dependencies": [
         "boost-algorithm",


### PR DESCRIPTION
`Forgot to update the manifest to reflect the submodule in the previous commit.`

My bad... I caused the failures not updating this.