### PR TITLE
android: lint: Delete generated ktlint folder between builds

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -160,6 +160,11 @@ android {
     }
 }
 
+tasks.create<Delete>("ktlintReset") {
+    delete(File(buildDir.path + File.separator + "intermediates/ktLint"))
+}
+
+tasks.getByPath("loadKtlintReporters").dependsOn("ktlintReset")
 tasks.getByPath("preBuild").dependsOn("ktlintCheck")
 
 ktlint {


### PR DESCRIPTION
There's a bug in ktlint where it will run into an error if you build the project, delete a source file, and then build again. It will be unable to find the file you deleted and can't recover until these files are deleted. This just deletes those files before every run.