### PR TITLE
Revert the Revert! Reverts the Revert of "Blacklist EDS3 blending from new AMD drivers"

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -558,7 +558,7 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         !features.shader_float16_int8.shaderFloat16 &&
         properties.properties.driverVersion >= VK_MAKE_API_VERSION(0, 2, 0, 258)) {
         LOG_WARNING(Render_Vulkan,
-                    "AMD's GCN4 architecture has broken extendedDynamicState3ColorBlendEquation");
+                    "AMD GCN4 has broken extendedDynamicState3ColorBlendEquation");
         features.extended_dynamic_state3.extendedDynamicState3ColorBlendEnable = false;
         features.extended_dynamic_state3.extendedDynamicState3ColorBlendEquation = false;
         dynamic_state3_blending = false;

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -554,6 +554,14 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
 
     sets_per_pool = 64;
+    if (extensions.extended_dynamic_state3 && is_amd_driver &&
+        properties.properties.driverVersion >= VK_MAKE_API_VERSION(0, 2, 0, 270)) {
+        LOG_WARNING(Render_Vulkan,
+                    "AMD drivers after 23.5.2 have broken extendedDynamicState3ColorBlendEquation");
+        features.extended_dynamic_state3.extendedDynamicState3ColorBlendEnable = false;
+        features.extended_dynamic_state3.extendedDynamicState3ColorBlendEquation = false;
+        dynamic_state3_blending = false;
+    }
     if (is_amd_driver) {
         // AMD drivers need a higher amount of Sets per Pool in certain circumstances like in XC2.
         sets_per_pool = 96;

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -557,8 +557,7 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     if (extensions.extended_dynamic_state3 && is_amd_driver &&
         !features.shader_float16_int8.shaderFloat16 &&
         properties.properties.driverVersion >= VK_MAKE_API_VERSION(0, 2, 0, 258)) {
-        LOG_WARNING(Render_Vulkan,
-                    "AMD GCN4 has broken extendedDynamicState3ColorBlendEquation");
+        LOG_WARNING(Render_Vulkan, "AMD GCN4 has broken extendedDynamicState3ColorBlendEquation");
         features.extended_dynamic_state3.extendedDynamicState3ColorBlendEnable = false;
         features.extended_dynamic_state3.extendedDynamicState3ColorBlendEquation = false;
         dynamic_state3_blending = false;

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -554,7 +554,8 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
 
     sets_per_pool = 64;
-    if (extensions.extended_dynamic_state3 && is_amd_driver && !features.shader_float16_int8.shaderFloat16 &&
+    if (extensions.extended_dynamic_state3 && is_amd_driver &&
+        !features.shader_float16_int8.shaderFloat16 &&
         properties.properties.driverVersion >= VK_MAKE_API_VERSION(0, 2, 0, 258)) {
         LOG_WARNING(Render_Vulkan,
                     "AMD's GCN4 architecture has broken extendedDynamicState3ColorBlendEquation");

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -554,10 +554,10 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
 
     sets_per_pool = 64;
-    if (extensions.extended_dynamic_state3 && is_amd_driver &&
-        properties.properties.driverVersion >= VK_MAKE_API_VERSION(0, 2, 0, 270)) {
+    if (extensions.extended_dynamic_state3 && is_amd_driver && !features.shader_float16_int8.shaderFloat16 &&
+        properties.properties.driverVersion >= VK_MAKE_API_VERSION(0, 2, 0, 258)) {
         LOG_WARNING(Render_Vulkan,
-                    "AMD drivers after 23.5.2 have broken extendedDynamicState3ColorBlendEquation");
+                    "AMD's GCN4 architecture has broken extendedDynamicState3ColorBlendEquation");
         features.extended_dynamic_state3.extendedDynamicState3ColorBlendEnable = false;
         features.extended_dynamic_state3.extendedDynamicState3ColorBlendEquation = false;
         dynamic_state3_blending = false;


### PR DESCRIPTION
Reverts #11163 

*Sighs*, turns out AMD hasn't fixed EDS3 blending for Polaris, they only fixed it for RDNA2 in 23.5.2
Thanks to [Blakbin](https://github.com/yuzu-emu/yuzu/issues/10285#issuecomment-1656729216) for bringing this to my attention so quickly

Further testing will be done before we implement a proper workaround/fix