### PR TITLE
Enable controller interaction in Controller Applet

### DIFF
--- a/dist/qt_themes/default/style.qss
+++ b/dist/qt_themes/default/style.qss
@@ -115,6 +115,10 @@ QWidget#connectedControllers {
     background: transparent;
 }
 
+QWidget#closeButtons {
+    background: transparent;
+}
+
 QWidget#playersSupported,
 QWidget#controllersSupported,
 QWidget#controllerSupported1,

--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -1380,6 +1380,10 @@ QWidget#connectedControllers {
     background: transparent;
 }
 
+QWidget#closeButtons {
+    background: transparent;
+}
+
 QWidget#playersSupported,
 QWidget#controllersSupported,
 QWidget#controllerSupported1,

--- a/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
+++ b/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
@@ -2301,6 +2301,10 @@ QWidget#connectedControllers {
   background: transparent;
 }
 
+QWidget#closeButtons {
+    background: transparent;
+}
+
 QWidget#playersSupported,
 QWidget#controllersSupported,
 QWidget#controllerSupported1,

--- a/src/yuzu/applets/qt_controller.cpp
+++ b/src/yuzu/applets/qt_controller.cpp
@@ -21,6 +21,7 @@
 #include "yuzu/configuration/configure_vibration.h"
 #include "yuzu/configuration/input_profiles.h"
 #include "yuzu/main.h"
+#include "yuzu/util/controller_navigation.h"
 
 namespace {
 
@@ -130,6 +131,8 @@ QtControllerSelectorDialog::QtControllerSelectorDialog(
         ui->checkboxPlayer7Connected, ui->checkboxPlayer8Connected,
     };
 
+    ui->labelError->setVisible(false);
+
     // Setup/load everything prior to setting up connections.
     // This avoids unintentionally changing the states of elements while loading them in.
     SetSupportedControllers();
@@ -141,6 +144,8 @@ QtControllerSelectorDialog::QtControllerSelectorDialog(
 
     LoadConfiguration();
 
+    controller_navigation = new ControllerNavigation(system.HIDCore(), this);
+
     for (std::size_t i = 0; i < NUM_PLAYERS; ++i) {
         SetExplainText(i);
         UpdateControllerIcon(i);
@@ -149,6 +154,8 @@ QtControllerSelectorDialog::QtControllerSelectorDialog(
 
         connect(player_groupboxes[i], &QGroupBox::toggled, [this, i](bool checked) {
             if (checked) {
+                // Hide eventual error message about number of controllers
+                ui->labelError->setVisible(false);
                 for (std::size_t index = 0; index <= i; ++index) {
                     connected_controller_checkboxes[index]->setChecked(checked);
                 }
@@ -197,6 +204,12 @@ QtControllerSelectorDialog::QtControllerSelectorDialog(
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
             &QtControllerSelectorDialog::ApplyConfiguration);
 
+    connect(controller_navigation, &ControllerNavigation::TriggerKeyboardEvent,
+            [this](Qt::Key key) {
+                QKeyEvent* event = new QKeyEvent(QEvent::KeyPress, key, Qt::NoModifier);
+                QCoreApplication::postEvent(this, event);
+            });
+
     // Enhancement: Check if the parameters have already been met before disconnecting controllers.
     // If all the parameters are met AND only allows a single player,
     // stop the constructor here as we do not need to continue.
@@ -215,6 +228,7 @@ QtControllerSelectorDialog::QtControllerSelectorDialog(
 }
 
 QtControllerSelectorDialog::~QtControllerSelectorDialog() {
+    controller_navigation->UnloadController();
     system.HIDCore().DisableAllControllerConfiguration();
 }
 
@@ -285,6 +299,31 @@ void QtControllerSelectorDialog::CallConfigureInputProfileDialog() {
                           Qt::WindowSystemMenuHint);
     dialog.setWindowModality(Qt::WindowModal);
     dialog.exec();
+}
+
+void QtControllerSelectorDialog::keyPressEvent(QKeyEvent* evt) {
+    const auto num_connected_players = static_cast<int>(
+        std::count_if(player_groupboxes.begin(), player_groupboxes.end(),
+                      [](const QGroupBox* player) { return player->isChecked(); }));
+
+    const auto min_supported_players = parameters.enable_single_mode ? 1 : parameters.min_players;
+    const auto max_supported_players = parameters.enable_single_mode ? 1 : parameters.max_players;
+
+    if ((evt->key() == Qt::Key_Enter || evt->key() == Qt::Key_Return) && !parameters_met) {
+        // Display error message when trying to validate using "Enter" and "OK" button is disabled
+        ui->labelError->setVisible(true);
+        return;
+    } else if (evt->key() == Qt::Key_Left && num_connected_players > min_supported_players) {
+        // Remove a player if possible
+        connected_controller_checkboxes[num_connected_players - 1]->setChecked(false);
+        return;
+    } else if (evt->key() == Qt::Key_Right && num_connected_players < max_supported_players) {
+        // Add a player, if possible
+        ui->labelError->setVisible(false);
+        connected_controller_checkboxes[num_connected_players]->setChecked(true);
+        return;
+    }
+    QDialog::keyPressEvent(evt);
 }
 
 bool QtControllerSelectorDialog::CheckIfParametersMet() {

--- a/src/yuzu/applets/qt_controller.h
+++ b/src/yuzu/applets/qt_controller.h
@@ -34,6 +34,8 @@ class HIDCore;
 enum class NpadStyleIndex : u8;
 } // namespace Core::HID
 
+class ControllerNavigation;
+
 class QtControllerSelectorDialog final : public QDialog {
     Q_OBJECT
 
@@ -45,6 +47,8 @@ public:
     ~QtControllerSelectorDialog() override;
 
     int exec() override;
+
+    void keyPressEvent(QKeyEvent* evt) override;
 
 private:
     // Applies the current configuration.
@@ -109,6 +113,8 @@ private:
     std::unique_ptr<InputProfiles> input_profiles;
 
     Core::System& system;
+
+    ControllerNavigation* controller_navigation = nullptr;
 
     // This is true if and only if all parameters are met. Otherwise, this is false.
     // This determines whether the "OK" button can be clicked to exit the applet.

--- a/src/yuzu/applets/qt_controller.ui
+++ b/src/yuzu/applets/qt_controller.ui
@@ -2624,13 +2624,53 @@
           </spacer>
          </item>
          <item alignment="Qt::AlignBottom">
-          <widget class="QDialogButtonBox" name="buttonBox">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="standardButtons">
-            <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-           </property>
+          <widget class="QWidget" name="closeButtons" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout_46">
+            <property name="spacing">
+             <number>7</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="labelError">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">QLabel { color : red; }</string>
+              </property>
+              <property name="text">
+               <string>Not enough controllers</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="margin">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDialogButtonBox" name="buttonBox">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="standardButtons">
+               <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
Allows to add controllers and validate current configuration when the Controller Applet is opened.

Add a controller if possible (less than maximum) by using "Right" and remove by using "Left" (more than minimum).
Use "A" to validate and "B" to cancel. If less controllers than minimum are selected and the user tries to validate, an error message is shown. It disappears when the number of controllers is increaed.