### PR TITLE
ssa_rewrite_pass: use proper maps

### DIFF
--- a/src/shader_recompiler/ir_opt/ssa_rewrite_pass.cpp
+++ b/src/shader_recompiler/ir_opt/ssa_rewrite_pass.cpp
@@ -14,11 +14,11 @@
 //
 
 #include <deque>
+#include <map>
 #include <span>
+#include <unordered_map>
 #include <variant>
 #include <vector>
-
-#include <boost/container/flat_map.hpp>
 
 #include "shader_recompiler/frontend/ir/basic_block.h"
 #include "shader_recompiler/frontend/ir/opcodes.h"
@@ -52,7 +52,7 @@ struct IndirectBranchVariable {
 
 using Variant = std::variant<IR::Reg, IR::Pred, ZeroFlagTag, SignFlagTag, CarryFlagTag,
                              OverflowFlagTag, GotoVariable, IndirectBranchVariable>;
-using ValueMap = boost::container::flat_map<IR::Block*, IR::Value>;
+using ValueMap = std::unordered_map<IR::Block*, IR::Value>;
 
 struct DefTable {
     const IR::Value& Def(IR::Block* block, IR::Reg variable) {
@@ -112,7 +112,7 @@ struct DefTable {
     }
 
     std::array<ValueMap, IR::NUM_USER_PREDS> preds;
-    boost::container::flat_map<u32, ValueMap> goto_vars;
+    std::unordered_map<u32, ValueMap> goto_vars;
     ValueMap indirect_branch_var;
     ValueMap zero_flag;
     ValueMap sign_flag;
@@ -295,8 +295,7 @@ private:
         return same;
     }
 
-    boost::container::flat_map<IR::Block*, boost::container::flat_map<Variant, IR::Inst*>>
-        incomplete_phis;
+    std::unordered_map<IR::Block*, std::map<Variant, IR::Inst*>> incomplete_phis;
     DefTable current_def;
 };
 


### PR DESCRIPTION
This significantly improves the performance of the slowest shader compilation in Splatoon 3, from 30 seconds down to about 4 seconds. This is still too slow, but substantially better now.

I originally only used map, but found that the extra space overhead of unordered_map was worth it for this case when benchmarking.