### PR TITLE
android: Android 14 support

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ val autoVersion = (((System.currentTimeMillis() / 1000) - 1451606400) / 10).toIn
 android {
     namespace = "org.yuzu.yuzu_emu"
 
-    compileSdkVersion = "android-33"
+    compileSdkVersion = "android-34"
     ndkVersion = "25.2.9519653"
 
     buildFeatures {
@@ -51,7 +51,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId = "org.yuzu.yuzu_emu"
         minSdk = 30
-        targetSdk = 33
+        targetSdk = 34
         versionName = getGitVersion()
 
         // If you want to use autoVersion for the versionCode, create a property in local.properties

--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
@@ -69,7 +70,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
                 android:resource="@xml/nfc_tech_filter" />
         </activity>
 
-        <service android:name="org.yuzu.yuzu_emu.utils.ForegroundService"/>
+        <service android:name="org.yuzu.yuzu_emu.utils.ForegroundService" android:foregroundServiceType="specialUse">
+            <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE" android:value="Keep emulation running in background"/>
+        </service>
 
         <provider
             android:name=".features.DocumentProvider"


### PR DESCRIPTION
Specifies the permissions needed for the changes to foreground services in Android 14.