### PR TITLE
gl_graphics_pipeline: GLASM: Fix transform feedback with multiple buffers

### DIFF
--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.cpp
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.cpp
@@ -559,15 +559,13 @@ void GraphicsPipeline::ConfigureImpl(bool is_indexed) {
 }
 
 void GraphicsPipeline::ConfigureTransformFeedbackImpl() const {
-    glTransformFeedbackStreamAttribsNV(num_xfb_attribs, xfb_attribs.data(), num_xfb_strides,
-                                       xfb_streams.data(), GL_INTERLEAVED_ATTRIBS);
+    glTransformFeedbackAttribsNV(num_xfb_attribs, xfb_attribs.data(), GL_SEPARATE_ATTRIBS);
 }
 
 void GraphicsPipeline::GenerateTransformFeedbackState() {
     // TODO(Rodrigo): Inject SKIP_COMPONENTS*_NV when required. An unimplemented message will signal
     // when this is required.
     GLint* cursor{xfb_attribs.data()};
-    GLint* current_stream{xfb_streams.data()};
 
     for (size_t feedback = 0; feedback < Maxwell::NumTransformFeedbackBuffers; ++feedback) {
         const auto& layout = key.xfb_state.layouts[feedback];
@@ -575,15 +573,6 @@ void GraphicsPipeline::GenerateTransformFeedbackState() {
         if (layout.varying_count == 0) {
             continue;
         }
-        *current_stream = static_cast<GLint>(feedback);
-        if (current_stream != xfb_streams.data()) {
-            // When stepping one stream, push the expected token
-            cursor[0] = GL_NEXT_BUFFER_NV;
-            cursor[1] = 0;
-            cursor[2] = 0;
-            cursor += XFB_ENTRY_STRIDE;
-        }
-        ++current_stream;
 
         const auto& locations = key.xfb_state.varyings[feedback];
         std::optional<u32> current_index;
@@ -619,7 +608,6 @@ void GraphicsPipeline::GenerateTransformFeedbackState() {
         }
     }
     num_xfb_attribs = static_cast<GLsizei>((cursor - xfb_attribs.data()) / XFB_ENTRY_STRIDE);
-    num_xfb_strides = static_cast<GLsizei>(current_stream - xfb_streams.data());
 }
 
 void GraphicsPipeline::WaitForBuild() {

--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.h
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.h
@@ -154,9 +154,7 @@ private:
 
     static constexpr std::size_t XFB_ENTRY_STRIDE = 3;
     GLsizei num_xfb_attribs{};
-    GLsizei num_xfb_strides{};
     std::array<GLint, 128 * XFB_ENTRY_STRIDE * Maxwell::NumTransformFeedbackBuffers> xfb_attribs{};
-    std::array<GLint, Maxwell::NumTransformFeedbackBuffers> xfb_streams{};
 
     std::mutex built_mutex;
     std::condition_variable built_condvar;


### PR DESCRIPTION
Fixes character shading in Pokemon Legends Arceus, and likely other titles that use Transform Feedback.

| Before | After |
| -------|------|
![pkmn_broken_shading](https://github.com/yuzu-emu/yuzu/assets/52414509/ec778181-3412-4970-ac66-6c3cf13460e7) | ![pkmn_shading](https://github.com/yuzu-emu/yuzu/assets/52414509/fc45e263-639b-4d5f-9bd3-54fb98a5e4d5)

Multiple streams is not currently supported:
https://github.com/yuzu-emu/yuzu/blob/26ff2147197352b571c394404de2be1a65d0cf9b/src/video_core/transform_feedback.cpp#L88

The correct usage here is to use multiple transform feedback buffers, not streams. So the buffer mode must be `GL_SEPARATE_ATTRIBS` and the stream used should always be Stream 0 (implicit in `glTransformFeedbackAttribs`)