### PR TITLE
Warnings cleanup for GCC 13 and Clang 16

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 add_subdirectory(mbedtls)
 target_include_directories(mbedtls PUBLIC ./mbedtls/include)
 target_compile_options(mbedcrypto PRIVATE
-    $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-but-set-variable>
-    $<$<CXX_COMPILER_ID:Clang>:-Wno-string-concatenation>)
+    -Wno-unused-but-set-variable
+    -Wno-string-concatenation)
 
 # MicroProfile
 add_library(microprofile INTERFACE)
@@ -98,7 +98,9 @@ if (ENABLE_CUBEB AND NOT TARGET cubeb::cubeb)
     add_subdirectory(cubeb)
     add_library(cubeb::cubeb ALIAS cubeb)
     if (NOT MSVC)
-        target_compile_options(speex PRIVATE -Wno-sign-compare)
+        if (TARGET speex)
+            target_compile_options(speex PRIVATE -Wno-sign-compare)
+        endif()
         target_compile_options(cubeb PRIVATE -Wno-implicit-const-int-float-conversion)
     endif()
 endif()

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -42,6 +42,9 @@ endif()
 # mbedtls
 add_subdirectory(mbedtls)
 target_include_directories(mbedtls PUBLIC ./mbedtls/include)
+target_compile_options(mbedcrypto PRIVATE
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-but-set-variable>
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-string-concatenation>)
 
 # MicroProfile
 add_library(microprofile INTERFACE)
@@ -94,6 +97,10 @@ if (ENABLE_CUBEB AND NOT TARGET cubeb::cubeb)
     set(BUILD_TOOLS OFF)
     add_subdirectory(cubeb)
     add_library(cubeb::cubeb ALIAS cubeb)
+    if (NOT MSVC)
+        target_compile_options(speex PRIVATE -Wno-sign-compare)
+        target_compile_options(cubeb PRIVATE -Wno-implicit-const-int-float-conversion)
+    endif()
 endif()
 
 # DiscordRPC
@@ -151,6 +158,9 @@ endif()
 if (NOT TARGET LLVM::Demangle)
     add_library(demangle demangle/ItaniumDemangle.cpp)
     target_include_directories(demangle PUBLIC ./demangle)
+    if (NOT MSVC)
+        target_compile_options(demangle PRIVATE -Wno-deprecated-declarations) # std::is_pod
+    endif()
     add_library(LLVM::Demangle ALIAS demangle)
 endif()
 

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -42,9 +42,11 @@ endif()
 # mbedtls
 add_subdirectory(mbedtls)
 target_include_directories(mbedtls PUBLIC ./mbedtls/include)
-target_compile_options(mbedcrypto PRIVATE
-    -Wno-unused-but-set-variable
-    -Wno-string-concatenation)
+if (NOT MSVC)
+    target_compile_options(mbedcrypto PRIVATE
+        -Wno-unused-but-set-variable
+        -Wno-string-concatenation)
+endif()
 
 # MicroProfile
 add_library(microprofile INTERFACE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,16 +114,18 @@ else()
         -Wno-attributes
         -Wno-invalid-offsetof
         -Wno-unused-parameter
-
-        $<$<CXX_COMPILER_ID:Clang>:-Wno-braced-scalar-init>
-        $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-private-field>
-        $<$<CXX_COMPILER_ID:Clang>:-Wno-nullability-completeness>
-        $<$<CXX_COMPILER_ID:Clang>:-Werror=shadow-uncaptured-local>
-        $<$<CXX_COMPILER_ID:Clang>:-Werror=implicit-fallthrough>
-        $<$<CXX_COMPILER_ID:Clang>:-Werror=type-limits>
-        $<$<CXX_COMPILER_ID:AppleClang>:-Wno-braced-scalar-init>
-        $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-private-field>
     )
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES Clang) # Clang or AppleClang
+        add_compile_options(
+            -Wno-braced-scalar-init
+            -Wno-unused-private-field
+            -Wno-nullability-completeness
+            -Werror=shadow-uncaptured-local
+            -Werror=implicit-fallthrough
+            -Werror=type-limits
+        )
+    endif()
 
     if (ARCHITECTURE_x86_64)
         add_compile_options("-mcx16")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ else()
 
         $<$<CXX_COMPILER_ID:Clang>:-Wno-braced-scalar-init>
         $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-private-field>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-nullability-completeness>
         $<$<CXX_COMPILER_ID:Clang>:-Werror=shadow-uncaptured-local>
         $<$<CXX_COMPILER_ID:Clang>:-Werror=implicit-fallthrough>
         $<$<CXX_COMPILER_ID:Clang>:-Werror=type-limits>

--- a/src/common/swap.h
+++ b/src/common/swap.h
@@ -460,11 +460,6 @@ S operator&(const S& i, const swap_struct_t<T, F> v) {
     return i & v.swap();
 }
 
-template <typename S, typename T, typename F>
-S operator&(const swap_struct_t<T, F> v, const S& i) {
-    return static_cast<S>(v.swap() & i);
-}
-
 // Comparison
 template <typename S, typename T, typename F>
 bool operator<(const S& p, const swap_struct_t<T, F> v) {

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -835,15 +835,15 @@ public:
         return input_engine->SupportsNfc(identifier);
     }
 
-    Common::Input::NfcState StartNfcPolling() {
+    Common::Input::NfcState StartNfcPolling() override {
         return input_engine->StartNfcPolling(identifier);
     }
 
-    Common::Input::NfcState StopNfcPolling() {
+    Common::Input::NfcState StopNfcPolling() override {
         return input_engine->StopNfcPolling(identifier);
     }
 
-    Common::Input::NfcState ReadAmiiboData(std::vector<u8>& out_data) {
+    Common::Input::NfcState ReadAmiiboData(std::vector<u8>& out_data) override {
         return input_engine->ReadAmiiboData(identifier, out_data);
     }
 
@@ -852,11 +852,11 @@ public:
     }
 
     Common::Input::NfcState ReadMifareData(const Common::Input::MifareRequest& request,
-                                           Common::Input::MifareRequest& out_data) {
+                                           Common::Input::MifareRequest& out_data) override {
         return input_engine->ReadMifareData(identifier, request, out_data);
     }
 
-    Common::Input::NfcState WriteMifareData(const Common::Input::MifareRequest& request) {
+    Common::Input::NfcState WriteMifareData(const Common::Input::MifareRequest& request) override {
         return input_engine->WriteMifareData(identifier, request);
     }
 

--- a/src/web_service/verify_user_jwt.cpp
+++ b/src/web_service/verify_user_jwt.cpp
@@ -4,6 +4,7 @@
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations" // for deprecated OpenSSL functions
 #endif
 #include <jwt/jwt.hpp>
 #if defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
Note: For GCC there are still a huge number of `-Warray-bounds` warnings coming from `externals/dynarmic`.  I could have added a workaround in `externals/CMakeLists.txt` similar to what this PR does for other externals, but given Dynarmic's close affiliation with Yuzu, it would be better to fix it upstream.

Besides that, on my machine, this makes the build warning-free except for some warnings from glslangValidator and AutoMoc.

Details:

- Disable some warnings in externals.

- Disable `-Wnullability-completeness`, which is a Clang warning triggered by the Vulkan SDK where if any pointers in the header are marked _Nullable, it wants all pointers to be marked _Nullable or _Nonnull. Most of them are, but some aren't.  Who knows why.

- `src/web_service/verify_user_jwt.cpp`: Disable another warning when including `jwt.hpp`.

- `src/input_common/input_poller.cpp`: Add missing `override` specifiers.

- src/common/swap.h: Remove redundant `operator&`.  In general, this file declares three overloads of each operator.  Using `+` as an example, the overloads are:

  - a member function for `swapped_t + integer`
  - a member function for `swapped_t + swapped_t`
  - a free function for `integer + swapped_t`

  But for `operator&`, there was an additional free function for
  `swapped_t + integer`, which was redundant with the member function.
  This caused a GCC warning saying "ISO C++ says that these are
  ambiguous".