### PR TITLE
kernel: offset code entry point for 39-bit address space type

### DIFF
--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -177,6 +177,10 @@ public:
         return m_program_id;
     }
 
+    KProcessAddress GetEntryPoint() const {
+        return m_code_address;
+    }
+
     /// Gets the resource limit descriptor for this process
     KResourceLimit* GetResourceLimit() const;
 
@@ -484,6 +488,9 @@ private:
 
     /// Address indicating the location of the process' dedicated TLS region.
     KProcessAddress m_plr_address = 0;
+
+    /// Address indicating the location of the process's entry point.
+    KProcessAddress m_code_address = 0;
 
     /// Random values for svcGetInfo RandomEntropy
     std::array<u64, RANDOM_ENTROPY_SIZE> m_random_entropy{};

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -153,7 +153,7 @@ AppLoader_DeconstructedRomDirectory::LoadResult AppLoader_DeconstructedRomDirect
 
     // Load NSO modules
     modules.clear();
-    const VAddr base_address{GetInteger(process.GetPageTable().GetCodeRegionStart())};
+    const VAddr base_address{GetInteger(process.GetEntryPoint())};
     VAddr next_load_addr{base_address};
     const FileSys::PatchManager pm{metadata.GetTitleID(), system.GetFileSystemController(),
                                    system.GetContentProvider()};

--- a/src/core/loader/kip.cpp
+++ b/src/core/loader/kip.cpp
@@ -96,7 +96,7 @@ AppLoader::LoadResult AppLoader_KIP::Load(Kernel::KProcess& process,
     }
 
     codeset.memory = std::move(program_image);
-    const VAddr base_address = GetInteger(process.GetPageTable().GetCodeRegionStart());
+    const VAddr base_address = GetInteger(process.GetEntryPoint());
     process.LoadModule(std::move(codeset), base_address);
 
     LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", kip->GetName(), base_address);

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -203,7 +203,7 @@ static bool LoadNroImpl(Kernel::KProcess& process, const std::vector<u8>& data) 
 
     // Load codeset for current process
     codeset.memory = std::move(program_image);
-    process.LoadModule(std::move(codeset), process.GetPageTable().GetCodeRegionStart());
+    process.LoadModule(std::move(codeset), process.GetEntryPoint());
 
     return true;
 }

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -167,7 +167,7 @@ AppLoader_NSO::LoadResult AppLoader_NSO::Load(Kernel::KProcess& process, Core::S
     modules.clear();
 
     // Load module
-    const VAddr base_address = GetInteger(process.GetPageTable().GetCodeRegionStart());
+    const VAddr base_address = GetInteger(process.GetEntryPoint());
     if (!LoadModule(process, system, *file, base_address, true, true)) {
         return {ResultStatus::ErrorLoadingNSO, {}};
     }

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -117,8 +117,8 @@ json GetProcessorStateDataAuto(Core::System& system) {
     arm.SaveContext(context);
 
     return GetProcessorStateData(process->Is64BitProcess() ? "AArch64" : "AArch32",
-                                 GetInteger(process->GetPageTable().GetCodeRegionStart()),
-                                 context.sp, context.pc, context.pstate, context.cpu_registers);
+                                 GetInteger(process->GetEntryPoint()), context.sp, context.pc,
+                                 context.pstate, context.cpu_registers);
 }
 
 json GetBacktraceData(Core::System& system) {


### PR DESCRIPTION
Prevents [this bug](https://github.com/skyline-dev/skyline/issues/79) from occurring by allowing space in the ASLR region to exist before the code load address.