### PR TITLE
service: set: Implement system settings for Qlaunch

### DIFF
--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -22,30 +22,6 @@ class Nvnflinger;
 
 namespace Service::AM {
 
-// This is nn::settings::Language
-enum SystemLanguage {
-    Japanese = 0,
-    English = 1, // en-US
-    French = 2,
-    German = 3,
-    Italian = 4,
-    Spanish = 5,
-    Chinese = 6,
-    Korean = 7,
-    Dutch = 8,
-    Portuguese = 9,
-    Russian = 10,
-    Taiwanese = 11,
-    BritishEnglish = 12, // en-GB
-    CanadianFrench = 13,
-    LatinAmericanSpanish = 14, // es-419
-    // 4.0.0+
-    SimplifiedChinese = 15,
-    TraditionalChinese = 16,
-    // 10.1.0+
-    BrazilianPortuguese = 17,
-};
-
 class AppletMessageQueue {
 public:
     // This is nn::am::AppletMessage

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -11,66 +11,6 @@
 
 namespace Service::Set {
 namespace {
-constexpr std::array<LanguageCode, 18> available_language_codes = {{
-    LanguageCode::JA,
-    LanguageCode::EN_US,
-    LanguageCode::FR,
-    LanguageCode::DE,
-    LanguageCode::IT,
-    LanguageCode::ES,
-    LanguageCode::ZH_CN,
-    LanguageCode::KO,
-    LanguageCode::NL,
-    LanguageCode::PT,
-    LanguageCode::RU,
-    LanguageCode::ZH_TW,
-    LanguageCode::EN_GB,
-    LanguageCode::FR_CA,
-    LanguageCode::ES_419,
-    LanguageCode::ZH_HANS,
-    LanguageCode::ZH_HANT,
-    LanguageCode::PT_BR,
-}};
-
-enum class KeyboardLayout : u64 {
-    Japanese = 0,
-    EnglishUs = 1,
-    EnglishUsInternational = 2,
-    EnglishUk = 3,
-    French = 4,
-    FrenchCa = 5,
-    Spanish = 6,
-    SpanishLatin = 7,
-    German = 8,
-    Italian = 9,
-    Portuguese = 10,
-    Russian = 11,
-    Korean = 12,
-    ChineseSimplified = 13,
-    ChineseTraditional = 14,
-};
-
-constexpr std::array<std::pair<LanguageCode, KeyboardLayout>, 18> language_to_layout{{
-    {LanguageCode::JA, KeyboardLayout::Japanese},
-    {LanguageCode::EN_US, KeyboardLayout::EnglishUs},
-    {LanguageCode::FR, KeyboardLayout::French},
-    {LanguageCode::DE, KeyboardLayout::German},
-    {LanguageCode::IT, KeyboardLayout::Italian},
-    {LanguageCode::ES, KeyboardLayout::Spanish},
-    {LanguageCode::ZH_CN, KeyboardLayout::ChineseSimplified},
-    {LanguageCode::KO, KeyboardLayout::Korean},
-    {LanguageCode::NL, KeyboardLayout::EnglishUsInternational},
-    {LanguageCode::PT, KeyboardLayout::Portuguese},
-    {LanguageCode::RU, KeyboardLayout::Russian},
-    {LanguageCode::ZH_TW, KeyboardLayout::ChineseTraditional},
-    {LanguageCode::EN_GB, KeyboardLayout::EnglishUk},
-    {LanguageCode::FR_CA, KeyboardLayout::FrenchCa},
-    {LanguageCode::ES_419, KeyboardLayout::SpanishLatin},
-    {LanguageCode::ZH_HANS, KeyboardLayout::ChineseSimplified},
-    {LanguageCode::ZH_HANT, KeyboardLayout::ChineseTraditional},
-    {LanguageCode::PT_BR, KeyboardLayout::Portuguese},
-}};
-
 constexpr std::size_t PRE_4_0_0_MAX_ENTRIES = 0xF;
 constexpr std::size_t POST_4_0_0_MAX_ENTRIES = 0x40;
 

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -32,6 +32,67 @@ enum class LanguageCode : u64 {
     ZH_HANT = 0x00746E61482D687A,
     PT_BR = 0x00000052422D7470,
 };
+
+enum class KeyboardLayout : u64 {
+    Japanese = 0,
+    EnglishUs = 1,
+    EnglishUsInternational = 2,
+    EnglishUk = 3,
+    French = 4,
+    FrenchCa = 5,
+    Spanish = 6,
+    SpanishLatin = 7,
+    German = 8,
+    Italian = 9,
+    Portuguese = 10,
+    Russian = 11,
+    Korean = 12,
+    ChineseSimplified = 13,
+    ChineseTraditional = 14,
+};
+
+constexpr std::array<LanguageCode, 18> available_language_codes = {{
+    LanguageCode::JA,
+    LanguageCode::EN_US,
+    LanguageCode::FR,
+    LanguageCode::DE,
+    LanguageCode::IT,
+    LanguageCode::ES,
+    LanguageCode::ZH_CN,
+    LanguageCode::KO,
+    LanguageCode::NL,
+    LanguageCode::PT,
+    LanguageCode::RU,
+    LanguageCode::ZH_TW,
+    LanguageCode::EN_GB,
+    LanguageCode::FR_CA,
+    LanguageCode::ES_419,
+    LanguageCode::ZH_HANS,
+    LanguageCode::ZH_HANT,
+    LanguageCode::PT_BR,
+}};
+
+static constexpr std::array<std::pair<LanguageCode, KeyboardLayout>, 18> language_to_layout{{
+    {LanguageCode::JA, KeyboardLayout::Japanese},
+    {LanguageCode::EN_US, KeyboardLayout::EnglishUs},
+    {LanguageCode::FR, KeyboardLayout::French},
+    {LanguageCode::DE, KeyboardLayout::German},
+    {LanguageCode::IT, KeyboardLayout::Italian},
+    {LanguageCode::ES, KeyboardLayout::Spanish},
+    {LanguageCode::ZH_CN, KeyboardLayout::ChineseSimplified},
+    {LanguageCode::KO, KeyboardLayout::Korean},
+    {LanguageCode::NL, KeyboardLayout::EnglishUsInternational},
+    {LanguageCode::PT, KeyboardLayout::Portuguese},
+    {LanguageCode::RU, KeyboardLayout::Russian},
+    {LanguageCode::ZH_TW, KeyboardLayout::ChineseTraditional},
+    {LanguageCode::EN_GB, KeyboardLayout::EnglishUk},
+    {LanguageCode::FR_CA, KeyboardLayout::FrenchCa},
+    {LanguageCode::ES_419, KeyboardLayout::SpanishLatin},
+    {LanguageCode::ZH_HANS, KeyboardLayout::ChineseSimplified},
+    {LanguageCode::ZH_HANT, KeyboardLayout::ChineseTraditional},
+    {LanguageCode::PT_BR, KeyboardLayout::Portuguese},
+}};
+
 LanguageCode GetLanguageCodeFromIndex(std::size_t idx);
 
 class SET final : public ServiceFramework<SET> {

--- a/src/core/hle/service/set/set_sys.h
+++ b/src/core/hle/service/set/set_sys.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include "common/uuid.h"
 #include "core/hle/service/service.h"
+#include "core/hle/service/time/clock_types.h"
 
 namespace Core {
 class System;
@@ -23,15 +25,293 @@ private:
         BasicBlack = 1,
     };
 
-    void GetSettingsItemValueSize(HLERequestContext& ctx);
-    void GetSettingsItemValue(HLERequestContext& ctx);
+    /// Indicates the current console is a retail or kiosk unit
+    enum class QuestFlag : u8 {
+        Retail = 0,
+        Kiosk = 1,
+    };
+
+    /// This is nn::settings::system::TvResolution
+    enum class TvResolution : u32 {
+        Auto,
+        Resolution1080p,
+        Resolution720p,
+        Resolution480p,
+    };
+
+    /// This is nn::settings::system::HdmiContentType
+    enum class HdmiContentType : u32 {
+        None,
+        Graphics,
+        Cinema,
+        Photo,
+        Game,
+    };
+
+    /// This is nn::settings::system::RgbRange
+    enum class RgbRange : u32 {
+        Auto,
+        Full,
+        Limited,
+    };
+
+    /// This is nn::settings::system::CmuMode
+    enum class CmuMode : u32 {
+        None,
+        ColorInvert,
+        HighContrast,
+        GrayScale,
+    };
+
+    /// This is nn::settings::system::PrimaryAlbumStorage
+    enum class PrimaryAlbumStorage : u32 {
+        Nand,
+        SdCard,
+    };
+
+    /// This is nn::settings::system::NotificationVolume
+    enum class NotificationVolume : u32 {
+        Mute,
+        Low,
+        High,
+    };
+
+    /// This is nn::settings::system::ChineseTraditionalInputMethod
+    enum class ChineseTraditionalInputMethod : u32 {
+        Unknown0 = 0,
+        Unknown1 = 1,
+        Unknown2 = 2,
+    };
+
+    /// This is nn::settings::system::ErrorReportSharePermission
+    enum class ErrorReportSharePermission : u32 {
+        NotConfirmed,
+        Granted,
+        Denied,
+    };
+
+    /// This is nn::settings::system::FriendPresenceOverlayPermission
+    enum class FriendPresenceOverlayPermission : u8 {
+        NotConfirmed,
+        NoDisplay,
+        FavoriteFriends,
+        Friends,
+    };
+
+    /// This is nn::settings::system::HandheldSleepPlan
+    enum class HandheldSleepPlan : u32 {
+        Sleep1Min,
+        Sleep3Min,
+        Sleep5Min,
+        Sleep10Min,
+        Sleep30Min,
+        Never,
+    };
+
+    /// This is nn::settings::system::ConsoleSleepPlan
+    enum class ConsoleSleepPlan : u32 {
+        Sleep1Hour,
+        Sleep2Hour,
+        Sleep3Hour,
+        Sleep6Hour,
+        Sleep12Hour,
+        Never,
+    };
+
+    /// This is nn::settings::system::SleepFlag
+    struct SleepFlag {
+        union {
+            u32 raw{};
+
+            BitField<0, 1, u32> SleepsWhilePlayingMedia;
+            BitField<1, 1, u32> WakesAtPowerStateChange;
+        };
+    };
+    static_assert(sizeof(SleepFlag) == 4, "TvFlag is an invalid size");
+
+    /// This is nn::settings::system::TvFlag
+    struct TvFlag {
+        union {
+            u32 raw{};
+
+            BitField<0, 1, u32> Allows4k;
+            BitField<1, 1, u32> Allows3d;
+            BitField<2, 1, u32> AllowsCec;
+            BitField<3, 1, u32> PreventsScreenBurnIn;
+        };
+    };
+    static_assert(sizeof(TvFlag) == 4, "TvFlag is an invalid size");
+
+    /// This is nn::settings::system::InitialLaunchFlag
+    struct InitialLaunchFlag {
+        union {
+            u32 raw{};
+
+            BitField<0, 1, u32> InitialLaunchCompletionFlag;
+            BitField<8, 1, u32> InitialLaunchUserAdditionFlag;
+            BitField<16, 1, u32> InitialLaunchTimestampFlag;
+        };
+    };
+    static_assert(sizeof(InitialLaunchFlag) == 4, "InitialLaunchFlag is an invalid size");
+
+    /// This is nn::settings::system::NotificationFlag
+    struct NotificationFlag {
+        union {
+            u32 raw{};
+
+            BitField<0, 1, u32> RingtoneFlag;
+            BitField<1, 1, u32> DownloadCompletionFlag;
+            BitField<8, 1, u32> EnablesNews;
+            BitField<9, 1, u32> IncomingLampFlag;
+        };
+    };
+    static_assert(sizeof(NotificationFlag) == 4, "NotificationFlag is an invalid size");
+
+    /// This is nn::settings::system::AccountNotificationFlag
+    struct AccountNotificationFlag {
+        union {
+            u32 raw{};
+
+            BitField<0, 1, u32> FriendOnlineFlag;
+            BitField<1, 1, u32> FriendRequestFlag;
+            BitField<8, 1, u32> CoralInvitationFlag;
+        };
+    };
+    static_assert(sizeof(AccountNotificationFlag) == 4,
+                  "AccountNotificationFlag is an invalid size");
+
+    /// This is nn::settings::system::TvSettings
+    struct TvSettings {
+        TvFlag flags;
+        TvResolution tv_resolution;
+        HdmiContentType hdmi_content_type;
+        RgbRange rgb_range;
+        CmuMode cmu_mode;
+        u32 tv_underscan;
+        f32 tv_gama;
+        f32 constrast_ratio;
+    };
+    static_assert(sizeof(TvSettings) == 0x20, "TvSettings is an invalid size");
+
+    /// This is nn::settings::system::NotificationTime
+    struct NotificationTime {
+        u32 hour;
+        u32 minute;
+    };
+    static_assert(sizeof(NotificationTime) == 0x8, "NotificationTime is an invalid size");
+
+    /// This is nn::settings::system::NotificationSettings
+    struct NotificationSettings {
+        NotificationFlag flags;
+        NotificationVolume volume;
+        NotificationTime start_time;
+        NotificationTime stop_time;
+    };
+    static_assert(sizeof(NotificationSettings) == 0x18, "NotificationSettings is an invalid size");
+
+    /// This is nn::settings::system::AccountSettings
+    struct AccountSettings {
+        u32 flags;
+    };
+    static_assert(sizeof(AccountSettings) == 0x4, "AccountSettings is an invalid size");
+
+    /// This is nn::settings::system::AccountNotificationSettings
+    struct AccountNotificationSettings {
+        Common::UUID uid;
+        AccountNotificationFlag flags;
+        FriendPresenceOverlayPermission friend_presence_permission;
+        FriendPresenceOverlayPermission friend_invitation_permission;
+        INSERT_PADDING_BYTES(0x2);
+    };
+    static_assert(sizeof(AccountNotificationSettings) == 0x18,
+                  "AccountNotificationSettings is an invalid size");
+
+    /// This is nn::settings::system::InitialLaunchSettings
+    struct SleepSettings {
+        SleepFlag flags;
+        HandheldSleepPlan handheld_sleep_plan;
+        ConsoleSleepPlan console_sleep_plan;
+    };
+    static_assert(sizeof(SleepSettings) == 0xc, "SleepSettings is incorrect size");
+
+    /// This is nn::settings::system::InitialLaunchSettings
+    struct InitialLaunchSettings {
+        InitialLaunchFlag flags;
+        INSERT_PADDING_BYTES(0x4);
+        Time::Clock::SteadyClockTimePoint timestamp;
+    };
+    static_assert(sizeof(InitialLaunchSettings) == 0x20, "InitialLaunchSettings is incorrect size");
+
     void GetFirmwareVersion(HLERequestContext& ctx);
     void GetFirmwareVersion2(HLERequestContext& ctx);
+    void GetAccountSettings(HLERequestContext& ctx);
+    void SetAccountSettings(HLERequestContext& ctx);
     void GetColorSetId(HLERequestContext& ctx);
     void SetColorSetId(HLERequestContext& ctx);
+    void GetNotificationSettings(HLERequestContext& ctx);
+    void SetNotificationSettings(HLERequestContext& ctx);
+    void GetAccountNotificationSettings(HLERequestContext& ctx);
+    void SetAccountNotificationSettings(HLERequestContext& ctx);
+    void GetSettingsItemValueSize(HLERequestContext& ctx);
+    void GetSettingsItemValue(HLERequestContext& ctx);
+    void GetTvSettings(HLERequestContext& ctx);
+    void SetTvSettings(HLERequestContext& ctx);
+    void GetQuestFlag(HLERequestContext& ctx);
+    void GetPrimaryAlbumStorage(HLERequestContext& ctx);
+    void GetSleepSettings(HLERequestContext& ctx);
+    void SetSleepSettings(HLERequestContext& ctx);
+    void GetInitialLaunchSettings(HLERequestContext& ctx);
+    void SetInitialLaunchSettings(HLERequestContext& ctx);
     void GetDeviceNickName(HLERequestContext& ctx);
+    void SetDeviceNickName(HLERequestContext& ctx);
+    void GetProductModel(HLERequestContext& ctx);
+    void GetMiiAuthorId(HLERequestContext& ctx);
+    void GetAutoUpdateEnableFlag(HLERequestContext& ctx);
+    void GetBatteryPercentageFlag(HLERequestContext& ctx);
+    void GetErrorReportSharePermission(HLERequestContext& ctx);
+    void GetAppletLaunchFlags(HLERequestContext& ctx);
+    void SetAppletLaunchFlags(HLERequestContext& ctx);
+    void GetKeyboardLayout(HLERequestContext& ctx);
+    void GetChineseTraditionalInputMethod(HLERequestContext& ctx);
+
+    AccountSettings account_settings{
+        .flags = {},
+    };
 
     ColorSet color_set = ColorSet::BasicWhite;
+
+    NotificationSettings notification_settings{
+        .flags = {0x300},
+        .volume = NotificationVolume::High,
+        .start_time = {.hour = 9, .minute = 0},
+        .stop_time = {.hour = 21, .minute = 0},
+    };
+
+    std::vector<AccountNotificationSettings> account_notifications{};
+
+    TvSettings tv_settings{
+        .flags = {0xc},
+        .tv_resolution = TvResolution::Auto,
+        .hdmi_content_type = HdmiContentType::Game,
+        .rgb_range = RgbRange::Auto,
+        .cmu_mode = CmuMode::None,
+        .tv_underscan = {},
+        .tv_gama = 1.0f,
+        .constrast_ratio = 0.5f,
+    };
+
+    InitialLaunchSettings launch_settings{
+        .flags = {0x10001},
+        .timestamp = {},
+    };
+
+    SleepSettings sleep_settings{
+        .flags = {0x3},
+        .handheld_sleep_plan = HandheldSleepPlan::Sleep10Min,
+        .console_sleep_plan = ConsoleSleepPlan::Sleep1Hour,
+    };
+
+    u32 applet_launch_flag{};
 };
 
 } // namespace Service::Set

--- a/src/core/hle/service/set/set_sys.h
+++ b/src/core/hle/service/set/set_sys.h
@@ -118,6 +118,22 @@ private:
         Never,
     };
 
+    /// This is nn::settings::system::RegionCode
+    enum class RegionCode : u32 {
+        Japan,
+        Usa,
+        Europe,
+        Australia,
+        HongKongTaiwanKorea,
+        China,
+    };
+
+    /// This is nn::settings::system::EulaVersionClockType
+    enum class EulaVersionClockType : u32 {
+        NetworkSystemClock,
+        SteadyClock,
+    };
+
     /// This is nn::settings::system::SleepFlag
     struct SleepFlag {
         union {
@@ -242,10 +258,24 @@ private:
     };
     static_assert(sizeof(InitialLaunchSettings) == 0x20, "InitialLaunchSettings is incorrect size");
 
+    /// This is nn::settings::system::InitialLaunchSettings
+    struct EulaVersion {
+        u32 version;
+        RegionCode region_code;
+        EulaVersionClockType clock_type;
+        INSERT_PADDING_BYTES(0x4);
+        s64 posix_time;
+        Time::Clock::SteadyClockTimePoint timestamp;
+    };
+    static_assert(sizeof(EulaVersion) == 0x30, "EulaVersion is incorrect size");
+
+    void SetLanguageCode(HLERequestContext& ctx);
     void GetFirmwareVersion(HLERequestContext& ctx);
     void GetFirmwareVersion2(HLERequestContext& ctx);
     void GetAccountSettings(HLERequestContext& ctx);
     void SetAccountSettings(HLERequestContext& ctx);
+    void GetEulaVersions(HLERequestContext& ctx);
+    void SetEulaVersions(HLERequestContext& ctx);
     void GetColorSetId(HLERequestContext& ctx);
     void SetColorSetId(HLERequestContext& ctx);
     void GetNotificationSettings(HLERequestContext& ctx);
@@ -257,6 +287,7 @@ private:
     void GetTvSettings(HLERequestContext& ctx);
     void SetTvSettings(HLERequestContext& ctx);
     void GetQuestFlag(HLERequestContext& ctx);
+    void SetRegionCode(HLERequestContext& ctx);
     void GetPrimaryAlbumStorage(HLERequestContext& ctx);
     void GetSleepSettings(HLERequestContext& ctx);
     void SetSleepSettings(HLERequestContext& ctx);
@@ -273,6 +304,7 @@ private:
     void SetAppletLaunchFlags(HLERequestContext& ctx);
     void GetKeyboardLayout(HLERequestContext& ctx);
     void GetChineseTraditionalInputMethod(HLERequestContext& ctx);
+    void GetFieldTestingFlag(HLERequestContext& ctx);
 
     AccountSettings account_settings{
         .flags = {},
@@ -312,6 +344,12 @@ private:
     };
 
     u32 applet_launch_flag{};
+
+    std::vector<EulaVersion> eula_versions{};
+
+    RegionCode region_code;
+
+    LanguageCode language_code_setting;
 };
 
 } // namespace Service::Set


### PR DESCRIPTION
Implements all setting functions required to launch Qlaunch and MiiEdit. The default values are verified through homebrew.