### PR TITLE
vulkan_device: disable features associated with unloaded extensions

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -639,7 +639,16 @@ private:
 
     // Remove extensions which have incomplete feature support.
     void RemoveUnsuitableExtensions();
+
+    void RemoveExtension(bool& extension, const std::string& extension_name);
     void RemoveExtensionIfUnsuitable(bool is_suitable, const std::string& extension_name);
+
+    template <typename Feature>
+    void RemoveExtensionFeature(bool& extension, Feature& feature,
+                                const std::string& extension_name);
+    template <typename Feature>
+    void RemoveExtensionFeatureIfUnsuitable(bool is_suitable, Feature& feature,
+                                            const std::string& extension_name);
 
     /// Sets up queue families.
     void SetupFamilies(VkSurfaceKHR surface);


### PR DESCRIPTION
This has been a minor sore spot since the refactor in #9530 -- you would need to disable both the feature and extension in separate ways. This allows us to cleanly disable all the features when we disable an extension, preventing crashes in debugging tools.