### PR TITLE
file_sys/content_archive: Detect compressed NCAs

### DIFF
--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -80,6 +80,7 @@ enum class ResultStatus : u16 {
     ErrorIncorrectPFSFileSize,
     ErrorBadNCAHeader,
     ErrorCompressedNCA,
+    ErrorSparseNCA,
     ErrorMissingProductionKeyFile,
     ErrorMissingHeaderKey,
     ErrorIncorrectHeaderKey,

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -79,6 +79,7 @@ enum class ResultStatus : u16 {
     ErrorBadPFSHeader,
     ErrorIncorrectPFSFileSize,
     ErrorBadNCAHeader,
+    ErrorCompressedNCA,
     ErrorMissingProductionKeyFile,
     ErrorMissingHeaderKey,
     ErrorIncorrectHeaderKey,


### PR DESCRIPTION
Instead of failing silently when reading compressed NCAs, print an Error in the log and abort the parsing.