### PR TITLE
yuzu/main: Ensure NCAs are registered in content provider when launching from CLI

### DIFF
--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -399,6 +399,7 @@ private:
     void OpenPerGameConfiguration(u64 title_id, const std::string& file_name);
     bool CheckDarkMode();
     bool CheckSystemArchiveDecryption();
+    void ConfigureFilesystemProvider(const std::string& filepath);
 
     QString GetTasStateDescription() const;
     bool CreateShortcut(const std::string& shortcut_path, const std::string& title,


### PR DESCRIPTION
Fixes updates and DLC not being loaded when launching yuzu from the command line.

Similar to https://github.com/yuzu-emu/yuzu/pull/11357. 
Fixes https://github.com/yuzu-emu/yuzu/issues/8352,