### PR TITLE
x64: Make use of monitorx instructions for power efficient sleeps (AMD)

### DIFF
--- a/src/common/telemetry.cpp
+++ b/src/common/telemetry.cpp
@@ -93,6 +93,7 @@ void AppendCPUInfo(FieldCollection& fc) {
     add_field("CPU_Extension_x64_GFNI", caps.gfni);
     add_field("CPU_Extension_x64_INVARIANT_TSC", caps.invariant_tsc);
     add_field("CPU_Extension_x64_LZCNT", caps.lzcnt);
+    add_field("CPU_Extension_x64_MONITORX", caps.monitorx);
     add_field("CPU_Extension_x64_MOVBE", caps.movbe);
     add_field("CPU_Extension_x64_PCLMULQDQ", caps.pclmulqdq);
     add_field("CPU_Extension_x64_POPCNT", caps.popcnt);

--- a/src/common/x64/cpu_detect.cpp
+++ b/src/common/x64/cpu_detect.cpp
@@ -168,6 +168,7 @@ static CPUCaps Detect() {
         __cpuid(cpu_id, 0x80000001);
         caps.lzcnt = Common::Bit<5>(cpu_id[2]);
         caps.fma4 = Common::Bit<16>(cpu_id[2]);
+        caps.monitorx = Common::Bit<29>(cpu_id[2]);
     }
 
     if (max_ex_fn >= 0x80000007) {

--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -63,6 +63,7 @@ struct CPUCaps {
     bool gfni : 1;
     bool invariant_tsc : 1;
     bool lzcnt : 1;
+    bool monitorx : 1;
     bool movbe : 1;
     bool pclmulqdq : 1;
     bool popcnt : 1;

--- a/src/common/x64/cpu_wait.cpp
+++ b/src/common/x64/cpu_wait.cpp
@@ -13,24 +13,30 @@
 
 namespace Common::X64 {
 
+namespace {
+
+// 100,000 cycles is a reasonable amount of time to wait to save on CPU resources.
+// For reference:
+// At 1 GHz, 100K cycles is 100us
+// At 2 GHz, 100K cycles is 50us
+// At 4 GHz, 100K cycles is 25us
+constexpr auto PauseCycles = 100'000U;
+
+} // Anonymous namespace
+
 #ifdef _MSC_VER
 __forceinline static void TPAUSE() {
-    // 100,000 cycles is a reasonable amount of time to wait to save on CPU resources.
-    // For reference:
-    // At 1 GHz, 100K cycles is 100us
-    // At 2 GHz, 100K cycles is 50us
-    // At 4 GHz, 100K cycles is 25us
-    static constexpr auto PauseCycles = 100'000;
     _tpause(0, FencedRDTSC() + PauseCycles);
+}
+
+__forceinline static void MWAITX() {
+    // monitor_var should be aligned to a cache line.
+    alignas(64) u64 monitor_var{};
+    _mm_monitorx(&monitor_var, 0, 0);
+    _mm_mwaitx(/* extensions*/ 2, /* hints */ 0, /* cycles */ PauseCycles);
 }
 #else
 static void TPAUSE() {
-    // 100,000 cycles is a reasonable amount of time to wait to save on CPU resources.
-    // For reference:
-    // At 1 GHz, 100K cycles is 100us
-    // At 2 GHz, 100K cycles is 50us
-    // At 4 GHz, 100K cycles is 25us
-    static constexpr auto PauseCycles = 100'000;
     const auto tsc = FencedRDTSC() + PauseCycles;
     const auto eax = static_cast<u32>(tsc & 0xFFFFFFFF);
     const auto edx = static_cast<u32>(tsc >> 32);
@@ -40,9 +46,12 @@ static void TPAUSE() {
 
 void MicroSleep() {
     static const bool has_waitpkg = GetCPUCaps().waitpkg;
+    static const bool has_monitorx = GetCPUCaps().monitorx;
 
     if (has_waitpkg) {
         TPAUSE();
+    } else if (has_monitorx) {
+        MWAITX();
     } else {
         std::this_thread::yield();
     }

--- a/src/common/x64/cpu_wait.cpp
+++ b/src/common/x64/cpu_wait.cpp
@@ -47,6 +47,16 @@ static void TPAUSE() {
     const auto edx = static_cast<u32>(tsc >> 32);
     asm volatile("tpause %0" : : "r"(RequestC02State), "d"(edx), "a"(eax));
 }
+
+static void MWAITX() {
+    static constexpr auto EnableWaitTimeFlag = 1U << 1;
+    static constexpr auto RequestC1State = 0U;
+
+    // monitor_var should be aligned to a cache line.
+    alignas(64) u64 monitor_var{};
+    asm volatile("monitorx" : : "a"(&monitor_var), "c"(0), "d"(0));
+    asm volatile("mwaitx" : : "a"(RequestC1State), "b"(PauseCycles), "c"(EnableWaitTimeFlag));
+}
 #endif
 
 void MicroSleep() {


### PR DESCRIPTION
It turns out that AMD had the equivalent of Intel's waitpkg instructions since 2015, starting with the AMD Carrizo CPUs.

In light of this, we are using these instructions to emulate the behavior of the TPAUSE instruction in #9982 to bring in significant power savings for AMD CPUs, which should benefit handhelds such as the Steam Deck (running Windows), and the recently released ROG Ally and other power/thermally limited systems.

Thanks to @goldenx86 and @gidoly for testing this,
and @goldenx86 providing the following numbers on his Ryzen 5 5600X:

### Power Consumption in The Legend of Zelda: Tears of the Kingdom
- Master: 69-71W
- This PR: 61-63W

### Performance in The Legend of Zelda: Tears of the Kingdom with 40W Power Limit:
- Master: 11-15 FPS
- This PR: 15-18 FPS