### PR TITLE
input_common: Tune mouse controls

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -527,12 +527,10 @@ struct Values {
     Setting<bool> mouse_panning{false, "mouse_panning"};
     Setting<u8, true> mouse_panning_x_sensitivity{50, 1, 100, "mouse_panning_x_sensitivity"};
     Setting<u8, true> mouse_panning_y_sensitivity{50, 1, 100, "mouse_panning_y_sensitivity"};
-    Setting<u8, true> mouse_panning_deadzone_x_counterweight{
-        0, 0, 100, "mouse_panning_deadzone_x_counterweight"};
-    Setting<u8, true> mouse_panning_deadzone_y_counterweight{
-        0, 0, 100, "mouse_panning_deadzone_y_counterweight"};
-    Setting<u8, true> mouse_panning_decay_strength{22, 0, 100, "mouse_panning_decay_strength"};
-    Setting<u8, true> mouse_panning_min_decay{5, 0, 100, "mouse_panning_min_decay"};
+    Setting<u8, true> mouse_panning_deadzone_counterweight{20, 0, 100,
+                                                           "mouse_panning_deadzone_counterweight"};
+    Setting<u8, true> mouse_panning_decay_strength{18, 0, 100, "mouse_panning_decay_strength"};
+    Setting<u8, true> mouse_panning_min_decay{6, 0, 100, "mouse_panning_min_decay"};
 
     Setting<bool> mouse_enabled{false, "mouse_enabled"};
     Setting<bool> emulate_analog_keyboard{false, "emulate_analog_keyboard"};

--- a/src/input_common/drivers/mouse.cpp
+++ b/src/input_common/drivers/mouse.cpp
@@ -85,7 +85,7 @@ void Mouse::UpdateThread(std::stop_token stop_token) {
 }
 
 void Mouse::UpdateStickInput() {
-    if (!Settings::values.mouse_panning) {
+    if (!IsMousePanningEnabled()) {
         return;
     }
 
@@ -111,8 +111,8 @@ void Mouse::UpdateStickInput() {
 }
 
 void Mouse::UpdateMotionInput() {
-    const float sensitivity = Settings::values.mouse_panning ? default_motion_panning_sensitivity
-                                                             : default_motion_sensitivity;
+    const float sensitivity =
+        IsMousePanningEnabled() ? default_motion_panning_sensitivity : default_motion_sensitivity;
 
     const float rotation_velocity = std::sqrt(last_motion_change.x * last_motion_change.x +
                                               last_motion_change.y * last_motion_change.y);
@@ -134,7 +134,7 @@ void Mouse::UpdateMotionInput() {
         .delta_timestamp = update_time * 1000,
     };
 
-    if (Settings::values.mouse_panning) {
+    if (IsMousePanningEnabled()) {
         last_motion_change.x = 0;
         last_motion_change.y = 0;
     }
@@ -144,7 +144,7 @@ void Mouse::UpdateMotionInput() {
 }
 
 void Mouse::Move(int x, int y, int center_x, int center_y) {
-    if (Settings::values.mouse_panning) {
+    if (IsMousePanningEnabled()) {
         const auto mouse_change =
             (Common::MakeVec(x, y) - Common::MakeVec(center_x, center_y)).Cast<float>();
         const float x_sensitivity =
@@ -219,7 +219,7 @@ void Mouse::ReleaseButton(MouseButton button) {
     SetButton(real_mouse_identifier, static_cast<int>(button), false);
     SetButton(touch_identifier, static_cast<int>(button), false);
 
-    if (!Settings::values.mouse_panning) {
+    if (!IsMousePanningEnabled()) {
         SetAxis(identifier, mouse_axis_x, 0);
         SetAxis(identifier, mouse_axis_y, 0);
     }
@@ -241,6 +241,11 @@ void Mouse::MouseWheelChange(int x, int y) {
 void Mouse::ReleaseAllButtons() {
     ResetButtonState();
     button_pressed = false;
+}
+
+bool Mouse::IsMousePanningEnabled() {
+    // Disable mouse panning when a real mouse is connected
+    return Settings::values.mouse_panning && !Settings::values.mouse_enabled;
 }
 
 std::vector<Common::ParamPackage> Mouse::GetInputDevices() const {

--- a/src/input_common/drivers/mouse.h
+++ b/src/input_common/drivers/mouse.h
@@ -99,6 +99,8 @@ private:
     void UpdateStickInput();
     void UpdateMotionInput();
 
+    bool IsMousePanningEnabled();
+
     Common::Input::ButtonNames GetUIButtonName(const Common::ParamPackage& params) const;
 
     Common::Vec2<int> mouse_origin;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -503,8 +503,7 @@ void Config::ReadMousePanningValues() {
     ReadBasicSetting(Settings::values.mouse_panning);
     ReadBasicSetting(Settings::values.mouse_panning_x_sensitivity);
     ReadBasicSetting(Settings::values.mouse_panning_y_sensitivity);
-    ReadBasicSetting(Settings::values.mouse_panning_deadzone_x_counterweight);
-    ReadBasicSetting(Settings::values.mouse_panning_deadzone_y_counterweight);
+    ReadBasicSetting(Settings::values.mouse_panning_deadzone_counterweight);
     ReadBasicSetting(Settings::values.mouse_panning_decay_strength);
     ReadBasicSetting(Settings::values.mouse_panning_min_decay);
 }
@@ -1122,8 +1121,7 @@ void Config::SaveMousePanningValues() {
     // Don't overwrite values.mouse_panning
     WriteBasicSetting(Settings::values.mouse_panning_x_sensitivity);
     WriteBasicSetting(Settings::values.mouse_panning_y_sensitivity);
-    WriteBasicSetting(Settings::values.mouse_panning_deadzone_x_counterweight);
-    WriteBasicSetting(Settings::values.mouse_panning_deadzone_y_counterweight);
+    WriteBasicSetting(Settings::values.mouse_panning_deadzone_counterweight);
     WriteBasicSetting(Settings::values.mouse_panning_decay_strength);
     WriteBasicSetting(Settings::values.mouse_panning_min_decay);
 }

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -3105,21 +3105,6 @@
                     </property>
                     <item>
                      <widget class="QPushButton" name="mousePanningButton">
-                      <property name="minimumSize">
-                       <size>
-                        <width>68</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>68</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="styleSheet">
-                       <string notr="true">min-width: 68px;</string>
-                      </property>
                       <property name="text">
                        <string>Configure</string>
                       </property>

--- a/src/yuzu/configuration/configure_mouse_panning.cpp
+++ b/src/yuzu/configuration/configure_mouse_panning.cpp
@@ -27,10 +27,8 @@ void ConfigureMousePanning::SetConfiguration(float right_stick_deadzone, float r
     ui->enable->setChecked(Settings::values.mouse_panning.GetValue());
     ui->x_sensitivity->setValue(Settings::values.mouse_panning_x_sensitivity.GetValue());
     ui->y_sensitivity->setValue(Settings::values.mouse_panning_y_sensitivity.GetValue());
-    ui->deadzone_x_counterweight->setValue(
-        Settings::values.mouse_panning_deadzone_x_counterweight.GetValue());
-    ui->deadzone_y_counterweight->setValue(
-        Settings::values.mouse_panning_deadzone_y_counterweight.GetValue());
+    ui->deadzone_counterweight->setValue(
+        Settings::values.mouse_panning_deadzone_counterweight.GetValue());
     ui->decay_strength->setValue(Settings::values.mouse_panning_decay_strength.GetValue());
     ui->min_decay->setValue(Settings::values.mouse_panning_min_decay.GetValue());
 
@@ -48,10 +46,8 @@ void ConfigureMousePanning::SetConfiguration(float right_stick_deadzone, float r
 void ConfigureMousePanning::SetDefaultConfiguration() {
     ui->x_sensitivity->setValue(Settings::values.mouse_panning_x_sensitivity.GetDefault());
     ui->y_sensitivity->setValue(Settings::values.mouse_panning_y_sensitivity.GetDefault());
-    ui->deadzone_x_counterweight->setValue(
-        Settings::values.mouse_panning_deadzone_x_counterweight.GetDefault());
-    ui->deadzone_y_counterweight->setValue(
-        Settings::values.mouse_panning_deadzone_y_counterweight.GetDefault());
+    ui->deadzone_counterweight->setValue(
+        Settings::values.mouse_panning_deadzone_counterweight.GetDefault());
     ui->decay_strength->setValue(Settings::values.mouse_panning_decay_strength.GetDefault());
     ui->min_decay->setValue(Settings::values.mouse_panning_min_decay.GetDefault());
 }
@@ -68,10 +64,8 @@ void ConfigureMousePanning::ApplyConfiguration() {
     Settings::values.mouse_panning = ui->enable->isChecked();
     Settings::values.mouse_panning_x_sensitivity = static_cast<float>(ui->x_sensitivity->value());
     Settings::values.mouse_panning_y_sensitivity = static_cast<float>(ui->y_sensitivity->value());
-    Settings::values.mouse_panning_deadzone_x_counterweight =
-        static_cast<float>(ui->deadzone_x_counterweight->value());
-    Settings::values.mouse_panning_deadzone_y_counterweight =
-        static_cast<float>(ui->deadzone_y_counterweight->value());
+    Settings::values.mouse_panning_deadzone_counterweight =
+        static_cast<float>(ui->deadzone_counterweight->value());
     Settings::values.mouse_panning_decay_strength = static_cast<float>(ui->decay_strength->value());
     Settings::values.mouse_panning_min_decay = static_cast<float>(ui->min_decay->value());
 

--- a/src/yuzu/configuration/configure_mouse_panning.ui
+++ b/src/yuzu/configuration/configure_mouse_panning.ui
@@ -9,10 +9,10 @@
    <item>
     <widget class="QCheckBox" name="enable">
      <property name="text">
-      <string>Enable</string>
+      <string>Enable mouse panning</string>
      </property>
      <property name="toolTip">
-      <string>Can be toggled via a hotkey</string>
+      <string>Can be toggled via a hotkey. Default hotkey is Ctrl + F9</string>
      </property>
     </widget>
    </item>

--- a/src/yuzu/configuration/configure_mouse_panning.ui
+++ b/src/yuzu/configuration/configure_mouse_panning.ui
@@ -89,40 +89,14 @@
        </property>
        <layout class="QGridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="deadzone_x_counterweight_label">
+         <widget class="QLabel" name="deadzone_counterweight_label">
           <property name="text">
-           <string>Horizontal</string>
+           <string>Deadzone</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QSpinBox" name="deadzone_x_counterweight">
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="suffix">
-           <string>%</string>
-          </property>
-          <property name="minimum">
-           <number>0</number>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>0</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="deadzone_y_counterweight_label">
-          <property name="text">
-           <string>Vertical</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="deadzone_y_counterweight">
+         <widget class="QSpinBox" name="deadzone_counterweight">
           <property name="alignment">
            <set>Qt::AlignCenter</set>
           </property>


### PR DESCRIPTION
Minor teaks to mouse input calibration. Removes all magic numbers from the code. Allows to return to center when using a deadzone. Motion input is now in the correct sensitivity. 