### PR TITLE
 OpenGL: Add Local Memory warmup shader for Nvidia

### DIFF
--- a/src/shader_recompiler/backend/glasm/emit_glasm.cpp
+++ b/src/shader_recompiler/backend/glasm/emit_glasm.cpp
@@ -461,7 +461,7 @@ std::string EmitGLASM(const Profile& profile, const RuntimeInfo& runtime_info, I
         header += fmt::format("R{},", index);
     }
     if (program.local_memory_size > 0) {
-        header += fmt::format("lmem[{}],", program.local_memory_size);
+        header += fmt::format("lmem[{}],", Common::DivCeil(program.local_memory_size, 4U));
     }
     if (program.info.uses_fswzadd) {
         header += "FSWZA[4],FSWZB[4],";

--- a/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
+++ b/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
@@ -424,6 +424,10 @@ void VisitUsages(Info& info, IR::Inst& inst) {
         info.used_constant_buffer_types |= IR::Type::U32 | IR::Type::U32x2;
         info.used_storage_buffer_types |= IR::Type::U32 | IR::Type::U32x2 | IR::Type::U32x4;
         break;
+    case IR::Opcode::LoadLocal:
+    case IR::Opcode::WriteLocal:
+        info.uses_local_memory = true;
+        break;
     default:
         break;
     }

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -172,6 +172,7 @@ struct Info {
     bool stores_indexed_attributes{};
 
     bool stores_global_memory{};
+    bool uses_local_memory{};
 
     bool uses_fp16{};
     bool uses_fp64{};

--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SHADER_FILES
     opengl_fidelityfx_fsr.frag
     opengl_fidelityfx_fsr_easu.frag
     opengl_fidelityfx_fsr_rcas.frag
+    opengl_lmem_warmup.comp
     opengl_present.frag
     opengl_present.vert
     opengl_present_scaleforce.frag

--- a/src/video_core/host_shaders/opengl_lmem_warmup.comp
+++ b/src/video_core/host_shaders/opengl_lmem_warmup.comp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright 2021 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// This shader is a workaround for a quirk in NVIDIA OpenGL drivers
+// Shaders using local memory see a great performance benefit if a shader that was dispatched
+// before it had more local memory allocated.
+// This shader allocates the maximum local memory allowed on NVIDIA drivers to ensure that
+// subsequent shaders see the performance boost.
+
+// NOTE: This shader does no actual meaningful work and returns immediately,
+// it is simply a means to have the driver expect a shader using lots of local memory.
+
+#version 450
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(location = 0) uniform uint uniform_data;
+
+layout(binding = 0, rgba8) uniform writeonly restrict image2DArray dest_image;
+
+#define MAX_LMEM_SIZE 4080 // Size chosen to avoid errors in Nvidia's GLSL compiler
+#define NUM_LMEM_CONSTANTS 1
+#define ARRAY_SIZE MAX_LMEM_SIZE - NUM_LMEM_CONSTANTS
+
+uint lmem_0[ARRAY_SIZE];
+const uvec4 constant_values[NUM_LMEM_CONSTANTS] = uvec4[](uvec4(0));
+
+void main() {
+    const uint global_id = gl_GlobalInvocationID.x;
+    if (global_id <= 128) {
+        // Since the shader is called with a dispatch of 1x1x1
+        // This should always be the case, and this shader will not actually execute
+        return;
+    }
+    for (uint t = 0; t < uniform_data; t++) {
+        const uint offset = (t * uniform_data);
+        lmem_0[offset] = t;
+    }
+    const uint offset = (gl_GlobalInvocationID.y * uniform_data + gl_GlobalInvocationID.x);
+    const uint value = lmem_0[offset];
+    const uint const_value = constant_values[offset / 4][offset % 4];
+    const uvec4 color = uvec4(value + const_value);
+
+    // A "side-effect" is needed so the variables don't get optimized out,
+    // but this should never execute so there should be no clobbering of previously bound state.
+    imageStore(dest_image, ivec3(gl_GlobalInvocationID), color);
+}

--- a/src/video_core/renderer_opengl/gl_compute_pipeline.cpp
+++ b/src/video_core/renderer_opengl/gl_compute_pipeline.cpp
@@ -63,6 +63,7 @@ ComputePipeline::ComputePipeline(const Device& device, TextureCache& texture_cac
     writes_global_memory = !use_storage_buffers &&
                            std::ranges::any_of(info.storage_buffers_descriptors,
                                                [](const auto& desc) { return desc.is_written; });
+    uses_local_memory = info.uses_local_memory;
     if (force_context_flush) {
         std::scoped_lock lock{built_mutex};
         built_fence.Create();

--- a/src/video_core/renderer_opengl/gl_compute_pipeline.h
+++ b/src/video_core/renderer_opengl/gl_compute_pipeline.h
@@ -59,6 +59,10 @@ public:
         return writes_global_memory;
     }
 
+    [[nodiscard]] bool UsesLocalMemory() const noexcept {
+        return uses_local_memory;
+    }
+
     void SetEngine(Tegra::Engines::KeplerCompute* kepler_compute_,
                    Tegra::MemoryManager* gpu_memory_) {
         kepler_compute = kepler_compute_;
@@ -84,6 +88,7 @@ private:
 
     bool use_storage_buffers{};
     bool writes_global_memory{};
+    bool uses_local_memory{};
 
     std::mutex built_mutex;
     std::condition_variable built_condvar;

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -194,6 +194,7 @@ Device::Device(Core::Frontend::EmuWindow& emu_window) {
             has_bool_ref_bug = true;
         }
     }
+    has_lmem_perf_bug = is_nvidia;
 
     strict_context_required = emu_window.StrictContextRequired();
     // Blocks AMD and Intel OpenGL drivers on Windows from using asynchronous shader compilation.

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -192,6 +192,10 @@ public:
         return supports_conditional_barriers;
     }
 
+    bool HasLmemPerfBug() const {
+        return has_lmem_perf_bug;
+    }
+
 private:
     static bool TestVariableAoffi();
     static bool TestPreciseBug();
@@ -238,6 +242,7 @@ private:
     bool can_report_memory{};
     bool strict_context_required{};
     bool supports_conditional_barriers{};
+    bool has_lmem_perf_bug{};
 
     std::string vendor_name;
 };

--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.cpp
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.cpp
@@ -215,6 +215,7 @@ GraphicsPipeline::GraphicsPipeline(const Device& device, TextureCache& texture_c
 
         writes_global_memory |= std::ranges::any_of(
             info.storage_buffers_descriptors, [](const auto& desc) { return desc.is_written; });
+        uses_local_memory |= info.uses_local_memory;
     }
     ASSERT(num_textures <= MAX_TEXTURES);
     ASSERT(num_images <= MAX_IMAGES);

--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.h
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.h
@@ -98,6 +98,10 @@ public:
         return writes_global_memory;
     }
 
+    [[nodiscard]] bool UsesLocalMemory() const noexcept {
+        return uses_local_memory;
+    }
+
     [[nodiscard]] bool IsBuilt() noexcept;
 
     template <typename Spec>
@@ -146,6 +150,7 @@ private:
 
     bool use_storage_buffers{};
     bool writes_global_memory{};
+    bool uses_local_memory{};
 
     static constexpr std::size_t XFB_ENTRY_STRIDE = 3;
     GLsizei num_xfb_attribs{};

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -222,7 +222,9 @@ void RasterizerOpenGL::PrepareDraw(bool is_indexed, Func&& draw_func) {
     gpu.TickWork();
 
     std::scoped_lock lock{buffer_cache.mutex, texture_cache.mutex};
-    program_manager.LocalMemoryWarmup();
+    if (pipeline->UsesLocalMemory()) {
+        program_manager.LocalMemoryWarmup();
+    }
     pipeline->SetEngine(maxwell3d, gpu_memory);
     pipeline->Configure(is_indexed);
 
@@ -372,7 +374,9 @@ void RasterizerOpenGL::DispatchCompute() {
     if (!pipeline) {
         return;
     }
-    program_manager.LocalMemoryWarmup();
+    if (pipeline->UsesLocalMemory()) {
+        program_manager.LocalMemoryWarmup();
+    }
     pipeline->SetEngine(kepler_compute, gpu_memory);
     pipeline->Configure();
     const auto& qmd{kepler_compute->launch_description};

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -222,6 +222,7 @@ void RasterizerOpenGL::PrepareDraw(bool is_indexed, Func&& draw_func) {
     gpu.TickWork();
 
     std::scoped_lock lock{buffer_cache.mutex, texture_cache.mutex};
+    program_manager.LocalMemoryWarmup();
     pipeline->SetEngine(maxwell3d, gpu_memory);
     pipeline->Configure(is_indexed);
 
@@ -371,6 +372,7 @@ void RasterizerOpenGL::DispatchCompute() {
     if (!pipeline) {
         return;
     }
+    program_manager.LocalMemoryWarmup();
     pipeline->SetEngine(kepler_compute, gpu_memory);
     pipeline->Configure();
     const auto& qmd{kepler_compute->launch_description};

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -30,6 +30,8 @@ public:
 
     void RestoreGuestCompute();
 
+    void LocalMemoryWarmup();
+
 private:
     void BindPipeline();
 
@@ -44,6 +46,7 @@ private:
     u32 current_stage_mask = 0;
     std::array<GLuint, NUM_STAGES> current_programs{};
     GLuint current_assembly_compute_program = 0;
+    OGLProgram lmem_warmup_program;
 };
 
 } // namespace OpenGL


### PR DESCRIPTION
Here's a fun one.

Nvidia's OpenGL drivers see a significant performance uplift in shaders using local memory if the previous shader that was executed uses more local memory (sort of..)

To take advantage of this discovery, this change introduces a dummy shader that allocates the maximum allowed local memory, but returns immediately without executing. This tricks the driver into boosting the performance of the later executing shaders which use local memory.

Here's a local memory torture test homebrew used to test this: 
[textured_cube_compute.zip](https://github.com/yuzu-emu/yuzu/files/11861207/textured_cube_compute.zip)

In this homebrew, my performance went from 7 to 8 FPS, up to 40 to 42 FPS, matching Vulkan's performance.

