### PR TITLE
android: Settings tweaks

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/adapters/LicenseAdapter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/adapters/LicenseAdapter.kt
@@ -49,6 +49,7 @@ class LicenseAdapter(private val activity: AppCompatActivity, var licenses: List
             val context = YuzuApplication.appContext
             binding.textSettingName.text = context.getString(license.titleId)
             binding.textSettingDescription.text = context.getString(license.descriptionId)
+            binding.textSettingValue.visibility = View.GONE
         }
     }
 }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsAdapter.kt
@@ -207,8 +207,11 @@ class SettingsAdapter(
         val sliderBinding = DialogSliderBinding.inflate(inflater)
 
         textSliderValue = sliderBinding.textValue
-        textSliderValue!!.text = sliderProgress.toString()
-        sliderBinding.textUnits.text = item.units
+        textSliderValue!!.text = String.format(
+            context.getString(R.string.value_with_units),
+            sliderProgress.toString(),
+            item.units
+        )
 
         sliderBinding.slider.apply {
             valueFrom = item.min.toFloat()
@@ -216,7 +219,11 @@ class SettingsAdapter(
             value = sliderProgress.toFloat()
             addOnChangeListener { _: Slider, value: Float, _: Boolean ->
                 sliderProgress = value.toInt()
-                textSliderValue!!.text = sliderProgress.toString()
+                textSliderValue!!.text = String.format(
+                    context.getString(R.string.value_with_units),
+                    sliderProgress.toString(),
+                    item.units
+                )
             }
         }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsAdapter.kt
@@ -232,10 +232,6 @@ class SettingsAdapter(
             .setView(sliderBinding.root)
             .setPositiveButton(android.R.string.ok, this)
             .setNegativeButton(android.R.string.cancel, defaultCancelListener)
-            .setNeutralButton(R.string.slider_default) { dialog: DialogInterface, which: Int ->
-                sliderBinding.slider.value = item.defaultValue!!.toFloat()
-                onClick(dialog, which)
-            }
             .show()
     }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/DateTimeViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/DateTimeViewHolder.kt
@@ -25,12 +25,15 @@ class DateTimeViewHolder(val binding: ListItemSettingBinding, adapter: SettingsA
             binding.textSettingDescription.setText(item.descriptionId)
             binding.textSettingDescription.visibility = View.VISIBLE
         } else {
-            val epochTime = setting.value.toLong()
-            val instant = Instant.ofEpochMilli(epochTime * 1000)
-            val zonedTime = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"))
-            val dateFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
-            binding.textSettingDescription.text = dateFormatter.format(zonedTime)
+            binding.textSettingDescription.visibility = View.GONE
         }
+
+        binding.textSettingValue.visibility = View.VISIBLE
+        val epochTime = setting.value.toLong()
+        val instant = Instant.ofEpochMilli(epochTime * 1000)
+        val zonedTime = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"))
+        val dateFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
+        binding.textSettingValue.text = dateFormatter.format(zonedTime)
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/DateTimeViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/DateTimeViewHolder.kt
@@ -34,6 +34,8 @@ class DateTimeViewHolder(val binding: ListItemSettingBinding, adapter: SettingsA
         val zonedTime = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"))
         val dateFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
         binding.textSettingValue.text = dateFormatter.format(zonedTime)
+
+        setStyle(setting.isEditable, binding)
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/RunnableViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/RunnableViewHolder.kt
@@ -24,6 +24,8 @@ class RunnableViewHolder(val binding: ListItemSettingBinding, adapter: SettingsA
             binding.textSettingDescription.visibility = View.GONE
         }
         binding.textSettingValue.visibility = View.GONE
+
+        setStyle(setting.isEditable, binding)
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/RunnableViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/RunnableViewHolder.kt
@@ -23,6 +23,7 @@ class RunnableViewHolder(val binding: ListItemSettingBinding, adapter: SettingsA
         } else {
             binding.textSettingDescription.visibility = View.GONE
         }
+        binding.textSettingValue.visibility = View.GONE
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SettingViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SettingViewHolder.kt
@@ -5,6 +5,8 @@ package org.yuzu.yuzu_emu.features.settings.ui.viewholder
 
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import org.yuzu.yuzu_emu.databinding.ListItemSettingBinding
+import org.yuzu.yuzu_emu.databinding.ListItemSettingSwitchBinding
 import org.yuzu.yuzu_emu.features.settings.model.view.SettingsItem
 import org.yuzu.yuzu_emu.features.settings.ui.SettingsAdapter
 
@@ -33,4 +35,18 @@ abstract class SettingViewHolder(itemView: View, protected val adapter: Settings
     abstract override fun onClick(clicked: View)
 
     abstract override fun onLongClick(clicked: View): Boolean
+
+    fun setStyle(isEditable: Boolean, binding: ListItemSettingBinding) {
+        val opacity = if (isEditable) 1.0f else 0.5f
+        binding.textSettingName.alpha = opacity
+        binding.textSettingDescription.alpha = opacity
+        binding.textSettingValue.alpha = opacity
+    }
+
+    fun setStyle(isEditable: Boolean, binding: ListItemSettingSwitchBinding) {
+        binding.switchWidget.isEnabled = isEditable
+        val opacity = if (isEditable) 1.0f else 0.5f
+        binding.textSettingName.alpha = opacity
+        binding.textSettingDescription.alpha = opacity
+    }
 }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SingleChoiceViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SingleChoiceViewHolder.kt
@@ -31,17 +31,19 @@ class SingleChoiceViewHolder(val binding: ListItemSettingBinding, adapter: Setti
             for (i in values.indices) {
                 if (values[i] == item.selectedValue) {
                     binding.textSettingValue.text = resMgr.getStringArray(item.choicesId)[i]
-                    return
+                    break
                 }
             }
         } else if (item is StringSingleChoiceSetting) {
             for (i in item.values!!.indices) {
                 if (item.values[i] == item.selectedValue) {
                     binding.textSettingValue.text = item.choices[i]
-                    return
+                    break
                 }
             }
         }
+
+        setStyle(setting.isEditable, binding)
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SingleChoiceViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SingleChoiceViewHolder.kt
@@ -17,27 +17,30 @@ class SingleChoiceViewHolder(val binding: ListItemSettingBinding, adapter: Setti
     override fun bind(item: SettingsItem) {
         setting = item
         binding.textSettingName.setText(item.nameId)
-        binding.textSettingDescription.visibility = View.VISIBLE
         if (item.descriptionId != 0) {
             binding.textSettingDescription.setText(item.descriptionId)
-        } else if (item is SingleChoiceSetting) {
-            val resMgr = binding.textSettingDescription.context.resources
+            binding.textSettingDescription.visibility = View.VISIBLE
+        } else {
+            binding.textSettingDescription.visibility = View.GONE
+        }
+
+        binding.textSettingValue.visibility = View.VISIBLE
+        if (item is SingleChoiceSetting) {
+            val resMgr = binding.textSettingValue.context.resources
             val values = resMgr.getIntArray(item.valuesId)
             for (i in values.indices) {
                 if (values[i] == item.selectedValue) {
-                    binding.textSettingDescription.text = resMgr.getStringArray(item.choicesId)[i]
+                    binding.textSettingValue.text = resMgr.getStringArray(item.choicesId)[i]
                     return
                 }
             }
         } else if (item is StringSingleChoiceSetting) {
             for (i in item.values!!.indices) {
                 if (item.values[i] == item.selectedValue) {
-                    binding.textSettingDescription.text = item.choices[i]
+                    binding.textSettingValue.text = item.choices[i]
                     return
                 }
             }
-        } else {
-            binding.textSettingDescription.visibility = View.GONE
         }
     }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SliderViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SliderViewHolder.kt
@@ -29,6 +29,8 @@ class SliderViewHolder(val binding: ListItemSettingBinding, adapter: SettingsAda
             setting.selectedValue,
             setting.units
         )
+
+        setStyle(setting.isEditable, binding)
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SliderViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SliderViewHolder.kt
@@ -4,6 +4,7 @@
 package org.yuzu.yuzu_emu.features.settings.ui.viewholder
 
 import android.view.View
+import org.yuzu.yuzu_emu.R
 import org.yuzu.yuzu_emu.databinding.ListItemSettingBinding
 import org.yuzu.yuzu_emu.features.settings.model.view.SettingsItem
 import org.yuzu.yuzu_emu.features.settings.model.view.SliderSetting
@@ -22,6 +23,12 @@ class SliderViewHolder(val binding: ListItemSettingBinding, adapter: SettingsAda
         } else {
             binding.textSettingDescription.visibility = View.GONE
         }
+        binding.textSettingValue.visibility = View.VISIBLE
+        binding.textSettingValue.text = String.format(
+            binding.textSettingValue.context.getString(R.string.value_with_units),
+            setting.selectedValue,
+            setting.units
+        )
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SubmenuViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SubmenuViewHolder.kt
@@ -22,6 +22,7 @@ class SubmenuViewHolder(val binding: ListItemSettingBinding, adapter: SettingsAd
         } else {
             binding.textSettingDescription.visibility = View.GONE
         }
+        binding.textSettingValue.visibility = View.GONE
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SwitchSettingViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SwitchSettingViewHolder.kt
@@ -30,7 +30,7 @@ class SwitchSettingViewHolder(val binding: ListItemSettingSwitchBinding, adapter
         }
         binding.switchWidget.isChecked = setting.isChecked
 
-        binding.switchWidget.isEnabled = setting.isEditable
+        setStyle(setting.isEditable, binding)
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SwitchSettingViewHolder.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/viewholder/SwitchSettingViewHolder.kt
@@ -25,10 +25,10 @@ class SwitchSettingViewHolder(val binding: ListItemSettingSwitchBinding, adapter
             binding.textSettingDescription.text = ""
             binding.textSettingDescription.visibility = View.GONE
         }
-        binding.switchWidget.isChecked = setting.isChecked
         binding.switchWidget.setOnCheckedChangeListener { _: CompoundButton, _: Boolean ->
             adapter.onBooleanClick(item, bindingAdapterPosition, binding.switchWidget.isChecked)
         }
+        binding.switchWidget.isChecked = setting.isChecked
 
         binding.switchWidget.isEnabled = setting.isEditable
     }

--- a/src/android/app/src/main/res/layout/dialog_slider.xml
+++ b/src/android/app/src/main/res/layout/dialog_slider.xml
@@ -5,23 +5,16 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_value"
+        style="@style/TextAppearance.Material3.LabelMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
         android:layout_marginBottom="@dimen/spacing_medlarge"
         android:layout_marginTop="@dimen/spacing_medlarge"
-        tools:text="75" />
-
-    <TextView
-        android:id="@+id/text_units"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignTop="@+id/text_value"
-        android:layout_toEndOf="@+id/text_value"
-        tools:text="%" />
+        tools:text="75%" />
 
     <com.google.android.material.slider.Slider
         android:id="@+id/slider"

--- a/src/android/app/src/main/res/layout/list_item_setting.xml
+++ b/src/android/app/src/main/res/layout/list_item_setting.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="?android:attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"
@@ -11,31 +12,40 @@
     android:minHeight="72dp"
     android:padding="@dimen/spacing_large">
 
-    <com.google.android.material.textview.MaterialTextView
-        style="@style/TextAppearance.Material3.HeadlineMedium"
-        android:id="@+id/text_setting_name"
-        android:layout_width="0dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:textSize="16sp"
-        android:textAlignment="viewStart"
-        app:lineHeight="28dp"
-        tools:text="Setting Name" />
+        android:orientation="vertical">
 
-    <TextView
-        style="@style/TextAppearance.Material3.BodySmall"
-        android:id="@+id/text_setting_description"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignStart="@+id/text_setting_name"
-        android:layout_below="@+id/text_setting_name"
-        android:layout_marginTop="@dimen/spacing_small"
-        android:visibility="visible"
-        android:textAlignment="viewStart"
-        tools:text="@string/app_disclaimer" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/text_setting_name"
+            style="@style/TextAppearance.Material3.HeadlineMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAlignment="viewStart"
+            android:textSize="16sp"
+            app:lineHeight="22dp"
+            tools:text="Setting Name" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/text_setting_description"
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_small"
+            android:textAlignment="viewStart"
+            tools:text="@string/app_disclaimer" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/text_setting_value"
+            style="@style/TextAppearance.Material3.LabelMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_small"
+            android:textAlignment="viewStart"
+            android:textStyle="bold"
+            tools:text="1x" />
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="frame_limit_slider">Limit speed percent</string>
     <string name="frame_limit_slider_description">Specifies the percentage to limit emulation speed. 100% is the normal speed. Values higher or lower will increase or decrease the speed limit.</string>
     <string name="cpu_accuracy">CPU accuracy</string>
+    <string name="value_with_units">%1$s%2$s</string>
 
     <!-- System settings strings -->
     <string name="use_docked_mode">Docked Mode</string>


### PR DESCRIPTION
+ Fixed a bug where a switch setting could apply the value of the recycled view
+ Display settings value in list view
![image](https://github.com/yuzu-emu/yuzu/assets/14132249/6b0b4511-95f1-402b-9878-9dc3093a3ff8)

+ Use string resource for slider value/units
+ Reduce opacity of non-editable settings
![image](https://github.com/yuzu-emu/yuzu/assets/14132249/f0d3bb3f-1a52-449e-8188-0d0f9d531652)

+ Remove redundant "Default" button in slider dialog
![image](https://github.com/yuzu-emu/yuzu/assets/14132249/51fe92cc-9dba-4deb-bd26-1979f3422630)
