### PR TITLE
Support masked depthstencil clears

### DIFF
--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SHADER_FILES
     vulkan_blit_depth_stencil.frag
     vulkan_color_clear.frag
     vulkan_color_clear.vert
+    vulkan_depthstencil_clear.frag
     vulkan_fidelityfx_fsr_easu_fp16.comp
     vulkan_fidelityfx_fsr_easu_fp32.comp
     vulkan_fidelityfx_fsr_rcas_fp16.comp

--- a/src/video_core/host_shaders/vulkan_depthstencil_clear.frag
+++ b/src/video_core/host_shaders/vulkan_depthstencil_clear.frag
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#version 460 core
+
+layout (push_constant) uniform PushConstants {
+    vec4 clear_depth;
+};
+
+void main() {
+    gl_FragDepth = clear_depth.x;
+}


### PR DESCRIPTION
Vulkan doesn't support masked clears, so we need to implement them another way. This PR implements the clear via drawing a full-screen tri, and allowing the regular stencil hardware to handle the masking and writing. The stencil test values are set up as normal, except we pass the clear value for the reference rather than the usual ref register, and the same for depth.

Closes #11313 and #11314 