### PR TITLE
Use `toUtf8()` for string passed to DBus

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -454,7 +454,7 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
     // the user through their desktop environment.
     //: TRANSLATORS: This string is shown to the user to explain why yuzu needs to prevent the
     //: computer from sleeping
-    QByteArray wakelock_reason = tr("Running a game").toLatin1();
+    QByteArray wakelock_reason = tr("Running a game").toUtf8();
     SDL_SetHint(SDL_HINT_SCREENSAVER_INHIBIT_ACTIVITY_NAME, wakelock_reason.data());
 
     // SDL disables the screen saver by default, and setting the hint


### PR DESCRIPTION
Fixes #11003.
DBus expects UTF-8 no matter the locale: https://dbus.freedesktop.org/doc/dbus-specification.html#:~:text=The%20value%20of%20any%20string%2Dlike%20type%20is%20conceptually%200%20or%20more%20Unicode%20codepoints%20encoded%20in%20UTF%2D8%2C%20none%20of%20which%20may%20be%20U%2B0000