### PR TITLE
Fix various misc pipeline/shader things

### DIFF
--- a/src/shader_recompiler/environment.h
+++ b/src/shader_recompiler/environment.h
@@ -39,7 +39,7 @@ public:
     [[nodiscard]] virtual std::optional<ReplaceConstant> GetReplaceConstBuffer(u32 bank,
                                                                                u32 offset) = 0;
 
-    virtual void Dump(u64 hash) = 0;
+    virtual void Dump(u64 pipeline_hash, u64 shader_hash) = 0;
 
     [[nodiscard]] const ProgramHeader& SPH() const noexcept {
         return sph;

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -445,7 +445,8 @@ std::unique_ptr<GraphicsPipeline> ShaderCache::CreateGraphicsPipeline(
     ShaderContext::ShaderPools& pools, const GraphicsPipelineKey& key,
     std::span<Shader::Environment* const> envs, bool use_shader_workers,
     bool force_context_flush) try {
-    LOG_INFO(Render_OpenGL, "0x{:016x}", key.Hash());
+    auto hash = key.Hash();
+    LOG_INFO(Render_OpenGL, "0x{:016x}", hash);
     size_t env_index{};
     u32 total_storage_buffers{};
     std::array<Shader::IR::Program, Maxwell::MaxShaderProgram> programs;
@@ -474,7 +475,7 @@ std::unique_ptr<GraphicsPipeline> ShaderCache::CreateGraphicsPipeline(
         Shader::Maxwell::Flow::CFG cfg(env, pools.flow_block, cfg_offset, index == 0);
 
         if (Settings::values.dump_shaders) {
-            env.Dump(key.unique_hashes[index]);
+            env.Dump(hash, key.unique_hashes[index]);
         }
 
         if (!uses_vertex_a || index != 1) {
@@ -566,12 +567,13 @@ std::unique_ptr<ComputePipeline> ShaderCache::CreateComputePipeline(
 std::unique_ptr<ComputePipeline> ShaderCache::CreateComputePipeline(
     ShaderContext::ShaderPools& pools, const ComputePipelineKey& key, Shader::Environment& env,
     bool force_context_flush) try {
-    LOG_INFO(Render_OpenGL, "0x{:016x}", key.Hash());
+    auto hash = key.Hash();
+    LOG_INFO(Render_OpenGL, "0x{:016x}", hash);
 
     Shader::Maxwell::Flow::CFG cfg{env, pools.flow_block, env.StartAddress()};
 
     if (Settings::values.dump_shaders) {
-        env.Dump(key.Hash());
+        env.Dump(hash, key.unique_hash);
     }
 
     auto program{TranslateProgram(pools.inst, pools.block, env, cfg, host_info)};

--- a/src/video_core/shader_cache.cpp
+++ b/src/video_core/shader_cache.cpp
@@ -51,6 +51,11 @@ bool ShaderCache::RefreshStages(std::array<u64, 6>& unique_hashes) {
         }
         const auto& shader_config{maxwell3d->regs.pipelines[index]};
         const auto program{static_cast<Tegra::Engines::Maxwell3D::Regs::ShaderType>(index)};
+        if (program == Tegra::Engines::Maxwell3D::Regs::ShaderType::Pixel &&
+            !maxwell3d->regs.rasterize_enable) {
+            unique_hashes[index] = 0;
+            continue;
+        }
         const GPUVAddr shader_addr{base_addr + shader_config.offset};
         const std::optional<VAddr> cpu_shader_addr{gpu_memory->GpuToCpuAddress(shader_addr)};
         if (!cpu_shader_addr) {

--- a/src/video_core/shader_cache.h
+++ b/src/video_core/shader_cache.h
@@ -70,7 +70,7 @@ public:
 protected:
     struct GraphicsEnvironments {
         std::array<GraphicsEnvironment, NUM_PROGRAMS> envs;
-        std::array<Shader::Environment*, NUM_PROGRAMS> env_ptrs;
+        std::array<Shader::Environment*, NUM_PROGRAMS> env_ptrs{};
 
         std::span<Shader::Environment* const> Span() const noexcept {
             return std::span(env_ptrs.begin(), std::ranges::find(env_ptrs, nullptr));

--- a/src/video_core/shader_environment.h
+++ b/src/video_core/shader_environment.h
@@ -58,7 +58,7 @@ public:
 
     [[nodiscard]] u64 CalculateHash() const;
 
-    void Dump(u64 hash) override;
+    void Dump(u64 pipeline_hash, u64 shader_hash) override;
 
     void Serialize(std::ofstream& file) const;
 
@@ -188,10 +188,10 @@ public:
         return cbuf_replacements.size() != 0;
     }
 
-    void Dump(u64 hash) override;
+    void Dump(u64 pipeline_hash, u64 shader_hash) override;
 
 private:
-    std::unique_ptr<u64[]> code;
+    std::vector<u64> code;
     std::unordered_map<u32, Shader::TextureType> texture_types;
     std::unordered_map<u32, Shader::TexturePixelFormat> texture_pixel_formats;
     std::unordered_map<u64, u32> cbuf_values;


### PR DESCRIPTION
This PR does a few minor things:

1. Fix shader dumps to work properly with nvdisasm. Currently they're 50/50 on whether nvdisasm will complain or not, this is now fixed from my testing, a good ~3K shaders all decompiled without issue. Also changed their names to \<key hash>\_\<stage>\_\<shader hash>, including the graphics key hash, since that's what we print in the console and how we store all the pipelines, making it easier to find them.

2. Skip fragment shaders when rasisation is disabled. In Xenoblade Chronicles 3, when using transform feedback pipelines with rasterisation disabled, the fragment shader is still enabled in the regs, but it's a leftover from whatever was drawn previously, and potentially invalid for the current draw. 

    In XC3, the fragment shaders often contain texture handles which have indexes way out of range of the current TIC table, leading to reading random invalid data as a TIC entry, and us then trying to create junk images with random addresses, random formats and huge sizes, luckily just saved by checking the index being out of range, but even if it was in range it would still be invalid, since it's (potentially) intended for a different table. It seems when raster is disabled, the fragment shader program in regs is not updated and left with its previous value, so it's better to skip it in that case.

    This means that raster enabled/disabled dynamic state no longer means anything, which may lead to a few more pipelines created. However on the other end, I don't know of any pipelines which are actually used with raster on/off, only ever one or the other, and before we were hashing a random leftover fragment shader which could split the same pipeline into 2 different ones, and now that's always set to 0. Either way, the pipeline count shouldn't be a big deal.

3. Initialise env_ptrs. Currently this is uninitialised, and when making a span of the environment pointers, usually leading to the span always being NUM_PROGRAMS in size, with invalid pointers. I think *technically* it is safe regardless, because it's only ever read when there's a corresponding valid shader hash, which is properly set. Still, it looks dodgy and it doesn't hurt to initialise them and make the span the correct size.