### PR TITLE
Use spans over guest memory where possible instead of copying data

### DIFF
--- a/src/audio_core/device/device_session.cpp
+++ b/src/audio_core/device/device_session.cpp
@@ -92,9 +92,9 @@ void DeviceSession::AppendBuffers(std::span<const AudioBuffer> buffers) {
         if (type == Sink::StreamType::In) {
             stream->AppendBuffer(new_buffer, tmp_samples);
         } else {
-            system.ApplicationMemory().ReadBlockUnsafe(buffer.samples, tmp_samples.data(),
-                                                       buffer.size);
-            stream->AppendBuffer(new_buffer, tmp_samples);
+            Core::Memory::CpuGuestMemory<s16, Core::Memory::GuestMemoryFlags::UnsafeRead> samples(
+                system.ApplicationMemory(), buffer.samples, buffer.size / sizeof(s16));
+            stream->AppendBuffer(new_buffer, samples);
         }
     }
 }

--- a/src/audio_core/renderer/command/effect/aux_.cpp
+++ b/src/audio_core/renderer/command/effect/aux_.cpp
@@ -21,23 +21,13 @@ static void ResetAuxBufferDsp(Core::Memory::Memory& memory, const CpuAddr aux_in
     }
 
     AuxInfo::AuxInfoDsp info{};
-    auto info_ptr{&info};
-    bool host_safe{(aux_info & Core::Memory::YUZU_PAGEMASK) <=
-                   (Core::Memory::YUZU_PAGESIZE - sizeof(AuxInfo::AuxInfoDsp))};
+    memory.ReadBlockUnsafe(aux_info, &info, sizeof(AuxInfo::AuxInfoDsp));
 
-    if (host_safe) [[likely]] {
-        info_ptr = memory.GetPointer<AuxInfo::AuxInfoDsp>(aux_info);
-    } else {
-        memory.ReadBlockUnsafe(aux_info, info_ptr, sizeof(AuxInfo::AuxInfoDsp));
-    }
+    info.read_offset = 0;
+    info.write_offset = 0;
+    info.total_sample_count = 0;
 
-    info_ptr->read_offset = 0;
-    info_ptr->write_offset = 0;
-    info_ptr->total_sample_count = 0;
-
-    if (!host_safe) [[unlikely]] {
-        memory.WriteBlockUnsafe(aux_info, info_ptr, sizeof(AuxInfo::AuxInfoDsp));
-    }
+    memory.WriteBlockUnsafe(aux_info, &info, sizeof(AuxInfo::AuxInfoDsp));
 }
 
 /**
@@ -86,17 +76,9 @@ static u32 WriteAuxBufferDsp(Core::Memory::Memory& memory, CpuAddr send_info_,
     }
 
     AuxInfo::AuxInfoDsp send_info{};
-    auto send_ptr = &send_info;
-    bool host_safe = (send_info_ & Core::Memory::YUZU_PAGEMASK) <=
-                     (Core::Memory::YUZU_PAGESIZE - sizeof(AuxInfo::AuxInfoDsp));
+    memory.ReadBlockUnsafe(send_info_, &send_info, sizeof(AuxInfo::AuxInfoDsp));
 
-    if (host_safe) [[likely]] {
-        send_ptr = memory.GetPointer<AuxInfo::AuxInfoDsp>(send_info_);
-    } else {
-        memory.ReadBlockUnsafe(send_info_, send_ptr, sizeof(AuxInfo::AuxInfoDsp));
-    }
-
-    u32 target_write_offset{send_ptr->write_offset + write_offset};
+    u32 target_write_offset{send_info.write_offset + write_offset};
     if (target_write_offset > count_max) {
         return 0;
     }
@@ -105,15 +87,9 @@ static u32 WriteAuxBufferDsp(Core::Memory::Memory& memory, CpuAddr send_info_,
     u32 read_pos{0};
     while (write_count > 0) {
         u32 to_write{std::min(count_max - target_write_offset, write_count)};
-        const auto write_addr = send_buffer + target_write_offset * sizeof(s32);
-        bool write_safe{(write_addr & Core::Memory::YUZU_PAGEMASK) <=
-                        (Core::Memory::YUZU_PAGESIZE - (write_addr + to_write * sizeof(s32)))};
-        if (write_safe) [[likely]] {
-            auto ptr = memory.GetPointer(write_addr);
-            std::memcpy(ptr, &input[read_pos], to_write * sizeof(s32));
-        } else {
-            memory.WriteBlockUnsafe(send_buffer + target_write_offset * sizeof(s32),
-                                    &input[read_pos], to_write * sizeof(s32));
+        if (to_write > 0) {
+            const auto write_addr = send_buffer + target_write_offset * sizeof(s32);
+            memory.WriteBlockUnsafe(write_addr, &input[read_pos], to_write * sizeof(s32));
         }
         target_write_offset = (target_write_offset + to_write) % count_max;
         write_count -= to_write;
@@ -121,13 +97,10 @@ static u32 WriteAuxBufferDsp(Core::Memory::Memory& memory, CpuAddr send_info_,
     }
 
     if (update_count) {
-        send_ptr->write_offset = (send_ptr->write_offset + update_count) % count_max;
+        send_info.write_offset = (send_info.write_offset + update_count) % count_max;
     }
 
-    if (!host_safe) [[unlikely]] {
-        memory.WriteBlockUnsafe(send_info_, send_ptr, sizeof(AuxInfo::AuxInfoDsp));
-    }
-
+    memory.WriteBlockUnsafe(send_info_, &send_info, sizeof(AuxInfo::AuxInfoDsp));
     return write_count_;
 }
 
@@ -174,17 +147,9 @@ static u32 ReadAuxBufferDsp(Core::Memory::Memory& memory, CpuAddr return_info_,
     }
 
     AuxInfo::AuxInfoDsp return_info{};
-    auto return_ptr = &return_info;
-    bool host_safe = (return_info_ & Core::Memory::YUZU_PAGEMASK) <=
-                     (Core::Memory::YUZU_PAGESIZE - sizeof(AuxInfo::AuxInfoDsp));
+    memory.ReadBlockUnsafe(return_info_, &return_info, sizeof(AuxInfo::AuxInfoDsp));
 
-    if (host_safe) [[likely]] {
-        return_ptr = memory.GetPointer<AuxInfo::AuxInfoDsp>(return_info_);
-    } else {
-        memory.ReadBlockUnsafe(return_info_, return_ptr, sizeof(AuxInfo::AuxInfoDsp));
-    }
-
-    u32 target_read_offset{return_ptr->read_offset + read_offset};
+    u32 target_read_offset{return_info.read_offset + read_offset};
     if (target_read_offset > count_max) {
         return 0;
     }
@@ -193,15 +158,9 @@ static u32 ReadAuxBufferDsp(Core::Memory::Memory& memory, CpuAddr return_info_,
     u32 write_pos{0};
     while (read_count > 0) {
         u32 to_read{std::min(count_max - target_read_offset, read_count)};
-        const auto read_addr = return_buffer + target_read_offset * sizeof(s32);
-        bool read_safe{(read_addr & Core::Memory::YUZU_PAGEMASK) <=
-                       (Core::Memory::YUZU_PAGESIZE - (read_addr + to_read * sizeof(s32)))};
-        if (read_safe) [[likely]] {
-            auto ptr = memory.GetPointer(read_addr);
-            std::memcpy(&output[write_pos], ptr, to_read * sizeof(s32));
-        } else {
-            memory.ReadBlockUnsafe(return_buffer + target_read_offset * sizeof(s32),
-                                   &output[write_pos], to_read * sizeof(s32));
+        if (to_read > 0) {
+            const auto read_addr = return_buffer + target_read_offset * sizeof(s32);
+            memory.ReadBlockUnsafe(read_addr, &output[write_pos], to_read * sizeof(s32));
         }
         target_read_offset = (target_read_offset + to_read) % count_max;
         read_count -= to_read;
@@ -209,13 +168,10 @@ static u32 ReadAuxBufferDsp(Core::Memory::Memory& memory, CpuAddr return_info_,
     }
 
     if (update_count) {
-        return_ptr->read_offset = (return_ptr->read_offset + update_count) % count_max;
+        return_info.read_offset = (return_info.read_offset + update_count) % count_max;
     }
 
-    if (!host_safe) [[unlikely]] {
-        memory.WriteBlockUnsafe(return_info_, return_ptr, sizeof(AuxInfo::AuxInfoDsp));
-    }
-
+    memory.WriteBlockUnsafe(return_info_, &return_info, sizeof(AuxInfo::AuxInfoDsp));
     return read_count_;
 }
 

--- a/src/common/page_table.cpp
+++ b/src/common/page_table.cpp
@@ -66,6 +66,7 @@ void PageTable::Resize(std::size_t address_space_width_in_bits, std::size_t page
                                              << (address_space_width_in_bits - page_size_in_bits)};
     pointers.resize(num_page_table_entries);
     backing_addr.resize(num_page_table_entries);
+    blocks.resize(num_page_table_entries);
     current_address_space_width_in_bits = address_space_width_in_bits;
     page_size = 1ULL << page_size_in_bits;
 }

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -122,6 +122,7 @@ struct PageTable {
      * corresponding attribute element is of type `Memory`.
      */
     VirtualBuffer<PageInfo> pointers;
+    VirtualBuffer<u64> blocks;
 
     VirtualBuffer<u64> backing_addr;
 

--- a/src/common/scratch_buffer.h
+++ b/src/common/scratch_buffer.h
@@ -40,8 +40,21 @@ public:
     ~ScratchBuffer() = default;
     ScratchBuffer(const ScratchBuffer&) = delete;
     ScratchBuffer& operator=(const ScratchBuffer&) = delete;
-    ScratchBuffer(ScratchBuffer&&) = default;
-    ScratchBuffer& operator=(ScratchBuffer&&) = default;
+
+    ScratchBuffer(ScratchBuffer&& other) noexcept {
+        swap(other);
+        other.last_requested_size = 0;
+        other.buffer_capacity = 0;
+        other.buffer.reset();
+    }
+
+    ScratchBuffer& operator=(ScratchBuffer&& other) noexcept {
+        swap(other);
+        other.last_requested_size = 0;
+        other.buffer_capacity = 0;
+        other.buffer.reset();
+        return *this;
+    }
 
     /// This will only grow the buffer's capacity if size is greater than the current capacity.
     /// The previously held data will remain intact.

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -70,7 +70,7 @@ void CoreTiming::Initialize(std::function<void()>&& on_thread_init_) {
         -> std::optional<std::chrono::nanoseconds> { return std::nullopt; };
     ev_lost = CreateEvent("_lost_event", empty_timed_callback);
     if (is_multicore) {
-        timer_thread = std::make_unique<std::thread>(ThreadEntry, std::ref(*this));
+        timer_thread = std::make_unique<std::jthread>(ThreadEntry, std::ref(*this));
     }
 }
 
@@ -255,7 +255,6 @@ void CoreTiming::ThreadLoop() {
 #ifdef _WIN32
                     while (!paused && !event.IsSet() && wait_time > 0) {
                         wait_time = *next_time - GetGlobalTimeNs().count();
-
                         if (wait_time >= timer_resolution_ns) {
                             Common::Windows::SleepForOneTick();
                         } else {

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -163,7 +163,7 @@ private:
     Common::Event pause_event{};
     std::mutex basic_lock;
     std::mutex advance_lock;
-    std::unique_ptr<std::thread> timer_thread;
+    std::unique_ptr<std::jthread> timer_thread;
     std::atomic<bool> paused{};
     std::atomic<bool> paused_set{};
     std::atomic<bool> wait_set{};

--- a/src/core/hle/service/hle_ipc.cpp
+++ b/src/core/hle/service/hle_ipc.cpp
@@ -329,8 +329,22 @@ std::vector<u8> HLERequestContext::ReadBufferCopy(std::size_t buffer_index) cons
 }
 
 std::span<const u8> HLERequestContext::ReadBuffer(std::size_t buffer_index) const {
-    static thread_local std::array<Common::ScratchBuffer<u8>, 2> read_buffer_a;
-    static thread_local std::array<Common::ScratchBuffer<u8>, 2> read_buffer_x;
+    static thread_local std::array read_buffer_a{
+        Core::Memory::CpuGuestMemory<u8, Core::Memory::GuestMemoryFlags::SafeRead>(memory, 0, 0),
+        Core::Memory::CpuGuestMemory<u8, Core::Memory::GuestMemoryFlags::SafeRead>(memory, 0, 0),
+    };
+    static thread_local std::array read_buffer_data_a{
+        Common::ScratchBuffer<u8>(),
+        Common::ScratchBuffer<u8>(),
+    };
+    static thread_local std::array read_buffer_x{
+        Core::Memory::CpuGuestMemory<u8, Core::Memory::GuestMemoryFlags::SafeRead>(memory, 0, 0),
+        Core::Memory::CpuGuestMemory<u8, Core::Memory::GuestMemoryFlags::SafeRead>(memory, 0, 0),
+    };
+    static thread_local std::array read_buffer_data_x{
+        Common::ScratchBuffer<u8>(),
+        Common::ScratchBuffer<u8>(),
+    };
 
     const bool is_buffer_a{BufferDescriptorA().size() > buffer_index &&
                            BufferDescriptorA()[buffer_index].Size()};
@@ -339,19 +353,17 @@ std::span<const u8> HLERequestContext::ReadBuffer(std::size_t buffer_index) cons
             BufferDescriptorA().size() > buffer_index, { return {}; },
             "BufferDescriptorA invalid buffer_index {}", buffer_index);
         auto& read_buffer = read_buffer_a[buffer_index];
-        read_buffer.resize_destructive(BufferDescriptorA()[buffer_index].Size());
-        memory.ReadBlock(BufferDescriptorA()[buffer_index].Address(), read_buffer.data(),
-                         read_buffer.size());
-        return read_buffer;
+        return read_buffer.Read(BufferDescriptorA()[buffer_index].Address(),
+                                BufferDescriptorA()[buffer_index].Size(),
+                                &read_buffer_data_a[buffer_index]);
     } else {
         ASSERT_OR_EXECUTE_MSG(
             BufferDescriptorX().size() > buffer_index, { return {}; },
             "BufferDescriptorX invalid buffer_index {}", buffer_index);
         auto& read_buffer = read_buffer_x[buffer_index];
-        read_buffer.resize_destructive(BufferDescriptorX()[buffer_index].Size());
-        memory.ReadBlock(BufferDescriptorX()[buffer_index].Address(), read_buffer.data(),
-                         read_buffer.size());
-        return read_buffer;
+        return read_buffer.Read(BufferDescriptorX()[buffer_index].Address(),
+                                BufferDescriptorX()[buffer_index].Size(),
+                                &read_buffer_data_x[buffer_index]);
     }
 }
 

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -234,9 +234,10 @@ bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 am
     if (has_new_downloads) {
         memory_tracker.MarkRegionAsGpuModified(*cpu_dest_address, amount);
     }
-    tmp_buffer.resize_destructive(amount);
-    cpu_memory.ReadBlockUnsafe(*cpu_src_address, tmp_buffer.data(), amount);
-    cpu_memory.WriteBlockUnsafe(*cpu_dest_address, tmp_buffer.data(), amount);
+
+    Core::Memory::CpuGuestMemoryScoped<u8, Core::Memory::GuestMemoryFlags::UnsafeReadWrite> tmp(
+        cpu_memory, *cpu_src_address, amount, &tmp_buffer);
+    tmp.SetAddressAndSize(*cpu_dest_address, amount);
     return true;
 }
 

--- a/src/video_core/engines/kepler_compute.cpp
+++ b/src/video_core/engines/kepler_compute.cpp
@@ -84,7 +84,6 @@ Texture::TICEntry KeplerCompute::GetTICEntry(u32 tic_index) const {
 
     Texture::TICEntry tic_entry;
     memory_manager.ReadBlockUnsafe(tic_address_gpu, &tic_entry, sizeof(Texture::TICEntry));
-
     return tic_entry;
 }
 

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -9,6 +9,7 @@
 #include "common/settings.h"
 #include "core/core.h"
 #include "core/core_timing.h"
+#include "core/memory.h"
 #include "video_core/dirty_flags.h"
 #include "video_core/engines/draw_manager.h"
 #include "video_core/engines/maxwell_3d.h"
@@ -679,17 +680,14 @@ void Maxwell3D::ProcessCBData(u32 value) {
 Texture::TICEntry Maxwell3D::GetTICEntry(u32 tic_index) const {
     const GPUVAddr tic_address_gpu{regs.tex_header.Address() +
                                    tic_index * sizeof(Texture::TICEntry)};
-
     Texture::TICEntry tic_entry;
     memory_manager.ReadBlockUnsafe(tic_address_gpu, &tic_entry, sizeof(Texture::TICEntry));
-
     return tic_entry;
 }
 
 Texture::TSCEntry Maxwell3D::GetTSCEntry(u32 tsc_index) const {
     const GPUVAddr tsc_address_gpu{regs.tex_sampler.Address() +
                                    tsc_index * sizeof(Texture::TSCEntry)};
-
     Texture::TSCEntry tsc_entry;
     memory_manager.ReadBlockUnsafe(tsc_address_gpu, &tsc_entry, sizeof(Texture::TSCEntry));
     return tsc_entry;

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -15,6 +15,7 @@
 #include "common/range_map.h"
 #include "common/scratch_buffer.h"
 #include "common/virtual_buffer.h"
+#include "core/memory.h"
 #include "video_core/cache_types.h"
 #include "video_core/pte_kind.h"
 
@@ -61,6 +62,20 @@ public:
 
     [[nodiscard]] u8* GetPointer(GPUVAddr addr);
     [[nodiscard]] const u8* GetPointer(GPUVAddr addr) const;
+
+    template <typename T>
+    [[nodiscard]] T* GetPointer(GPUVAddr addr) {
+        const auto address{GpuToCpuAddress(addr)};
+        if (!address) {
+            return {};
+        }
+        return memory.GetPointer(*address);
+    }
+
+    template <typename T>
+    [[nodiscard]] const T* GetPointer(GPUVAddr addr) const {
+        return GetPointer<T*>(addr);
+    }
 
     /**
      * ReadBlock and WriteBlock are full read and write operations over virtual
@@ -138,6 +153,9 @@ public:
                                size_t max_size = std::numeric_limits<size_t>::max()) const;
 
     void FlushCaching();
+
+    const u8* GetSpan(const GPUVAddr src_addr, const std::size_t size) const;
+    u8* GetSpan(const GPUVAddr src_addr, const std::size_t size);
 
 private:
     template <bool is_big_pages, typename FuncMapped, typename FuncReserved, typename FuncUnmapped>

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -8,6 +8,7 @@
 
 #include "common/alignment.h"
 #include "common/settings.h"
+#include "core/memory.h"
 #include "video_core/control/channel_state.h"
 #include "video_core/dirty_flags.h"
 #include "video_core/engines/kepler_compute.h"
@@ -1022,19 +1023,19 @@ void TextureCache<P>::UploadImageContents(Image& image, StagingBuffer& staging) 
         runtime.AccelerateImageUpload(image, staging, uploads);
         return;
     }
-    const size_t guest_size_bytes = image.guest_size_bytes;
-    swizzle_data_buffer.resize_destructive(guest_size_bytes);
-    gpu_memory->ReadBlockUnsafe(gpu_addr, swizzle_data_buffer.data(), guest_size_bytes);
+
+    Core::Memory::GpuGuestMemory<u8, Core::Memory::GuestMemoryFlags::UnsafeRead> swizzle_data(
+        *gpu_memory, gpu_addr, image.guest_size_bytes, &swizzle_data_buffer);
 
     if (True(image.flags & ImageFlagBits::Converted)) {
         unswizzle_data_buffer.resize_destructive(image.unswizzled_size_bytes);
-        auto copies = UnswizzleImage(*gpu_memory, gpu_addr, image.info, swizzle_data_buffer,
-                                     unswizzle_data_buffer);
+        auto copies =
+            UnswizzleImage(*gpu_memory, gpu_addr, image.info, swizzle_data, unswizzle_data_buffer);
         ConvertImage(unswizzle_data_buffer, image.info, mapped_span, copies);
         image.UploadMemory(staging, copies);
     } else {
         const auto copies =
-            UnswizzleImage(*gpu_memory, gpu_addr, image.info, swizzle_data_buffer, mapped_span);
+            UnswizzleImage(*gpu_memory, gpu_addr, image.info, swizzle_data, mapped_span);
         image.UploadMemory(staging, copies);
     }
 }
@@ -1227,11 +1228,12 @@ void TextureCache<P>::QueueAsyncDecode(Image& image, ImageId image_id) {
     decode->image_id = image_id;
     async_decodes.push_back(std::move(decode));
 
-    Common::ScratchBuffer<u8> local_unswizzle_data_buffer(image.unswizzled_size_bytes);
-    const size_t guest_size_bytes = image.guest_size_bytes;
-    swizzle_data_buffer.resize_destructive(guest_size_bytes);
-    gpu_memory->ReadBlockUnsafe(image.gpu_addr, swizzle_data_buffer.data(), guest_size_bytes);
-    auto copies = UnswizzleImage(*gpu_memory, image.gpu_addr, image.info, swizzle_data_buffer,
+    static Common::ScratchBuffer<u8> local_unswizzle_data_buffer;
+    local_unswizzle_data_buffer.resize_destructive(image.unswizzled_size_bytes);
+    Core::Memory::GpuGuestMemory<u8, Core::Memory::GuestMemoryFlags::UnsafeRead> swizzle_data(
+        *gpu_memory, image.gpu_addr, image.guest_size_bytes, &swizzle_data_buffer);
+
+    auto copies = UnswizzleImage(*gpu_memory, image.gpu_addr, image.info, swizzle_data,
                                  local_unswizzle_data_buffer);
     const size_t out_size = MapSizeBytes(image);
 

--- a/src/video_core/texture_cache/util.h
+++ b/src/video_core/texture_cache/util.h
@@ -66,9 +66,6 @@ struct OverlapResult {
     Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr, const ImageInfo& info,
     std::span<const u8> input, std::span<u8> output);
 
-[[nodiscard]] BufferCopy UploadBufferCopy(Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr,
-                                          const ImageBase& image, std::span<u8> output);
-
 void ConvertImage(std::span<const u8> input, const ImageInfo& info, std::span<u8> output,
                   std::span<BufferImageCopy> copies);
 


### PR DESCRIPTION
#10457 aimed to reduce memory allocations when copying from guest memory, this PR goes another step and aims to eliminate the data copy entirely.

The minimum guarantee we can have of data contiguity is 1 page (4Kb), but in reality, almost all guest memory is allocated contiguously in host memory. We can exploit that and use spans directly over guest memory, rather than requiring separate reads and writes every time we interact with it. From testing various games, this is able to eliminate a non-trivial amount of copying, and can give a noticable perf boost to a bunch of games, I get ~10% on SMO's metro scene for example. XCDE seems to get similar results.

Still could use some more testing that it doesn't break any games, and if anyone has any ideas for making a cleaner interface/making it more usable then I'm all ears. I wanted it to not be inconvenient or annoying to use over current read/write calls.