### PR TITLE
vulkan_device: Restrict compute disable only to affected Intel drivers

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -705,7 +705,7 @@ std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline(
 std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline(
     ShaderPools& pools, const ComputePipelineCacheKey& key, Shader::Environment& env,
     PipelineStatistics* statistics, bool build_in_parallel) try {
-    if (device.HasBrokenCompute() && !Settings::values.enable_compute_pipelines.GetValue()) {
+    if (device.HasBrokenCompute()) {
         LOG_ERROR(Render_Vulkan, "Skipping 0x{:016x}", key.Hash());
         return nullptr;
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -705,10 +705,7 @@ std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline(
 std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline(
     ShaderPools& pools, const ComputePipelineCacheKey& key, Shader::Environment& env,
     PipelineStatistics* statistics, bool build_in_parallel) try {
-    // TODO: Remove this when Intel fixes their shader compiler.
-    //       https://github.com/IGCIT/Intel-GPU-Community-Issue-Tracker-IGCIT/issues/159
-    if (device.GetDriverID() == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS &&
-        !Settings::values.enable_compute_pipelines.GetValue()) {
+    if (device.HasBrokenCompute() && !Settings::values.enable_compute_pipelines.GetValue()) {
         LOG_ERROR(Render_Vulkan, "Skipping 0x{:016x}", key.Hash());
         return nullptr;
     }

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -563,7 +563,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         cant_blit_msaa = true;
     }
     has_broken_compute =
-        CheckBrokenCompute(properties.driver.driverID, properties.properties.driverVersion);
+        CheckBrokenCompute(properties.driver.driverID, properties.properties.driverVersion) &&
+        !Settings::values.enable_compute_pipelines.GetValue();
     if (is_intel_anv || (is_qualcomm && !is_s8gen2)) {
         LOG_WARNING(Render_Vulkan, "Driver does not support native BGR format");
         must_emulate_bgr565 = true;

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -562,6 +562,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         LOG_WARNING(Render_Vulkan, "Intel proprietary drivers do not support MSAA image blits");
         cant_blit_msaa = true;
     }
+    has_broken_compute =
+        CheckBrokenCompute(properties.driver.driverID, properties.properties.driverVersion);
     if (is_intel_anv || (is_qualcomm && !is_s8gen2)) {
         LOG_WARNING(Render_Vulkan, "Driver does not support native BGR format");
         must_emulate_bgr565 = true;

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "common/common_types.h"
+#include "common/logging/log.h"
 #include "common/settings.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 
@@ -518,6 +519,11 @@ public:
         return has_renderdoc || has_nsight_graphics || Settings::values.renderer_debug.GetValue();
     }
 
+    /// @returns True if compute pipelines can cause crashing.
+    bool HasBrokenCompute() const {
+        return has_broken_compute;
+    }
+
     /// Returns true when the device does not properly support cube compatibility.
     bool HasBrokenCubeImageCompability() const {
         return has_broken_cube_compatibility;
@@ -577,6 +583,22 @@ public:
 
     bool SupportsConditionalBarriers() const {
         return supports_conditional_barriers;
+    }
+
+    [[nodiscard]] static constexpr bool CheckBrokenCompute(VkDriverId driver_id,
+                                                           u32 driver_version) {
+        if (driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS) {
+            const u32 major = VK_API_VERSION_MAJOR(driver_version);
+            const u32 minor = VK_API_VERSION_MINOR(driver_version);
+            const u32 patch = VK_API_VERSION_PATCH(driver_version);
+            if (major == 0 && minor == 405 && patch < 286) {
+                LOG_WARNING(
+                    Render_Vulkan,
+                    "Intel proprietary drivers 0.405.0 until 0.405.286 have broken compute");
+                return true;
+            }
+        }
+        return {};
     }
 
 private:
@@ -672,6 +694,7 @@ private:
     bool is_integrated{};                   ///< Is GPU an iGPU.
     bool is_virtual{};                      ///< Is GPU a virtual GPU.
     bool is_non_gpu{};                      ///< Is SoftwareRasterizer, FPGA, non-GPU device.
+    bool has_broken_compute{};              ///< Compute shaders can cause crashes
     bool has_broken_cube_compatibility{};   ///< Has broken cube compatibility bit
     bool has_renderdoc{};                   ///< Has RenderDoc attached
     bool has_nsight_graphics{};             ///< Has Nsight Graphics attached

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -598,7 +598,7 @@ public:
                 return true;
             }
         }
-        return {};
+        return false;
     }
 
 private:

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -508,7 +508,7 @@ void ConfigureGraphics::RetrieveVulkanDevices() {
         vulkan_devices.push_back(QString::fromStdString(record.name));
         device_present_modes.push_back(record.vsync_support);
 
-        if (record.is_intel_proprietary) {
+        if (record.has_broken_compute) {
             expose_compute_option();
         }
     }

--- a/src/yuzu/vk_device_info.h
+++ b/src/yuzu/vk_device_info.h
@@ -24,12 +24,12 @@ namespace VkDeviceInfo {
 class Record {
 public:
     explicit Record(std::string_view name, const std::vector<VkPresentModeKHR>& vsync_modes,
-                    bool is_intel_proprietary);
+                    bool has_broken_compute);
     ~Record();
 
     const std::string name;
     const std::vector<VkPresentModeKHR> vsync_support;
-    const bool is_intel_proprietary;
+    const bool has_broken_compute;
 };
 
 void PopulateRecords(std::vector<Record>& records, QWindow* window);


### PR DESCRIPTION
Followup to #10181

Intel finally fixed the compute issue, so we can disable it here where needed. Currently the only fixed driver is a beta version, so this just checks for affected drivers. As a side effect, this also re-enables compute on older unsupported Intel graphics devices where they never had the compute issue in the first place.