### PR TITLE
android: Don't prompt to save user data on uninstall

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         android:label="@string/app_name_suffixed"
         android:icon="@drawable/ic_launcher"
         android:allowBackup="true"
-        android:hasFragileUserData="true"
+        android:hasFragileUserData="false"
         android:supportsRtl="true"
         android:isGame="true"
         android:localeConfig="@xml/locales_config"


### PR DESCRIPTION
While this can be convenient in some scenarios, this will be a big problem for users trying to sideload different APK versions. If they forget the last one they had installed, they could have problems installing a new copy.