### PR TITLE
memory: cleanup

### DIFF
--- a/src/core/debugger/gdbstub.cpp
+++ b/src/core/debugger/gdbstub.cpp
@@ -261,10 +261,8 @@ void GDBStub::ExecuteCommand(std::string_view packet, std::vector<DebuggerAction
         const size_t addr{static_cast<size_t>(strtoll(command.data(), nullptr, 16))};
         const size_t size{static_cast<size_t>(strtoll(command.data() + sep, nullptr, 16))};
 
-        if (system.ApplicationMemory().IsValidVirtualAddressRange(addr, size)) {
-            std::vector<u8> mem(size);
-            system.ApplicationMemory().ReadBlock(addr, mem.data(), size);
-
+        std::vector<u8> mem(size);
+        if (system.ApplicationMemory().ReadBlock(addr, mem.data(), size)) {
             SendReply(Common::HexToString(mem));
         } else {
             SendReply(GDB_STUB_REPLY_ERR);
@@ -281,8 +279,7 @@ void GDBStub::ExecuteCommand(std::string_view packet, std::vector<DebuggerAction
         const auto mem_substr{std::string_view(command).substr(mem_sep)};
         const auto mem{Common::HexStringToVector(mem_substr, false)};
 
-        if (system.ApplicationMemory().IsValidVirtualAddressRange(addr, size)) {
-            system.ApplicationMemory().WriteBlock(addr, mem.data(), size);
+        if (system.ApplicationMemory().WriteBlock(addr, mem.data(), size)) {
             system.InvalidateCpuInstructionCacheRange(addr, size);
             SendReply(GDB_STUB_REPLY_OK);
         } else {

--- a/src/core/hle/kernel/svc/svc_ipc.cpp
+++ b/src/core/hle/kernel/svc/svc_ipc.cpp
@@ -8,6 +8,7 @@
 #include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_server_session.h"
 #include "core/hle/kernel/svc.h"
+#include "core/hle/kernel/svc_results.h"
 
 namespace Kernel::Svc {
 
@@ -49,14 +50,10 @@ Result ReplyAndReceive(Core::System& system, s32* out_index, uint64_t handles_ad
 
     // Copy user handles.
     if (num_handles > 0) {
-        // Ensure we can try to get the handles.
-        R_UNLESS(GetCurrentMemory(kernel).IsValidVirtualAddressRange(
-                     handles_addr, static_cast<u64>(sizeof(Handle) * num_handles)),
-                 ResultInvalidPointer);
-
         // Get the handles.
-        GetCurrentMemory(kernel).ReadBlock(handles_addr, handles.data(),
-                                           sizeof(Handle) * num_handles);
+        R_UNLESS(GetCurrentMemory(kernel).ReadBlock(handles_addr, handles.data(),
+                                                    sizeof(Handle) * num_handles),
+                 ResultInvalidPointer);
 
         // Convert the handles to objects.
         R_UNLESS(handle_table.GetMultipleObjects<KSynchronizationObject>(

--- a/src/core/hle/kernel/svc/svc_synchronization.cpp
+++ b/src/core/hle/kernel/svc/svc_synchronization.cpp
@@ -7,6 +7,7 @@
 #include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_readable_event.h"
 #include "core/hle/kernel/svc.h"
+#include "core/hle/kernel/svc_results.h"
 
 namespace Kernel::Svc {
 
@@ -64,14 +65,10 @@ Result WaitSynchronization(Core::System& system, int32_t* out_index, u64 user_ha
 
     // Copy user handles.
     if (num_handles > 0) {
-        // Ensure we can try to get the handles.
-        R_UNLESS(GetCurrentMemory(kernel).IsValidVirtualAddressRange(
-                     user_handles, static_cast<u64>(sizeof(Handle) * num_handles)),
-                 ResultInvalidPointer);
-
         // Get the handles.
-        GetCurrentMemory(kernel).ReadBlock(user_handles, handles.data(),
-                                           sizeof(Handle) * num_handles);
+        R_UNLESS(GetCurrentMemory(kernel).ReadBlock(user_handles, handles.data(),
+                                                    sizeof(Handle) * num_handles),
+                 ResultInvalidPointer);
 
         // Convert the handles to objects.
         R_UNLESS(handle_table.GetMultipleObjects<KSynchronizationObject>(

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -24,7 +24,6 @@ class GPUDirtyMemoryManager;
 } // namespace Core
 
 namespace Kernel {
-class PhysicalMemory;
 class KProcess;
 } // namespace Kernel
 
@@ -330,7 +329,7 @@ public:
      * @post The range [dest_buffer, size) contains the read bytes from the
      *       current process' address space.
      */
-    void ReadBlock(Common::ProcessAddress src_addr, void* dest_buffer, std::size_t size);
+    bool ReadBlock(Common::ProcessAddress src_addr, void* dest_buffer, std::size_t size);
 
     /**
      * Reads a contiguous block of bytes from the current process' address space.
@@ -349,7 +348,7 @@ public:
      * @post The range [dest_buffer, size) contains the read bytes from the
      *       current process' address space.
      */
-    void ReadBlockUnsafe(Common::ProcessAddress src_addr, void* dest_buffer, std::size_t size);
+    bool ReadBlockUnsafe(Common::ProcessAddress src_addr, void* dest_buffer, std::size_t size);
 
     const u8* GetSpan(const VAddr src_addr, const std::size_t size) const;
     u8* GetSpan(const VAddr src_addr, const std::size_t size);
@@ -373,7 +372,7 @@ public:
      *       and will mark that region as invalidated to caches that the active
      *       graphics backend may be maintaining over the course of execution.
      */
-    void WriteBlock(Common::ProcessAddress dest_addr, const void* src_buffer, std::size_t size);
+    bool WriteBlock(Common::ProcessAddress dest_addr, const void* src_buffer, std::size_t size);
 
     /**
      * Writes a range of bytes into the current process' address space at the specified
@@ -391,7 +390,7 @@ public:
      *       will be ignored and an error will be logged.
      *
      */
-    void WriteBlockUnsafe(Common::ProcessAddress dest_addr, const void* src_buffer,
+    bool WriteBlockUnsafe(Common::ProcessAddress dest_addr, const void* src_buffer,
                           std::size_t size);
 
     /**
@@ -405,7 +404,7 @@ public:
      * @post The range [dest_addr, size) within the process' address space contains the
      *       same data within the range [src_addr, size).
      */
-    void CopyBlock(Common::ProcessAddress dest_addr, Common::ProcessAddress src_addr,
+    bool CopyBlock(Common::ProcessAddress dest_addr, Common::ProcessAddress src_addr,
                    std::size_t size);
 
     /**
@@ -418,7 +417,7 @@ public:
      * @post The range [dest_addr, size) within the process' address space contains the
      *       value 0.
      */
-    void ZeroBlock(Common::ProcessAddress dest_addr, std::size_t size);
+    bool ZeroBlock(Common::ProcessAddress dest_addr, std::size_t size);
 
     /**
      * Invalidates a range of bytes within the current process' address space at the specified


### PR DESCRIPTION
- Mostly eliminates the dependency on process, but a lot of code still calls into memory during initialization which needs to be fixed, and that felt out of scope for this.
- Removes some TOCTTOU mapping issues with IsValidVirtualAddress[Range] by having WalkBlock return whether all pages were user-accessible during traversal.