### PR TITLE
ci/linux: Target deploy script from appimage path

### DIFF
--- a/.ci/scripts/linux/docker.sh
+++ b/.ci/scripts/linux/docker.sh
@@ -35,7 +35,7 @@ DESTDIR="$PWD/AppDir" ninja install
 rm -vf AppDir/usr/bin/yuzu-cmd AppDir/usr/bin/yuzu-tester
 
 # Download tools needed to build an AppImage
-wget -nc https://raw.githubusercontent.com/yuzu-emu/ext-linux-bin/main/gcc/deploy-linux.sh
+wget -nc https://raw.githubusercontent.com/yuzu-emu/ext-linux-bin/main/appimage/deploy-linux.sh
 wget -nc https://raw.githubusercontent.com/yuzu-emu/AppImageKit-checkrt/old/AppRun.sh
 wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/exec-x86_64.so
 # Set executable bit


### PR DESCRIPTION
I was asked recently if we could enable Wayland on our official releases. Does it work very well? Errr if you only like Vulkan on Intel or AMD then sure. But the point of this PR is to enable the feature even if it's not fully functional.

The new script includes AppImage changes so that the needed Qt Wayland libraries are included. The path was changed due to it previously existing in the GCC path for some odd reason. This also gives us an opportunity to make sure it's work on our CI before merging. Testing locally can be only half the battle sometimes.

