### PR TITLE
AccelerateDMA: Don't accelerate 3D texture DMA operations

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -879,6 +879,10 @@ ImageId TextureCache<P>::DmaImageId(const Tegra::DMA::ImageOperand& operand, boo
         return NULL_IMAGE_ID;
     }
     auto& image = slot_images[image_id];
+    if (image.info.type == ImageType::e3D) {
+        // Don't accelerate 3D images.
+        return NULL_IMAGE_ID;
+    }
     if (!is_upload && !image.info.dma_downloaded) {
         // Force a full sync.
         image.info.dma_downloaded = true;


### PR DESCRIPTION
This fixes the crash in Pikmin 4 Demo.

It will now use the LLE slow path. Unless a game really requires the acceleration, I don't see it necessary to accelerate.