### PR TITLE
renderer_vulkan: add missing include

### DIFF
--- a/src/video_core/renderer_vulkan/vk_master_semaphore.cpp
+++ b/src/video_core/renderer_vulkan/vk_master_semaphore.cpp
@@ -3,6 +3,7 @@
 
 #include <thread>
 
+#include "common/polyfill_ranges.h"
 #include "common/settings.h"
 #include "video_core/renderer_vulkan/vk_master_semaphore.h"
 #include "video_core/vulkan_common/vulkan_device.h"


### PR DESCRIPTION
Fixes build on Apple Clang (please update to llvm 16 soon, thanks)