### PR TITLE
settings: Disable C++20 time zone path on MSVC

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -26,7 +26,8 @@ std::string GetTimeZoneString() {
 
     std::string location_name;
     if (time_zone_index == 0) { // Auto
-#if __cpp_lib_chrono >= 201907L
+#if __cpp_lib_chrono >= 201907L && !defined(_MSC_VER)
+        // TODO: Remove `!defined(_MSC_VER)` when we no longer support Windows 10 1809 LTSC
         const struct std::chrono::tzdb& time_zone_data = std::chrono::get_tzdb();
         try {
             const std::chrono::time_zone* current_zone = time_zone_data.current_zone();


### PR DESCRIPTION
Even though it compiles and runs fine on the latest Windows versions, older LTSC builds will crash due to lacking support somewhere in the OS.

For now just disable it for MSVC until either Microsoft fixes this or we no longer support 1809 LTSC.

Needs testing by someone using an old build of Windows 10.