### PR TITLE
Clarify Ring-Con configuration message in UI

### DIFF
--- a/src/yuzu/configuration/configure_ringcon.ui
+++ b/src/yuzu/configuration/configure_ringcon.ui
@@ -23,7 +23,7 @@
       </size>
      </property>
      <property name="text">
-      <string>If you want to use this controller configure player 1 as right controller and player 2 as dual joycon before starting the game to allow this controller to be detected properly.</string>
+      <string>To use Ring-Con configure player 1 as right JoyCon both physical and emulated, and player 2 as left JoyCon physical and dual (!) JoyCon emulated before starting the game.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/yuzu/configuration/configure_ringcon.ui
+++ b/src/yuzu/configuration/configure_ringcon.ui
@@ -23,7 +23,7 @@
       </size>
      </property>
      <property name="text">
-      <string>To use Ring-Con configure player 1 as right JoyCon both physical and emulated, and player 2 as left JoyCon physical and dual (!) JoyCon emulated before starting the game.</string>
+      <string>To use Ring-Con, configure player 1 as right Joy-Con (both physical and emulated), and player 2 as left Joy-Con (left physical and dual emulated) before starting the game.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
It is not obvious how the left Joy-Con should be set up.
Clarify message and mention that it should be left physical, but dual emulated according to [this comment](https://github.com/yuzu-emu/yuzu/issues/8489#issuecomment-1546490439).

Without this clarification one might think to set up left controller as dual both physical and emulated, and this won't work. In fact, this confusion has already happened as we can see from comment history on the same issue #8489.

