### PR TITLE
android: Visualize disabled home options

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/adapters/HomeSettingAdapter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/adapters/HomeSettingAdapter.kt
@@ -12,6 +12,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.RecyclerView
 import org.yuzu.yuzu_emu.R
 import org.yuzu.yuzu_emu.databinding.CardHomeOptionBinding
+import org.yuzu.yuzu_emu.fragments.MessageDialogFragment
 import org.yuzu.yuzu_emu.model.HomeSetting
 
 class HomeSettingAdapter(private val activity: AppCompatActivity, var options: List<HomeSetting>) :
@@ -34,7 +35,14 @@ class HomeSettingAdapter(private val activity: AppCompatActivity, var options: L
 
     override fun onClick(view: View) {
         val holder = view.tag as HomeOptionViewHolder
-        holder.option.onClick.invoke()
+        if (holder.option.isEnabled.invoke()) {
+            holder.option.onClick.invoke()
+        } else {
+            MessageDialogFragment.newInstance(
+                holder.option.disabledTitleId,
+                holder.option.disabledMessageId
+            ).show(activity.supportFragmentManager, MessageDialogFragment.TAG)
+        }
     }
 
     inner class HomeOptionViewHolder(val binding: CardHomeOptionBinding) :
@@ -64,6 +72,12 @@ class HomeSettingAdapter(private val activity: AppCompatActivity, var options: L
                             binding.optionCard.context,
                             R.drawable.premium_background
                         )
+            }
+
+            if (!option.isEnabled.invoke()) {
+                binding.optionTitle.alpha = 0.5f
+                binding.optionDescription.alpha = 0.5f
+                binding.optionIcon.alpha = 0.5f
             }
         }
     }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/HomeSettingsFragment.kt
@@ -73,102 +73,113 @@ class HomeSettingsFragment : Fragment() {
                 HomeSetting(
                     R.string.advanced_settings,
                     R.string.settings_description,
-                    R.drawable.ic_settings
-                ) { SettingsActivity.launch(requireContext(), SettingsFile.FILE_NAME_CONFIG, "") }
+                    R.drawable.ic_settings,
+                    { SettingsActivity.launch(requireContext(), SettingsFile.FILE_NAME_CONFIG, "") }
+                )
             )
             add(
                 HomeSetting(
                     R.string.open_user_folder,
                     R.string.open_user_folder_description,
-                    R.drawable.ic_folder_open
-                ) { openFileManager() }
+                    R.drawable.ic_folder_open,
+                    { openFileManager() }
+                )
             )
             add(
                 HomeSetting(
                     R.string.preferences_theme,
                     R.string.theme_and_color_description,
-                    R.drawable.ic_palette
-                ) { SettingsActivity.launch(requireContext(), Settings.SECTION_THEME, "") }
-            )
-
-            if (GpuDriverHelper.supportsCustomDriverLoading()) {
-                add(
-                    HomeSetting(
-                        R.string.install_gpu_driver,
-                        R.string.install_gpu_driver_description,
-                        R.drawable.ic_exit
-                    ) { driverInstaller() }
+                    R.drawable.ic_palette,
+                    { SettingsActivity.launch(requireContext(), Settings.SECTION_THEME, "") }
                 )
-            }
-
+            )
+            add(
+                HomeSetting(
+                    R.string.install_gpu_driver,
+                    R.string.install_gpu_driver_description,
+                    R.drawable.ic_exit,
+                    { driverInstaller() },
+                    { GpuDriverHelper.supportsCustomDriverLoading() },
+                    R.string.custom_driver_not_supported,
+                    R.string.custom_driver_not_supported_description
+                )
+            )
             add(
                 HomeSetting(
                     R.string.install_amiibo_keys,
                     R.string.install_amiibo_keys_description,
-                    R.drawable.ic_nfc
-                ) { mainActivity.getAmiiboKey.launch(arrayOf("*/*")) }
+                    R.drawable.ic_nfc,
+                    { mainActivity.getAmiiboKey.launch(arrayOf("*/*")) }
+                )
             )
             add(
                 HomeSetting(
                     R.string.install_game_content,
                     R.string.install_game_content_description,
-                    R.drawable.ic_system_update_alt
-                ) { mainActivity.installGameUpdate.launch(arrayOf("*/*")) }
+                    R.drawable.ic_system_update_alt,
+                    { mainActivity.installGameUpdate.launch(arrayOf("*/*")) }
+                )
             )
             add(
                 HomeSetting(
                     R.string.select_games_folder,
                     R.string.select_games_folder_description,
-                    R.drawable.ic_add
-                ) {
-                    mainActivity.getGamesDirectory.launch(
-                        Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).data
-                    )
-                }
+                    R.drawable.ic_add,
+                    {
+                        mainActivity.getGamesDirectory.launch(
+                            Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).data
+                        )
+                    }
+                )
             )
             add(
                 HomeSetting(
                     R.string.manage_save_data,
                     R.string.import_export_saves_description,
-                    R.drawable.ic_save
-                ) {
-                    ImportExportSavesFragment().show(
-                        parentFragmentManager,
-                        ImportExportSavesFragment.TAG
-                    )
-                }
+                    R.drawable.ic_save,
+                    {
+                        ImportExportSavesFragment().show(
+                            parentFragmentManager,
+                            ImportExportSavesFragment.TAG
+                        )
+                    }
+                )
             )
             add(
                 HomeSetting(
                     R.string.install_prod_keys,
                     R.string.install_prod_keys_description,
-                    R.drawable.ic_unlock
-                ) { mainActivity.getProdKey.launch(arrayOf("*/*")) }
+                    R.drawable.ic_unlock,
+                    { mainActivity.getProdKey.launch(arrayOf("*/*")) }
+                )
             )
             add(
                 HomeSetting(
                     R.string.install_firmware,
                     R.string.install_firmware_description,
-                    R.drawable.ic_firmware
-                ) { mainActivity.getFirmware.launch(arrayOf("application/zip")) }
+                    R.drawable.ic_firmware,
+                    { mainActivity.getFirmware.launch(arrayOf("application/zip")) }
+                )
             )
             add(
                 HomeSetting(
                     R.string.share_log,
                     R.string.share_log_description,
-                    R.drawable.ic_log
-                ) { shareLog() }
+                    R.drawable.ic_log,
+                    { shareLog() }
+                )
             )
             add(
                 HomeSetting(
                     R.string.about,
                     R.string.about_description,
-                    R.drawable.ic_info_outline
-                ) {
-                    exitTransition = MaterialSharedAxis(MaterialSharedAxis.X, true)
-                    parentFragmentManager.primaryNavigationFragment?.findNavController()
-                        ?.navigate(R.id.action_homeSettingsFragment_to_aboutFragment)
-                }
+                    R.drawable.ic_info_outline,
+                    {
+                        exitTransition = MaterialSharedAxis(MaterialSharedAxis.X, true)
+                        parentFragmentManager.primaryNavigationFragment?.findNavController()
+                            ?.navigate(R.id.action_homeSettingsFragment_to_aboutFragment)
+                    }
+                )
             )
         }
 
@@ -178,12 +189,13 @@ class HomeSettingsFragment : Fragment() {
                 HomeSetting(
                     R.string.get_early_access,
                     R.string.get_early_access_description,
-                    R.drawable.ic_diamond
-                ) {
-                    exitTransition = MaterialSharedAxis(MaterialSharedAxis.X, true)
-                    parentFragmentManager.primaryNavigationFragment?.findNavController()
-                        ?.navigate(R.id.action_homeSettingsFragment_to_earlyAccessFragment)
-                }
+                    R.drawable.ic_diamond,
+                    {
+                        exitTransition = MaterialSharedAxis(MaterialSharedAxis.X, true)
+                        parentFragmentManager.primaryNavigationFragment?.findNavController()
+                            ?.navigate(R.id.action_homeSettingsFragment_to_earlyAccessFragment)
+                    }
+                )
             )
         }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/HomeSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/HomeSetting.kt
@@ -7,5 +7,8 @@ data class HomeSetting(
     val titleId: Int,
     val descriptionId: Int,
     val iconId: Int,
-    val onClick: () -> Unit
+    val onClick: () -> Unit,
+    val isEnabled: () -> Boolean = { true },
+    val disabledTitleId: Int = 0,
+    val disabledMessageId: Int = 0
 )

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="install_game_content_success_install">%1$d installed successfully</string>
     <string name="install_game_content_success_overwrite">%1$d overwritten successfully</string>
     <string name="install_game_content_help_link">https://yuzu-emu.org/help/quickstart/#dumping-installed-updates</string>
+    <string name="custom_driver_not_supported">Custom drivers not supported</string>
+    <string name="custom_driver_not_supported_description">Custom driver loading isn\'t currently supported for this device.\nCheck this option again in the future to see if support was added!</string>
 
     <!-- About screen strings -->
     <string name="gaia_is_not_real">Gaia isn\'t real</string>


### PR DESCRIPTION
Allow for displaying options in the home options that are disabled with messages that explain why they are disabled.

This includes reasoning for the GPU driver installation button.