### PR TITLE
ci/mingw: Remove pefile installation step

### DIFF
--- a/.ci/scripts/windows/docker.sh
+++ b/.ci/scripts/windows/docker.sh
@@ -56,7 +56,6 @@ for i in package/*.exe; do
   x86_64-w64-mingw32-strip "${i}"
 done
 
-pip3 install pefile
 python3 .ci/scripts/windows/scan_dll.py package/*.exe package/imageformats/*.dll "package/"
 
 # copy FFmpeg libraries


### PR DESCRIPTION
This is unnecessary here: pefile is already installed on the container.
This step also causes issues in coming changes to the container.