### PR TITLE
Pre-test for valid audio backends

### DIFF
--- a/src/audio_core/sink/cubeb_sink.h
+++ b/src/audio_core/sink/cubeb_sink.h
@@ -97,10 +97,11 @@ private:
 std::vector<std::string> ListCubebSinkDevices(bool capture);
 
 /**
- * Get the reported latency for this sink.
+ * Check if this backend is suitable for use.
+ * Checks if enabled, its latency, whether it opens successfully, etc.
  *
- * @return Minimum latency for this sink.
+ * @return True is this backend is suitable, false otherwise.
  */
-u32 GetCubebLatency();
+bool IsCubebSuitable();
 
 } // namespace AudioCore::Sink

--- a/src/audio_core/sink/sdl2_sink.h
+++ b/src/audio_core/sink/sdl2_sink.h
@@ -88,10 +88,11 @@ private:
 std::vector<std::string> ListSDLSinkDevices(bool capture);
 
 /**
- * Get the reported latency for this sink.
+ * Check if this backend is suitable for use.
+ * Checks if enabled, its latency, whether it opens successfully, etc.
  *
- * @return Minimum latency for this sink.
+ * @return True is this backend is suitable, false otherwise.
  */
-u32 GetSDLLatency();
+bool IsSDLSuitable();
 
 } // namespace AudioCore::Sink

--- a/src/audio_core/sink/sink_details.cpp
+++ b/src/audio_core/sink/sink_details.cpp
@@ -22,7 +22,7 @@ namespace {
 struct SinkDetails {
     using FactoryFn = std::unique_ptr<Sink> (*)(std::string_view);
     using ListDevicesFn = std::vector<std::string> (*)(bool);
-    using LatencyFn = u32 (*)();
+    using SuitableFn = bool (*)();
 
     /// Name for this sink.
     Settings::AudioEngine id;
@@ -30,8 +30,8 @@ struct SinkDetails {
     FactoryFn factory;
     /// A method to call to list available devices.
     ListDevicesFn list_devices;
-    /// Method to get the latency of this backend.
-    LatencyFn latency;
+    /// Check whether this backend is suitable to be used.
+    SuitableFn is_suitable;
 };
 
 // sink_details is ordered in terms of desirability, with the best choice at the top.
@@ -43,7 +43,7 @@ constexpr SinkDetails sink_details[] = {
             return std::make_unique<CubebSink>(device_id);
         },
         &ListCubebSinkDevices,
-        &GetCubebLatency,
+        &IsCubebSuitable,
     },
 #endif
 #ifdef HAVE_SDL2
@@ -53,14 +53,17 @@ constexpr SinkDetails sink_details[] = {
             return std::make_unique<SDLSink>(device_id);
         },
         &ListSDLSinkDevices,
-        &GetSDLLatency,
+        &IsSDLSuitable,
     },
 #endif
-    SinkDetails{Settings::AudioEngine::Null,
-                [](std::string_view device_id) -> std::unique_ptr<Sink> {
-                    return std::make_unique<NullSink>(device_id);
-                },
-                [](bool capture) { return std::vector<std::string>{"null"}; }, []() { return 0u; }},
+    SinkDetails{
+        Settings::AudioEngine::Null,
+        [](std::string_view device_id) -> std::unique_ptr<Sink> {
+            return std::make_unique<NullSink>(device_id);
+        },
+        [](bool capture) { return std::vector<std::string>{"null"}; },
+        []() { return true; },
+    },
 };
 
 const SinkDetails& GetOutputSinkDetails(Settings::AudioEngine sink_id) {
@@ -72,18 +75,22 @@ const SinkDetails& GetOutputSinkDetails(Settings::AudioEngine sink_id) {
     auto iter = find_backend(sink_id);
 
     if (sink_id == Settings::AudioEngine::Auto) {
-        // Auto-select a backend. Prefer CubeB, but it may report a large minimum latency which
-        // causes audio issues, in that case go with SDL.
-#if defined(HAVE_CUBEB) && defined(HAVE_SDL2)
-        iter = find_backend(Settings::AudioEngine::Cubeb);
-        if (iter->latency() > TargetSampleCount * 3) {
-            iter = find_backend(Settings::AudioEngine::Sdl2);
+        // Auto-select a backend. Use the sink details ordering, preferring cubeb first, checking
+        // that the backend is available and suitable to use.
+        for (auto& details : sink_details) {
+            if (details.is_suitable()) {
+                iter = &details;
+                break;
+            }
         }
-#else
-        iter = std::begin(sink_details);
-#endif
-        LOG_INFO(Service_Audio, "Auto-selecting the {} backend",
-                 Settings::CanonicalizeEnum(iter->id));
+        LOG_ERROR(Service_Audio, "Auto-selecting the {} backend",
+                  Settings::CanonicalizeEnum(iter->id));
+    } else {
+        if (iter != std::end(sink_details) && !iter->is_suitable()) {
+            LOG_ERROR(Service_Audio, "Selected backend {} is not suitable, falling back to null",
+                      Settings::CanonicalizeEnum(iter->id));
+            iter = find_backend(Settings::AudioEngine::Null);
+        }
     }
 
     if (iter == std::end(sink_details)) {


### PR DESCRIPTION
Avoids the problem of badly configured audio devices that fail to init, and then softlocking games on boot. Tests each of the preferential backends in turn to see if they're valid, and falls back to null when they aren't, which avoids games softlocking.