### PR TITLE
yuzu: Avoid reading broken games

### DIFF
--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -265,7 +265,11 @@ void GameListWorker::AddTitlesToGameList(GameListDir* parent_dir) {
         std::vector<u8> icon;
         std::string name;
         u64 program_id = 0;
-        loader->ReadProgramId(program_id);
+        const auto result = loader->ReadProgramId(program_id);
+
+        if (result != Loader::ResultStatus::Success) {
+            continue;
+        }
 
         const PatchManager patch{program_id, system.GetFileSystemController(),
                                  system.GetContentProvider()};


### PR DESCRIPTION
If you load yuzu without keys and already have a cache entry the game list will crash as soon as it tries to get the localized title id. Return early when the loader fails.