### PR TITLE
video_core: vulkan_device: Disable timeline semaphore on Turnip, fix qcom version check.

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -528,13 +528,7 @@ public:
         return extensions.shader_atomic_int64;
     }
 
-    bool HasTimelineSemaphore() const {
-        if (GetDriverID() == VK_DRIVER_ID_QUALCOMM_PROPRIETARY) {
-            // Timeline semaphores do not work properly on all Qualcomm drivers.
-            return false;
-        }
-        return features.timeline_semaphore.timelineSemaphore;
-    }
+    bool HasTimelineSemaphore() const;
 
     /// Returns the minimum supported version of SPIR-V.
     u32 SupportedSpirvVersion() const {


### PR DESCRIPTION
- Fixes Turnip driver usage on certain handsets (e.g. ZTE Snapdragon 870 devices)
- Fixes version check for broken Qualcomm 7xx drivers.