### PR TITLE
android: Fix size check for content uris

### DIFF
--- a/src/common/fs/fs.cpp
+++ b/src/common/fs/fs.cpp
@@ -605,6 +605,12 @@ fs::file_type GetEntryType(const fs::path& path) {
 }
 
 u64 GetSize(const fs::path& path) {
+#ifdef ANDROID
+    if (Android::IsContentUri(path)) {
+        return Android::GetSize(path);
+    }
+#endif
+
     std::error_code ec;
 
     const auto file_size = fs::file_size(path, ec);


### PR DESCRIPTION
Games on android will fail to load game data and metadata without this change.

I'm not familiar with the vfs here but switching back to this way of getting size works. I'd definitely want @liamwhite to check this out to make sure I didn't break anything else.