### PR TITLE
Blacklist EDS3 blending from new AMD drivers

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -528,6 +528,14 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
 
     sets_per_pool = 64;
+    if (extensions.extended_dynamic_state3 && is_amd_driver &&
+        properties.properties.driverVersion >= VK_MAKE_API_VERSION(0, 2, 0, 270)) {
+        LOG_WARNING(Render_Vulkan,
+                    "AMD drivers after 23.5.2 have broken extendedDynamicState3ColorBlendEquation");
+        features.extended_dynamic_state3.extendedDynamicState3ColorBlendEnable = false;
+        features.extended_dynamic_state3.extendedDynamicState3ColorBlendEquation = false;
+        dynamic_state3_blending = false;
+    }
     if (is_amd_driver) {
         // AMD drivers need a higher amount of Sets per Pool in certain circumstances like in XC2.
         sets_per_pool = 96;


### PR DESCRIPTION
Drivers after 23.5.2 like 23.10.01.41 or current Windows Insider drivers have broken colour blending in extended dynamic state. Adding a check to disable it for now.

Solves rendering issues in Tears of the Kingdom with at least RDNA2 and older GPUs:
![amdbug](https://github.com/yuzu-emu/yuzu/assets/42481638/124021b0-f5b3-4710-83d8-9b85103c164e)
![amdfix](https://github.com/yuzu-emu/yuzu/assets/42481638/8599a907-4a6d-4552-84f6-ca0e717cc3ef)
