### PR TITLE
general: remove uses of dynamic_cast

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -449,7 +449,7 @@ private:
         loader->ReadTitle(entry.title);
         loader->ReadIcon(entry.icon);
         if (loader->GetFileType() == Loader::FileType::NRO) {
-            jauto loader_nro = dynamic_cast<Loader::AppLoader_NRO*>(loader.get());
+            jauto loader_nro = reinterpret_cast<Loader::AppLoader_NRO*>(loader.get());
             entry.isHomebrew = loader_nro->IsHomebrew();
         } else {
             entry.isHomebrew = false;

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -346,11 +346,11 @@ void ARM_Dynarmic_32::RewindBreakpointInstruction() {
 }
 
 ARM_Dynarmic_32::ARM_Dynarmic_32(System& system_, bool uses_wall_clock_,
-                                 ExclusiveMonitor& exclusive_monitor_, std::size_t core_index_)
+                                 DynarmicExclusiveMonitor& exclusive_monitor_,
+                                 std::size_t core_index_)
     : ARM_Interface{system_, uses_wall_clock_}, cb(std::make_unique<DynarmicCallbacks32>(*this)),
       cp15(std::make_shared<DynarmicCP15>(*this)), core_index{core_index_},
-      exclusive_monitor{dynamic_cast<DynarmicExclusiveMonitor&>(exclusive_monitor_)},
-      null_jit{MakeJit(nullptr)}, jit{null_jit.get()} {}
+      exclusive_monitor{exclusive_monitor_}, null_jit{MakeJit(nullptr)}, jit{null_jit.get()} {}
 
 ARM_Dynarmic_32::~ARM_Dynarmic_32() = default;
 

--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -12,7 +12,7 @@
 #include "common/common_types.h"
 #include "common/hash.h"
 #include "core/arm/arm_interface.h"
-#include "core/arm/exclusive_monitor.h"
+#include "core/arm/dynarmic/dynarmic_exclusive_monitor.h"
 
 namespace Core::Memory {
 class Memory;
@@ -28,8 +28,8 @@ class System;
 
 class ARM_Dynarmic_32 final : public ARM_Interface {
 public:
-    ARM_Dynarmic_32(System& system_, bool uses_wall_clock_, ExclusiveMonitor& exclusive_monitor_,
-                    std::size_t core_index_);
+    ARM_Dynarmic_32(System& system_, bool uses_wall_clock_,
+                    DynarmicExclusiveMonitor& exclusive_monitor_, std::size_t core_index_);
     ~ARM_Dynarmic_32() override;
 
     void SetPC(u64 pc) override;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -405,11 +405,11 @@ void ARM_Dynarmic_64::RewindBreakpointInstruction() {
 }
 
 ARM_Dynarmic_64::ARM_Dynarmic_64(System& system_, bool uses_wall_clock_,
-                                 ExclusiveMonitor& exclusive_monitor_, std::size_t core_index_)
+                                 DynarmicExclusiveMonitor& exclusive_monitor_,
+                                 std::size_t core_index_)
     : ARM_Interface{system_, uses_wall_clock_},
       cb(std::make_unique<DynarmicCallbacks64>(*this)), core_index{core_index_},
-      exclusive_monitor{dynamic_cast<DynarmicExclusiveMonitor&>(exclusive_monitor_)},
-      null_jit{MakeJit(nullptr, 48)}, jit{null_jit.get()} {}
+      exclusive_monitor{exclusive_monitor_}, null_jit{MakeJit(nullptr, 48)}, jit{null_jit.get()} {}
 
 ARM_Dynarmic_64::~ARM_Dynarmic_64() = default;
 

--- a/src/core/arm/dynarmic/arm_dynarmic_64.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.h
@@ -11,7 +11,7 @@
 #include "common/common_types.h"
 #include "common/hash.h"
 #include "core/arm/arm_interface.h"
-#include "core/arm/exclusive_monitor.h"
+#include "core/arm/dynarmic/dynarmic_exclusive_monitor.h"
 
 namespace Core::Memory {
 class Memory;
@@ -25,8 +25,8 @@ class System;
 
 class ARM_Dynarmic_64 final : public ARM_Interface {
 public:
-    ARM_Dynarmic_64(System& system_, bool uses_wall_clock_, ExclusiveMonitor& exclusive_monitor_,
-                    std::size_t core_index_);
+    ARM_Dynarmic_64(System& system_, bool uses_wall_clock_,
+                    DynarmicExclusiveMonitor& exclusive_monitor_, std::size_t core_index_);
     ~ARM_Dynarmic_64() override;
 
     void SetPC(u64 pc) override;

--- a/src/core/arm/dynarmic/dynarmic_exclusive_monitor.h
+++ b/src/core/arm/dynarmic/dynarmic_exclusive_monitor.h
@@ -6,8 +6,6 @@
 #include <dynarmic/interface/exclusive_monitor.h>
 
 #include "common/common_types.h"
-#include "core/arm/dynarmic/arm_dynarmic_32.h"
-#include "core/arm/dynarmic/arm_dynarmic_64.h"
 #include "core/arm/exclusive_monitor.h"
 
 namespace Core::Memory {
@@ -15,6 +13,9 @@ class Memory;
 }
 
 namespace Core {
+
+class ARM_Dynarmic_32;
+class ARM_Dynarmic_64;
 
 class DynarmicExclusiveMonitor final : public ExclusiveMonitor {
 public:

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -880,6 +880,14 @@ const FileSys::ContentProvider& System::GetContentProvider() const {
     return *impl->content_provider;
 }
 
+FileSys::ContentProviderUnion& System::GetContentProviderUnion() {
+    return *impl->content_provider;
+}
+
+const FileSys::ContentProviderUnion& System::GetContentProviderUnion() const {
+    return *impl->content_provider;
+}
+
 Service::FileSystem::FileSystemController& System::GetFileSystemController() {
     return impl->fs_controller;
 }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -381,6 +381,9 @@ public:
     [[nodiscard]] FileSys::ContentProvider& GetContentProvider();
     [[nodiscard]] const FileSys::ContentProvider& GetContentProvider() const;
 
+    [[nodiscard]] FileSys::ContentProviderUnion& GetContentProviderUnion();
+    [[nodiscard]] const FileSys::ContentProviderUnion& GetContentProviderUnion() const;
+
     [[nodiscard]] Service::FileSystem::FileSystemController& GetFileSystemController();
     [[nodiscard]] const Service::FileSystem::FileSystemController& GetFileSystemController() const;
 

--- a/src/core/hle/kernel/physical_core.cpp
+++ b/src/core/hle/kernel/physical_core.cpp
@@ -17,7 +17,9 @@ PhysicalCore::PhysicalCore(std::size_t core_index, Core::System& system, KSchedu
     // a 32-bit instance of Dynarmic. This should be abstracted out to a CPU manager.
     auto& kernel = system.Kernel();
     m_arm_interface = std::make_unique<Core::ARM_Dynarmic_64>(
-        system, kernel.IsMulticore(), kernel.GetExclusiveMonitor(), m_core_index);
+        system, kernel.IsMulticore(),
+        reinterpret_cast<Core::DynarmicExclusiveMonitor&>(kernel.GetExclusiveMonitor()),
+        m_core_index);
 #else
 #error Platform not supported yet.
 #endif
@@ -31,7 +33,9 @@ void PhysicalCore::Initialize(bool is_64_bit) {
     if (!is_64_bit) {
         // We already initialized a 64-bit core, replace with a 32-bit one.
         m_arm_interface = std::make_unique<Core::ARM_Dynarmic_32>(
-            m_system, kernel.IsMulticore(), kernel.GetExclusiveMonitor(), m_core_index);
+            m_system, kernel.IsMulticore(),
+            reinterpret_cast<Core::DynarmicExclusiveMonitor&>(kernel.GetExclusiveMonitor()),
+            m_core_index);
     }
 #else
 #error Platform not supported yet.

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -235,7 +235,7 @@ GameListWorker::~GameListWorker() = default;
 void GameListWorker::AddTitlesToGameList(GameListDir* parent_dir) {
     using namespace FileSys;
 
-    const auto& cache = dynamic_cast<ContentProviderUnion&>(system.GetContentProvider());
+    const auto& cache = system.GetContentProviderUnion();
 
     auto installed_games = cache.ListEntriesFilterOrigin(std::nullopt, TitleType::Application,
                                                          ContentRecordType::Program);


### PR DESCRIPTION
Each of these instances happened to be one where we know the underlying type in one way or another and there is no need for an RTTI-based cast.