### PR TITLE
Fix regressions that damaged compute indirect & use reinterpret for copies with different byteblocksizes

### DIFF
--- a/src/shader_recompiler/frontend/maxwell/translate/impl/move_special_register.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate/impl/move_special_register.cpp
@@ -161,7 +161,8 @@ enum class SpecialRegister : u64 {
         LOG_WARNING(Shader, "(STUBBED) SR_AFFINITY");
         return ir.Imm32(0); // This is the default value hardware returns.
     default:
-        throw NotImplementedException("S2R special register {}", special_register);
+        LOG_CRITICAL(Shader, "(STUBBED) Special register {}", special_register);
+        return ir.Imm32(0); // This is the default value hardware returns.
     }
 }
 } // Anonymous namespace

--- a/src/video_core/dma_pusher.cpp
+++ b/src/video_core/dma_pusher.cpp
@@ -14,6 +14,7 @@
 namespace Tegra {
 
 constexpr u32 MacroRegistersStart = 0xE00;
+constexpr u32 ComputeInline = 0x6D;
 
 DmaPusher::DmaPusher(Core::System& system_, GPU& gpu_, MemoryManager& memory_manager_,
                      Control::ChannelState& channel_state_)
@@ -83,20 +84,35 @@ bool DmaPusher::Step() {
                     dma_state.dma_get, command_list_header.size * sizeof(u32));
             }
         }
-        if (Settings::IsGPULevelHigh() && dma_state.method < MacroRegistersStart) {
+        const auto safe_process = [&] {
             Core::Memory::GpuGuestMemory<Tegra::CommandHeader,
                                          Core::Memory::GuestMemoryFlags::SafeRead>
                 headers(memory_manager, dma_state.dma_get, command_list_header.size,
                         &command_headers);
             ProcessCommands(headers);
+        };
+        const auto unsafe_process = [&] {
+            Core::Memory::GpuGuestMemory<Tegra::CommandHeader,
+                                         Core::Memory::GuestMemoryFlags::UnsafeRead>
+                headers(memory_manager, dma_state.dma_get, command_list_header.size,
+                        &command_headers);
+            ProcessCommands(headers);
+        };
+        if (Settings::IsGPULevelHigh()) {
+            if (dma_state.method >= MacroRegistersStart) {
+                unsafe_process();
+                return true;
+            }
+            if (subchannel_type[dma_state.subchannel] == Engines::EngineTypes::KeplerCompute &&
+                dma_state.method == ComputeInline) {
+                unsafe_process();
+                return true;
+            }
+            safe_process();
             return true;
         }
-        Core::Memory::GpuGuestMemory<Tegra::CommandHeader,
-                                     Core::Memory::GuestMemoryFlags::UnsafeRead>
-            headers(memory_manager, dma_state.dma_get, command_list_header.size, &command_headers);
-        ProcessCommands(headers);
+        unsafe_process();
     }
-
     return true;
 }
 

--- a/src/video_core/dma_pusher.cpp
+++ b/src/video_core/dma_pusher.cpp
@@ -83,6 +83,14 @@ bool DmaPusher::Step() {
                     dma_state.dma_get, command_list_header.size * sizeof(u32));
             }
         }
+        if (Settings::IsGPULevelHigh() && dma_state.method < MacroRegistersStart) {
+            Core::Memory::GpuGuestMemory<Tegra::CommandHeader,
+                                         Core::Memory::GuestMemoryFlags::SafeRead>
+                headers(memory_manager, dma_state.dma_get, command_list_header.size,
+                        &command_headers);
+            ProcessCommands(headers);
+            return true;
+        }
         Core::Memory::GpuGuestMemory<Tegra::CommandHeader,
                                      Core::Memory::GuestMemoryFlags::UnsafeRead>
             headers(memory_manager, dma_state.dma_get, command_list_header.size, &command_headers);

--- a/src/video_core/dma_pusher.h
+++ b/src/video_core/dma_pusher.h
@@ -130,8 +130,10 @@ public:
 
     void DispatchCalls();
 
-    void BindSubchannel(Engines::EngineInterface* engine, u32 subchannel_id) {
+    void BindSubchannel(Engines::EngineInterface* engine, u32 subchannel_id,
+                        Engines::EngineTypes engine_type) {
         subchannels[subchannel_id] = engine;
+        subchannel_type[subchannel_id] = engine_type;
     }
 
     void BindRasterizer(VideoCore::RasterizerInterface* rasterizer);
@@ -170,6 +172,7 @@ private:
     const bool ib_enable{true}; ///< IB mode enabled
 
     std::array<Engines::EngineInterface*, max_subchannels> subchannels{};
+    std::array<Engines::EngineTypes, max_subchannels> subchannel_type;
 
     GPU& gpu;
     Core::System& system;

--- a/src/video_core/engines/engine_interface.h
+++ b/src/video_core/engines/engine_interface.h
@@ -11,6 +11,14 @@
 
 namespace Tegra::Engines {
 
+enum class EngineTypes : u32 {
+    KeplerCompute,
+    Maxwell3D,
+    Fermi2D,
+    MaxwellDMA,
+    KeplerMemory,
+};
+
 class EngineInterface {
 public:
     virtual ~EngineInterface() = default;

--- a/src/video_core/engines/engine_upload.h
+++ b/src/video_core/engines/engine_upload.h
@@ -69,6 +69,14 @@ public:
     /// Binds a rasterizer to this engine.
     void BindRasterizer(VideoCore::RasterizerInterface* rasterizer);
 
+    GPUVAddr ExecTargetAddress() const {
+        return regs.dest.Address();
+    }
+
+    u32 GetUploadSize() const {
+        return copy_size;
+    }
+
 private:
     void ProcessData(std::span<const u8> read_buffer);
 

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <vector>
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
@@ -35,6 +36,9 @@ namespace Tegra::Engines {
 
 #define KEPLER_COMPUTE_REG_INDEX(field_name)                                                       \
     (offsetof(Tegra::Engines::KeplerCompute::Regs, field_name) / sizeof(u32))
+
+#define LAUNCH_REG_INDEX(field_name)                                                               \
+    (offsetof(Tegra::Engines::KeplerCompute::LaunchParams, field_name) / sizeof(u32))
 
 class KeplerCompute final : public EngineInterface {
 public:
@@ -201,6 +205,10 @@ public:
     void CallMultiMethod(u32 method, const u32* base_start, u32 amount,
                          u32 methods_pending) override;
 
+    std::optional<GPUVAddr> GetIndirectComputeAddress() const {
+        return indirect_compute;
+    }
+
 private:
     void ProcessLaunch();
 
@@ -216,6 +224,15 @@ private:
     MemoryManager& memory_manager;
     VideoCore::RasterizerInterface* rasterizer = nullptr;
     Upload::State upload_state;
+    GPUVAddr upload_address;
+
+    struct UploadInfo {
+        GPUVAddr upload_address;
+        GPUVAddr exec_address;
+        u32 copy_size;
+    };
+    std::vector<UploadInfo> uploads;
+    std::optional<GPUVAddr> indirect_compute{};
 };
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \

--- a/src/video_core/engines/puller.cpp
+++ b/src/video_core/engines/puller.cpp
@@ -34,19 +34,24 @@ void Puller::ProcessBindMethod(const MethodCall& method_call) {
     bound_engines[method_call.subchannel] = engine_id;
     switch (engine_id) {
     case EngineID::FERMI_TWOD_A:
-        dma_pusher.BindSubchannel(channel_state.fermi_2d.get(), method_call.subchannel);
+        dma_pusher.BindSubchannel(channel_state.fermi_2d.get(), method_call.subchannel,
+                                  EngineTypes::Fermi2D);
         break;
     case EngineID::MAXWELL_B:
-        dma_pusher.BindSubchannel(channel_state.maxwell_3d.get(), method_call.subchannel);
+        dma_pusher.BindSubchannel(channel_state.maxwell_3d.get(), method_call.subchannel,
+                                  EngineTypes::Maxwell3D);
         break;
     case EngineID::KEPLER_COMPUTE_B:
-        dma_pusher.BindSubchannel(channel_state.kepler_compute.get(), method_call.subchannel);
+        dma_pusher.BindSubchannel(channel_state.kepler_compute.get(), method_call.subchannel,
+                                  EngineTypes::KeplerCompute);
         break;
     case EngineID::MAXWELL_DMA_COPY_A:
-        dma_pusher.BindSubchannel(channel_state.maxwell_dma.get(), method_call.subchannel);
+        dma_pusher.BindSubchannel(channel_state.maxwell_dma.get(), method_call.subchannel,
+                                  EngineTypes::MaxwellDMA);
         break;
     case EngineID::KEPLER_INLINE_TO_MEMORY_B:
-        dma_pusher.BindSubchannel(channel_state.kepler_memory.get(), method_call.subchannel);
+        dma_pusher.BindSubchannel(channel_state.kepler_memory.get(), method_call.subchannel,
+                                  EngineTypes::KeplerMemory);
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented engine {:04X}", engine_id);

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -664,6 +664,19 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline(
         std::move(modules), infos);
 
 } catch (const Shader::Exception& exception) {
+    auto hash = key.Hash();
+    size_t env_index{0};
+    for (size_t index = 0; index < Maxwell::MaxShaderProgram; ++index) {
+        if (key.unique_hashes[index] == 0) {
+            continue;
+        }
+        Shader::Environment& env{*envs[env_index]};
+        ++env_index;
+
+        const u32 cfg_offset{static_cast<u32>(env.StartAddress() + sizeof(Shader::ProgramHeader))};
+        Shader::Maxwell::Flow::CFG cfg(env, pools.flow_block, cfg_offset, index == 0);
+        env.Dump(hash, key.unique_hashes[index]);
+    }
     LOG_ERROR(Render_Vulkan, "{}", exception.what());
     return nullptr;
 }

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -92,6 +92,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
     X(vkCmdCopyImage);
     X(vkCmdCopyImageToBuffer);
     X(vkCmdDispatch);
+    X(vkCmdDispatchIndirect);
     X(vkCmdDraw);
     X(vkCmdDrawIndexed);
     X(vkCmdDrawIndirect);

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -203,6 +203,7 @@ struct DeviceDispatch : InstanceDispatch {
     PFN_vkCmdCopyImage vkCmdCopyImage{};
     PFN_vkCmdCopyImageToBuffer vkCmdCopyImageToBuffer{};
     PFN_vkCmdDispatch vkCmdDispatch{};
+    PFN_vkCmdDispatchIndirect vkCmdDispatchIndirect{};
     PFN_vkCmdDraw vkCmdDraw{};
     PFN_vkCmdDrawIndexed vkCmdDrawIndexed{};
     PFN_vkCmdDrawIndirect vkCmdDrawIndirect{};
@@ -1207,6 +1208,10 @@ public:
 
     void Dispatch(u32 x, u32 y, u32 z) const noexcept {
         dld->vkCmdDispatch(handle, x, y, z);
+    }
+
+    void DispatchIndirect(VkBuffer indirect_buffer, VkDeviceSize offset) const noexcept {
+        dld->vkCmdDispatchIndirect(handle, indirect_buffer, offset);
     }
 
     void PipelineBarrier(VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,


### PR DESCRIPTION
Big credits to Maide @Kelebek1 who investigated this issue.

This fixes Mario + Rabbids Kingdom Battle. I have not tested Sparks of hope:
![image](https://github.com/yuzu-emu/yuzu/assets/1731197/b1e73bfb-c772-4482-b288-cf06b32e9b08)

and Sea of Solitude:
![image](https://github.com/yuzu-emu/yuzu/assets/1731197/99f0b9ec-8659-46b1-aca8-cbf2cd5ab36e)
