### PR TITLE
Mark accelerated DMA destination buffers and images as GPU-modified

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -830,7 +830,8 @@ bool AccelerateDMA::DmaBufferImageCopy(const Tegra::DMA::ImageCopy& copy_info,
     }
     const u32 buffer_size = static_cast<u32>(buffer_operand.pitch * buffer_operand.height);
     static constexpr auto sync_info = VideoCommon::ObtainBufferSynchronize::FullSynchronize;
-    const auto post_op = VideoCommon::ObtainBufferOperation::DoNothing;
+    const auto post_op = IS_IMAGE_UPLOAD ? VideoCommon::ObtainBufferOperation::DoNothing
+                                         : VideoCommon::ObtainBufferOperation::MarkAsWritten;
     const auto [buffer, offset] =
         buffer_cache.ObtainBuffer(buffer_operand.address, buffer_size, sync_info, post_op);
 
@@ -839,8 +840,12 @@ bool AccelerateDMA::DmaBufferImageCopy(const Tegra::DMA::ImageCopy& copy_info,
     const std::span copy_span{&copy, 1};
 
     if constexpr (IS_IMAGE_UPLOAD) {
+        texture_cache.PrepareImage(image_id, true, false);
         image->UploadMemory(buffer->Handle(), offset, copy_span);
     } else {
+        if (offset % BytesPerBlock(image->info.format)) {
+            return false;
+        }
         texture_cache.DownloadImageIntoBuffer(image, buffer->Handle(), offset, copy_span,
                                               buffer_operand.address, buffer_size);
     }

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -243,6 +243,9 @@ public:
     /// Create channel state.
     void CreateChannel(Tegra::Control::ChannelState& channel) final override;
 
+    /// Prepare an image to be used
+    void PrepareImage(ImageId image_id, bool is_modification, bool invalidate);
+
     std::recursive_mutex mutex;
 
 private:
@@ -386,9 +389,6 @@ private:
 
     /// Synchronize image aliases, copying data if needed
     void SynchronizeAliases(ImageId image_id);
-
-    /// Prepare an image to be used
-    void PrepareImage(ImageId image_id, bool is_modification, bool invalidate);
 
     /// Prepare an image view to be used
     void PrepareImageView(ImageViewId image_view_id, bool is_modification, bool invalidate);


### PR DESCRIPTION
The accelerated engine functions in 2d/dma/upload do GPU <-> GPU copies where possible, skipping a write to the CPU-side destination address, but we're currently not marking the destination buffer/image as being modified in DMA, which they should be, otherwise any future reads will not trigger a download and read the wrong data.

The non-accelerated paths in all engines are likely also causing some issues, due to the fact that they don't mark the relevant image/buffer as CPU-modified. I'm not sure how to correctly find them from the various engines, and if this is really even an issue, so I'll leave that to @FernandoS27 to check.

We also now fallback to a software blit when encountering an address which isn't valid for the given image's format. That case needs some more research.

Closes #10080