### PR TITLE
android: Ktlint fixes

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -163,7 +163,7 @@ android {
 tasks.getByPath("preBuild").dependsOn("ktlintCheck")
 
 ktlint {
-    version.set("0.47.0")
+    version.set("0.47.1")
     android.set(true)
     ignoreFailures.set(false)
     disabledRules.set(

--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -169,7 +169,8 @@ ktlint {
     disabledRules.set(
         setOf(
             "no-wildcard-imports",
-            "package-name"
+            "package-name",
+            "import-ordering"
         )
     )
     reporters {


### PR DESCRIPTION
Bumping ktlint to 0.47.1 fixes an issue where it tries to check nonexistent files and removing the `import-ordering` check fixes conflicts with android studio formatting.