### PR TITLE
sockets: avoid locking around socket session calls

### DIFF
--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -79,8 +79,8 @@ protected:
     using HandlerFnP = void (Self::*)(HLERequestContext&);
 
     /// Used to gain exclusive access to the service members, e.g. from CoreTiming thread.
-    [[nodiscard]] std::scoped_lock<std::mutex> LockService() {
-        return std::scoped_lock{lock_service};
+    [[nodiscard]] virtual std::unique_lock<std::mutex> LockService() {
+        return std::unique_lock{lock_service};
     }
 
     /// System context that the service operates under.

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -1029,6 +1029,11 @@ BSD::~BSD() {
     }
 }
 
+std::unique_lock<std::mutex> BSD::LockService() {
+    // Do not lock socket IClient instances.
+    return {};
+}
+
 BSDCFG::BSDCFG(Core::System& system_) : ServiceFramework{system_, "bsdcfg"} {
     // clang-format off
     static const FunctionInfo functions[] = {

--- a/src/core/hle/service/sockets/bsd.h
+++ b/src/core/hle/service/sockets/bsd.h
@@ -186,6 +186,9 @@ private:
 
     // Callback identifier for the OnProxyPacketReceived event.
     Network::RoomMember::CallbackHandle<Network::ProxyPacket> proxy_packet_received;
+
+protected:
+    virtual std::unique_lock<std::mutex> LockService() override;
 };
 
 class BSDCFG final : public ServiceFramework<BSDCFG> {


### PR DESCRIPTION
Among the numerous tragedies inside yuzu's service handling code, there is a `LockService` call that prevents multiple requests to the same instance of an IPC server from executing simultaneously:
https://github.com/yuzu-emu/yuzu/blob/6a5db5679b61d3d73244e42682f1b34d401e7736/src/core/hle/service/service.cpp#L170

This should not exist, and real server manager code does not do this, but a fair amount of yuzu code now depends on having this lock. Instead of unlocking them all and seeing what breaks, we will incrementally move any required locking inside the interface methods as needed, starting with sockets.

This allows calling sockets methods from multiple threads using a cloned session.