### PR TITLE
nvnflinger: add missing scale mode

### DIFF
--- a/src/core/hle/service/nvnflinger/buffer_queue_producer.cpp
+++ b/src/core/hle/service/nvnflinger/buffer_queue_producer.cpp
@@ -449,6 +449,7 @@ Status BufferQueueProducer::QueueBuffer(s32 slot, const QueueBufferInput& input,
     case NativeWindowScalingMode::ScaleToWindow:
     case NativeWindowScalingMode::ScaleCrop:
     case NativeWindowScalingMode::NoScaleCrop:
+    case NativeWindowScalingMode::PreserveAspectRatio:
         break;
     default:
         LOG_ERROR(Service_Nvnflinger, "unknown scaling mode {}", scaling_mode);

--- a/src/core/hle/service/nvnflinger/window.h
+++ b/src/core/hle/service/nvnflinger/window.h
@@ -41,6 +41,7 @@ enum class NativeWindowScalingMode : s32 {
     ScaleToWindow = 1,
     ScaleCrop = 2,
     NoScaleCrop = 3,
+    PreserveAspectRatio = 4,
 };
 
 /// Transform parameter for QueueBuffer


### PR DESCRIPTION
Fixes graphics on Gunvolt Chronicles Luminous Avenger iX 1.0.0.