### PR TITLE
input_common: Add foomiibo support

### DIFF
--- a/src/input_common/drivers/virtual_amiibo.cpp
+++ b/src/input_common/drivers/virtual_amiibo.cpp
@@ -82,6 +82,7 @@ VirtualAmiibo::Info VirtualAmiibo::LoadAmiibo(const std::string& filename) {
     switch (nfc_file.GetSize()) {
     case AmiiboSize:
     case AmiiboSizeWithoutPassword:
+    case AmiiboSizeWithSignature:
         data.resize(AmiiboSize);
         if (nfc_file.Read(data) < AmiiboSizeWithoutPassword) {
             return Info::NotAnAmiibo;
@@ -109,6 +110,7 @@ VirtualAmiibo::Info VirtualAmiibo::LoadAmiibo(std::span<u8> data) {
     switch (data.size_bytes()) {
     case AmiiboSize:
     case AmiiboSizeWithoutPassword:
+    case AmiiboSizeWithSignature:
         nfc_data.resize(AmiiboSize);
         break;
     case MifareSize:

--- a/src/input_common/drivers/virtual_amiibo.h
+++ b/src/input_common/drivers/virtual_amiibo.h
@@ -57,6 +57,7 @@ public:
 private:
     static constexpr std::size_t AmiiboSize = 0x21C;
     static constexpr std::size_t AmiiboSizeWithoutPassword = AmiiboSize - 0x8;
+    static constexpr std::size_t AmiiboSizeWithSignature = AmiiboSize + 0x20;
     static constexpr std::size_t MifareSize = 0x400;
 
     std::string file_path{};


### PR DESCRIPTION
Foomiibo is a plain amiibo that has been autogenerated. The only difference is that they contain an extra header at the end compared to a regular amiibo dump. Add this file size to supported amiibo formats.