### PR TITLE
android: Show associated value in home settings

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/adapters/HomeSettingAdapter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/adapters/HomeSettingAdapter.kt
@@ -3,19 +3,25 @@
 
 package org.yuzu.yuzu_emu.adapters
 
+import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
 import org.yuzu.yuzu_emu.R
 import org.yuzu.yuzu_emu.databinding.CardHomeOptionBinding
 import org.yuzu.yuzu_emu.fragments.MessageDialogFragment
 import org.yuzu.yuzu_emu.model.HomeSetting
 
-class HomeSettingAdapter(private val activity: AppCompatActivity, var options: List<HomeSetting>) :
+class HomeSettingAdapter(
+    private val activity: AppCompatActivity,
+    private val viewLifecycle: LifecycleOwner,
+    var options: List<HomeSetting>
+) :
     RecyclerView.Adapter<HomeSettingAdapter.HomeOptionViewHolder>(),
     View.OnClickListener {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HomeOptionViewHolder {
@@ -78,6 +84,22 @@ class HomeSettingAdapter(private val activity: AppCompatActivity, var options: L
                 binding.optionTitle.alpha = 0.5f
                 binding.optionDescription.alpha = 0.5f
                 binding.optionIcon.alpha = 0.5f
+            }
+
+            option.details.observe(viewLifecycle) { updateOptionDetails(it) }
+            binding.optionDetail.postDelayed(
+                {
+                    binding.optionDetail.ellipsize = TextUtils.TruncateAt.MARQUEE
+                    binding.optionDetail.isSelected = true
+                },
+                3000
+            )
+        }
+
+        private fun updateOptionDetails(detailString: String) {
+            if (detailString.isNotEmpty()) {
+                binding.optionDetail.text = detailString
+                binding.optionDetail.visibility = View.VISIBLE
             }
         }
     }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/HomeSettingsFragment.kt
@@ -129,7 +129,11 @@ class HomeSettingsFragment : Fragment() {
                         mainActivity.getGamesDirectory.launch(
                             Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).data
                         )
-                    }
+                    },
+                    { true },
+                    0,
+                    0,
+                    homeViewModel.gamesDir
                 )
             )
             add(
@@ -201,7 +205,11 @@ class HomeSettingsFragment : Fragment() {
 
         binding.homeSettingsList.apply {
             layoutManager = LinearLayoutManager(requireContext())
-            adapter = HomeSettingAdapter(requireActivity() as AppCompatActivity, optionsList)
+            adapter = HomeSettingAdapter(
+                requireActivity() as AppCompatActivity,
+                viewLifecycleOwner,
+                optionsList
+            )
         }
 
         setInsets()

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/HomeSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/HomeSetting.kt
@@ -3,6 +3,9 @@
 
 package org.yuzu.yuzu_emu.model
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+
 data class HomeSetting(
     val titleId: Int,
     val descriptionId: Int,
@@ -10,5 +13,6 @@ data class HomeSetting(
     val onClick: () -> Unit,
     val isEnabled: () -> Boolean = { true },
     val disabledTitleId: Int = 0,
-    val disabledMessageId: Int = 0
+    val disabledMessageId: Int = 0,
+    val details: LiveData<String> = MutableLiveData("")
 )

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/HomeViewModel.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/HomeViewModel.kt
@@ -3,9 +3,15 @@
 
 package org.yuzu.yuzu_emu.model
 
+import android.net.Uri
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.preference.PreferenceManager
+import org.yuzu.yuzu_emu.YuzuApplication
+import org.yuzu.yuzu_emu.utils.GameHelper
 
 class HomeViewModel : ViewModel() {
     private val _navigationVisible = MutableLiveData<Pair<Boolean, Boolean>>()
@@ -16,6 +22,14 @@ class HomeViewModel : ViewModel() {
 
     private val _shouldPageForward = MutableLiveData(false)
     val shouldPageForward: LiveData<Boolean> get() = _shouldPageForward
+
+    private val _gamesDir = MutableLiveData(
+        Uri.parse(
+            PreferenceManager.getDefaultSharedPreferences(YuzuApplication.appContext)
+                .getString(GameHelper.KEY_GAME_PATH, "")
+        ).path ?: ""
+    )
+    val gamesDir: LiveData<String> get() = _gamesDir
 
     var navigatedToSetup = false
 
@@ -39,5 +53,10 @@ class HomeViewModel : ViewModel() {
 
     fun setShouldPageForward(pageForward: Boolean) {
         _shouldPageForward.value = pageForward
+    }
+
+    fun setGamesDir(activity: FragmentActivity, dir: String) {
+        ViewModelProvider(activity)[GamesViewModel::class.java].reloadGames(true)
+        _gamesDir.value = dir
     }
 }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
@@ -290,6 +290,7 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
         ).show()
 
         gamesViewModel.reloadGames(true)
+        homeViewModel.setGamesDir(this, result.path!!)
     }
 
     val getProdKey =

--- a/src/android/app/src/main/res/layout/card_home_option.xml
+++ b/src/android/app/src/main/res/layout/card_home_option.xml
@@ -53,6 +53,23 @@
                 android:layout_marginTop="5dp"
                 tools:text="@string/install_prod_keys_description" />
 
+            <com.google.android.material.textview.MaterialTextView
+                style="@style/TextAppearance.Material3.LabelMedium"
+                android:id="@+id/option_detail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAlignment="viewStart"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                android:singleLine="true"
+                android:marqueeRepeatLimit="marquee_forever"
+                android:ellipsize="none"
+                android:requiresFadingEdge="horizontal"
+                android:layout_marginTop="5dp"
+                android:visibility="gone"
+                tools:visibility="visible"
+                tools:text="/tree/primary:Games" />
+
         </LinearLayout>
 
     </LinearLayout>


### PR DESCRIPTION
You can now attach live data to a home setting item to display relevant information about that option.

![image](https://github.com/yuzu-emu/yuzu/assets/14132249/19a58945-14b8-4d67-a90e-ec1cae4f24ca)
