### PR TITLE
input_common: Improve nfc state handling and 3rd party support

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -1250,6 +1250,11 @@ Common::Input::DriverResult EmulatedController::SetPollingMode(
         const auto virtual_nfc_result = nfc_output_device->SetPollingMode(polling_mode);
         const auto mapped_nfc_result = right_output_device->SetPollingMode(polling_mode);
 
+        // Restore previous state
+        if (mapped_nfc_result != Common::Input::DriverResult::Success) {
+            right_output_device->SetPollingMode(Common::Input::PollingMode::Active);
+        }
+
         if (virtual_nfc_result == Common::Input::DriverResult::Success) {
             return virtual_nfc_result;
         }

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -1334,16 +1334,22 @@ bool EmulatedController::StartNfcPolling() {
     auto& nfc_output_device = output_devices[static_cast<std::size_t>(DeviceIndex::Right)];
     auto& nfc_virtual_output_device = output_devices[3];
 
-    return nfc_output_device->StartNfcPolling() == Common::Input::NfcState::Success ||
-           nfc_virtual_output_device->StartNfcPolling() == Common::Input::NfcState::Success;
+    const auto device_result = nfc_output_device->StartNfcPolling();
+    const auto virtual_device_result = nfc_virtual_output_device->StartNfcPolling();
+
+    return device_result == Common::Input::NfcState::Success ||
+           virtual_device_result == Common::Input::NfcState::Success;
 }
 
 bool EmulatedController::StopNfcPolling() {
     auto& nfc_output_device = output_devices[static_cast<std::size_t>(DeviceIndex::Right)];
     auto& nfc_virtual_output_device = output_devices[3];
 
-    return nfc_output_device->StopNfcPolling() == Common::Input::NfcState::Success ||
-           nfc_virtual_output_device->StopNfcPolling() == Common::Input::NfcState::Success;
+    const auto device_result = nfc_output_device->StopNfcPolling();
+    const auto virtual_device_result = nfc_virtual_output_device->StopNfcPolling();
+
+    return device_result == Common::Input::NfcState::Success ||
+           virtual_device_result == Common::Input::NfcState::Success;
 }
 
 bool EmulatedController::ReadAmiiboData(std::vector<u8>& data) {

--- a/src/input_common/helpers/joycon_driver.h
+++ b/src/input_common/helpers/joycon_driver.h
@@ -120,6 +120,7 @@ private:
     // Hardware configuration
     u8 leds{};
     ReportMode mode{};
+    bool input_only_device{};
     bool passive_enabled{};   // Low power mode, Ideal for multiple controllers at the same time
     bool hidbus_enabled{};    // External device support
     bool irs_enabled{};       // Infrared camera input

--- a/src/input_common/helpers/joycon_protocol/common_protocol.cpp
+++ b/src/input_common/helpers/joycon_protocol/common_protocol.cpp
@@ -73,7 +73,7 @@ DriverResult JoyconCommonProtocol::SendRawData(std::span<const u8> buffer) {
 DriverResult JoyconCommonProtocol::GetSubCommandResponse(SubCommand sc,
                                                          SubCommandResponse& output) {
     constexpr int timeout_mili = 66;
-    constexpr int MaxTries = 15;
+    constexpr int MaxTries = 3;
     int tries = 0;
 
     do {
@@ -113,9 +113,7 @@ DriverResult JoyconCommonProtocol::SendSubCommand(SubCommand sc, std::span<const
         return result;
     }
 
-    result = GetSubCommandResponse(sc, output);
-
-    return DriverResult::Success;
+    return GetSubCommandResponse(sc, output);
 }
 
 DriverResult JoyconCommonProtocol::SendSubCommand(SubCommand sc, std::span<const u8> buffer) {
@@ -158,7 +156,7 @@ DriverResult JoyconCommonProtocol::SendVibrationReport(std::span<const u8> buffe
 
 DriverResult JoyconCommonProtocol::ReadRawSPI(SpiAddress addr, std::span<u8> output) {
     constexpr std::size_t HeaderSize = 5;
-    constexpr std::size_t MaxTries = 10;
+    constexpr std::size_t MaxTries = 5;
     std::size_t tries = 0;
     SubCommandResponse response{};
     std::array<u8, sizeof(ReadSpiPacket)> buffer{};


### PR DESCRIPTION
Some 3rd party controllers don't accept commands. I have reduced the number of attempts to obtain valid data and disabled most commands to minimize the stutter caused by attempting to configure the controller.

SetPollingMode also forwards the failure so that EmulatedController can properly restore the previous state. This fixes missing input when the controller fails to use NFC.

If the game stops polling for amiibos while an amiibo was in range, the amiibo is lost but never signaled.

Finally, if your controller supports NFC but you try to use a bin dump, it will now detect it properly instead of displaying an error."

Fixes #10877