### PR TITLE
input_common: Implement native mifare/skylander support for joycons/pro controller

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -86,7 +86,7 @@ enum class NfcState {
     NewAmiibo,
     WaitingForAmiibo,
     AmiiboRemoved,
-    NotAnAmiibo,
+    InvalidTagType,
     NotSupported,
     WrongDeviceState,
     WriteFailed,
@@ -218,8 +218,22 @@ struct CameraStatus {
 };
 
 struct NfcStatus {
-    NfcState state{};
-    std::vector<u8> data{};
+    NfcState state{NfcState::Unknown};
+    u8 uuid_length;
+    u8 protocol;
+    u8 tag_type;
+    std::array<u8, 10> uuid;
+};
+
+struct MifareData {
+    u8 command;
+    u8 sector;
+    std::array<u8, 0x6> key;
+    std::array<u8, 0x10> data;
+};
+
+struct MifareRequest {
+    std::array<MifareData, 0x10> data;
 };
 
 // List of buttons to be passed to Qt that can be translated
@@ -294,7 +308,7 @@ struct CallbackStatus {
     BatteryStatus battery_status{};
     VibrationStatus vibration_status{};
     CameraFormat camera_status{CameraFormat::None};
-    NfcState nfc_status{NfcState::Unknown};
+    NfcStatus nfc_status{};
     std::vector<u8> raw_data{};
 };
 
@@ -356,7 +370,28 @@ public:
         return NfcState::NotSupported;
     }
 
+    virtual NfcState StartNfcPolling() {
+        return NfcState::NotSupported;
+    }
+
+    virtual NfcState StopNfcPolling() {
+        return NfcState::NotSupported;
+    }
+
+    virtual NfcState ReadAmiiboData([[maybe_unused]] std::vector<u8>& out_data) {
+        return NfcState::NotSupported;
+    }
+
     virtual NfcState WriteNfcData([[maybe_unused]] const std::vector<u8>& data) {
+        return NfcState::NotSupported;
+    }
+
+    virtual NfcState ReadMifareData([[maybe_unused]] const MifareRequest& request,
+                                    [[maybe_unused]] MifareRequest& out_data) {
+        return NfcState::NotSupported;
+    }
+
+    virtual NfcState WriteMifareData([[maybe_unused]] const MifareRequest& request) {
         return NfcState::NotSupported;
     }
 };

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -97,10 +97,7 @@ struct RingSensorForce {
     f32 force;
 };
 
-struct NfcState {
-    Common::Input::NfcState state{};
-    std::vector<u8> data{};
-};
+using NfcState = Common::Input::NfcStatus;
 
 struct ControllerMotion {
     Common::Vec3f accel{};
@@ -393,8 +390,30 @@ public:
     /// Returns true if the device has nfc support
     bool HasNfc() const;
 
+    /// Sets the joycon in nfc mode and increments the handle count
+    bool AddNfcHandle();
+
+    /// Decrements the handle count if zero sets the joycon in active mode
+    bool RemoveNfcHandle();
+
+    /// Start searching for nfc tags
+    bool StartNfcPolling();
+
+    /// Stop searching for nfc tags
+    bool StopNfcPolling();
+
+    /// Returns true if the nfc tag was readable
+    bool ReadAmiiboData(std::vector<u8>& data);
+
     /// Returns true if the nfc tag was written
     bool WriteNfc(const std::vector<u8>& data);
+
+    /// Returns true if the nfc tag was readable
+    bool ReadMifareData(const Common::Input::MifareRequest& request,
+                        Common::Input::MifareRequest& out_data);
+
+    /// Returns true if the nfc tag was written
+    bool WriteMifareData(const Common::Input::MifareRequest& request);
 
     /// Returns the led pattern corresponding to this emulated controller
     LedPattern GetLedPattern() const;
@@ -532,6 +551,7 @@ private:
     bool system_buttons_enabled{true};
     f32 motion_sensitivity{Core::HID::MotionInput::IsAtRestStandard};
     u32 turbo_button_state{0};
+    std::size_t nfc_handles{0};
 
     // Temporary values to avoid doing changes while the controller is in configuring mode
     NpadStyleIndex tmp_npad_type{NpadStyleIndex::None};

--- a/src/core/hid/input_converter.cpp
+++ b/src/core/hid/input_converter.cpp
@@ -299,11 +299,7 @@ Common::Input::NfcStatus TransformToNfc(const Common::Input::CallbackStatus& cal
     Common::Input::NfcStatus nfc{};
     switch (callback.type) {
     case Common::Input::InputType::Nfc:
-        nfc = {
-            .state = callback.nfc_status,
-            .data = callback.raw_data,
-        };
-        break;
+        return callback.nfc_status;
     default:
         LOG_ERROR(Input, "Conversion from type {} to NFC not implemented", callback.type);
         break;

--- a/src/core/hle/service/am/applets/applet_cabinet.cpp
+++ b/src/core/hle/service/am/applets/applet_cabinet.cpp
@@ -141,7 +141,7 @@ void Cabinet::DisplayCompleted(bool apply_changes, std::string_view amiibo_name)
     applet_output.device_handle = applet_input_common.device_handle;
     applet_output.result = CabinetResult::Cancel;
     const auto reg_result = nfp_device->GetRegisterInfo(applet_output.register_info);
-    const auto tag_result = nfp_device->GetTagInfo(applet_output.tag_info, false);
+    const auto tag_result = nfp_device->GetTagInfo(applet_output.tag_info);
     nfp_device->Finalize();
 
     if (reg_result.IsSuccess()) {

--- a/src/core/hle/service/nfc/common/device.h
+++ b/src/core/hle/service/nfc/common/device.h
@@ -42,15 +42,12 @@ public:
     Result StartDetection(NfcProtocol allowed_protocol);
     Result StopDetection();
 
-    Result GetTagInfo(TagInfo& tag_info, bool is_mifare) const;
+    Result GetTagInfo(TagInfo& tag_info) const;
 
     Result ReadMifare(std::span<const MifareReadBlockParameter> parameters,
                       std::span<MifareReadBlockData> read_block_data) const;
-    Result ReadMifare(const MifareReadBlockParameter& parameter,
-                      MifareReadBlockData& read_block_data) const;
 
     Result WriteMifare(std::span<const MifareWriteBlockParameter> parameters);
-    Result WriteMifare(const MifareWriteBlockParameter& parameter);
 
     Result SendCommandByPassThrough(const Time::Clock::TimeSpanType& timeout,
                                     std::span<const u8> command_data, std::span<u8> out_data);
@@ -105,7 +102,8 @@ public:
 
 private:
     void NpadUpdate(Core::HID::ControllerTriggerType type);
-    bool LoadNfcTag(std::span<const u8> data);
+    bool LoadNfcTag(u8 protocol, u8 tag_type, u8 uuid_length, UniqueSerialNumber uuid);
+    bool LoadAmiiboData();
     void CloseNfcTag();
 
     NFP::AmiiboName GetAmiiboName(const NFP::AmiiboSettings& settings) const;
@@ -140,8 +138,8 @@ private:
     bool is_write_protected{};
     NFP::MountTarget mount_target{NFP::MountTarget::None};
 
+    TagInfo real_tag_info{};
     NFP::NTAG215File tag_data{};
-    std::vector<u8> mifare_data{};
     NFP::EncryptedNTAG215File encrypted_tag_data{};
 };
 

--- a/src/core/hle/service/nfc/common/device_manager.cpp
+++ b/src/core/hle/service/nfc/common/device_manager.cpp
@@ -29,6 +29,9 @@ DeviceManager::DeviceManager(Core::System& system_, KernelHelpers::ServiceContex
 }
 
 DeviceManager ::~DeviceManager() {
+    if (is_initialized) {
+        Finalize();
+    }
     service_context.CloseEvent(availability_change_event);
 }
 
@@ -125,14 +128,14 @@ Result DeviceManager::StopDetection(u64 device_handle) {
     return result;
 }
 
-Result DeviceManager::GetTagInfo(u64 device_handle, TagInfo& tag_info, bool is_mifare) const {
+Result DeviceManager::GetTagInfo(u64 device_handle, TagInfo& tag_info) const {
     std::scoped_lock lock{mutex};
 
     std::shared_ptr<NfcDevice> device = nullptr;
     auto result = GetDeviceHandle(device_handle, device);
 
     if (result.IsSuccess()) {
-        result = device->GetTagInfo(tag_info, is_mifare);
+        result = device->GetTagInfo(tag_info);
         result = VerifyDeviceResult(device, result);
     }
 
@@ -546,7 +549,7 @@ Result DeviceManager::ReadBackupData(u64 device_handle, std::span<u8> data) cons
     NFC::TagInfo tag_info{};
 
     if (result.IsSuccess()) {
-        result = device->GetTagInfo(tag_info, false);
+        result = device->GetTagInfo(tag_info);
     }
 
     if (result.IsSuccess()) {
@@ -565,7 +568,7 @@ Result DeviceManager::WriteBackupData(u64 device_handle, std::span<const u8> dat
     NFC::TagInfo tag_info{};
 
     if (result.IsSuccess()) {
-        result = device->GetTagInfo(tag_info, false);
+        result = device->GetTagInfo(tag_info);
     }
 
     if (result.IsSuccess()) {

--- a/src/core/hle/service/nfc/common/device_manager.h
+++ b/src/core/hle/service/nfc/common/device_manager.h
@@ -33,7 +33,7 @@ public:
     Kernel::KReadableEvent& AttachAvailabilityChangeEvent() const;
     Result StartDetection(u64 device_handle, NfcProtocol tag_protocol);
     Result StopDetection(u64 device_handle);
-    Result GetTagInfo(u64 device_handle, NFP::TagInfo& tag_info, bool is_mifare) const;
+    Result GetTagInfo(u64 device_handle, NFP::TagInfo& tag_info) const;
     Kernel::KReadableEvent& AttachActivateEvent(u64 device_handle) const;
     Kernel::KReadableEvent& AttachDeactivateEvent(u64 device_handle) const;
     Result ReadMifare(u64 device_handle,

--- a/src/core/hle/service/nfc/mifare_types.h
+++ b/src/core/hle/service/nfc/mifare_types.h
@@ -11,9 +11,10 @@
 namespace Service::NFC {
 
 enum class MifareCmd : u8 {
+    None = 0x00,
+    Read = 0x30,
     AuthA = 0x60,
     AuthB = 0x61,
-    Read = 0x30,
     Write = 0xA0,
     Transfer = 0xB0,
     Decrement = 0xC0,
@@ -35,17 +36,17 @@ static_assert(sizeof(SectorKey) == 0x10, "SectorKey is an invalid size");
 
 // This is nn::nfc::MifareReadBlockParameter
 struct MifareReadBlockParameter {
-    u8 sector_number;
+    u8 sector_number{};
     INSERT_PADDING_BYTES(0x7);
-    SectorKey sector_key;
+    SectorKey sector_key{};
 };
 static_assert(sizeof(MifareReadBlockParameter) == 0x18,
               "MifareReadBlockParameter is an invalid size");
 
 // This is nn::nfc::MifareReadBlockData
 struct MifareReadBlockData {
-    DataBlock data;
-    u8 sector_number;
+    DataBlock data{};
+    u8 sector_number{};
     INSERT_PADDING_BYTES(0x7);
 };
 static_assert(sizeof(MifareReadBlockData) == 0x18, "MifareReadBlockData is an invalid size");

--- a/src/core/hle/service/nfc/nfc_interface.cpp
+++ b/src/core/hle/service/nfc/nfc_interface.cpp
@@ -174,8 +174,7 @@ void NfcInterface::GetTagInfo(HLERequestContext& ctx) {
     LOG_INFO(Service_NFC, "called, device_handle={}", device_handle);
 
     TagInfo tag_info{};
-    auto result =
-        GetManager()->GetTagInfo(device_handle, tag_info, backend_type == BackendType::Mifare);
+    auto result = GetManager()->GetTagInfo(device_handle, tag_info);
     result = TranslateResultToServiceError(result);
 
     if (result.IsSuccess()) {
@@ -216,8 +215,8 @@ void NfcInterface::ReadMifare(HLERequestContext& ctx) {
     memcpy(read_commands.data(), buffer.data(),
            number_of_commands * sizeof(MifareReadBlockParameter));
 
-    LOG_INFO(Service_NFC, "(STUBBED) called, device_handle={}, read_commands_size={}",
-             device_handle, number_of_commands);
+    LOG_INFO(Service_NFC, "called, device_handle={}, read_commands_size={}", device_handle,
+             number_of_commands);
 
     std::vector<MifareReadBlockData> out_data(number_of_commands);
     auto result = GetManager()->ReadMifare(device_handle, read_commands, out_data);

--- a/src/input_common/drivers/joycon.cpp
+++ b/src/input_common/drivers/joycon.cpp
@@ -195,8 +195,8 @@ void Joycons::RegisterNewDevice(SDL_hid_device_info* device_info) {
                 OnMotionUpdate(port, type, id, value);
             }},
             .on_ring_data = {[this](f32 ring_data) { OnRingConUpdate(ring_data); }},
-            .on_amiibo_data = {[this, port, type](const std::vector<u8>& amiibo_data) {
-                OnAmiiboUpdate(port, type, amiibo_data);
+            .on_amiibo_data = {[this, port, type](const Joycon::TagInfo& tag_info) {
+                OnAmiiboUpdate(port, type, tag_info);
             }},
             .on_camera_data = {[this, port](const std::vector<u8>& camera_data,
                                             Joycon::IrsResolution format) {
@@ -291,13 +291,105 @@ Common::Input::NfcState Joycons::SupportsNfc(const PadIdentifier& identifier_) c
     return Common::Input::NfcState::Success;
 };
 
+Common::Input::NfcState Joycons::StartNfcPolling(const PadIdentifier& identifier) {
+    auto handle = GetHandle(identifier);
+    if (handle == nullptr) {
+        return Common::Input::NfcState::Unknown;
+    }
+    return TranslateDriverResult(handle->StartNfcPolling());
+};
+
+Common::Input::NfcState Joycons::StopNfcPolling(const PadIdentifier& identifier) {
+    auto handle = GetHandle(identifier);
+    if (handle == nullptr) {
+        return Common::Input::NfcState::Unknown;
+    }
+    return TranslateDriverResult(handle->StopNfcPolling());
+};
+
+Common::Input::NfcState Joycons::ReadAmiiboData(const PadIdentifier& identifier,
+                                                std::vector<u8>& out_data) {
+    auto handle = GetHandle(identifier);
+    if (handle == nullptr) {
+        return Common::Input::NfcState::Unknown;
+    }
+    return TranslateDriverResult(handle->ReadAmiiboData(out_data));
+}
+
 Common::Input::NfcState Joycons::WriteNfcData(const PadIdentifier& identifier,
                                               const std::vector<u8>& data) {
     auto handle = GetHandle(identifier);
-    if (handle->WriteNfcData(data) != Joycon::DriverResult::Success) {
-        return Common::Input::NfcState::WriteFailed;
+    if (handle == nullptr) {
+        return Common::Input::NfcState::Unknown;
     }
-    return Common::Input::NfcState::Success;
+    return TranslateDriverResult(handle->WriteNfcData(data));
+};
+
+Common::Input::NfcState Joycons::ReadMifareData(const PadIdentifier& identifier,
+                                                const Common::Input::MifareRequest& request,
+                                                Common::Input::MifareRequest& data) {
+    auto handle = GetHandle(identifier);
+    if (handle == nullptr) {
+        return Common::Input::NfcState::Unknown;
+    }
+
+    const auto command = static_cast<Joycon::MifareCmd>(request.data[0].command);
+    std::vector<Joycon::MifareReadChunk> read_request{};
+    for (const auto& request_data : request.data) {
+        if (request_data.command == 0) {
+            continue;
+        }
+        Joycon::MifareReadChunk chunk = {
+            .command = command,
+            .sector_key = {},
+            .sector = request_data.sector,
+        };
+        memcpy(chunk.sector_key.data(), request_data.key.data(),
+               sizeof(Joycon::MifareReadChunk::sector_key));
+        read_request.emplace_back(chunk);
+    }
+
+    std::vector<Joycon::MifareReadData> read_data(read_request.size());
+    const auto result = handle->ReadMifareData(read_request, read_data);
+    if (result == Joycon::DriverResult::Success) {
+        for (std::size_t i = 0; i < read_request.size(); i++) {
+            data.data[i] = {
+                .command = static_cast<u8>(command),
+                .sector = read_data[i].sector,
+                .key = {},
+                .data = read_data[i].data,
+            };
+        }
+    }
+    return TranslateDriverResult(result);
+};
+
+Common::Input::NfcState Joycons::WriteMifareData(const PadIdentifier& identifier,
+                                                 const Common::Input::MifareRequest& request) {
+    auto handle = GetHandle(identifier);
+    if (handle == nullptr) {
+        return Common::Input::NfcState::Unknown;
+    }
+
+    const auto command = static_cast<Joycon::MifareCmd>(request.data[0].command);
+    std::vector<Joycon::MifareWriteChunk> write_request{};
+    for (const auto& request_data : request.data) {
+        if (request_data.command == 0) {
+            continue;
+        }
+        Joycon::MifareWriteChunk chunk = {
+            .command = command,
+            .sector_key = {},
+            .sector = request_data.sector,
+            .data = {},
+        };
+        memcpy(chunk.sector_key.data(), request_data.key.data(),
+               sizeof(Joycon::MifareReadChunk::sector_key));
+        memcpy(chunk.data.data(), request_data.data.data(), sizeof(Joycon::MifareWriteChunk::data));
+        write_request.emplace_back(chunk);
+    }
+
+    return TranslateDriverResult(handle->WriteMifareData(write_request));
 };
 
 Common::Input::DriverResult Joycons::SetPollingMode(const PadIdentifier& identifier,
@@ -403,11 +495,20 @@ void Joycons::OnRingConUpdate(f32 ring_data) {
 }
 
 void Joycons::OnAmiiboUpdate(std::size_t port, Joycon::ControllerType type,
-                             const std::vector<u8>& amiibo_data) {
+                             const Joycon::TagInfo& tag_info) {
     const auto identifier = GetIdentifier(port, type);
-    const auto nfc_state = amiibo_data.empty() ? Common::Input::NfcState::AmiiboRemoved
-                                               : Common::Input::NfcState::NewAmiibo;
-    SetNfc(identifier, {nfc_state, amiibo_data});
+    const auto nfc_state = tag_info.uuid_length == 0 ? Common::Input::NfcState::AmiiboRemoved
+                                                     : Common::Input::NfcState::NewAmiibo;
+
+    const Common::Input::NfcStatus nfc_status{
+        .state = nfc_state,
+        .uuid_length = tag_info.uuid_length,
+        .protocol = tag_info.protocol,
+        .tag_type = tag_info.tag_type,
+        .uuid = tag_info.uuid,
+    };
+
+    SetNfc(identifier, nfc_status);
 }
 
 void Joycons::OnCameraUpdate(std::size_t port, const std::vector<u8>& camera_data,
@@ -726,4 +827,18 @@ std::string Joycons::JoyconName(Joycon::ControllerType type) const {
         return "Unknown Switch Controller";
     }
 }
+
+Common::Input::NfcState Joycons::TranslateDriverResult(Joycon::DriverResult result) const {
+    switch (result) {
+    case Joycon::DriverResult::Success:
+        return Common::Input::NfcState::Success;
+    case Joycon::DriverResult::Disabled:
+        return Common::Input::NfcState::WrongDeviceState;
+    case Joycon::DriverResult::NotSupported:
+        return Common::Input::NfcState::NotSupported;
+    default:
+        return Common::Input::NfcState::Unknown;
+    }
+}
+
 } // namespace InputCommon

--- a/src/input_common/drivers/joycon.h
+++ b/src/input_common/drivers/joycon.h
@@ -15,6 +15,7 @@ using SerialNumber = std::array<u8, 15>;
 struct Battery;
 struct Color;
 struct MotionData;
+struct TagInfo;
 enum class ControllerType : u8;
 enum class DriverResult;
 enum class IrsResolution;
@@ -39,9 +40,18 @@ public:
     Common::Input::DriverResult SetCameraFormat(const PadIdentifier& identifier,
                                                 Common::Input::CameraFormat camera_format) override;
 
-    Common::Input::NfcState SupportsNfc(const PadIdentifier& identifier_) const override;
-    Common::Input::NfcState WriteNfcData(const PadIdentifier& identifier_,
+    Common::Input::NfcState SupportsNfc(const PadIdentifier& identifier) const override;
+    Common::Input::NfcState StartNfcPolling(const PadIdentifier& identifier) override;
+    Common::Input::NfcState StopNfcPolling(const PadIdentifier& identifier) override;
+    Common::Input::NfcState ReadAmiiboData(const PadIdentifier& identifier,
+                                           std::vector<u8>& out_data) override;
+    Common::Input::NfcState WriteNfcData(const PadIdentifier& identifier,
                                          const std::vector<u8>& data) override;
+    Common::Input::NfcState ReadMifareData(const PadIdentifier& identifier,
+                                           const Common::Input::MifareRequest& request,
+                                           Common::Input::MifareRequest& out_data) override;
+    Common::Input::NfcState WriteMifareData(const PadIdentifier& identifier,
+                                            const Common::Input::MifareRequest& request) override;
 
     Common::Input::DriverResult SetPollingMode(
         const PadIdentifier& identifier, const Common::Input::PollingMode polling_mode) override;
@@ -82,7 +92,7 @@ private:
                         const Joycon::MotionData& value);
     void OnRingConUpdate(f32 ring_data);
     void OnAmiiboUpdate(std::size_t port, Joycon::ControllerType type,
-                        const std::vector<u8>& amiibo_data);
+                        const Joycon::TagInfo& amiibo_data);
     void OnCameraUpdate(std::size_t port, const std::vector<u8>& camera_data,
                         Joycon::IrsResolution format);
 
@@ -101,6 +111,8 @@ private:
 
     /// Returns the name of the device in text format
     std::string JoyconName(Joycon::ControllerType type) const;
+
+    Common::Input::NfcState TranslateDriverResult(Joycon::DriverResult result) const;
 
     std::jthread scan_thread;
 

--- a/src/input_common/drivers/virtual_amiibo.h
+++ b/src/input_common/drivers/virtual_amiibo.h
@@ -20,9 +20,10 @@ namespace InputCommon {
 class VirtualAmiibo final : public InputEngine {
 public:
     enum class State {
+        Disabled,
         Initialized,
         WaitingForAmiibo,
-        AmiiboIsOpen,
+        TagNearby,
     };
 
     enum class Info {
@@ -41,9 +42,17 @@ public:
         const PadIdentifier& identifier_, const Common::Input::PollingMode polling_mode_) override;
 
     Common::Input::NfcState SupportsNfc(const PadIdentifier& identifier_) const override;
-
+    Common::Input::NfcState StartNfcPolling(const PadIdentifier& identifier_) override;
+    Common::Input::NfcState StopNfcPolling(const PadIdentifier& identifier_) override;
+    Common::Input::NfcState ReadAmiiboData(const PadIdentifier& identifier_,
+                                           std::vector<u8>& out_data) override;
     Common::Input::NfcState WriteNfcData(const PadIdentifier& identifier_,
                                          const std::vector<u8>& data) override;
+    Common::Input::NfcState ReadMifareData(const PadIdentifier& identifier_,
+                                           const Common::Input::MifareRequest& data,
+                                           Common::Input::MifareRequest& out_data) override;
+    Common::Input::NfcState WriteMifareData(const PadIdentifier& identifier_,
+                                            const Common::Input::MifareRequest& data) override;
 
     State GetCurrentState() const;
 
@@ -61,8 +70,9 @@ private:
     static constexpr std::size_t MifareSize = 0x400;
 
     std::string file_path{};
-    State state{State::Initialized};
+    State state{State::Disabled};
     std::vector<u8> nfc_data;
+    Common::Input::NfcStatus status;
     Common::Input::PollingMode polling_mode{Common::Input::PollingMode::Passive};
 };
 } // namespace InputCommon

--- a/src/input_common/helpers/joycon_driver.h
+++ b/src/input_common/helpers/joycon_driver.h
@@ -49,7 +49,13 @@ public:
     DriverResult SetIrMode();
     DriverResult SetNfcMode();
     DriverResult SetRingConMode();
+    DriverResult StartNfcPolling();
+    DriverResult StopNfcPolling();
+    DriverResult ReadAmiiboData(std::vector<u8>& out_data);
     DriverResult WriteNfcData(std::span<const u8> data);
+    DriverResult ReadMifareData(std::span<const MifareReadChunk> request,
+                                std::span<MifareReadData> out_data);
+    DriverResult WriteMifareData(std::span<const MifareWriteChunk> request);
 
     void SetCallbacks(const JoyconCallbacks& callbacks);
 

--- a/src/input_common/helpers/joycon_protocol/nfc.h
+++ b/src/input_common/helpers/joycon_protocol/nfc.h
@@ -25,13 +25,24 @@ public:
 
     DriverResult StartNFCPollingMode();
 
-    DriverResult ScanAmiibo(std::vector<u8>& data);
+    DriverResult StopNFCPollingMode();
+
+    DriverResult GetTagInfo(Joycon::TagInfo& tag_info);
+
+    DriverResult ReadAmiibo(std::vector<u8>& data);
 
     DriverResult WriteAmiibo(std::span<const u8> data);
+
+    DriverResult ReadMifare(std::span<const MifareReadChunk> read_request,
+                            std::span<MifareReadData> out_data);
+
+    DriverResult WriteMifare(std::span<const MifareWriteChunk> write_request);
 
     bool HasAmiibo();
 
     bool IsEnabled() const;
+
+    bool IsPolling() const;
 
 private:
     // Number of times the function will be delayed until it outputs valid data
@@ -51,6 +62,13 @@ private:
 
     DriverResult WriteAmiiboData(const TagUUID& tag_uuid, std::span<const u8> data);
 
+    DriverResult GetMifareData(const MifareUUID& tag_uuid,
+                               std::span<const MifareReadChunk> read_request,
+                               std::span<MifareReadData> out_data);
+
+    DriverResult WriteMifareData(const MifareUUID& tag_uuid,
+                                 std::span<const MifareWriteChunk> write_request);
+
     DriverResult SendStartPollingRequest(MCUCommandResponse& output,
                                          bool is_second_attempt = false);
 
@@ -65,17 +83,31 @@ private:
     DriverResult SendWriteDataAmiiboRequest(MCUCommandResponse& output, u8 block_id,
                                             bool is_last_packet, std::span<const u8> data);
 
+    DriverResult SendReadDataMifareRequest(MCUCommandResponse& output, u8 block_id,
+                                           bool is_last_packet, std::span<const u8> data);
+
     std::vector<u8> SerializeWritePackage(const NFCWritePackage& package) const;
+
+    std::vector<u8> SerializeMifareReadPackage(const MifareReadPackage& package) const;
+
+    std::vector<u8> SerializeMifareWritePackage(const MifareWritePackage& package) const;
 
     NFCWritePackage MakeAmiiboWritePackage(const TagUUID& tag_uuid, std::span<const u8> data) const;
 
     NFCDataChunk MakeAmiiboChunk(u8 page, u8 size, std::span<const u8> data) const;
+
+    MifareReadPackage MakeMifareReadPackage(const MifareUUID& tag_uuid,
+                                            std::span<const MifareReadChunk> read_request) const;
+
+    MifareWritePackage MakeMifareWritePackage(const MifareUUID& tag_uuid,
+                                              std::span<const MifareWriteChunk> read_request) const;
 
     NFCReadBlockCommand GetReadBlockCommand(NFCPages pages) const;
 
     TagUUID GetTagUUID(std::span<const u8> data) const;
 
     bool is_enabled{};
+    bool is_polling{};
     std::size_t update_counter{};
 };
 

--- a/src/input_common/helpers/joycon_protocol/poller.cpp
+++ b/src/input_common/helpers/joycon_protocol/poller.cpp
@@ -70,8 +70,8 @@ void JoyconPoller::UpdateColor(const Color& color) {
     callbacks.on_color_data(color);
 }
 
-void JoyconPoller::UpdateAmiibo(const std::vector<u8>& amiibo_data) {
-    callbacks.on_amiibo_data(amiibo_data);
+void JoyconPoller::UpdateAmiibo(const Joycon::TagInfo& tag_info) {
+    callbacks.on_amiibo_data(tag_info);
 }
 
 void JoyconPoller::UpdateCamera(const std::vector<u8>& camera_data, IrsResolution format) {

--- a/src/input_common/helpers/joycon_protocol/poller.h
+++ b/src/input_common/helpers/joycon_protocol/poller.h
@@ -36,8 +36,8 @@ public:
 
     void UpdateColor(const Color& color);
     void UpdateRing(s16 value, const RingStatus& ring_status);
-    void UpdateAmiibo(const std::vector<u8>& amiibo_data);
-    void UpdateCamera(const std::vector<u8>& amiibo_data, IrsResolution format);
+    void UpdateAmiibo(const Joycon::TagInfo& tag_info);
+    void UpdateCamera(const std::vector<u8>& camera_data, IrsResolution format);
 
 private:
     void UpdateActiveLeftPadInput(const InputReportActive& input,

--- a/src/input_common/input_engine.h
+++ b/src/input_common/input_engine.h
@@ -143,9 +143,43 @@ public:
         return Common::Input::NfcState::NotSupported;
     }
 
+    // Start scanning for nfc tags
+    virtual Common::Input::NfcState StartNfcPolling(
+        [[maybe_unused]] const PadIdentifier& identifier_) {
+        return Common::Input::NfcState::NotSupported;
+    }
+
+    // Start scanning for nfc tags
+    virtual Common::Input::NfcState StopNfcPolling(
+        [[maybe_unused]] const PadIdentifier& identifier_) {
+        return Common::Input::NfcState::NotSupported;
+    }
+
+    // Reads data from amiibo tag
+    virtual Common::Input::NfcState ReadAmiiboData(
+        [[maybe_unused]] const PadIdentifier& identifier_,
+        [[maybe_unused]] std::vector<u8>& out_data) {
+        return Common::Input::NfcState::NotSupported;
+    }
+
     // Writes data to an nfc tag
     virtual Common::Input::NfcState WriteNfcData([[maybe_unused]] const PadIdentifier& identifier,
                                                  [[maybe_unused]] const std::vector<u8>& data) {
+        return Common::Input::NfcState::NotSupported;
+    }
+
+    // Reads data from mifare tag
+    virtual Common::Input::NfcState ReadMifareData(
+        [[maybe_unused]] const PadIdentifier& identifier_,
+        [[maybe_unused]] const Common::Input::MifareRequest& request,
+        [[maybe_unused]] Common::Input::MifareRequest& out_data) {
+        return Common::Input::NfcState::NotSupported;
+    }
+
+    // Write data to mifare tag
+    virtual Common::Input::NfcState WriteMifareData(
+        [[maybe_unused]] const PadIdentifier& identifier_,
+        [[maybe_unused]] const Common::Input::MifareRequest& request) {
         return Common::Input::NfcState::NotSupported;
     }
 

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -792,8 +792,7 @@ public:
 
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::Nfc,
-            .nfc_status = nfc_status.state,
-            .raw_data = nfc_status.data,
+            .nfc_status = nfc_status,
         };
 
         TriggerOnChange(status);
@@ -836,8 +835,29 @@ public:
         return input_engine->SupportsNfc(identifier);
     }
 
+    Common::Input::NfcState StartNfcPolling() {
+        return input_engine->StartNfcPolling(identifier);
+    }
+
+    Common::Input::NfcState StopNfcPolling() {
+        return input_engine->StopNfcPolling(identifier);
+    }
+
+    Common::Input::NfcState ReadAmiiboData(std::vector<u8>& out_data) {
+        return input_engine->ReadAmiiboData(identifier, out_data);
+    }
+
     Common::Input::NfcState WriteNfcData(const std::vector<u8>& data) override {
         return input_engine->WriteNfcData(identifier, data);
+    }
+
+    Common::Input::NfcState ReadMifareData(const Common::Input::MifareRequest& request,
+                                           Common::Input::MifareRequest& out_data) {
+        return input_engine->ReadMifareData(identifier, request, out_data);
+    }
+
+    Common::Input::NfcState WriteMifareData(const Common::Input::MifareRequest& request) {
+        return input_engine->WriteMifareData(identifier, request);
     }
 
 private:

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3836,7 +3836,7 @@ void GMainWindow::OnLoadAmiibo() {
     auto* virtual_amiibo = input_subsystem->GetVirtualAmiibo();
 
     // Remove amiibo if one is connected
-    if (virtual_amiibo->GetCurrentState() == InputCommon::VirtualAmiibo::State::AmiiboIsOpen) {
+    if (virtual_amiibo->GetCurrentState() == InputCommon::VirtualAmiibo::State::TagNearby) {
         virtual_amiibo->CloseAmiibo();
         QMessageBox::warning(this, tr("Amiibo"), tr("The current amiibo has been removed"));
         return;
@@ -3864,7 +3864,7 @@ void GMainWindow::LoadAmiibo(const QString& filename) {
     auto* virtual_amiibo = input_subsystem->GetVirtualAmiibo();
     const QString title = tr("Error loading Amiibo data");
     // Remove amiibo if one is connected
-    if (virtual_amiibo->GetCurrentState() == InputCommon::VirtualAmiibo::State::AmiiboIsOpen) {
+    if (virtual_amiibo->GetCurrentState() == InputCommon::VirtualAmiibo::State::TagNearby) {
         virtual_amiibo->CloseAmiibo();
         QMessageBox::warning(this, tr("Amiibo"), tr("The current amiibo has been removed"));
         return;


### PR DESCRIPTION
Implements native Skylander toys with Joy-Cons or a Pro Controller. You should be able to load them just as you would on the Switch. No additional setup is required; simply connecting and mapping the controller is sufficient.

This pull request removes certain hacks. Consequently, a significant portion of the tag detection process had to be rewritten to accommodate different types of tag support. As Joy-Cons handle all the encryption, there is no need for any keys to read or write data, allowing them to be used directly.