### PR TITLE
Texture cache: Fix YFC regression due to code testing

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -598,14 +598,6 @@ void TextureCache<P>::UnmapGPUMemory(size_t as_id, GPUVAddr gpu_addr, size_t siz
                             [&](ImageId id, Image&) { deleted_images.push_back(id); });
     for (const ImageId id : deleted_images) {
         Image& image = slot_images[id];
-        if (True(image.flags & ImageFlagBits::CpuModified)) {
-            return;
-        }
-        image.flags |= ImageFlagBits::CpuModified;
-        if (True(image.flags & ImageFlagBits::Tracked)) {
-            UntrackImage(image, id);
-        }
-        /*
         if (True(image.flags & ImageFlagBits::Remapped)) {
             continue;
         }
@@ -613,7 +605,6 @@ void TextureCache<P>::UnmapGPUMemory(size_t as_id, GPUVAddr gpu_addr, size_t siz
         if (True(image.flags & ImageFlagBits::Tracked)) {
             UntrackImage(image, id);
         }
-        */
     }
 }
 


### PR DESCRIPTION
This fixes a regression with NVN virtual images not being correctly remapped when sparse memory changes to mapped.

It should fix regressions in UE4 games like bravely default, SMT V and Pikmin 4 demo.