### PR TITLE
Pass optimisations to CMake via build.gradle.kts

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -154,6 +154,9 @@ android {
                     "-DYUZU_ENABLE_LTO=ON"
                 )
 
+                cFlags("-O3", "-march=armv8.7a", "-pipe", "-flto=thin")
+                cppFlags("-O3", "-march=armv8.7a", "-pipe", "-flto=thin")
+
                 abiFilters("arm64-v8a", "x86_64")
             }
         }


### PR DESCRIPTION
This passes compiler flags from Gradle to CMake

I'm running this locally, I'm not sure if you have something that could benchmark this change and I'm not sure if armv8.7a is too high for what you officially support 

I'm on a OnePlus 11 here (Snapdragon 8 Gen 2) but it doesn't seem to like compiling with sve or sve2, neither of them appear in /proc/cpuinfo

I'm running something similar to build the Turnip drivers with optimisations too, Danil's branch rebased onto main