### PR TITLE
sink_stream: Resolve heap buffer corruption due to out of bounds write

### DIFF
--- a/src/audio_core/sink/sink_stream.h
+++ b/src/audio_core/sink/sink_stream.h
@@ -16,7 +16,6 @@
 #include "common/polyfill_thread.h"
 #include "common/reader_writer_queue.h"
 #include "common/ring_buffer.h"
-#include "common/scratch_buffer.h"
 #include "common/thread.h"
 
 namespace Core {
@@ -256,8 +255,6 @@ private:
     /// Signalled when ring buffer entries are consumed
     std::condition_variable_any release_cv;
     std::mutex release_mutex;
-    /// Temporary buffer for appending samples when upmixing
-    Common::ScratchBuffer<s16> tmp_samples{};
 };
 
 using SinkStreamPtr = std::unique_ptr<SinkStream>;


### PR DESCRIPTION
Also, remove the use of ScratchBuffer when upmixing, as other channels may not be initialized with zeroed out data.

Note: This may resolve several unexplainable crashes and memory corruption unrelated to audio.

Fixes #10897
Fixes #10900
Fixes #10960
Fixes #10965