### PR TITLE
Fix regression by unreal engine fix pr

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -598,6 +598,13 @@ void TextureCache<P>::UnmapGPUMemory(size_t as_id, GPUVAddr gpu_addr, size_t siz
                             [&](ImageId id, Image&) { deleted_images.push_back(id); });
     for (const ImageId id : deleted_images) {
         Image& image = slot_images[id];
+        if (True(image.flags & ImageFlagBits::CpuModified)) {
+            return;
+        }
+        image.flags |= ImageFlagBits::CpuModified;
+        if (True(image.flags & ImageFlagBits::Tracked)) {
+            UntrackImage(image, id);
+        }
         if (True(image.flags & ImageFlagBits::Remapped)) {
             continue;
         }

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -610,7 +610,7 @@ void TextureCache<P>::UnmapGPUMemory(size_t as_id, GPUVAddr gpu_addr, size_t siz
             UntrackImage(image, id);
         }
     }
-}        
+}
 
 template <class P>
 bool TextureCache<P>::BlitImage(const Tegra::Engines::Fermi2D::Surface& dst,

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -599,12 +599,9 @@ void TextureCache<P>::UnmapGPUMemory(size_t as_id, GPUVAddr gpu_addr, size_t siz
     for (const ImageId id : deleted_images) {
         Image& image = slot_images[id];
         if (True(image.flags & ImageFlagBits::CpuModified)) {
-            return;
+            continue;
         }
         image.flags |= ImageFlagBits::CpuModified;
-        if (True(image.flags & ImageFlagBits::Tracked)) {
-            UntrackImage(image, id);
-        }
         if (True(image.flags & ImageFlagBits::Remapped)) {
             continue;
         }
@@ -613,7 +610,7 @@ void TextureCache<P>::UnmapGPUMemory(size_t as_id, GPUVAddr gpu_addr, size_t siz
             UntrackImage(image, id);
         }
     }
-}
+}        
 
 template <class P>
 bool TextureCache<P>::BlitImage(const Tegra::Engines::Fermi2D::Surface& dst,


### PR DESCRIPTION
It seems that pr #10953 regressed Metroid Prime Remastered rendering.

This pr bring back code that removed by #10953 pr. Reason why mentioned pr fixed smt v and other ue4 game rendering seems it enable the code that marked as comment rather than cause by code that this pr trying to bring back.
I have tested ue4 games and metroid prime to see if it regress any game but couldn't found one. since i am not dev this will need to get approve from other devs like @FernandoS27 .

Before
![yuzu_jy1I1M2V9x](https://github.com/yuzu-emu/yuzu/assets/66776795/794f2367-fe2c-4bdf-ae0c-3e6691e37229)

after
![yuzu_ULOjPPZIuQ](https://github.com/yuzu-emu/yuzu/assets/66776795/a987272c-e6d0-499d-86e3-f044c5195146)

