### PR TITLE
video_core: preallocate fewer IR blocks

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_context.h
+++ b/src/video_core/renderer_opengl/gl_shader_context.h
@@ -16,9 +16,9 @@ struct ShaderPools {
         inst.ReleaseContents();
     }
 
-    Shader::ObjectPool<Shader::IR::Inst> inst;
-    Shader::ObjectPool<Shader::IR::Block> block;
-    Shader::ObjectPool<Shader::Maxwell::Flow::Block> flow_block;
+    Shader::ObjectPool<Shader::IR::Inst> inst{8192};
+    Shader::ObjectPool<Shader::IR::Block> block{32};
+    Shader::ObjectPool<Shader::Maxwell::Flow::Block> flow_block{32};
 };
 
 struct Context {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -92,9 +92,9 @@ struct ShaderPools {
         inst.ReleaseContents();
     }
 
-    Shader::ObjectPool<Shader::IR::Inst> inst;
-    Shader::ObjectPool<Shader::IR::Block> block;
-    Shader::ObjectPool<Shader::Maxwell::Flow::Block> flow_block;
+    Shader::ObjectPool<Shader::IR::Inst> inst{8192};
+    Shader::ObjectPool<Shader::IR::Block> block{32};
+    Shader::ObjectPool<Shader::Maxwell::Flow::Block> flow_block{32};
 };
 
 class PipelineCache : public VideoCommon::ShaderCache {


### PR DESCRIPTION
IR::Block is a 4192-byte structure. The default number of pooled blocks to allocate is 8192, which leads to 34MB of IR::Blocks allocated twice per thread. This seems excessive.