### PR TITLE
Fix regression by unreal engine fix pr #11009

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -598,6 +598,10 @@ void TextureCache<P>::UnmapGPUMemory(size_t as_id, GPUVAddr gpu_addr, size_t siz
                             [&](ImageId id, Image&) { deleted_images.push_back(id); });
     for (const ImageId id : deleted_images) {
         Image& image = slot_images[id];
+        if (True(image.flags & ImageFlagBits::CpuModified)) {
+            continue;
+        }
+        image.flags |= ImageFlagBits::CpuModified;
         if (True(image.flags & ImageFlagBits::Remapped)) {
             continue;
         }


### PR DESCRIPTION
It seems that pr https://github.com/yuzu-emu/yuzu/pull/10953 regressed Metroid Prime Remastered rendering.

This pr bring back code that removed by https://github.com/yuzu-emu/yuzu/pull/10953 pr. Reason why mentioned pr fixed smt v and other ue4 game rendering seems it enable the code that marked as comment rather than cause by code that this pr trying to bring back.
I have tested ue4 games and metroid prime to see if it regress any game but couldn't found one. since i am not dev this will need to get approve from other devs like @FernandoS27 .

before
![yuzu_jy1I1M2V9x](https://github.com/yuzu-emu/yuzu/assets/66776795/146f23ff-ec07-436f-b078-37f9ad16b89c)

after
![yuzu_ULOjPPZIuQ](https://github.com/yuzu-emu/yuzu/assets/66776795/bc14826e-f81d-4782-98f9-f83daf5c2de6)

reopen cuz it auto closed original pr while switch branch name and less commit for bonus