### PR TITLE
tz_content_man: Generate the time zone binary once

### DIFF
--- a/src/core/hle/service/time/time_zone_content_manager.h
+++ b/src/core/hle/service/time/time_zone_content_manager.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "core/file_sys/vfs_types.h"
 #include "core/hle/service/time/time_zone_manager.h"
 
 namespace Core {
@@ -41,6 +42,7 @@ private:
 
     Core::System& system;
     TimeZoneManager time_zone_manager;
+    const FileSys::VirtualDir time_zone_binary;
     const std::vector<std::string> location_name_cache;
 };
 


### PR DESCRIPTION
Some games such as Pokemon Legends: Arceus will rapidly ask for a single time zone rule many times in certain scenarios. In case of no dumped firmware, yuzu would generate the time zone binary from our own data. We were not storing this data for more than a moment, so the shared ptrs would accumulate, resulting in a memory leak.

This sets up TimeZoneContentManager to keep track of the time zone binary after it first generates it, thereby plugging the memory leak.

 Closes #11174