### PR TITLE
desktop shortcut support for windows

### DIFF
--- a/src/common/fs/fs_paths.h
+++ b/src/common/fs/fs_paths.h
@@ -22,6 +22,7 @@
 #define SDMC_DIR "sdmc"
 #define SHADER_DIR "shader"
 #define TAS_DIR "tas"
+#define ICONS_DIR "icons"
 
 // yuzu-specific files
 

--- a/src/common/fs/path_util.cpp
+++ b/src/common/fs/path_util.cpp
@@ -126,6 +126,7 @@ public:
         GenerateYuzuPath(YuzuPath::SDMCDir, yuzu_path / SDMC_DIR);
         GenerateYuzuPath(YuzuPath::ShaderDir, yuzu_path / SHADER_DIR);
         GenerateYuzuPath(YuzuPath::TASDir, yuzu_path / TAS_DIR);
+        GenerateYuzuPath(YuzuPath::IconsDir, yuzu_path / ICONS_DIR);
     }
 
 private:

--- a/src/common/fs/path_util.h
+++ b/src/common/fs/path_util.h
@@ -24,6 +24,7 @@ enum class YuzuPath {
     SDMCDir,        // Where the emulated SDMC is stored.
     ShaderDir,      // Where shaders are stored.
     TASDir,         // Where TAS scripts are stored.
+    IconsDir,       // Where Icons for windows shortcuts are stored.
 };
 
 /**

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -559,9 +559,9 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     QAction* dump_romfs_sdmc = dump_romfs_menu->addAction(tr("Dump RomFS to SDMC"));
     QAction* copy_tid = context_menu.addAction(tr("Copy Title ID to Clipboard"));
     QAction* navigate_to_gamedb_entry = context_menu.addAction(tr("Navigate to GameDB entry"));
-#ifndef WIN32
     QMenu* shortcut_menu = context_menu.addMenu(tr("Create Shortcut"));
     QAction* create_desktop_shortcut = shortcut_menu->addAction(tr("Add to Desktop"));
+#ifndef WIN32
     QAction* create_applications_menu_shortcut =
         shortcut_menu->addAction(tr("Add to Applications Menu"));
 #endif
@@ -633,10 +633,10 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     connect(navigate_to_gamedb_entry, &QAction::triggered, [this, program_id]() {
         emit NavigateToGamedbEntryRequested(program_id, compatibility_list);
     });
-#ifndef WIN32
     connect(create_desktop_shortcut, &QAction::triggered, [this, program_id, path]() {
         emit CreateShortcut(program_id, path, GameListShortcutTarget::Desktop);
     });
+#ifndef WIN32
     connect(create_applications_menu_shortcut, &QAction::triggered, [this, program_id, path]() {
         emit CreateShortcut(program_id, path, GameListShortcutTarget::Applications);
     });

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2717,7 +2717,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 
     std::string title{fmt::format("{:016X}", program_id)};
 
-    if (control.first != nullptr) {
+    if (control.first) {
         title = control.first->GetApplicationName();
     } else {
         loader->ReadTitle(title);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2677,7 +2677,11 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 
     std::filesystem::path target_directory{};
     // Determine target directory for shortcut
+#if defined(WIN32)
+    const char* home = std::getenv("USERPROFILE");
+#else
     const char* home = std::getenv("HOME");
+#endif
     const std::filesystem::path home_path = (home == nullptr ? "~" : home);
     const char* xdg_data_home = std::getenv("XDG_DATA_HOME");
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2691,7 +2691,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
             QMessageBox::critical(
                 this, tr("Create Shortcut"),
                 tr("Cannot create shortcut on desktop. Path \"%1\" does not exist.")
-                    .arg(target_directory.c_str()),
+                    .arg(QString::fromStdString(target_directory.generic_string())),
                 QMessageBox::StandardButton::Ok);
             return;
         }
@@ -2699,11 +2699,12 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
         target_directory = (xdg_data_home == nullptr ? home_path / ".local/share" : xdg_data_home) /
                            "applications";
         if (!Common::FS::CreateDirs(target_directory)) {
-            QMessageBox::critical(this, tr("Create Shortcut"),
-                                  tr("Cannot create shortcut in applications menu. Path \"%1\" "
-                                     "does not exist and cannot be created.")
-                                      .arg(target_directory.c_str()),
-                                  QMessageBox::StandardButton::Ok);
+            QMessageBox::critical(
+                this, tr("Create Shortcut"),
+                tr("Cannot create shortcut in applications menu. Path \"%1\" "
+                   "does not exist and cannot be created.")
+                    .arg(QString::fromStdString(target_directory.generic_string())),
+                QMessageBox::StandardButton::Ok);
             return;
         }
     }
@@ -2742,7 +2743,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
         QMessageBox::critical(
             this, tr("Create Icon"),
             tr("Cannot create icon file. Path \"%1\" does not exist and cannot be created.")
-                .arg(QString::fromStdString(system_icons_path)),
+                .arg(QString::fromStdString(icons_path)),
             QMessageBox::StandardButton::Ok);
         return;
     }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2761,7 +2761,8 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 #endif
     std::filesystem::path icon_path =
             icons_path / ((program_id == 0 ? fmt::format("yuzu-{}", game_file_name)
-                                           : fmt::format("yuzu-{:016X}", program_id)) + icon_extension);
+                                           : fmt::format("yuzu-{:016X}", program_id)) +
+                          icon_extension);
 
     // Get icon from game file
     std::vector<u8> icon_image_file{};

--- a/src/yuzu/util/util.cpp
+++ b/src/yuzu/util/util.cpp
@@ -112,8 +112,7 @@ bool SaveIconToFile(const char* path, QImage image) {
     return true;
 }
 #else
-
 bool SaveAsIco(QImage image) {
     return false;
-    }
+}
 #endif

--- a/src/yuzu/util/util.cpp
+++ b/src/yuzu/util/util.cpp
@@ -103,7 +103,8 @@ bool SaveIconToFile(const char* path, QImage image) {
     iconFile.write(reinterpret_cast<const char*>(&bmih), sizeof(BITMAPINFOHEADER));
 
     for (int y = 0; y < image.height(); y++) {
-        auto line = reinterpret_cast<const char*>(sourceImage.scanLine(sourceImage.height() - 1 - y));
+        auto line =
+            reinterpret_cast<const char*>(sourceImage.scanLine(sourceImage.height() - 1 - y));
         iconFile.write(line, sourceImage.width() * bytesPerPixel);
     }
 

--- a/src/yuzu/util/util.cpp
+++ b/src/yuzu/util/util.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <QPainter>
 #include "yuzu/util/util.h"
+#include <fstream>
 
 QFont GetMonospaceFont() {
     QFont font(QStringLiteral("monospace"));
@@ -37,3 +38,82 @@ QPixmap CreateCirclePixmapFromColor(const QColor& color) {
     painter.drawEllipse({circle_pixmap.width() / 2.0, circle_pixmap.height() / 2.0}, 7.0, 7.0);
     return circle_pixmap;
 }
+
+#if defined(WIN32)
+#include <Windows.h>
+
+#pragma pack(push, 2)
+struct ICONDIR {
+    WORD idReserved;
+    WORD idType;
+    WORD idCount;
+};
+
+struct ICONDIRENTRY {
+    BYTE bWidth;
+    BYTE bHeight;
+    BYTE bColorCount;
+    BYTE bReserved;
+    WORD wPlanes;
+    WORD wBitCount;
+    DWORD dwBytesInRes;
+    DWORD dwImageOffset;
+};
+
+#pragma pack(pop)
+
+bool SaveIconToFile(const char* path, QImage image) {
+
+    QImage sourceImage = image.convertToFormat(QImage::Format_RGB32);
+
+    const int bytesPerPixel = 4;
+    const int imageSize = sourceImage.width() * sourceImage.height() * bytesPerPixel;
+
+    BITMAPINFOHEADER bmih = {};
+    bmih.biSize = sizeof(BITMAPINFOHEADER);
+    bmih.biWidth = sourceImage.width();
+    bmih.biHeight = sourceImage.height() * 2;
+    bmih.biPlanes = 1;
+    bmih.biBitCount = 32;
+    bmih.biCompression = BI_RGB;
+
+    // Create an ICO header
+    ICONDIR iconDir;
+    iconDir.idReserved = 0;
+    iconDir.idType = 1;
+    iconDir.idCount = 1;
+
+    // Create an ICONDIRENTRY
+    ICONDIRENTRY iconEntry;
+    iconEntry.bWidth = sourceImage.width();
+    iconEntry.bHeight = sourceImage.height() * 2;
+    iconEntry.bColorCount = 0;
+    iconEntry.bReserved = 0;
+    iconEntry.wPlanes = 1;
+    iconEntry.wBitCount = 32;
+    iconEntry.dwBytesInRes = sizeof(BITMAPINFOHEADER) + imageSize;
+    iconEntry.dwImageOffset = sizeof(ICONDIR) + sizeof(ICONDIRENTRY);
+
+    // Save the icon data to a file
+    std::ofstream iconFile(path, std::ios::binary);
+    if (iconFile.fail())
+        return false;
+    iconFile.write(reinterpret_cast<const char*>(&iconDir), sizeof(ICONDIR));
+    iconFile.write(reinterpret_cast<const char*>(&iconEntry), sizeof(ICONDIRENTRY));
+    iconFile.write(reinterpret_cast<const char*>(&bmih), sizeof(BITMAPINFOHEADER));
+
+    for (int y = 0; y < image.height(); y++) {
+        auto line = (char*)sourceImage.scanLine(sourceImage.height() - 1 - y);
+        iconFile.write(line, sourceImage.width() * 4);
+    }
+
+    iconFile.close();
+
+    return true;
+}
+#else
+
+bool SaveAsIco(QImage image) {
+    return false;
+    }
+#endif

--- a/src/yuzu/util/util.h
+++ b/src/yuzu/util/util.h
@@ -18,3 +18,5 @@ QString ReadableByteSize(qulonglong size);
  * @return QPixmap circle pixmap
  */
 QPixmap CreateCirclePixmapFromColor(const QColor& color);
+
+bool SaveIconToFile(const char* path, QImage image);


### PR DESCRIPTION
implemented the windows path for desktop shortcut creation of titles.

Icons are saved in the yuzu appdata folder under /icons