### PR TITLE
android: Use appCategory to specify the app is a game

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         android:hasFragileUserData="false"
         android:supportsRtl="true"
         android:isGame="true"
+        android:appCategory="game"
         android:localeConfig="@xml/locales_config"
         android:banner="@drawable/tv_banner"
         android:extractNativeLibs="true"


### PR DESCRIPTION
This still doesn't make builds appear as a game to the Samsung game launcher but this could help for the version of the app that is delivered from that play store. `isGame` was deprecated in Android Oreo and `appCategory` is supposed to be the replacement. But I'll be keeping both just in case there are game launchers that only check for `isGame`.