### PR TITLE
kernel: remove relative task registration

### DIFF
--- a/src/core/hle/kernel/k_hardware_timer.h
+++ b/src/core/hle/kernel/k_hardware_timer.h
@@ -19,13 +19,7 @@ public:
     void Initialize();
     void Finalize();
 
-    s64 GetCount() const {
-        return GetTick();
-    }
-
-    void RegisterTask(KTimerTask* task, s64 time_from_now) {
-        this->RegisterAbsoluteTask(task, GetTick() + time_from_now);
-    }
+    s64 GetTick() const;
 
     void RegisterAbsoluteTask(KTimerTask* task, s64 task_time) {
         KScopedDisableDispatch dd{m_kernel};
@@ -42,7 +36,6 @@ private:
     void EnableInterrupt(s64 wakeup_time);
     void DisableInterrupt();
     bool GetInterruptEnabled();
-    s64 GetTick() const;
     void DoTask();
 
 private:

--- a/src/core/hle/kernel/k_resource_limit.h
+++ b/src/core/hle/kernel/k_resource_limit.h
@@ -31,7 +31,7 @@ public:
     explicit KResourceLimit(KernelCore& kernel);
     ~KResourceLimit() override;
 
-    void Initialize(const Core::Timing::CoreTiming* core_timing);
+    void Initialize();
     void Finalize() override;
 
     s64 GetLimitValue(LimitableResource which) const;
@@ -57,7 +57,6 @@ private:
     mutable KLightLock m_lock;
     s32 m_waiter_count{};
     KLightConditionVariable m_cond_var;
-    const Core::Timing::CoreTiming* m_core_timing{};
 };
 
 KResourceLimit* CreateResourceLimitForProcess(Core::System& system, s64 physical_memory_size);

--- a/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
+++ b/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
@@ -28,7 +28,7 @@ public:
     ~KScopedSchedulerLockAndSleep() {
         // Register the sleep.
         if (m_timeout_tick > 0) {
-            m_timer->RegisterTask(m_thread, m_timeout_tick);
+            m_timer->RegisterAbsoluteTask(m_thread, m_timeout_tick);
         }
 
         // Unlock the scheduler.

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -231,7 +231,7 @@ struct KernelCore::Impl {
     void InitializeSystemResourceLimit(KernelCore& kernel,
                                        const Core::Timing::CoreTiming& core_timing) {
         system_resource_limit = KResourceLimit::Create(system.Kernel());
-        system_resource_limit->Initialize(&core_timing);
+        system_resource_limit->Initialize();
         KResourceLimit::Register(kernel, system_resource_limit);
 
         const auto sizes{memory_layout->GetTotalAndKernelMemorySizes()};

--- a/src/core/hle/kernel/svc/svc_address_arbiter.cpp
+++ b/src/core/hle/kernel/svc/svc_address_arbiter.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "core/core.h"
+#include "core/hle/kernel/k_hardware_timer.h"
 #include "core/hle/kernel/k_memory_layout.h"
 #include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/kernel.h"
@@ -52,7 +53,7 @@ Result WaitForAddress(Core::System& system, u64 address, ArbitrationType arb_typ
     if (timeout_ns > 0) {
         const s64 offset_tick(timeout_ns);
         if (offset_tick > 0) {
-            timeout = offset_tick + 2;
+            timeout = system.Kernel().HardwareTimer().GetTick() + offset_tick + 2;
             if (timeout <= 0) {
                 timeout = std::numeric_limits<s64>::max();
             }

--- a/src/core/hle/kernel/svc/svc_condition_variable.cpp
+++ b/src/core/hle/kernel/svc/svc_condition_variable.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "core/core.h"
+#include "core/hle/kernel/k_hardware_timer.h"
 #include "core/hle/kernel/k_memory_layout.h"
 #include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/kernel.h"
@@ -25,7 +26,7 @@ Result WaitProcessWideKeyAtomic(Core::System& system, u64 address, u64 cv_key, u
     if (timeout_ns > 0) {
         const s64 offset_tick(timeout_ns);
         if (offset_tick > 0) {
-            timeout = offset_tick + 2;
+            timeout = system.Kernel().HardwareTimer().GetTick() + offset_tick + 2;
             if (timeout <= 0) {
                 timeout = std::numeric_limits<s64>::max();
             }

--- a/src/core/hle/kernel/svc/svc_resource_limit.cpp
+++ b/src/core/hle/kernel/svc/svc_resource_limit.cpp
@@ -21,7 +21,7 @@ Result CreateResourceLimit(Core::System& system, Handle* out_handle) {
     SCOPE_EXIT({ resource_limit->Close(); });
 
     // Initialize the resource limit.
-    resource_limit->Initialize(std::addressof(system.CoreTiming()));
+    resource_limit->Initialize();
 
     // Register the limit.
     KResourceLimit::Register(kernel, resource_limit);


### PR DESCRIPTION
This resulted in svcs waiting for longer than they needed to, in general, as well as KResourceLimit and Svc::CreateThread specifically never waiting for the correct amount of time when a timeout was passed.