### PR TITLE
vma: enable options everywhere

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -275,6 +275,8 @@ add_library(video_core STATIC
     vulkan_common/nsight_aftermath_tracker.cpp
     vulkan_common/nsight_aftermath_tracker.h
     vulkan_common/vma.cpp
+    vulkan_common/vma.h
+    vulkan_common/vulkan.h
 )
 
 create_target_directory_groups(video_core)

--- a/src/video_core/vulkan_common/vma.cpp
+++ b/src/video_core/vulkan_common/vma.cpp
@@ -2,7 +2,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #define VMA_IMPLEMENTATION
-#define VMA_STATIC_VULKAN_FUNCTIONS 0
-#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
 
-#include <vk_mem_alloc.h>
+#include "video_core/vulkan_common/vma.h"

--- a/src/video_core/vulkan_common/vma.h
+++ b/src/video_core/vulkan_common/vma.h
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "video_core/vulkan_common/vulkan.h"
+
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
+
+#include <vk_mem_alloc.h>

--- a/src/video_core/vulkan_common/vulkan.h
+++ b/src/video_core/vulkan_common/vulkan.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define VK_NO_PROTOTYPES
+#ifdef _WIN32
+#define VK_USE_PLATFORM_WIN32_KHR
+#elif defined(__APPLE__)
+#define VK_USE_PLATFORM_METAL_EXT
+#endif
+
+#include <vulkan/vulkan.h>

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -15,14 +15,13 @@
 #include "common/polyfill_ranges.h"
 #include "common/settings.h"
 #include "video_core/vulkan_common/nsight_aftermath_tracker.h"
+#include "video_core/vulkan_common/vma.h"
 #include "video_core/vulkan_common/vulkan_device.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 
 #if defined(ANDROID) && defined(ARCHITECTURE_arm64)
 #include <adrenotools/bcenabler.h>
 #endif
-
-#include <vk_mem_alloc.h>
 
 namespace Vulkan {
 using namespace Common::Literals;

--- a/src/video_core/vulkan_common/vulkan_memory_allocator.cpp
+++ b/src/video_core/vulkan_common/vulkan_memory_allocator.cpp
@@ -11,11 +11,10 @@
 #include "common/common_types.h"
 #include "common/logging/log.h"
 #include "common/polyfill_ranges.h"
+#include "video_core/vulkan_common/vma.h"
 #include "video_core/vulkan_common/vulkan_device.h"
 #include "video_core/vulkan_common/vulkan_memory_allocator.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
-
-#include <vk_mem_alloc.h>
 
 namespace Vulkan {
 namespace {

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -9,10 +9,8 @@
 
 #include "common/common_types.h"
 #include "common/logging/log.h"
-
+#include "video_core/vulkan_common/vma.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
-
-#include <vk_mem_alloc.h>
 
 namespace Vulkan::vk {
 

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -12,13 +12,8 @@
 #include <utility>
 #include <vector>
 
-#define VK_NO_PROTOTYPES
-#ifdef _WIN32
-#define VK_USE_PLATFORM_WIN32_KHR
-#elif defined(__APPLE__)
-#define VK_USE_PLATFORM_METAL_EXT
-#endif
-#include <vulkan/vulkan.h>
+#include "common/common_types.h"
+#include "video_core/vulkan_common/vulkan.h"
 
 // Sanitize macros
 #ifdef CreateEvent
@@ -27,8 +22,6 @@
 #ifdef CreateSemaphore
 #undef CreateSemaphore
 #endif
-
-#include "common/common_types.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable : 26812) // Disable prefer enum class over enum


### PR DESCRIPTION
The `VMA_*` options need to be defined before every inclusion of `vk_mem_alloc.h`, not just in the implementation. So regroup them in a header file with `vk_mem_alloc.h` and include this one everywhere instead.