### PR TITLE
Partially Revert "Silence nifm spam"

### DIFF
--- a/src/core/internal_network/network.cpp
+++ b/src/core/internal_network/network.cpp
@@ -476,7 +476,13 @@ NetworkInstance::~NetworkInstance() {
 std::optional<IPv4Address> GetHostIPv4Address() {
     const auto network_interface = Network::GetSelectedNetworkInterface();
     if (!network_interface.has_value()) {
-        LOG_DEBUG(Network, "GetSelectedNetworkInterface returned no interface");
+        // Only print the error once to avoid log spam
+        static bool print_error = true;
+        if (print_error) {
+            LOG_ERROR(Network, "GetSelectedNetworkInterface returned no interface");
+            print_error = false;
+        }
+
         return {};
     }
 

--- a/src/core/internal_network/network_interface.cpp
+++ b/src/core/internal_network/network_interface.cpp
@@ -200,7 +200,14 @@ std::optional<NetworkInterface> GetSelectedNetworkInterface() {
         });
 
     if (res == network_interfaces.end()) {
-        LOG_DEBUG(Network, "Couldn't find selected interface \"{}\"", selected_network_interface);
+        // Only print the error once to avoid log spam
+        static bool print_error = true;
+        if (print_error) {
+            LOG_ERROR(Network, "Couldn't find selected interface \"{}\"",
+                      selected_network_interface);
+            print_error = false;
+        }
+
         return std::nullopt;
     }
 


### PR DESCRIPTION
This made it impossible to diagnose some LDN issues since the error messages were not printed anymore.