### PR TITLE
Mark decompiled macros on dump, dump shaders after translation

### DIFF
--- a/src/video_core/macro/macro.cpp
+++ b/src/video_core/macro/macro.cpp
@@ -27,14 +27,24 @@ MICROPROFILE_DEFINE(MacroHLE, "GPU", "Execute macro HLE", MP_RGB(128, 192, 192))
 
 namespace Tegra {
 
-static void Dump(u64 hash, std::span<const u32> code) {
+static void Dump(u64 hash, std::span<const u32> code, bool decompiled = false) {
     const auto base_dir{Common::FS::GetYuzuPath(Common::FS::YuzuPath::DumpDir)};
     const auto macro_dir{base_dir / "macros"};
     if (!Common::FS::CreateDir(base_dir) || !Common::FS::CreateDir(macro_dir)) {
         LOG_ERROR(Common_Filesystem, "Failed to create macro dump directories");
         return;
     }
-    const auto name{macro_dir / fmt::format("{:016x}.macro", hash)};
+    auto name{macro_dir / fmt::format("{:016x}.macro", hash)};
+
+    if (decompiled) {
+        auto new_name{macro_dir / fmt::format("decompiled_{:016x}.macro", hash)};
+        if (Common::FS::Exists(name)) {
+            (void)Common::FS::RenameFile(name, new_name);
+            return;
+        }
+        name = new_name;
+    }
+
     std::fstream macro_file(name, std::ios::out | std::ios::binary);
     if (!macro_file) {
         LOG_ERROR(Common_Filesystem, "Unable to open or create file at {}",
@@ -90,9 +100,6 @@ void MacroEngine::Execute(u32 method, const std::vector<u32>& parameters) {
         if (!mid_method.has_value()) {
             cache_info.lle_program = Compile(macro_code->second);
             cache_info.hash = Common::HashValue(macro_code->second);
-            if (Settings::values.dump_macros) {
-                Dump(cache_info.hash, macro_code->second);
-            }
         } else {
             const auto& macro_cached = uploaded_macro_code[mid_method.value()];
             const auto rebased_method = method - mid_method.value();
@@ -102,9 +109,6 @@ void MacroEngine::Execute(u32 method, const std::vector<u32>& parameters) {
                         code.size() * sizeof(u32));
             cache_info.hash = Common::HashValue(code);
             cache_info.lle_program = Compile(code);
-            if (Settings::values.dump_macros) {
-                Dump(cache_info.hash, code);
-            }
         }
 
         auto hle_program = hle_macros->GetHLEProgram(cache_info.hash);
@@ -116,6 +120,10 @@ void MacroEngine::Execute(u32 method, const std::vector<u32>& parameters) {
             cache_info.hle_program = std::move(hle_program);
             MICROPROFILE_SCOPE(MacroHLE);
             cache_info.hle_program->Execute(parameters, method);
+        }
+
+        if (Settings::values.dump_macros) {
+            Dump(cache_info.hash, macro_code->second, cache_info.has_hle_program);
         }
     }
 }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -611,9 +611,6 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
 
         const u32 cfg_offset{static_cast<u32>(env.StartAddress() + sizeof(Shader::ProgramHeader))};
         Shader::Maxwell::Flow::CFG cfg(env, pools.flow_block, cfg_offset, index == 0);
-        if (Settings::values.dump_shaders) {
-            env.Dump(hash, key.unique_hashes[index]);
-        }
         if (!uses_vertex_a || index != 1) {
             // Normal path
             programs[index] = TranslateProgram(pools.inst, pools.block, env, cfg, host_info);
@@ -622,6 +619,10 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
             auto& program_va{programs[0]};
             auto program_vb{TranslateProgram(pools.inst, pools.block, env, cfg, host_info)};
             programs[index] = MergeDualVertexPrograms(program_va, program_vb, env);
+        }
+
+        if (Settings::values.dump_shaders) {
+            env.Dump(hash, key.unique_hashes[index]);
         }
 
         if (programs[index].info.requires_layer_emulation) {


### PR DESCRIPTION
Currently we have no real way to tell which macros we've already decompiled and which we haven't, besides manual checking of hashes. This PR just changes their name to `decompiled_` when they've already been decompiled to make it easy to see what's new.

Also dumps shaders after they're been translated, rather than before, which makes it possible to conditionally dump some shaders based on instructions they use. I wanted this for only dumping shaders that use the SAM/RAM instructions in Bayonetta 3 for example.