### PR TITLE
time_zone_manager: Stop on comma

### DIFF
--- a/src/core/hle/service/time/time_zone_manager.cpp
+++ b/src/core/hle/service/time/time_zone_manager.cpp
@@ -911,11 +911,13 @@ static Result ToCalendarTimeInternal(const TimeZoneRule& rules, s64 time,
 
     calendar_additional_info.is_dst = rules.ttis[tti_index].is_dst;
     const char* time_zone{&rules.chars[rules.ttis[tti_index].abbreviation_list_index]};
-    for (u32 index{}; time_zone[index] != '\0' && time_zone[index] != ',' &&
-                      index < calendar_additional_info.timezone_name.size() - 1;
+    u32 index;
+    for (index = 0; time_zone[index] != '\0' && time_zone[index] != ',' &&
+                    index < calendar_additional_info.timezone_name.size() - 1;
          ++index) {
         calendar_additional_info.timezone_name[index] = time_zone[index];
     }
+    calendar_additional_info.timezone_name[index] = '\0';
     return ResultSuccess;
 }
 

--- a/src/core/hle/service/time/time_zone_manager.cpp
+++ b/src/core/hle/service/time/time_zone_manager.cpp
@@ -911,7 +911,9 @@ static Result ToCalendarTimeInternal(const TimeZoneRule& rules, s64 time,
 
     calendar_additional_info.is_dst = rules.ttis[tti_index].is_dst;
     const char* time_zone{&rules.chars[rules.ttis[tti_index].abbreviation_list_index]};
-    for (int index{}; time_zone[index] != '\0'; ++index) {
+    for (u32 index{}; time_zone[index] != '\0' && time_zone[index] != ',' &&
+                      index < calendar_additional_info.timezone_name.size() - 1;
+         ++index) {
         calendar_additional_info.timezone_name[index] = time_zone[index];
     }
     return ResultSuccess;


### PR DESCRIPTION
This is a deviation from the reference time zone implementation. The actual code will set a pointer to the time zone name here, but for us we have a limited number of characters to work with, and the name of the time zone here could be larger than 8 characters. This causes an oob array access (#10817).

We can make the assumption that time zone names greater than five characters in length include a comma that denotes more data. Nintendo just truncates that data for the name, so we can do the same. And just to be doubly sure that we never break past the array length, directly compare against the length.

Closes #10817