### PR TITLE
android: Add a notice when RAM inadequate

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
@@ -109,9 +109,9 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
             Toast.makeText(
                 this,
                 getString(
-                    R.string.device_memory_inadequate_description,
+                    R.string.device_memory_inadequate,
                     memoryUtil.getDeviceRAM(),
-                    "8 GB"
+                    "8 ${getString(R.string.memory_gigabyte)}"
                 ),
                 Toast.LENGTH_LONG
             ).show()

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
@@ -27,13 +27,13 @@ import android.view.MotionEvent
 import android.view.Surface
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation.fragment.NavHostFragment
-import kotlin.math.roundToInt
 import org.yuzu.yuzu_emu.NativeLibrary
 import org.yuzu.yuzu_emu.R
 import org.yuzu.yuzu_emu.databinding.ActivityEmulationBinding
@@ -44,8 +44,10 @@ import org.yuzu.yuzu_emu.model.Game
 import org.yuzu.yuzu_emu.utils.ControllerMappingHelper
 import org.yuzu.yuzu_emu.utils.ForegroundService
 import org.yuzu.yuzu_emu.utils.InputHandler
+import org.yuzu.yuzu_emu.utils.MemoryUtil
 import org.yuzu.yuzu_emu.utils.NfcReader
 import org.yuzu.yuzu_emu.utils.ThemeHelper
+import kotlin.math.roundToInt
 
 class EmulationActivity : AppCompatActivity(), SensorEventListener {
     private lateinit var binding: ActivityEmulationBinding
@@ -101,6 +103,19 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
 
         inputHandler = InputHandler()
         inputHandler.initialize()
+
+        val memoryUtil = MemoryUtil(this)
+        if (memoryUtil.isLessThan(8, MemoryUtil.Gb)) {
+            Toast.makeText(
+                this,
+                getString(
+                    R.string.device_memory_inadequate_description,
+                    memoryUtil.getDeviceRAM(),
+                    "8 GB"
+                ),
+                Toast.LENGTH_LONG
+            ).show()
+        }
 
         // Start a foreground service to prevent the app from getting killed in the background
         val startIntent = Intent(this, ForegroundService::class.java)

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/MemoryUtil.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/MemoryUtil.kt
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.yuzu.yuzu_emu.utils
+
+import android.app.ActivityManager
+import android.content.Context
+import java.util.Locale
+
+class MemoryUtil(context: Context) {
+
+    private val Long.floatForm: String
+        get() = String.format(Locale.ROOT, "%.2f", this.toDouble())
+
+    private fun bytesToSizeUnit(size: Long): String {
+        return when {
+            size < Kb -> size.floatForm + " byte"
+            size < Mb -> (size / Kb).floatForm + " KB"
+            size < Gb -> (size / Mb).floatForm + " MB"
+            size < Tb -> (size / Gb).floatForm + " GB"
+            size < Pb -> (size / Tb).floatForm + " TB"
+            size < Eb -> (size / Pb).floatForm + " Pb"
+            else -> (size / Eb).floatForm + " Eb"
+        }
+    }
+
+    private val totalMemory =
+        with(context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager) {
+            val memInfo = ActivityManager.MemoryInfo()
+            getMemoryInfo(memInfo)
+            memInfo.totalMem
+        }
+
+    fun isLessThan(minimum: Int, size: Long): Boolean {
+        return when (size) {
+            Kb -> totalMemory < Mb && totalMemory < minimum
+            Mb -> totalMemory < Gb && (totalMemory / Mb) < minimum
+            Gb -> totalMemory < Tb && (totalMemory / Gb) < minimum
+            Tb -> totalMemory < Pb && (totalMemory / Tb) < minimum
+            Pb -> totalMemory < Eb && (totalMemory / Pb) < minimum
+            Eb -> totalMemory / Eb < minimum
+            else -> totalMemory < Kb && totalMemory < minimum
+        }
+    }
+
+    fun getDeviceRAM(): String {
+        return bytesToSizeUnit(totalMemory)
+    }
+
+    companion object {
+        const val Kb: Long = 1024
+        const val Mb = Kb * 1024
+        const val Gb = Mb * 1024
+        const val Tb = Gb * 1024
+        const val Pb = Tb * 1024
+        const val Eb = Pb * 1024
+    }
+}

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/MemoryUtil.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/MemoryUtil.kt
@@ -5,22 +5,23 @@ package org.yuzu.yuzu_emu.utils
 
 import android.app.ActivityManager
 import android.content.Context
+import org.yuzu.yuzu_emu.R
 import java.util.Locale
 
-class MemoryUtil(context: Context) {
+class MemoryUtil(val context: Context) {
 
     private val Long.floatForm: String
         get() = String.format(Locale.ROOT, "%.2f", this.toDouble())
 
     private fun bytesToSizeUnit(size: Long): String {
         return when {
-            size < Kb -> size.floatForm + " byte"
-            size < Mb -> (size / Kb).floatForm + " KB"
-            size < Gb -> (size / Mb).floatForm + " MB"
-            size < Tb -> (size / Gb).floatForm + " GB"
-            size < Pb -> (size / Tb).floatForm + " TB"
-            size < Eb -> (size / Pb).floatForm + " Pb"
-            else -> (size / Eb).floatForm + " Eb"
+            size < Kb -> "${size.floatForm} ${context.getString(R.string.memory_byte)}"
+            size < Mb -> "${(size / Kb).floatForm} ${context.getString(R.string.memory_kilobyte)}"
+            size < Gb -> "${(size / Mb).floatForm} ${context.getString(R.string.memory_megabyte)}"
+            size < Tb -> "${(size / Gb).floatForm} ${context.getString(R.string.memory_gigabyte)}"
+            size < Pb -> "${(size / Tb).floatForm} ${context.getString(R.string.memory_terabyte)}"
+            size < Eb -> "${(size / Pb).floatForm} ${context.getString(R.string.memory_petabyte)}"
+            else -> "${(size / Eb).floatForm} ${context.getString(R.string.memory_exabyte)}"
         }
     }
 

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -270,7 +270,7 @@
     <string name="fatal_error">Fatal Error</string>
     <string name="fatal_error_message">A fatal error occurred. Check the log for details.\nContinuing emulation may result in crashes and bugs.</string>
     <string name="performance_warning">Turning off this setting will significantly reduce emulation performance! For the best experience, it is recommended that you leave this setting enabled.</string>
-    <string name="device_memory_inadequate_description">Device RAM: %1$s\nRecommended: %2$s</string>
+    <string name="device_memory_inadequate">Device RAM: %1$s\nRecommended: %2$s</string>
 
     <!-- Region Names -->
     <string name="region_japan">Japan</string>
@@ -300,6 +300,15 @@
     <string name="language_simplified_chinese">Simplified Chinese (简体中文)</string>
     <string name="language_traditional_chinese">Traditional Chinese (正體中文)</string>
     <string name="language_brazilian_portuguese">Brazilian Portuguese (Português do Brasil)</string>
+
+    <!-- Memory Sizes -->
+    <string name="memory_byte">Byte</string>
+    <string name="memory_kilobyte">KB</string>
+    <string name="memory_megabyte">MB</string>
+    <string name="memory_gigabyte">GB</string>
+    <string name="memory_terabyte">TB</string>
+    <string name="memory_petabyte">PB</string>
+    <string name="memory_exabyte">EB</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -270,6 +270,7 @@
     <string name="fatal_error">Fatal Error</string>
     <string name="fatal_error_message">A fatal error occurred. Check the log for details.\nContinuing emulation may result in crashes and bugs.</string>
     <string name="performance_warning">Turning off this setting will significantly reduce emulation performance! For the best experience, it is recommended that you leave this setting enabled.</string>
+    <string name="device_memory_inadequate_description">Device RAM: %1$s\nRecommended: %2$s</string>
 
     <!-- Region Names -->
     <string name="region_japan">Japan</string>


### PR DESCRIPTION
Separated this from the multi-install PR by switching to a Toast. In all honesty, most users with insufficient RAM should at least have some idea what they are getting into. No need to pause the entire load just to remind them.

Completes the request at https://github.com/yuzu-emu/yuzu/issues/10789