### PR TITLE
android: Use sensor landscape for landscape mode

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -297,11 +297,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
         emulationActivity?.let {
             it.requestedOrientation = when (IntSetting.RENDERER_SCREEN_LAYOUT.int) {
                 Settings.LayoutOption_MobileLandscape ->
-                    ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+                    ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
                 Settings.LayoutOption_MobilePortrait ->
                     ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
                 Settings.LayoutOption_Unspecified -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-                else -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+                else -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
             }
         }
     }


### PR DESCRIPTION
Previously when switching between landscape modes when in orientation lock, you would have to press the button that appears when you reorient the screen. Now the app will switch between landscape and reverse-landscape automatically.

Closes #11335 