### PR TITLE
gitmodules: normalize indentation and url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,35 +2,35 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 [submodule "enet"]
-    path = externals/enet
-    url = https://github.com/lsalzman/enet.git
+	path = externals/enet
+	url = https://github.com/lsalzman/enet.git
 [submodule "inih"]
-    path = externals/inih/inih
-    url = https://github.com/benhoyt/inih.git
+	path = externals/inih/inih
+	url = https://github.com/benhoyt/inih.git
 [submodule "cubeb"]
-    path = externals/cubeb
-    url = https://github.com/mozilla/cubeb.git
+	path = externals/cubeb
+	url = https://github.com/mozilla/cubeb.git
 [submodule "dynarmic"]
-    path = externals/dynarmic
-    url = https://github.com/MerryMage/dynarmic.git
+	path = externals/dynarmic
+	url = https://github.com/merryhime/dynarmic.git
 [submodule "libusb"]
 	path = externals/libusb/libusb
 	url = https://github.com/libusb/libusb.git
 [submodule "discord-rpc"]
-    path = externals/discord-rpc
-    url = https://github.com/yuzu-emu/discord-rpc.git
+	path = externals/discord-rpc
+	url = https://github.com/yuzu-emu/discord-rpc.git
 [submodule "Vulkan-Headers"]
-    path = externals/Vulkan-Headers
-    url = https://github.com/KhronosGroup/Vulkan-Headers.git
+	path = externals/Vulkan-Headers
+	url = https://github.com/KhronosGroup/Vulkan-Headers.git
 [submodule "sirit"]
-    path = externals/sirit
-    url = https://github.com/yuzu-emu/sirit
+	path = externals/sirit
+	url = https://github.com/yuzu-emu/sirit.git
 [submodule "mbedtls"]
-    path = externals/mbedtls
-    url = https://github.com/yuzu-emu/mbedtls
+	path = externals/mbedtls
+	url = https://github.com/yuzu-emu/mbedtls.git
 [submodule "xbyak"]
-    path = externals/xbyak
-    url = https://github.com/herumi/xbyak.git
+	path = externals/xbyak
+	url = https://github.com/herumi/xbyak.git
 [submodule "opus"]
 	path = externals/opus/opus
 	url = https://github.com/xiph/opus.git
@@ -45,16 +45,16 @@
 	url = https://github.com/FFmpeg/FFmpeg.git
 [submodule "vcpkg"]
 	path = externals/vcpkg
-	url = https://github.com/Microsoft/vcpkg.git
+	url = https://github.com/microsoft/vcpkg.git
 [submodule "cpp-jwt"]
 	path = externals/cpp-jwt
 	url = https://github.com/arun11299/cpp-jwt.git
 [submodule "libadrenotools"]
 	path = externals/libadrenotools
-	url = https://github.com/bylaws/libadrenotools
+	url = https://github.com/bylaws/libadrenotools.git
 [submodule "tzdb_to_nx"]
 	path = externals/nx_tzdb/tzdb_to_nx
 	url = https://github.com/lat9nq/tzdb_to_nx.git
 [submodule "VulkanMemoryAllocator"]
 	path = externals/vma/VulkanMemoryAllocator
-	url = https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator
+	url = https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git


### PR DESCRIPTION
- Use tab everywhere because `git submodule add ...` always inserts tab.
- Some usernames in repo url have changed.
- Add the `.git` suffix in all url.