### PR TITLE
vulkan_device: Return true if either depth/stencil format supports blit

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1043,15 +1043,27 @@ void TextureCacheRuntime::BlitImage(Framebuffer* dst_framebuffer, ImageView& dst
                                     dst_region, src_region, filter, operation);
         return;
     }
+    ASSERT(src.format == dst.format);
     if (aspect_mask == (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
-        if (!device.IsBlitDepthStencilSupported()) {
+        const auto format = src.format;
+        const auto can_blit_depth_stencil = [this, format] {
+            switch (format) {
+            case VideoCore::Surface::PixelFormat::D24_UNORM_S8_UINT:
+            case VideoCore::Surface::PixelFormat::S8_UINT_D24_UNORM:
+                return device.IsBlitDepth24Stencil8Supported();
+            case VideoCore::Surface::PixelFormat::D32_FLOAT_S8_UINT:
+                return device.IsBlitDepth32Stencil8Supported();
+            default:
+                UNREACHABLE();
+            }
+        }();
+        if (!can_blit_depth_stencil) {
             UNIMPLEMENTED_IF(is_src_msaa || is_dst_msaa);
             blit_image_helper.BlitDepthStencil(dst_framebuffer, src.DepthView(), src.StencilView(),
                                                dst_region, src_region, filter, operation);
             return;
         }
     }
-    ASSERT(src.format == dst.format);
     ASSERT(!(is_dst_msaa && !is_src_msaa));
     ASSERT(operation == Fermi2D::Operation::SrcCopy);
 

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -376,7 +376,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         first_next = &diagnostics_nv;
     }
 
-    is_blit_depth_stencil_supported = TestDepthStencilBlits();
+    is_blit_depth24_stencil8_supported = TestDepthStencilBlits(VK_FORMAT_D24_UNORM_S8_UINT);
+    is_blit_depth32_stencil8_supported = TestDepthStencilBlits(VK_FORMAT_D32_SFLOAT_S8_UINT);
     is_optimal_astc_supported = ComputeIsOptimalAstcSupported();
     is_warp_potentially_bigger = !extensions.subgroup_size_control ||
                                  properties.subgroup_size_control.maxSubgroupSize > GuestWarpSize;
@@ -739,14 +740,13 @@ bool Device::ComputeIsOptimalAstcSupported() const {
     return true;
 }
 
-bool Device::TestDepthStencilBlits() const {
+bool Device::TestDepthStencilBlits(VkFormat format) const {
     static constexpr VkFormatFeatureFlags required_features =
         VK_FORMAT_FEATURE_BLIT_SRC_BIT | VK_FORMAT_FEATURE_BLIT_DST_BIT;
     const auto test_features = [](VkFormatProperties props) {
         return (props.optimalTilingFeatures & required_features) == required_features;
     };
-    return test_features(format_properties.at(VK_FORMAT_D32_SFLOAT_S8_UINT)) ||
-           test_features(format_properties.at(VK_FORMAT_D24_UNORM_S8_UINT));
+    return test_features(format_properties.at(format));
 }
 
 bool Device::IsFormatSupported(VkFormat wanted_format, VkFormatFeatureFlags wanted_usage,

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -745,7 +745,7 @@ bool Device::TestDepthStencilBlits() const {
     const auto test_features = [](VkFormatProperties props) {
         return (props.optimalTilingFeatures & required_features) == required_features;
     };
-    return test_features(format_properties.at(VK_FORMAT_D32_SFLOAT_S8_UINT)) &&
+    return test_features(format_properties.at(VK_FORMAT_D32_SFLOAT_S8_UINT)) ||
            test_features(format_properties.at(VK_FORMAT_D24_UNORM_S8_UINT));
 }
 

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -359,9 +359,14 @@ public:
         return features.features.depthBounds;
     }
 
-    /// Returns true when blitting from and to depth stencil images is supported.
-    bool IsBlitDepthStencilSupported() const {
-        return is_blit_depth_stencil_supported;
+    /// Returns true when blitting from and to D24S8 images is supported.
+    bool IsBlitDepth24Stencil8Supported() const {
+        return is_blit_depth24_stencil8_supported;
+    }
+
+    /// Returns true when blitting from and to D32S8 images is supported.
+    bool IsBlitDepth32Stencil8Supported() const {
+        return is_blit_depth32_stencil8_supported;
     }
 
     /// Returns true if the device supports VK_NV_viewport_swizzle.
@@ -657,7 +662,7 @@ private:
     bool ComputeIsOptimalAstcSupported() const;
 
     /// Returns true if the device natively supports blitting depth stencil images.
-    bool TestDepthStencilBlits() const;
+    bool TestDepthStencilBlits(VkFormat format) const;
 
 private:
     VkInstance instance;         ///< Vulkan instance.
@@ -721,25 +726,26 @@ private:
     VkPhysicalDeviceProperties2 properties2{};
 
     // Misc features
-    bool is_optimal_astc_supported{};       ///< Support for all guest ASTC formats.
-    bool is_blit_depth_stencil_supported{}; ///< Support for blitting from and to depth stencil.
-    bool is_warp_potentially_bigger{};      ///< Host warp size can be bigger than guest.
-    bool is_integrated{};                   ///< Is GPU an iGPU.
-    bool is_virtual{};                      ///< Is GPU a virtual GPU.
-    bool is_non_gpu{};                      ///< Is SoftwareRasterizer, FPGA, non-GPU device.
-    bool has_broken_compute{};              ///< Compute shaders can cause crashes
-    bool has_broken_cube_compatibility{};   ///< Has broken cube compatibility bit
-    bool has_renderdoc{};                   ///< Has RenderDoc attached
-    bool has_nsight_graphics{};             ///< Has Nsight Graphics attached
-    bool supports_d24_depth{};              ///< Supports D24 depth buffers.
-    bool cant_blit_msaa{};                  ///< Does not support MSAA<->MSAA blitting.
-    bool must_emulate_scaled_formats{};     ///< Requires scaled vertex format emulation
-    bool must_emulate_bgr565{};             ///< Emulates BGR565 by swizzling RGB565 format.
-    bool dynamic_state3_blending{};         ///< Has all blending features of dynamic_state3.
-    bool dynamic_state3_enables{};          ///< Has all enables features of dynamic_state3.
-    bool supports_conditional_barriers{};   ///< Allows barriers in conditional control flow.
-    u64 device_access_memory{};             ///< Total size of device local memory in bytes.
-    u32 sets_per_pool{};                    ///< Sets per Description Pool
+    bool is_optimal_astc_supported{};          ///< Support for all guest ASTC formats.
+    bool is_blit_depth24_stencil8_supported{}; ///< Support for blitting from and to D24S8.
+    bool is_blit_depth32_stencil8_supported{}; ///< Support for blitting from and to D32S8.
+    bool is_warp_potentially_bigger{};         ///< Host warp size can be bigger than guest.
+    bool is_integrated{};                      ///< Is GPU an iGPU.
+    bool is_virtual{};                         ///< Is GPU a virtual GPU.
+    bool is_non_gpu{};                         ///< Is SoftwareRasterizer, FPGA, non-GPU device.
+    bool has_broken_compute{};                 ///< Compute shaders can cause crashes
+    bool has_broken_cube_compatibility{};      ///< Has broken cube compatibility bit
+    bool has_renderdoc{};                      ///< Has RenderDoc attached
+    bool has_nsight_graphics{};                ///< Has Nsight Graphics attached
+    bool supports_d24_depth{};                 ///< Supports D24 depth buffers.
+    bool cant_blit_msaa{};                     ///< Does not support MSAA<->MSAA blitting.
+    bool must_emulate_scaled_formats{};        ///< Requires scaled vertex format emulation
+    bool must_emulate_bgr565{};                ///< Emulates BGR565 by swizzling RGB565 format.
+    bool dynamic_state3_blending{};            ///< Has all blending features of dynamic_state3.
+    bool dynamic_state3_enables{};             ///< Has all enables features of dynamic_state3.
+    bool supports_conditional_barriers{};      ///< Allows barriers in conditional control flow.
+    u64 device_access_memory{};                ///< Total size of device local memory in bytes.
+    u32 sets_per_pool{};                       ///< Sets per Description Pool
 
     // Telemetry parameters
     std::set<std::string, std::less<>> supported_extensions; ///< Reported Vulkan extensions.


### PR DESCRIPTION
On devices that don't support D24S8 but supports D32S8, this should still return true if D32S8 supports src and dst blit