### PR TITLE
android: Suppress a known incompatibility

### DIFF
--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -15,3 +15,6 @@ android.useAndroidX=true
 kotlin.code.style=official
 kotlin.parallel.tasks.in.project=true
 android.defaults.buildfeatures.buildconfig=true
+
+# Android Gradle plugin 8.0.2
+android.suppressUnsupportedCompileSdk=34


### PR DESCRIPTION
> Android Gradle plugin 8.0.2 is designed for API 33, but a newer plugin hasn't been released yet. The warning message is rather extravagant, but also suggests adding this property if you are aware of the risks.

```
You are strongly encouraged to update your project to use a newer
Android Gradle plugin that has been tested with compileSdk = 34.

If you are already using the latest version of the Android Gradle plugin,
you may need to wait until a newer version with support for compileSdk = 34 is available.

To suppress this warning, add/update
    android.suppressUnsupportedCompileSdk=34
to this project's gradle.properties.
```

Note: This property should be removed when the Android Gradle plugin is updated.