### PR TITLE
rm Taiwansk，There is no Taiwansk in the world. There is no so-called ‘Taiwanese’ language

### DIFF
--- a/dist/languages/ca.ts
+++ b/dist/languages/ca.ts
@@ -3954,11 +3954,6 @@ UUID: %2</source>
         <translation>Rus (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanès</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Anglès britànic</translation>

--- a/dist/languages/cs.ts
+++ b/dist/languages/cs.ts
@@ -3946,11 +3946,6 @@ UUID: %2</source>
         <translation>Ruština (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Tajwanština</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Britská Angličtina</translation>

--- a/dist/languages/da.ts
+++ b/dist/languages/da.ts
@@ -3962,11 +3962,6 @@ UUID: %2</source>
         <translation>Russisk (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanesisk</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Britisk Engelsk</translation>

--- a/dist/languages/de.ts
+++ b/dist/languages/de.ts
@@ -3964,11 +3964,6 @@ UUID: %2</source>
         <translation>Russisch (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanesisch</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Britisches Englisch</translation>

--- a/dist/languages/el.ts
+++ b/dist/languages/el.ts
@@ -3954,11 +3954,6 @@ UUID: %2</source>
         <translation>Ρώσικα (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Ταϊβανέζικα</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Βρετανικά Αγγλικά</translation>

--- a/dist/languages/es.ts
+++ b/dist/languages/es.ts
@@ -3970,11 +3970,6 @@ UUID: %2</translation>
         <translation>Ruso (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanés</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Inglés británico</translation>

--- a/dist/languages/fi.ts
+++ b/dist/languages/fi.ts
@@ -3096,11 +3096,6 @@ To invert the axes, first move your joystick vertically, and then horizontally.<
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation type="unfinished"/>

--- a/dist/languages/fr.ts
+++ b/dist/languages/fr.ts
@@ -3970,11 +3970,6 @@ UUID : %2</translation>
         <translation>Russe (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taïwanais</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Anglais Britannique</translation>

--- a/dist/languages/id.ts
+++ b/dist/languages/id.ts
@@ -3921,11 +3921,6 @@ UUID: %2</source>
         <translation>Rusia (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwan</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Inggris Britania</translation>

--- a/dist/languages/it.ts
+++ b/dist/languages/it.ts
@@ -3951,11 +3951,6 @@ UUID: %2</translation>
         <translation>Russo (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanese</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Inglese britannico</translation>

--- a/dist/languages/ja_JP.ts
+++ b/dist/languages/ja_JP.ts
@@ -3966,11 +3966,6 @@ UUID: %2</translation>
         <translation>ロシア語 (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>台湾語</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>イギリス英語</translation>

--- a/dist/languages/ko_KR.ts
+++ b/dist/languages/ko_KR.ts
@@ -3971,11 +3971,6 @@ UUID: %2</translation>
         <translation>러시아어(Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>대만어</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>영어(영국)</translation>

--- a/dist/languages/nb.ts
+++ b/dist/languages/nb.ts
@@ -3970,11 +3970,6 @@ UUID: %2</translation>
         <translation>Russisk (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwansk</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Britisk Engelsk</translation>

--- a/dist/languages/nl.ts
+++ b/dist/languages/nl.ts
@@ -3952,11 +3952,6 @@ UUID: %2</translation>
         <translation>Russisch (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanese</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Brits-Engels</translation>

--- a/dist/languages/pl.ts
+++ b/dist/languages/pl.ts
@@ -3960,11 +3960,6 @@ UUID: %2</translation>
         <translation>Rosyjski (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Tajwański</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Angielski (Brytyjski)</translation>

--- a/dist/languages/pt_BR.ts
+++ b/dist/languages/pt_BR.ts
@@ -3966,11 +3966,6 @@ UUID: %2</translation>
         <translation>Russo (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanês</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Inglês britânico (British English)</translation>

--- a/dist/languages/pt_PT.ts
+++ b/dist/languages/pt_PT.ts
@@ -3956,11 +3956,6 @@ UUID: %2</translation>
         <translation>Russo (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanês</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Inglês Britânico</translation>

--- a/dist/languages/ru_RU.ts
+++ b/dist/languages/ru_RU.ts
@@ -3970,11 +3970,6 @@ UUID: %2</translation>
         <translation>Русский</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Тайваньский</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Британский английский</translation>

--- a/dist/languages/sv.ts
+++ b/dist/languages/sv.ts
@@ -3941,11 +3941,6 @@ UUID: %2</source>
         <translation>Ryska (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Taiwanesiska</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Brittisk Engelska</translation>

--- a/dist/languages/tr_TR.ts
+++ b/dist/languages/tr_TR.ts
@@ -3959,11 +3959,6 @@ UUID: %2</translation>
         <translation>Rusça (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Tayvanca</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>İngiliz İngilizcesi</translation>

--- a/dist/languages/uk.ts
+++ b/dist/languages/uk.ts
@@ -3970,11 +3970,6 @@ UUID: %2</translation>
         <translation>Російська (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Тайванська</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Британська англійська</translation>

--- a/dist/languages/vi.ts
+++ b/dist/languages/vi.ts
@@ -3936,11 +3936,6 @@ UUID: %2</source>
         <translation>Tiếng Nga (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Tiếng Đài Loan</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Tiếng Anh Anh</translation>

--- a/dist/languages/vi_VN.ts
+++ b/dist/languages/vi_VN.ts
@@ -3936,11 +3936,6 @@ UUID: %2</source>
         <translation>Tiếng Nga (Russian)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>Tiếng Đài Loan</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>Tiếng Anh UK</translation>

--- a/dist/languages/zh_CN.ts
+++ b/dist/languages/zh_CN.ts
@@ -3967,11 +3967,6 @@ UUID: %2</translation>
         <translation>俄语 (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>台湾中文</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>英式英语</translation>

--- a/dist/languages/zh_TW.ts
+++ b/dist/languages/zh_TW.ts
@@ -3969,11 +3969,6 @@ UUID: %2</translation>
         <translation>俄文 (Русский)</translation>
     </message>
     <message>
-        <location filename="../../src/yuzu/configuration/configure_system.ui" line="379"/>
-        <source>Taiwanese</source>
-        <translation>台灣中文</translation>
-    </message>
-    <message>
         <location filename="../../src/yuzu/configuration/configure_system.ui" line="384"/>
         <source>British English</source>
         <translation>英式英文</translation>

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -431,8 +431,8 @@ custom_rtc =
 
 # Sets the systems language index
 # 0: Japanese, 1: English (default), 2: French, 3: German, 4: Italian, 5: Spanish, 6: Chinese,
-# 7: Korean, 8: Dutch, 9: Portuguese, 10: Russian, 11: Taiwanese, 12: British English, 13: Canadian French,
-# 14: Latin American Spanish, 15: Simplified Chinese, 16: Traditional Chinese, 17: Brazilian Portuguese
+# 7: Korean, 8: Dutch, 9: Portuguese, 10: Russian, 11: British English, 12: Canadian French,
+# 13: Latin American Spanish, 14: Simplified Chinese, 15: Traditional Chinese, 16: Brazilian Portuguese
 language_index =
 
 # The system region that yuzu will use during emulation

--- a/src/android/app/src/main/res/values-de/strings.xml
+++ b/src/android/app/src/main/res/values-de/strings.xml
@@ -247,7 +247,6 @@
     <string name="language_dutch">Niederländisch (Nederlands)</string>
     <string name="language_portuguese">Portugiesisch (Português)</string>
     <string name="language_russian">Russisch (Русский)</string>
-    <string name="language_taiwanese">Taiwanesisch (台湾)</string>
     <string name="language_british_english">Britisches Englisch</string>
     <string name="language_canadian_french">Kanadisches Französisch (Français canadien)</string>
     <string name="language_latin_american_spanish">Lateinamerikanisches Spanisch (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Holandés (nederlands)</string>
     <string name="language_portuguese">Portugués (Português)</string>
     <string name="language_russian">Ruso (Русский)</string>
-    <string name="language_taiwanese">Taiwanés (台湾)</string>
     <string name="language_british_english">Inglés británico</string>
     <string name="language_canadian_french">Francés Canadiense (Français canadien)</string>
     <string name="language_latin_american_spanish">Español Latinoamericano (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-fr/strings.xml
+++ b/src/android/app/src/main/res/values-fr/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Néerlandais (Nederlands)</string>
     <string name="language_portuguese">Portugais (Português)</string>
     <string name="language_russian">Russe (Русский)</string>
-    <string name="language_taiwanese">Taïwanais (台湾)</string>
     <string name="language_british_english">Anglais Britannique</string>
     <string name="language_canadian_french">Français canadien (Français canadien)</string>
     <string name="language_latin_american_spanish">Espagnol latino-américain (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-it/strings.xml
+++ b/src/android/app/src/main/res/values-it/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Olandese (Nederlands)</string>
     <string name="language_portuguese">Portoghese (Português)</string>
     <string name="language_russian">Russo (Русский)</string>
-    <string name="language_taiwanese">Taiwanese (台湾)</string>
     <string name="language_british_english">Inglese britannico</string>
     <string name="language_canadian_french">Francese Canadese (Français canadien)</string>
     <string name="language_latin_american_spanish">Spagnolo Latino Americano (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-ja/strings.xml
+++ b/src/android/app/src/main/res/values-ja/strings.xml
@@ -250,7 +250,6 @@
     <string name="language_dutch">オランダ語 (Nederlands)</string>
     <string name="language_portuguese">ポルトガル語 (Português)</string>
     <string name="language_russian">ロシア語 (Русский)</string>
-    <string name="language_taiwanese">台湾語 (台湾)</string>
     <string name="language_british_english">イギリス英語</string>
     <string name="language_canadian_french">フランス語(カナダ) (Français canadien)</string>
     <string name="language_latin_american_spanish">スペイン語(ラテンアメリカ) (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-ko/strings.xml
+++ b/src/android/app/src/main/res/values-ko/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">네덜란드어 (Nederlands)</string>
     <string name="language_portuguese">포르투갈어 (Português)</string>
     <string name="language_russian">러시아어 (Русский)</string>
-    <string name="language_taiwanese">대만어 (台湾)</string>
     <string name="language_british_english">영어 (British English)</string>
     <string name="language_canadian_french">캐나다 프랑스어 (Français canadien)</string>
     <string name="language_latin_american_spanish">라틴 아메리카 스페인어 (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-nb/strings.xml
+++ b/src/android/app/src/main/res/values-nb/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Nederlandsk (Nederlands)</string>
     <string name="language_portuguese">Portugisisk (Português)</string>
     <string name="language_russian">Russisk (Русский)</string>
-    <string name="language_taiwanese">Taiwansk (台湾)</string>
     <string name="language_british_english">Britisk Engelsk</string>
     <string name="language_canadian_french">Kanadisk fransk (Français canadien)</string>
     <string name="language_latin_american_spanish">Latinamerikansk spansk (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-pl/strings.xml
+++ b/src/android/app/src/main/res/values-pl/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Duński (Holandia)</string>
     <string name="language_portuguese">Portugalski (Portugalia)</string>
     <string name="language_russian">Rosyjski (Русский)</string>
-    <string name="language_taiwanese">Tajwański (台湾)</string>
     <string name="language_british_english">Angielski Brytyjski</string>
     <string name="language_canadian_french">Francuski (Kanada)</string>
     <string name="language_latin_american_spanish">Hiszpański (Ameryka Latynoska)</string>

--- a/src/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/src/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Holandês (Nederlands)</string>
     <string name="language_portuguese">Português (Português)</string>
     <string name="language_russian">Russo (Русский)</string>
-    <string name="language_taiwanese">Taiwanês (台湾)</string>
     <string name="language_british_english">Inglês britânico (British English)</string>
     <string name="language_canadian_french">Fracês Canadiano (Français canadien)</string>
     <string name="language_latin_american_spanish">Espanhol da América Latina (Español latino-americano)</string>

--- a/src/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/src/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Holandês (Nederlands)</string>
     <string name="language_portuguese">Português (Português)</string>
     <string name="language_russian">Russo (Русский)</string>
-    <string name="language_taiwanese">Taiwanês (台湾)</string>
     <string name="language_british_english">Inglês Britânico</string>
     <string name="language_canadian_french">Fracês Canadiano (Français canadien)</string>
     <string name="language_latin_american_spanish">Espanhol da América Latina (Español latino-americano)</string>

--- a/src/android/app/src/main/res/values-ru/strings.xml
+++ b/src/android/app/src/main/res/values-ru/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Голландский (Nederlands)</string>
     <string name="language_portuguese">Португальский (Português)</string>
     <string name="language_russian">Русский</string>
-    <string name="language_taiwanese">Тайваньский (台湾)</string>
     <string name="language_british_english">Британский английский</string>
     <string name="language_canadian_french">Канадский французский (Français canadien)</string>
     <string name="language_latin_american_spanish">Латиноамериканский испанский (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-uk/strings.xml
+++ b/src/android/app/src/main/res/values-uk/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">Голландська (Nederlands)</string>
     <string name="language_portuguese">Португальська (Português)</string>
     <string name="language_russian">Російська (Русский)</string>
-    <string name="language_taiwanese">Тайванська (台湾)</string>
     <string name="language_british_english">Британська англійська</string>
     <string name="language_canadian_french">Канадська французька (Français canadien)</string>
     <string name="language_latin_american_spanish">Латиноамериканська іспанська (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">荷兰语 (Nederlands)</string>
     <string name="language_portuguese">葡萄牙语 (Português)</string>
     <string name="language_russian">俄语 (Русский)</string>
-    <string name="language_taiwanese">台湾中文 (台灣)</string>
     <string name="language_british_english">英式英语</string>
     <string name="language_canadian_french">加拿大法语 (Français canadien)</string>
     <string name="language_latin_american_spanish">拉丁美洲西班牙语 (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -252,7 +252,6 @@
     <string name="language_dutch">荷蘭文 (Nederlands)</string>
     <string name="language_portuguese">葡萄牙文 (Português)</string>
     <string name="language_russian">俄文 (Русский)</string>
-    <string name="language_taiwanese">台文 (台灣)</string>
     <string name="language_british_english">英式英文</string>
     <string name="language_canadian_french">加拿大法文 (Français canadien)</string>
     <string name="language_latin_american_spanish">拉丁美洲西班牙文 (Español latinoamericano)</string>

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -40,7 +40,6 @@
         <item>@string/language_russian</item>
         <item>@string/language_simplified_chinese</item>
         <item>@string/language_spanish</item>
-        <item>@string/language_taiwanese</item>
         <item>@string/language_traditional_chinese</item>
     </string-array>
 

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -298,7 +298,6 @@
     <string name="language_dutch">Dutch (Nederlands)</string>
     <string name="language_portuguese">Portuguese (Português)</string>
     <string name="language_russian">Russian (Русский)</string>
-    <string name="language_taiwanese">Taiwanese (台湾)</string>
     <string name="language_british_english">British English</string>
     <string name="language_canadian_french">Canadian French (Français canadien)</string>
     <string name="language_latin_american_spanish">Latin American Spanish (Español latinoamericano)</string>

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -35,15 +35,14 @@ enum SystemLanguage {
     Dutch = 8,
     Portuguese = 9,
     Russian = 10,
-    Taiwanese = 11,
-    BritishEnglish = 12, // en-GB
-    CanadianFrench = 13,
-    LatinAmericanSpanish = 14, // es-419
+    BritishEnglish = 11, // en-GB
+    CanadianFrench = 12,
+    LatinAmericanSpanish = 13, // es-419
     // 4.0.0+
-    SimplifiedChinese = 15,
-    TraditionalChinese = 16,
+    SimplifiedChinese (Chinese mainland) = 14,
+    TraditionalChinese (Taiwan region) = 15,
     // 10.1.0+
-    BrazilianPortuguese = 17,
+    BrazilianPortuguese = 16,
 };
 
 class AppletMessageQueue {

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -376,11 +376,6 @@
             </item>
             <item>
              <property name="text">
-              <string>Taiwanese</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
               <string>British English</string>
              </property>
             </item>

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -473,8 +473,8 @@ custom_rtc =
 
 # Sets the systems language index
 # 0: Japanese, 1: English (default), 2: French, 3: German, 4: Italian, 5: Spanish, 6: Chinese,
-# 7: Korean, 8: Dutch, 9: Portuguese, 10: Russian, 11: Taiwanese, 12: British English, 13: Canadian French,
-# 14: Latin American Spanish, 15: Simplified Chinese, 16: Traditional Chinese, 17: Brazilian Portuguese
+# 7: Korean, 8: Dutch, 9: Portuguese, 10: Russian, 11: British English, 12: Canadian French,
+# 13: Latin American Spanish, 14: Simplified Chinese, 15: Traditional Chinese, 16: Brazilian Portuguese
 language_index =
 
 # The system region that yuzu will use during emulation


### PR DESCRIPTION
According to UN Resolution 2758, Taiwan is not a country but a regional political entity, and there is no Taiwansk in the world.

According to the "Constitution of the Republic of China" of Taiwan and the current "Constitution of the People's republic of the China“ of the Chinese Mainland，Taiwan regional is not a country ：

”Taiwan is a part of China，There is no Taiwansk in the world.“

According to Article 10 of the current amendment to the “Constitution of the Republic of China” in Taiwan, the state shall safeguard the language and culture of Taiwan's indigenous people. The indigenous languages in Taiwan include: Amis language, Atayal language, Bunun language, Puyuma language, Zou language, Rukai language, Paiwan language, etc.

Traditional Chinese is used for legal provisions, government documents, and road signs in Taiwan. This also reflects the official language status of Traditional Chinese.

“There is no so-called ‘Taiwanese’ language”


https://github.com/yuzu-emu/yuzu/pull/11151

Q : Taiwanese exists independent of Taiwan being considered from anyone as a country or not.

A: This statement is illegal, whether it is international law, the legal system of Chinese Mainland or Taiwan，This also violates the documents on the establishment of diplomatic relations between your country and the Chinese Mainland or between a few countries and Taiwan.

And this is also a treacherous statement

Q: Should we propose a change to remove
" Latin American Spanish", "Brazilian Portuguese" and "American English" too?
lol

A: Of course not, because these languages are recognized in legal documents of various countries. If you really support the minority languages in Taiwan, please make localized translations of all Minority language in Taiwan, such as Amis language, Atayal language, Bunun language, Puyuma language, Zou, Rukai language, Paiwan language, etc. I support you in making meaningful contributions to the development of minority languages in Taiwan

Q: I encourage you to do it yourself instead of coming here to try to remove the community effort already done just bc of your political positions.


A: Yes ，But It shouldn't be insulting, like “Taiwansk”, such as “Floridask” ，“Tokoyoese”，“New York Stan” "Connecticut Stan" or “Republic of Hawaii”. This kind of thing happening in the open source community would be catastrophic
