### PR TITLE
android: Only label language with language

### DIFF
--- a/src/android/app/src/main/res/values-de/strings.xml
+++ b/src/android/app/src/main/res/values-de/strings.xml
@@ -235,26 +235,6 @@
     <string name="region_korea">Korea</string>
     <string name="region_taiwan">Taiwan</string>
 
-    <!-- Language Names -->
-    <string name="language_japanese">Japanisch (日本語)</string>
-    <string name="language_english">Englisch</string>
-    <string name="language_french">Französisch (Français)</string>
-    <string name="langauge_german">Deutsch (German)</string>
-    <string name="language_italian">Italienisch (Italiano)</string>
-    <string name="language_spanish">Spanisch (Español)</string>
-    <string name="language_chinese">Chinesisch (简体中文)</string>
-    <string name="language_korean">Koreanisch (한국어)</string>
-    <string name="language_dutch">Niederländisch (Nederlands)</string>
-    <string name="language_portuguese">Portugiesisch (Português)</string>
-    <string name="language_russian">Russisch (Русский)</string>
-    <string name="language_taiwanese">Taiwanesisch (台湾)</string>
-    <string name="language_british_english">Britisches Englisch</string>
-    <string name="language_canadian_french">Kanadisches Französisch (Français canadien)</string>
-    <string name="language_latin_american_spanish">Lateinamerikanisches Spanisch (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">Vereinfachtes Chinesisch (简体中文)</string>
-    <string name="language_traditional_chinese">Traditionelles Chinesisch (正體中文)</string>
-    <string name="language_brazilian_portuguese">Brasilianisches Portugiesisch (Português do Brasil)</string>
-
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>
     <string name="renderer_none">Keiner</string>

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Taiwán</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Japonés (日本語)</string>
-    <string name="language_english">Inglés (English)</string>
-    <string name="language_french">Francés (Français)</string>
-    <string name="langauge_german">Alemán (deutsch)</string>
-    <string name="language_italian">Italiano (Italiano)</string>
-    <string name="language_spanish">Español (Español)</string>
-    <string name="language_chinese">Chino (简体中文)</string>
-    <string name="language_korean">Coreano (한국어)</string>
-    <string name="language_dutch">Holandés (nederlands)</string>
-    <string name="language_portuguese">Portugués (Português)</string>
-    <string name="language_russian">Ruso (Русский)</string>
-    <string name="language_taiwanese">Taiwanés (台湾)</string>
-    <string name="language_british_english">Inglés británico</string>
-    <string name="language_canadian_french">Francés Canadiense (Français canadien)</string>
-    <string name="language_latin_american_spanish">Español Latinoamericano (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">Chino Simplificado (简体中文)</string>
-    <string name="language_traditional_chinese">Chino tradicional (正體中文)</string>
-    <string name="language_brazilian_portuguese">Portugués Brasileño (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-fr/strings.xml
+++ b/src/android/app/src/main/res/values-fr/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Taïwan</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Japonais (日本語)</string>
-    <string name="language_english">Anglais</string>
-    <string name="language_french">Français (Français)</string>
-    <string name="langauge_german">Allemand (Deutsch)</string>
-    <string name="language_italian">Italien (Italiano)</string>
-    <string name="language_spanish">Espagnol (Español)</string>
-    <string name="language_chinese">Chinois (简体中文)</string>
-    <string name="language_korean">Coréen (한국어)</string>
-    <string name="language_dutch">Néerlandais (Nederlands)</string>
-    <string name="language_portuguese">Portugais (Português)</string>
-    <string name="language_russian">Russe (Русский)</string>
-    <string name="language_taiwanese">Taïwanais (台湾)</string>
-    <string name="language_british_english">Anglais Britannique</string>
-    <string name="language_canadian_french">Français canadien (Français canadien)</string>
-    <string name="language_latin_american_spanish">Espagnol latino-américain (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">Chinois simplifié (简体中文)</string>
-    <string name="language_traditional_chinese">Chinois Traditionnel (正體中文)</string>
-    <string name="language_brazilian_portuguese">Portugais brésilien (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-it/strings.xml
+++ b/src/android/app/src/main/res/values-it/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Taiwan</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Giapponese  (日本語)</string>
-    <string name="language_english">Inglese (English)</string>
-    <string name="language_french">Francese (Français)</string>
-    <string name="langauge_german">Tedesco (Deutsch)</string>
-    <string name="language_italian">Italiano (Italiano)</string>
-    <string name="language_spanish">Spagnolo (Español)</string>
-    <string name="language_chinese">Cinese (简体中文)</string>
-    <string name="language_korean">Coreano (한국어)</string>
-    <string name="language_dutch">Olandese (Nederlands)</string>
-    <string name="language_portuguese">Portoghese (Português)</string>
-    <string name="language_russian">Russo (Русский)</string>
-    <string name="language_taiwanese">Taiwanese (台湾)</string>
-    <string name="language_british_english">Inglese britannico</string>
-    <string name="language_canadian_french">Francese Canadese (Français canadien)</string>
-    <string name="language_latin_american_spanish">Spagnolo Latino Americano (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">Cinese Semplificato (简体中文)</string>
-    <string name="language_traditional_chinese">Cinese tradizionale (正體中文)</string>
-    <string name="language_brazilian_portuguese">Portoghese (Português)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-ja/strings.xml
+++ b/src/android/app/src/main/res/values-ja/strings.xml
@@ -239,24 +239,6 @@
     <string name="region_taiwan">台湾</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">日本語</string>
-    <string name="language_english">英語</string>
-    <string name="language_french">フランス語 (Français)</string>
-    <string name="langauge_german">ドイツ語 (Deutsch)</string>
-    <string name="language_italian">イタリア語 (Italiano)</string>
-    <string name="language_spanish">スペイン語 (Español)</string>
-    <string name="language_chinese">中国語 (简体中文)</string>
-    <string name="language_korean">韓国語 (한국어)</string>
-    <string name="language_dutch">オランダ語 (Nederlands)</string>
-    <string name="language_portuguese">ポルトガル語 (Português)</string>
-    <string name="language_russian">ロシア語 (Русский)</string>
-    <string name="language_taiwanese">台湾語 (台湾)</string>
-    <string name="language_british_english">イギリス英語</string>
-    <string name="language_canadian_french">フランス語(カナダ) (Français canadien)</string>
-    <string name="language_latin_american_spanish">スペイン語(ラテンアメリカ) (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">中国語 (简体中文)</string>
-    <string name="language_traditional_chinese">繁体字中国語 (正體中文)</string>
-    <string name="language_brazilian_portuguese">ポルトガル語(ブラジル) (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-ko/strings.xml
+++ b/src/android/app/src/main/res/values-ko/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">타이완</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">일본어 (日本語)</string>
-    <string name="language_english">영어 (English)</string>
-    <string name="language_french">프랑스어 (Français)</string>
-    <string name="langauge_german">독일어(Deutsch)</string>
-    <string name="language_italian">이탈리아어 (Italiano)</string>
-    <string name="language_spanish">스페인어 (Español)</string>
-    <string name="language_chinese">중국어 (简体中文)</string>
-    <string name="language_korean">한국어 (Korean)</string>
-    <string name="language_dutch">네덜란드어 (Nederlands)</string>
-    <string name="language_portuguese">포르투갈어 (Português)</string>
-    <string name="language_russian">러시아어 (Русский)</string>
-    <string name="language_taiwanese">대만어 (台湾)</string>
-    <string name="language_british_english">영어 (British English)</string>
-    <string name="language_canadian_french">캐나다 프랑스어 (Français canadien)</string>
-    <string name="language_latin_american_spanish">라틴 아메리카 스페인어 (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">중국어 간체 (简体中文)</string>
-    <string name="language_traditional_chinese">중국어 번체 (正體中文)</string>
-    <string name="language_brazilian_portuguese">브라질 포르투갈어 (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">불칸</string>

--- a/src/android/app/src/main/res/values-nb/strings.xml
+++ b/src/android/app/src/main/res/values-nb/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Taiwan</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Japansk (日本語)</string>
-    <string name="language_english">Engelsk</string>
-    <string name="language_french">Fransk (Français)</string>
-    <string name="langauge_german">Tysk (Deutsch)</string>
-    <string name="language_italian">Italiensk (Italiano)</string>
-    <string name="language_spanish">Spansk (Español)</string>
-    <string name="language_chinese">Kinesisk (简体中文)</string>
-    <string name="language_korean">Koreansk (한국어)</string>
-    <string name="language_dutch">Nederlandsk (Nederlands)</string>
-    <string name="language_portuguese">Portugisisk (Português)</string>
-    <string name="language_russian">Russisk (Русский)</string>
-    <string name="language_taiwanese">Taiwansk (台湾)</string>
-    <string name="language_british_english">Britisk Engelsk</string>
-    <string name="language_canadian_french">Kanadisk fransk (Français canadien)</string>
-    <string name="language_latin_american_spanish">Latinamerikansk spansk (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">Forenklet kinesisk (简体中文)</string>
-    <string name="language_traditional_chinese">Tradisjonell Kinesisk (正體中文)</string>
-    <string name="language_brazilian_portuguese">Brasiliansk portugisisk (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-pl/strings.xml
+++ b/src/android/app/src/main/res/values-pl/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Tajwan</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Japoński (日本語)</string>
-    <string name="language_english">Angielski</string>
-    <string name="language_french">Francuski (Francja)</string>
-    <string name="langauge_german">Niemiecki (Niemcy)</string>
-    <string name="language_italian">Włoski (Włochy)</string>
-    <string name="language_spanish">Hiszpański (Hiszpania)</string>
-    <string name="language_chinese">Chiński (简体中文)</string>
-    <string name="language_korean">Koreański (한국어)</string>
-    <string name="language_dutch">Duński (Holandia)</string>
-    <string name="language_portuguese">Portugalski (Portugalia)</string>
-    <string name="language_russian">Rosyjski (Русский)</string>
-    <string name="language_taiwanese">Tajwański (台湾)</string>
-    <string name="language_british_english">Angielski Brytyjski</string>
-    <string name="language_canadian_french">Francuski (Kanada)</string>
-    <string name="language_latin_american_spanish">Hiszpański (Ameryka Latynoska)</string>
-    <string name="language_simplified_chinese">Chiński uproszczony (简体中文)</string>
-    <string name="language_traditional_chinese">Chiński tradycyjny (正體中文)</string>
-    <string name="language_brazilian_portuguese">Portugalski (Brazylia)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/src/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Taiwan</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Japônes (日本語)</string>
-    <string name="language_english">Português do Brasil</string>
-    <string name="language_french">Francês (Français)</string>
-    <string name="langauge_german">Alemão (Deutsch)</string>
-    <string name="language_italian">Italiano (Italiano)</string>
-    <string name="language_spanish">Espanhol (Español)</string>
-    <string name="language_chinese">Mandarim (简体中文)</string>
-    <string name="language_korean">Coreano (한국어)</string>
-    <string name="language_dutch">Holandês (Nederlands)</string>
-    <string name="language_portuguese">Português (Português)</string>
-    <string name="language_russian">Russo (Русский)</string>
-    <string name="language_taiwanese">Taiwanês (台湾)</string>
-    <string name="language_british_english">Inglês britânico (British English)</string>
-    <string name="language_canadian_french">Fracês Canadiano (Français canadien)</string>
-    <string name="language_latin_american_spanish">Espanhol da América Latina (Español latino-americano)</string>
-    <string name="language_simplified_chinese">Chinês Simplificado (简体中文)</string>
-    <string name="language_traditional_chinese">Chinês tradicional (正體中文)</string>
-    <string name="language_brazilian_portuguese">Português do Brasil (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulcano</string>

--- a/src/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/src/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Taiwan</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Japonês (日本語)</string>
-    <string name="language_english">Inglês</string>
-    <string name="language_french">Francês (Français)</string>
-    <string name="langauge_german">Alemão (Deutsch)</string>
-    <string name="language_italian">Italiano (Italiano)</string>
-    <string name="language_spanish">Espanhol (Español)</string>
-    <string name="language_chinese">Chinês simplificado (简体中文)</string>
-    <string name="language_korean">Coreano (한국어)</string>
-    <string name="language_dutch">Holandês (Nederlands)</string>
-    <string name="language_portuguese">Português (Português)</string>
-    <string name="language_russian">Russo (Русский)</string>
-    <string name="language_taiwanese">Taiwanês (台湾)</string>
-    <string name="language_british_english">Inglês Britânico</string>
-    <string name="language_canadian_french">Fracês Canadiano (Français canadien)</string>
-    <string name="language_latin_american_spanish">Espanhol da América Latina (Español latino-americano)</string>
-    <string name="language_simplified_chinese">Chinês Simplificado (简体中文)</string>
-    <string name="language_traditional_chinese">Chinês Tradicional (正 體 中文)</string>
-    <string name="language_brazilian_portuguese">Português do Brasil (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulcano</string>

--- a/src/android/app/src/main/res/values-ru/strings.xml
+++ b/src/android/app/src/main/res/values-ru/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Тайвань</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Японский (日本語)</string>
-    <string name="language_english">Английский (English)</string>
-    <string name="language_french">Французский (Français)</string>
-    <string name="langauge_german">Немецкий (Deutsch)</string>
-    <string name="language_italian">Итальянский (Italiano)</string>
-    <string name="language_spanish">Испанский (Español)</string>
-    <string name="language_chinese">Китайский (简体中文)</string>
-    <string name="language_korean">Корейский (한국어)</string>
-    <string name="language_dutch">Голландский (Nederlands)</string>
-    <string name="language_portuguese">Португальский (Português)</string>
-    <string name="language_russian">Русский</string>
-    <string name="language_taiwanese">Тайваньский (台湾)</string>
-    <string name="language_british_english">Британский английский</string>
-    <string name="language_canadian_french">Канадский французский (Français canadien)</string>
-    <string name="language_latin_american_spanish">Латиноамериканский испанский (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">Упрощенный китайский (简体中文)</string>
-    <string name="language_traditional_chinese">Традиционный китайский (正體中文)</string>
-    <string name="language_brazilian_portuguese">Бразильский португальский (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-uk/strings.xml
+++ b/src/android/app/src/main/res/values-uk/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">Тайвань</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Японська (日本語)</string>
-    <string name="language_english">Англійська (English)</string>
-    <string name="language_french">Французька (Français)</string>
-    <string name="langauge_german">Німецька (Deutsch)</string>
-    <string name="language_italian">Італійська (Italiano)</string>
-    <string name="language_spanish">Іспанська (Español)</string>
-    <string name="language_chinese">Китайскька (简体中文)</string>
-    <string name="language_korean">Корейська (한국어)</string>
-    <string name="language_dutch">Голландська (Nederlands)</string>
-    <string name="language_portuguese">Португальська (Português)</string>
-    <string name="language_russian">Російська (Русский)</string>
-    <string name="language_taiwanese">Тайванська (台湾)</string>
-    <string name="language_british_english">Британська англійська</string>
-    <string name="language_canadian_french">Канадська французька (Français canadien)</string>
-    <string name="language_latin_american_spanish">Латиноамериканська іспанська (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">Спрощена китайська (简体中文)</string>
-    <string name="language_traditional_chinese">Традиційна китайська (正體中文)</string>
-    <string name="language_brazilian_portuguese">Бразильська португальська (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">中国台湾</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">日语 (日本語)</string>
-    <string name="language_english">英语 (English)</string>
-    <string name="language_french">法语 (Français)</string>
-    <string name="langauge_german">德语 (Deutsch)</string>
-    <string name="language_italian">意大利语 (Italiano)</string>
-    <string name="language_spanish">西班牙语 (Español)</string>
-    <string name="language_chinese">中文 (简体中文)</string>
-    <string name="language_korean">韩语 (한국어)</string>
-    <string name="language_dutch">荷兰语 (Nederlands)</string>
-    <string name="language_portuguese">葡萄牙语 (Português)</string>
-    <string name="language_russian">俄语 (Русский)</string>
-    <string name="language_taiwanese">台湾中文 (台灣)</string>
-    <string name="language_british_english">英式英语</string>
-    <string name="language_canadian_french">加拿大法语 (Français canadien)</string>
-    <string name="language_latin_american_spanish">拉丁美洲西班牙语 (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">简体中文 (简体中文)</string>
-    <string name="language_traditional_chinese">繁体中文 (正體中文)</string>
-    <string name="language_brazilian_portuguese">巴西葡萄牙语 (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -241,24 +241,6 @@
     <string name="region_taiwan">台灣</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">日文 (日本語)</string>
-    <string name="language_english">英文</string>
-    <string name="language_french">法文 (Français)</string>
-    <string name="langauge_german">德文 (Deutsch)</string>
-    <string name="language_italian">義大利文 (Italiano)</string>
-    <string name="language_spanish">西班牙文 (Español)</string>
-    <string name="language_chinese">中文 (简体中文)</string>
-    <string name="language_korean">韓文 (한국어)</string>
-    <string name="language_dutch">荷蘭文 (Nederlands)</string>
-    <string name="language_portuguese">葡萄牙文 (Português)</string>
-    <string name="language_russian">俄文 (Русский)</string>
-    <string name="language_taiwanese">台文 (台灣)</string>
-    <string name="language_british_english">英式英文</string>
-    <string name="language_canadian_french">加拿大法文 (Français canadien)</string>
-    <string name="language_latin_american_spanish">拉丁美洲西班牙文 (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">簡體中文 (简体中文)</string>
-    <string name="language_traditional_chinese">正體中文 (正體中文)</string>
-    <string name="language_brazilian_portuguese">巴西葡萄牙文 (Português do Brasil)</string>
 
     <!-- Renderer APIs -->
     <string name="renderer_vulkan">Vulkan</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -287,24 +287,24 @@
     <string name="region_taiwan">Taiwan</string>
 
     <!-- Language Names -->
-    <string name="language_japanese">Japanese (日本語)</string>
-    <string name="language_english">English</string>
-    <string name="language_french">French (Français)</string>
-    <string name="langauge_german">German (Deutsch)</string>
-    <string name="language_italian">Italian (Italiano)</string>
-    <string name="language_spanish">Spanish (Español)</string>
-    <string name="language_chinese">Chinese (简体中文)</string>
-    <string name="language_korean">Korean (한국어)</string>
-    <string name="language_dutch">Dutch (Nederlands)</string>
-    <string name="language_portuguese">Portuguese (Português)</string>
-    <string name="language_russian">Russian (Русский)</string>
-    <string name="language_taiwanese">Taiwanese (台湾)</string>
-    <string name="language_british_english">British English</string>
-    <string name="language_canadian_french">Canadian French (Français canadien)</string>
-    <string name="language_latin_american_spanish">Latin American Spanish (Español latinoamericano)</string>
-    <string name="language_simplified_chinese">Simplified Chinese (简体中文)</string>
-    <string name="language_traditional_chinese">Traditional Chinese (正體中文)</string>
-    <string name="language_brazilian_portuguese">Brazilian Portuguese (Português do Brasil)</string>
+    <string name="language_japanese" translatable="false">日本語</string>
+    <string name="language_english" translatable="false">English</string>
+    <string name="language_french" translatable="false">Français</string>
+    <string name="langauge_german" translatable="false">Deutsch</string>
+    <string name="language_italian" translatable="false">Italiano</string>
+    <string name="language_spanish" translatable="false">Español</string>
+    <string name="language_chinese" translatable="false">简体中文</string>
+    <string name="language_korean" translatable="false">한국어</string>
+    <string name="language_dutch" translatable="false">Nederlands</string>
+    <string name="language_portuguese" translatable="false">Português</string>
+    <string name="language_russian" translatable="false">Русский</string>
+    <string name="language_taiwanese" translatable="false">台湾</string>
+    <string name="language_british_english" translatable="false">British English</string>
+    <string name="language_canadian_french" translatable="false">Français canadien</string>
+    <string name="language_latin_american_spanish" translatable="false">Español latinoamericano</string>
+    <string name="language_simplified_chinese" translatable="false">简体中文</string>
+    <string name="language_traditional_chinese" translatable="false">正體中文</string>
+    <string name="language_brazilian_portuguese" translatable="false">Português do Brasil</string>
 
     <!-- Memory Sizes -->
     <string name="memory_byte">Byte</string>


### PR DESCRIPTION
If you are fluent in French and want to change an app to French, are you looking for French or Française?

If you accidentally change the language to Spanish, but only speak English, are you looking for Inglés or English?

Honestly, there is no real use for having the language name translated beyond curiosity, but it also avoids the entire discussion of what translations might be considered sensitive.