### PR TITLE
file_sys/card_image: support dumps with prepended key area

### DIFF
--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -128,6 +128,7 @@ public:
 
 private:
     Loader::ResultStatus AddNCAFromPartition(XCIPartition part);
+    Loader::ResultStatus TryReadHeader();
 
     VirtualFile file;
     GamecardHeader header{};


### PR DESCRIPTION
Fixes #9902 (probably)
Fixes #9141
Fixes #4410