### PR TITLE
Add an option to set the amiibo directory

### DIFF
--- a/src/yuzu/configuration/configure_filesystem.cpp
+++ b/src/yuzu/configuration/configure_filesystem.cpp
@@ -19,6 +19,8 @@ ConfigureFilesystem::ConfigureFilesystem(QWidget* parent)
             [this] { SetDirectory(DirectoryTarget::NAND, ui->nand_directory_edit); });
     connect(ui->sdmc_directory_button, &QToolButton::pressed, this,
             [this] { SetDirectory(DirectoryTarget::SD, ui->sdmc_directory_edit); });
+    connect(ui->amiibo_directory_button, &QToolButton::pressed, this,
+            [this] { SetDirectory(DirectoryTarget::Amiibo, ui->amiibo_directory_edit); });
     connect(ui->gamecard_path_button, &QToolButton::pressed, this,
             [this] { SetDirectory(DirectoryTarget::Gamecard, ui->gamecard_path_edit); });
     connect(ui->dump_path_button, &QToolButton::pressed, this,
@@ -50,6 +52,8 @@ void ConfigureFilesystem::SetConfiguration() {
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::NANDDir)));
     ui->sdmc_directory_edit->setText(
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::SDMCDir)));
+    ui->amiibo_directory_edit->setText(
+        QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::AmiiboDir)));
     ui->gamecard_path_edit->setText(
         QString::fromStdString(Settings::values.gamecard_path.GetValue()));
     ui->dump_path_edit->setText(
@@ -72,6 +76,8 @@ void ConfigureFilesystem::ApplyConfiguration() {
                             ui->nand_directory_edit->text().toStdString());
     Common::FS::SetYuzuPath(Common::FS::YuzuPath::SDMCDir,
                             ui->sdmc_directory_edit->text().toStdString());
+    Common::FS::SetYuzuPath(Common::FS::YuzuPath::AmiiboDir,
+                            ui->amiibo_directory_edit->text().toStdString());
     Common::FS::SetYuzuPath(Common::FS::YuzuPath::DumpDir,
                             ui->dump_path_edit->text().toStdString());
     Common::FS::SetYuzuPath(Common::FS::YuzuPath::LoadDir,
@@ -94,6 +100,9 @@ void ConfigureFilesystem::SetDirectory(DirectoryTarget target, QLineEdit* edit) 
         break;
     case DirectoryTarget::SD:
         caption = tr("Select Emulated SD Directory...");
+        break;
+    case DirectoryTarget::Amiibo:
+        caption = tr("Select Emulated Amiibo Directory...");
         break;
     case DirectoryTarget::Gamecard:
         caption = tr("Select Gamecard Path...");

--- a/src/yuzu/configuration/configure_filesystem.h
+++ b/src/yuzu/configuration/configure_filesystem.h
@@ -30,6 +30,7 @@ private:
     enum class DirectoryTarget {
         NAND,
         SD,
+        Amiibo,
         Gamecard,
         Dump,
         Load,

--- a/src/yuzu/configuration/configure_filesystem.ui
+++ b/src/yuzu/configuration/configure_filesystem.ui
@@ -75,6 +75,39 @@
           </property>
          </spacer>
         </item>
+        <item row="2" column="2">
+         <widget class="QLineEdit" name="amiibo_directory_edit"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Amiibo</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QToolButton" name="amiibo_directory_button">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Maximum</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>60</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -227,6 +227,9 @@ void Config::ReadValues() {
     FS::SetYuzuPath(FS::YuzuPath::SDMCDir,
                     sdl2_config->Get("Data Storage", "sdmc_directory",
                                      FS::GetYuzuPathString(FS::YuzuPath::SDMCDir)));
+    FS::SetYuzuPath(FS::YuzuPath::AmiiboDir,
+                    sdl2_config->Get("Data Storage", "amiibo_directory",
+                                     FS::GetYuzuPathString(FS::YuzuPath::AmiiboDir)));
     FS::SetYuzuPath(FS::YuzuPath::LoadDir,
                     sdl2_config->Get("Data Storage", "load_directory",
                                      FS::GetYuzuPathString(FS::YuzuPath::LoadDir)));


### PR DESCRIPTION
I imagine it can't really be this easy, but I have minimal experience with C / Qt / Visual Studio. What I do have is a ROG Ally with a microsd card slot and a very risky hard drive replacement procedure for a device that only released two days ago.

Anyway, it was worth a shot if it can make the folder a little more accessible.