### PR TITLE
android: Fix aspect ratio when rotating screen

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -53,6 +53,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <activity
             android:name="org.yuzu.yuzu_emu.activities.EmulationActivity"
             android:theme="@style/Theme.Yuzu.Main"
+            android:screenOrientation="userLandscape"
             android:supportsPictureInPicture="true"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|uiMode"
             android:exported="true">

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -85,20 +85,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             onReturnFromSettings = context.activityResultRegistry.register(
                 "SettingsResult",
                 ActivityResultContracts.StartActivityForResult()
-            ) {
-                binding.surfaceEmulation.setAspectRatio(
-                    when (IntSetting.RENDERER_ASPECT_RATIO.int) {
-                        0 -> Rational(16, 9)
-                        1 -> Rational(4, 3)
-                        2 -> Rational(21, 9)
-                        3 -> Rational(16, 10)
-                        4 -> null // Stretch
-                        else -> Rational(16, 9)
-                    }
-                )
-                emulationActivity?.buildPictureInPictureParams()
-                updateScreenLayout()
-            }
+            ) { updateScreenLayout() }
         } else {
             throw IllegalStateException("EmulationFragment must have EmulationActivity parent")
         }
@@ -242,17 +229,6 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             DirectoryInitialization.start(requireContext())
         }
 
-        binding.surfaceEmulation.setAspectRatio(
-            when (IntSetting.RENDERER_ASPECT_RATIO.int) {
-                0 -> Rational(16, 9)
-                1 -> Rational(4, 3)
-                2 -> Rational(21, 9)
-                3 -> Rational(16, 10)
-                4 -> null // Stretch
-                else -> Rational(16, 9)
-            }
-        )
-
         updateScreenLayout()
 
         emulationState.run(emulationActivity!!.isActivityRecreated)
@@ -315,7 +291,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     }
 
     @SuppressLint("SourceLockedOrientationActivity")
-    private fun updateScreenLayout() {
+    private fun updateOrientation() {
         emulationActivity?.let {
             it.requestedOrientation = when (IntSetting.RENDERER_SCREEN_LAYOUT.int) {
                 Settings.LayoutOption_MobileLandscape ->
@@ -326,7 +302,21 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                 else -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
             }
         }
-        onConfigurationChanged(resources.configuration)
+    }
+
+    private fun updateScreenLayout() {
+        binding.surfaceEmulation.setAspectRatio(
+            when (IntSetting.RENDERER_ASPECT_RATIO.int) {
+                0 -> Rational(16, 9)
+                1 -> Rational(4, 3)
+                2 -> Rational(21, 9)
+                3 -> Rational(16, 10)
+                4 -> null // Stretch
+                else -> Rational(16, 9)
+            }
+        )
+        emulationActivity?.buildPictureInPictureParams()
+        updateOrientation()
     }
 
     private fun updateFoldableLayout(
@@ -359,7 +349,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             binding.overlayContainer.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
             binding.inGameMenu.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
             isInFoldableLayout = false
-            updateScreenLayout()
+            updateOrientation()
+            onConfigurationChanged(resources.configuration)
         }
         binding.emulationContainer.requestLayout()
         binding.inputContainer.requestLayout()


### PR DESCRIPTION
The "locked" aspect ratio is based on landscape, so allowing the activity to start in portrait means landscape will use the width and height of portrait to dictate the landscape aspect ratio. The end result is an emulation surface that is short and wide. By launching in landscape, this sets the proper aspect ratio at the cost of a quick transition.