### PR TITLE
vulkan: Improvements to macOS surface creation

### DIFF
--- a/src/video_core/vulkan_common/vulkan_instance.cpp
+++ b/src/video_core/vulkan_common/vulkan_instance.cpp
@@ -19,11 +19,9 @@
 #include <windows.h>
 // ensure include order
 #include <vulkan/vulkan_win32.h>
-#elif defined(__APPLE__)
-#include <vulkan/vulkan_macos.h>
 #elif defined(__ANDROID__)
 #include <vulkan/vulkan_android.h>
-#else
+#elif !defined(__APPLE__)
 #include <X11/Xlib.h>
 #include <vulkan/vulkan_wayland.h>
 #include <vulkan/vulkan_xlib.h>
@@ -68,7 +66,7 @@ namespace {
         break;
 #elif defined(__APPLE__)
     case Core::Frontend::WindowSystemType::Cocoa:
-        extensions.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+        extensions.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
         break;
 #elif defined(__ANDROID__)
     case Core::Frontend::WindowSystemType::Android:

--- a/src/video_core/vulkan_common/vulkan_surface.cpp
+++ b/src/video_core/vulkan_common/vulkan_surface.cpp
@@ -11,11 +11,9 @@
 #include <windows.h>
 // ensure include order
 #include <vulkan/vulkan_win32.h>
-#elif defined(__APPLE__)
-#include <vulkan/vulkan_macos.h>
 #elif defined(__ANDROID__)
 #include <vulkan/vulkan_android.h>
-#else
+#elif !defined(__APPLE__)
 #include <X11/Xlib.h>
 #include <vulkan/vulkan_wayland.h>
 #include <vulkan/vulkan_xlib.h>
@@ -44,12 +42,13 @@ vk::SurfaceKHR CreateSurface(
     }
 #elif defined(__APPLE__)
     if (window_info.type == Core::Frontend::WindowSystemType::Cocoa) {
-        const VkMacOSSurfaceCreateInfoMVK mvk_ci{VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK,
-                                                 nullptr, 0, window_info.render_surface};
-        const auto vkCreateMacOSSurfaceMVK = reinterpret_cast<PFN_vkCreateMacOSSurfaceMVK>(
-            dld.vkGetInstanceProcAddr(*instance, "vkCreateMacOSSurfaceMVK"));
-        if (!vkCreateMacOSSurfaceMVK ||
-            vkCreateMacOSSurfaceMVK(*instance, &mvk_ci, nullptr, &unsafe_surface) != VK_SUCCESS) {
+        const VkMetalSurfaceCreateInfoEXT macos_ci = {
+            .pLayer = static_cast<const CAMetalLayer*>(window_info.render_surface),
+        };
+        const auto vkCreateMetalSurfaceEXT = reinterpret_cast<PFN_vkCreateMetalSurfaceEXT>(
+            dld.vkGetInstanceProcAddr(*instance, "vkCreateMetalSurfaceEXT"));
+        if (!vkCreateMetalSurfaceEXT ||
+            vkCreateMetalSurfaceEXT(*instance, &macos_ci, nullptr, &unsafe_surface) != VK_SUCCESS) {
             LOG_ERROR(Render_Vulkan, "Failed to initialize Metal surface");
             throw vk::Exception(VK_ERROR_INITIALIZATION_FAILED);
         }

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -15,6 +15,8 @@
 #define VK_NO_PROTOTYPES
 #ifdef _WIN32
 #define VK_USE_PLATFORM_WIN32_KHR
+#elif defined(__APPLE__)
+#define VK_USE_PLATFORM_METAL_EXT
 #endif
 #include <vulkan/vulkan.h>
 

--- a/src/yuzu/vk_device_info.cpp
+++ b/src/yuzu/vk_device_info.cpp
@@ -26,7 +26,10 @@ Record::~Record() = default;
 void PopulateRecords(std::vector<Record>& records, QWindow* window) try {
     using namespace Vulkan;
 
-    auto wsi = QtCommon::GetWindowSystemInfo(window);
+    // Create a test window with a Vulkan surface type for checking present modes.
+    QWindow test_window(window);
+    test_window.setSurfaceType(QWindow::VulkanSurface);
+    auto wsi = QtCommon::GetWindowSystemInfo(&test_window);
 
     vk::InstanceDispatch dld;
     const auto library = OpenLibrary();


### PR DESCRIPTION
* Migrates from the legacy VK_MVK_macos_surface to the recommended VK_EXT_metal_surface. We can fetch the required CAMetalLayer from the window using a simple objc_msgSend trick, same as in Citra.
* Fixes a preferences crash on macOS following the addition of present mode detection.
  * The code for this passes in a GMainWindow for surface creation, which is not configured to have a Vulkan surface. On other platforms this seems to work, but on macOS this fails due to the window not having a CAMetalLayer.
  * Instead, create a dummy invisible window with surface type VulkanSurface to perform this test.