### PR TITLE
buffer_cache: Increase number of texture buffers

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -442,6 +442,11 @@ void BufferCache<P>::UnbindComputeStorageBuffers() {
 template <class P>
 void BufferCache<P>::BindComputeStorageBuffer(size_t ssbo_index, u32 cbuf_index, u32 cbuf_offset,
                                               bool is_written) {
+    if (ssbo_index >= channel_state->compute_storage_buffers.size()) [[unlikely]] {
+        LOG_ERROR(HW_GPU, "Storage buffer index {} exceeds maximum storage buffer count",
+                  ssbo_index);
+        return;
+    }
     channel_state->enabled_compute_storage_buffers |= 1U << ssbo_index;
     channel_state->written_compute_storage_buffers |= (is_written ? 1U : 0U) << ssbo_index;
 
@@ -464,6 +469,11 @@ void BufferCache<P>::UnbindComputeTextureBuffers() {
 template <class P>
 void BufferCache<P>::BindComputeTextureBuffer(size_t tbo_index, GPUVAddr gpu_addr, u32 size,
                                               PixelFormat format, bool is_written, bool is_image) {
+    if (tbo_index >= channel_state->compute_texture_buffers.size()) [[unlikely]] {
+        LOG_ERROR(HW_GPU, "Texture buffer index {} exceeds maximum texture buffer count",
+                  tbo_index);
+        return;
+    }
     channel_state->enabled_compute_texture_buffers |= 1U << tbo_index;
     channel_state->written_compute_texture_buffers |= (is_written ? 1U : 0U) << tbo_index;
     if constexpr (SEPARATE_IMAGE_BUFFERS_BINDINGS) {

--- a/src/video_core/buffer_cache/buffer_cache_base.h
+++ b/src/video_core/buffer_cache/buffer_cache_base.h
@@ -67,7 +67,7 @@ constexpr u32 NUM_TRANSFORM_FEEDBACK_BUFFERS = 4;
 constexpr u32 NUM_GRAPHICS_UNIFORM_BUFFERS = 18;
 constexpr u32 NUM_COMPUTE_UNIFORM_BUFFERS = 8;
 constexpr u32 NUM_STORAGE_BUFFERS = 16;
-constexpr u32 NUM_TEXTURE_BUFFERS = 16;
+constexpr u32 NUM_TEXTURE_BUFFERS = 32;
 constexpr u32 NUM_STAGES = 5;
 
 using UniformBufferSizes = std::array<std::array<u32, NUM_GRAPHICS_UNIFORM_BUFFERS>, NUM_STAGES>;


### PR DESCRIPTION
Should fix crashes when defeating the first boss in Master Detective Archives: Rain Code (#10987)
The game configures a compute pipeline with 18 texture buffers which overflows compute_texture_buffers and causes garbage data to be written in compute_uniform_buffer_sizes.

According to the vulkan spec the limit for texture buffers is `maxPerStageDescriptorSampledImages`. Looking at the switch vulkan driver in [vulkaninfo](https://vulkan.gpuinfo.org/displayreport.php?id=15757#properties) the limit appears much higher than the current 16, so I am not exactly sure on what the correct value is. Bumped it to 32 to match the number of bits in `enabled_compute_texture_buffers` in the buffer cache.