### PR TITLE
android: Input overlay updates

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/Settings.kt
@@ -112,25 +112,36 @@ class Settings {
 
         const val PREF_MEMORY_WARNING_SHOWN = "MemoryWarningShown"
 
-        const val PREF_OVERLAY_INIT = "OverlayInit"
+        const val PREF_OVERLAY_VERSION = "OverlayVersion"
+        const val PREF_LANDSCAPE_OVERLAY_VERSION = "LandscapeOverlayVersion"
+        const val PREF_PORTRAIT_OVERLAY_VERSION = "PortraitOverlayVersion"
+        const val PREF_FOLDABLE_OVERLAY_VERSION = "FoldableOverlayVersion"
+        val overlayLayoutPrefs = listOf(
+            PREF_LANDSCAPE_OVERLAY_VERSION,
+            PREF_PORTRAIT_OVERLAY_VERSION,
+            PREF_FOLDABLE_OVERLAY_VERSION
+        )
+
         const val PREF_CONTROL_SCALE = "controlScale"
         const val PREF_CONTROL_OPACITY = "controlOpacity"
         const val PREF_TOUCH_ENABLED = "isTouchEnabled"
-        const val PREF_BUTTON_TOGGLE_0 = "buttonToggle0"
-        const val PREF_BUTTON_TOGGLE_1 = "buttonToggle1"
-        const val PREF_BUTTON_TOGGLE_2 = "buttonToggle2"
-        const val PREF_BUTTON_TOGGLE_3 = "buttonToggle3"
-        const val PREF_BUTTON_TOGGLE_4 = "buttonToggle4"
-        const val PREF_BUTTON_TOGGLE_5 = "buttonToggle5"
-        const val PREF_BUTTON_TOGGLE_6 = "buttonToggle6"
-        const val PREF_BUTTON_TOGGLE_7 = "buttonToggle7"
-        const val PREF_BUTTON_TOGGLE_8 = "buttonToggle8"
-        const val PREF_BUTTON_TOGGLE_9 = "buttonToggle9"
-        const val PREF_BUTTON_TOGGLE_10 = "buttonToggle10"
-        const val PREF_BUTTON_TOGGLE_11 = "buttonToggle11"
-        const val PREF_BUTTON_TOGGLE_12 = "buttonToggle12"
-        const val PREF_BUTTON_TOGGLE_13 = "buttonToggle13"
-        const val PREF_BUTTON_TOGGLE_14 = "buttonToggle14"
+        const val PREF_BUTTON_A = "buttonToggle0"
+        const val PREF_BUTTON_B = "buttonToggle1"
+        const val PREF_BUTTON_X = "buttonToggle2"
+        const val PREF_BUTTON_Y = "buttonToggle3"
+        const val PREF_BUTTON_L = "buttonToggle4"
+        const val PREF_BUTTON_R = "buttonToggle5"
+        const val PREF_BUTTON_ZL = "buttonToggle6"
+        const val PREF_BUTTON_ZR = "buttonToggle7"
+        const val PREF_BUTTON_PLUS = "buttonToggle8"
+        const val PREF_BUTTON_MINUS = "buttonToggle9"
+        const val PREF_BUTTON_DPAD = "buttonToggle10"
+        const val PREF_STICK_L = "buttonToggle11"
+        const val PREF_STICK_R = "buttonToggle12"
+        const val PREF_BUTTON_STICK_L = "buttonToggle13"
+        const val PREF_BUTTON_STICK_R = "buttonToggle14"
+        const val PREF_BUTTON_HOME = "buttonToggle15"
+        const val PREF_BUTTON_SCREENSHOT = "buttonToggle16"
 
         const val PREF_MENU_SETTINGS_JOYSTICK_REL_CENTER = "EmulationMenuSettings_JoystickRelCenter"
         const val PREF_MENU_SETTINGS_DPAD_SLIDE = "EmulationMenuSettings_DpadSlideEnable"
@@ -144,6 +155,30 @@ class Settings {
         const val PREF_BLACK_BACKGROUNDS = "BlackBackgrounds"
 
         private val configFileSectionsMap: MutableMap<String, List<String>> = HashMap()
+
+        val overlayPreferences = listOf(
+            PREF_OVERLAY_VERSION,
+            PREF_CONTROL_SCALE,
+            PREF_CONTROL_OPACITY,
+            PREF_TOUCH_ENABLED,
+            PREF_BUTTON_A,
+            PREF_BUTTON_B,
+            PREF_BUTTON_X,
+            PREF_BUTTON_Y,
+            PREF_BUTTON_L,
+            PREF_BUTTON_R,
+            PREF_BUTTON_ZL,
+            PREF_BUTTON_ZR,
+            PREF_BUTTON_PLUS,
+            PREF_BUTTON_MINUS,
+            PREF_BUTTON_DPAD,
+            PREF_STICK_L,
+            PREF_STICK_R,
+            PREF_BUTTON_HOME,
+            PREF_BUTTON_SCREENSHOT,
+            PREF_BUTTON_STICK_L,
+            PREF_BUTTON_STICK_R
+        )
 
         const val LayoutOption_Unspecified = 0
         const val LayoutOption_MobilePortrait = 4

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -212,9 +212,9 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             }
             if (!isInFoldableLayout) {
                 if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                    binding.surfaceInputOverlay.orientation = InputOverlay.PORTRAIT
+                    binding.surfaceInputOverlay.layout = InputOverlay.PORTRAIT
                 } else {
-                    binding.surfaceInputOverlay.orientation = InputOverlay.LANDSCAPE
+                    binding.surfaceInputOverlay.layout = InputOverlay.LANDSCAPE
                 }
             }
             if (!binding.surfaceInputOverlay.isInEditMode) {
@@ -260,7 +260,9 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             .remove(Settings.PREF_CONTROL_SCALE)
             .remove(Settings.PREF_CONTROL_OPACITY)
             .apply()
-        binding.surfaceInputOverlay.post { binding.surfaceInputOverlay.resetButtonPlacement() }
+        binding.surfaceInputOverlay.post {
+            binding.surfaceInputOverlay.resetLayoutVisibilityAndPlacement()
+        }
     }
 
     private fun updateShowFpsOverlay() {
@@ -337,7 +339,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                         binding.inGameMenu.layoutParams.height = it.bounds.bottom
 
                         isInFoldableLayout = true
-                        binding.surfaceInputOverlay.orientation = InputOverlay.FOLDABLE
+                        binding.surfaceInputOverlay.layout = InputOverlay.FOLDABLE
                         refreshInputOverlay()
                     }
                 }
@@ -410,9 +412,9 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                 R.id.menu_toggle_controls -> {
                     val preferences =
                         PreferenceManager.getDefaultSharedPreferences(YuzuApplication.appContext)
-                    val optionsArray = BooleanArray(15)
-                    for (i in 0..14) {
-                        optionsArray[i] = preferences.getBoolean("buttonToggle$i", i < 13)
+                    val optionsArray = BooleanArray(Settings.overlayPreferences.size)
+                    Settings.overlayPreferences.forEachIndexed { i, _ ->
+                        optionsArray[i] = preferences.getBoolean("buttonToggle$i", i < 15)
                     }
 
                     val dialog = MaterialAlertDialogBuilder(requireContext())
@@ -436,7 +438,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                     dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
                         .setOnClickListener {
                             val isChecked = !optionsArray[0]
-                            for (i in 0..14) {
+                            Settings.overlayPreferences.forEachIndexed { i, _ ->
                                 optionsArray[i] = isChecked
                                 dialog.listView.setItemChecked(i, isChecked)
                                 preferences.edit()

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/overlay/InputOverlayDrawableButton.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/overlay/InputOverlayDrawableButton.kt
@@ -24,7 +24,8 @@ class InputOverlayDrawableButton(
     res: Resources,
     defaultStateBitmap: Bitmap,
     pressedStateBitmap: Bitmap,
-    val buttonId: Int
+    val buttonId: Int,
+    val prefId: String
 ) {
     // The ID value what motion event is tracking
     var trackId: Int

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/overlay/InputOverlayDrawableJoystick.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/overlay/InputOverlayDrawableJoystick.kt
@@ -37,7 +37,8 @@ class InputOverlayDrawableJoystick(
     rectOuter: Rect,
     rectInner: Rect,
     val joystickId: Int,
-    val buttonId: Int
+    val buttonId: Int,
+    val prefId: String
 ) {
     // The ID value what motion event is tracking
     var trackId = -1

--- a/src/android/app/src/main/res/drawable/button_l3.xml
+++ b/src/android/app/src/main/res/drawable/button_l3.xml
@@ -1,0 +1,128 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="34.963dp"
+    android:height="37.265dp"
+    android:viewportWidth="34.963"
+    android:viewportHeight="37.265">
+    <path
+        android:fillAlpha="0.5"
+        android:pathData="M19.451,19.024A3.498,3.498 0,0 0,21.165 19.508c1.336,0 1.749,-0.852 1.738,-1.49 0,-1.077 -0.982,-1.537 -1.987,-1.537L20.327,16.481L20.327,15.7L20.901,15.7c0.757,0 1.714,-0.392 1.714,-1.302C22.621,13.785 22.224,13.229 21.271,13.229a2.834,2.834 0,0 0,-1.537 0.529l-0.265,-0.757a3.662,3.662 0,0 1,2.008 -0.59c1.513,0 2.201,0.897 2.201,1.834 0,0.794 -0.474,1.466 -1.421,1.807l0,0.024c0.947,0.19 1.714,0.9 1.714,1.976C23.967,19.27 23.017,20.346 21.165,20.346a3.929,3.929 135,0 1,-1.998 -0.529z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="21.568"
+                android:endY="33.938"
+                android:startX="21.568"
+                android:startY="16.14"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.5"
+        android:pathData="M16.062,9.353 L9.624,3.405A1.963,1.963 0,0 1,10.955 0l12.88,0a1.963,1.963 135,0 1,1.323 3.405L18.726,9.353a1.961,1.961 135,0 1,-2.664 0z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="17.395"
+                android:endY="18.74"
+                android:startX="17.395"
+                android:startY="-1.296"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.5"
+        android:pathData="m25.79,5.657l0,0a2.09,2.09 45,0 0,0.23 3.262c3.522,2.402 4.762,5.927 4.741,10.52A13.279,13.279 135,0 1,4.206 19.365c0,-4.516 0.931,-7.71 4.374,-10.107a2.098,2.098 0,0 0,0.233 -3.265l0,0a2.101,2.101 135,0 0,-2.646 -0.169C1.433,9.133 -0.266,13.941 0.033,20.233a17.468,17.468 0,0 0,34.925 -0.868c0,-6.006 -1.971,-10.771 -6.585,-13.917a2.088,2.088 45,0 0,-2.582 0.209z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:centerX="17.477"
+                android:centerY="19.92"
+                android:gradientRadius="17.201"
+                android:type="radial">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0.58" />
+                <item
+                    android:color="#FFC6C6C6"
+                    android:offset="0.84" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.88" />
+                <item
+                    android:color="#FFC2C2C2"
+                    android:offset="0.91" />
+                <item
+                    android:color="#FFB5B5B5"
+                    android:offset="0.94" />
+                <item
+                    android:color="#FF9E9E9E"
+                    android:offset="0.98" />
+                <item
+                    android:color="#FF8F8F8F"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.5"
+        android:pathData="m12.516,12.729l2,0l0,13.822l6.615,0l0,1.68L12.516,28.231Z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="16.829"
+                android:endY="46.882"
+                android:startX="16.829"
+                android:startY="20.479"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/src/android/app/src/main/res/drawable/button_l3_depressed.xml
+++ b/src/android/app/src/main/res/drawable/button_l3_depressed.xml
@@ -1,0 +1,75 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="34.963dp"
+    android:height="37.265dp"
+    android:viewportWidth="34.963"
+    android:viewportHeight="37.265">
+    <path
+        android:fillAlpha="0.3"
+        android:fillColor="#151515"
+        android:pathData="M16.062,9.353 L9.624,3.405A1.963,1.963 0,0 1,10.955 0l12.88,0a1.963,1.963 135,0 1,1.323 3.405L18.726,9.353a1.961,1.961 135,0 1,-2.664 0z"
+        android:strokeAlpha="0.3" />
+    <path
+        android:fillAlpha="0.6"
+        android:fillColor="#151515"
+        android:pathData="m25.79,5.657l0,0a2.09,2.09 45,0 0,0.23 3.262c3.522,2.402 4.762,5.927 4.741,10.52A13.279,13.279 135,0 1,4.206 19.365c0,-4.516 0.931,-7.71 4.374,-10.107a2.098,2.098 0,0 0,0.233 -3.265l0,0a2.101,2.101 135,0 0,-2.646 -0.169C1.433,9.133 -0.266,13.941 0.033,20.233a17.468,17.468 0,0 0,34.925 -0.868c0,-6.006 -1.971,-10.771 -6.585,-13.917a2.088,2.088 45,0 0,-2.582 0.209z"
+        android:strokeAlpha="0.6" />
+    <path
+        android:fillAlpha="0.6"
+        android:pathData="M19.451,19.024A3.498,3.498 0,0 0,21.165 19.508c1.336,0 1.749,-0.852 1.738,-1.49 0,-1.077 -0.982,-1.537 -1.987,-1.537L20.327,16.481L20.327,15.7L20.901,15.7c0.757,0 1.714,-0.392 1.714,-1.302C22.621,13.785 22.224,13.229 21.271,13.229a2.834,2.834 0,0 0,-1.537 0.529l-0.265,-0.757a3.662,3.662 0,0 1,2.008 -0.59c1.513,0 2.201,0.897 2.201,1.834 0,0.794 -0.474,1.466 -1.421,1.807l0,0.024c0.947,0.19 1.714,0.9 1.714,1.976C23.967,19.27 23.017,20.346 21.165,20.346a3.929,3.929 135,0 1,-1.998 -0.529z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="21.568"
+                android:endY="33.938"
+                android:startX="21.568"
+                android:startY="16.14"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.6"
+        android:pathData="m12.516,12.729l2,0l0,13.822l6.615,0l0,1.68L12.516,28.231Z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="16.829"
+                android:endY="46.882"
+                android:startX="16.829"
+                android:startY="20.479"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/src/android/app/src/main/res/drawable/button_r3.xml
+++ b/src/android/app/src/main/res/drawable/button_r3.xml
@@ -1,0 +1,128 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="34.963dp"
+    android:height="37.265dp"
+    android:viewportWidth="34.963"
+    android:viewportHeight="37.265">
+    <path
+        android:fillAlpha="0.5"
+        android:pathData="m10.781,12.65a19.579,19.579 0,0 1,3.596 -0.302c2.003,0 3.294,0.368 4.199,1.185a3.622,3.622 0,0 1,1.14 2.757c0,1.916 -1.206,3.175 -2.733,3.704l0,0.063c1.119,0.386 1.786,1.421 2.117,2.929 0.474,2.024 0.818,3.424 1.119,3.982l-1.924,0c-0.238,-0.407 -0.561,-1.656 -0.968,-3.466 -0.431,-2.003 -1.206,-2.757 -2.91,-2.82l-1.762,0l0,6.286l-1.873,0zM12.654,19.264l1.916,0c2.003,0 3.273,-1.098 3.273,-2.757 0,-1.873 -1.357,-2.691 -3.336,-2.712a7.649,7.649 0,0 0,-1.852 0.172z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="15.506"
+                android:endY="48.977"
+                android:startX="15.506"
+                android:startY="19.659"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.5"
+        android:pathData="M16.062,9.353 L9.624,3.405A1.963,1.963 0,0 1,10.955 0l12.88,0a1.963,1.963 135,0 1,1.323 3.405L18.726,9.353a1.961,1.961 135,0 1,-2.664 0z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="17.395"
+                android:endY="18.74"
+                android:startX="17.395"
+                android:startY="-1.296"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.5"
+        android:pathData="m25.79,5.657l0,0a2.09,2.09 45,0 0,0.23 3.262c3.522,2.402 4.762,5.927 4.741,10.52A13.279,13.279 135,0 1,4.206 19.365c0,-4.516 0.931,-7.71 4.374,-10.107a2.098,2.098 0,0 0,0.233 -3.265l0,0a2.101,2.101 135,0 0,-2.646 -0.169C1.433,9.133 -0.266,13.941 0.033,20.233a17.468,17.468 0,0 0,34.925 -0.868c0,-6.006 -1.971,-10.771 -6.585,-13.917a2.088,2.088 45,0 0,-2.582 0.209z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:centerX="17.477"
+                android:centerY="19.92"
+                android:gradientRadius="17.201"
+                android:type="radial">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0.58" />
+                <item
+                    android:color="#FFC6C6C6"
+                    android:offset="0.84" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.88" />
+                <item
+                    android:color="#FFC2C2C2"
+                    android:offset="0.91" />
+                <item
+                    android:color="#FFB5B5B5"
+                    android:offset="0.94" />
+                <item
+                    android:color="#FF9E9E9E"
+                    android:offset="0.98" />
+                <item
+                    android:color="#FF8F8F8F"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.5"
+        android:pathData="M21.832,19.024A3.498,3.498 0,0 0,23.547 19.508c1.336,0 1.749,-0.852 1.738,-1.49 0,-1.077 -0.982,-1.537 -1.987,-1.537L22.708,16.481L22.708,15.7L23.282,15.7c0.757,0 1.714,-0.392 1.714,-1.302C25.002,13.785 24.605,13.229 23.652,13.229a2.834,2.834 0,0 0,-1.537 0.529l-0.265,-0.757a3.662,3.662 0,0 1,2.008 -0.59c1.513,0 2.201,0.897 2.201,1.834 0,0.794 -0.474,1.466 -1.421,1.807l0,0.024c0.947,0.19 1.714,0.9 1.714,1.976C26.349,19.27 25.399,20.346 23.547,20.346a3.929,3.929 135,0 1,-1.998 -0.529z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="23.949"
+                android:endY="33.938"
+                android:startX="23.949"
+                android:startY="16.14"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/src/android/app/src/main/res/drawable/button_r3_depressed.xml
+++ b/src/android/app/src/main/res/drawable/button_r3_depressed.xml
@@ -1,0 +1,75 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="34.963dp"
+    android:height="37.265dp"
+    android:viewportWidth="34.963"
+    android:viewportHeight="37.265">
+    <path
+        android:fillAlpha="0.3"
+        android:fillColor="#151515"
+        android:pathData="M16.062,9.353 L9.624,3.405A1.963,1.963 0,0 1,10.955 0l12.88,0a1.963,1.963 135,0 1,1.323 3.405L18.726,9.353a1.961,1.961 135,0 1,-2.664 0z"
+        android:strokeAlpha="0.3" />
+    <path
+        android:fillAlpha="0.6"
+        android:fillColor="#151515"
+        android:pathData="m25.79,5.657l0,0a2.09,2.09 45,0 0,0.23 3.262c3.522,2.402 4.762,5.927 4.741,10.52A13.279,13.279 135,0 1,4.206 19.365c0,-4.516 0.931,-7.71 4.374,-10.107a2.098,2.098 0,0 0,0.233 -3.265l0,0a2.101,2.101 135,0 0,-2.646 -0.169C1.433,9.133 -0.266,13.941 0.033,20.233a17.468,17.468 0,0 0,34.925 -0.868c0,-6.006 -1.971,-10.771 -6.585,-13.917a2.088,2.088 45,0 0,-2.582 0.209z"
+        android:strokeAlpha="0.6" />
+    <path
+        android:fillAlpha="0.6"
+        android:pathData="m10.781,12.65a19.579,19.579 0,0 1,3.596 -0.302c2.003,0 3.294,0.368 4.199,1.185a3.622,3.622 0,0 1,1.14 2.757c0,1.916 -1.206,3.175 -2.733,3.704l0,0.063c1.119,0.386 1.786,1.421 2.117,2.929 0.474,2.024 0.818,3.424 1.119,3.982l-1.924,0c-0.238,-0.407 -0.561,-1.656 -0.968,-3.466 -0.431,-2.003 -1.206,-2.757 -2.91,-2.82l-1.762,0l0,6.286l-1.873,0zM12.654,19.264l1.916,0c2.003,0 3.273,-1.098 3.273,-2.757 0,-1.873 -1.357,-2.691 -3.336,-2.712a7.649,7.649 0,0 0,-1.852 0.172z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="15.506"
+                android:endY="48.977"
+                android:startX="15.506"
+                android:startY="19.659"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.6"
+        android:pathData="M21.832,19.024A3.498,3.498 0,0 0,23.547 19.508c1.336,0 1.749,-0.852 1.738,-1.49 0,-1.077 -0.982,-1.537 -1.987,-1.537L22.708,16.481L22.708,15.7L23.282,15.7c0.757,0 1.714,-0.392 1.714,-1.302C25.002,13.785 24.605,13.229 23.652,13.229a2.834,2.834 0,0 0,-1.537 0.529l-0.265,-0.757a3.662,3.662 0,0 1,2.008 -0.59c1.513,0 2.201,0.897 2.201,1.834 0,0.794 -0.474,1.466 -1.421,1.807l0,0.024c0.947,0.19 1.714,0.9 1.714,1.976C26.349,19.27 25.399,20.346 23.547,20.346a3.929,3.929 135,0 1,-1.998 -0.529z"
+        android:strokeAlpha="0.6">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="23.949"
+                android:endY="33.938"
+                android:startX="23.949"
+                android:startY="16.14"
+                android:type="linear">
+                <item
+                    android:color="#FFC3C4C5"
+                    android:offset="0" />
+                <item
+                    android:color="#FFC5C6C6"
+                    android:offset="0.03" />
+                <item
+                    android:color="#FFC7C7C7"
+                    android:offset="0.19" />
+                <item
+                    android:color="#DBB5B5B5"
+                    android:offset="0.44" />
+                <item
+                    android:color="#7F878787"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -205,6 +205,8 @@
         <item>@string/gamepad_d_pad</item>
         <item>@string/gamepad_left_stick</item>
         <item>@string/gamepad_right_stick</item>
+        <item>L3</item>
+        <item>R3</item>
         <item>@string/gamepad_home</item>
         <item>@string/gamepad_screenshot</item>
     </string-array>

--- a/src/android/app/src/main/res/values/integers.xml
+++ b/src/android/app/src/main/res/values/integers.xml
@@ -33,6 +33,10 @@
     <integer name="SWITCH_BUTTON_CAPTURE_Y">950</integer>
     <integer name="SWITCH_BUTTON_DPAD_X">260</integer>
     <integer name="SWITCH_BUTTON_DPAD_Y">790</integer>
+    <integer name="SWITCH_BUTTON_STICK_L_X">870</integer>
+    <integer name="SWITCH_BUTTON_STICK_L_Y">400</integer>
+    <integer name="SWITCH_BUTTON_STICK_R_X">960</integer>
+    <integer name="SWITCH_BUTTON_STICK_R_Y">430</integer>
 
     <!-- Default SWITCH portrait layout -->
     <integer name="SWITCH_BUTTON_A_X_PORTRAIT">840</integer>
@@ -65,6 +69,10 @@
     <integer name="SWITCH_BUTTON_CAPTURE_Y_PORTRAIT">950</integer>
     <integer name="SWITCH_BUTTON_DPAD_X_PORTRAIT">240</integer>
     <integer name="SWITCH_BUTTON_DPAD_Y_PORTRAIT">840</integer>
+    <integer name="SWITCH_BUTTON_STICK_L_X_PORTRAIT">730</integer>
+    <integer name="SWITCH_BUTTON_STICK_L_Y_PORTRAIT">510</integer>
+    <integer name="SWITCH_BUTTON_STICK_R_X_PORTRAIT">900</integer>
+    <integer name="SWITCH_BUTTON_STICK_R_Y_PORTRAIT">540</integer>
 
     <!-- Default SWITCH foldable layout -->
     <integer name="SWITCH_BUTTON_A_X_FOLDABLE">840</integer>
@@ -97,5 +105,9 @@
     <integer name="SWITCH_BUTTON_CAPTURE_Y_FOLDABLE">470</integer>
     <integer name="SWITCH_BUTTON_DPAD_X_FOLDABLE">240</integer>
     <integer name="SWITCH_BUTTON_DPAD_Y_FOLDABLE">390</integer>
+    <integer name="SWITCH_BUTTON_STICK_L_X_FOLDABLE">550</integer>
+    <integer name="SWITCH_BUTTON_STICK_L_Y_FOLDABLE">210</integer>
+    <integer name="SWITCH_BUTTON_STICK_R_X_FOLDABLE">550</integer>
+    <integer name="SWITCH_BUTTON_STICK_R_Y_FOLDABLE">280</integer>
 
 </resources>


### PR DESCRIPTION
Now within the Input Overlay file, there is an `OVERLAY_VERSION` code that will determine when the overlay will be reset. This is intended for breaking changes like the ones we had with the additions of percentage based layouts or the addition of foldable/portrait layouts.

This also includes L3/R3 buttons with icons provided by @Schplee 

![Screenshot_20230628-145030](https://github.com/yuzu-emu/yuzu/assets/14132249/b1787670-ce63-4367-a507-47482b9d39bf)
