### PR TITLE
service: nfc: Ensure controller is in the correct mode

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -54,6 +54,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <activity
             android:name="org.yuzu.yuzu_emu.activities.EmulationActivity"
             android:theme="@style/Theme.Yuzu.Main"
+            android:launchMode="singleTop"
             android:screenOrientation="userLandscape"
             android:supportsPictureInPicture="true"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|uiMode"

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -1243,10 +1243,12 @@ Common::Input::DriverResult EmulatedController::SetPollingMode(
     auto& nfc_output_device = output_devices[3];
 
     if (device_index == EmulatedDeviceIndex::LeftIndex) {
+        controller.left_polling_mode = polling_mode;
         return left_output_device->SetPollingMode(polling_mode);
     }
 
     if (device_index == EmulatedDeviceIndex::RightIndex) {
+        controller.right_polling_mode = polling_mode;
         const auto virtual_nfc_result = nfc_output_device->SetPollingMode(polling_mode);
         const auto mapped_nfc_result = right_output_device->SetPollingMode(polling_mode);
 
@@ -1261,10 +1263,20 @@ Common::Input::DriverResult EmulatedController::SetPollingMode(
         return mapped_nfc_result;
     }
 
+    controller.left_polling_mode = polling_mode;
+    controller.right_polling_mode = polling_mode;
     left_output_device->SetPollingMode(polling_mode);
     right_output_device->SetPollingMode(polling_mode);
     nfc_output_device->SetPollingMode(polling_mode);
     return Common::Input::DriverResult::Success;
+}
+
+Common::Input::PollingMode EmulatedController::GetPollingMode(
+    EmulatedDeviceIndex device_index) const {
+    if (device_index == EmulatedDeviceIndex::LeftIndex) {
+        return controller.left_polling_mode;
+    }
+    return controller.right_polling_mode;
 }
 
 bool EmulatedController::SetCameraFormat(

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -143,6 +143,8 @@ struct ControllerStatus {
     CameraState camera_state{};
     RingSensorForce ring_analog_state{};
     NfcState nfc_state{};
+    Common::Input::PollingMode left_polling_mode{};
+    Common::Input::PollingMode right_polling_mode{};
 };
 
 enum class ControllerTriggerType {
@@ -370,6 +372,12 @@ public:
      */
     Common::Input::DriverResult SetPollingMode(EmulatedDeviceIndex device_index,
                                                Common::Input::PollingMode polling_mode);
+    /**
+     * Get the current polling mode from a controller
+     * @param device_index index of the controller to set the polling mode
+     * @return current polling mode
+     */
+    Common::Input::PollingMode GetPollingMode(EmulatedDeviceIndex device_index) const;
 
     /**
      * Sets the desired camera format to be polled from a controller


### PR DESCRIPTION
This is a bug due missing HID services. This ensures nfc mode is active when the nfc service is being used.