### PR TITLE
am: shorten shutdown timeout when lock is not held

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -273,7 +273,8 @@ struct System::Impl {
         time_manager.Initialize();
 
         is_powered_on = true;
-        exit_lock = false;
+        exit_locked = false;
+        exit_requested = false;
 
         microprofile_cpu[0] = MICROPROFILE_TOKEN(ARM_CPU0);
         microprofile_cpu[1] = MICROPROFILE_TOKEN(ARM_CPU1);
@@ -398,7 +399,8 @@ struct System::Impl {
         }
 
         is_powered_on = false;
-        exit_lock = false;
+        exit_locked = false;
+        exit_requested = false;
 
         if (gpu_core != nullptr) {
             gpu_core->NotifyShutdown();
@@ -507,7 +509,8 @@ struct System::Impl {
 
     CpuManager cpu_manager;
     std::atomic_bool is_powered_on{};
-    bool exit_lock = false;
+    bool exit_locked = false;
+    bool exit_requested = false;
 
     bool nvdec_active{};
 
@@ -943,12 +946,20 @@ const Service::Time::TimeManager& System::GetTimeManager() const {
     return impl->time_manager;
 }
 
-void System::SetExitLock(bool locked) {
-    impl->exit_lock = locked;
+void System::SetExitLocked(bool locked) {
+    impl->exit_locked = locked;
 }
 
-bool System::GetExitLock() const {
-    return impl->exit_lock;
+bool System::GetExitLocked() const {
+    return impl->exit_locked;
+}
+
+void System::SetExitRequested(bool requested) {
+    impl->exit_requested = requested;
+}
+
+bool System::GetExitRequested() const {
+    return impl->exit_requested;
 }
 
 void System::SetApplicationProcessBuildID(const CurrentBuildProcessID& id) {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -412,8 +412,11 @@ public:
     /// Gets an immutable reference to the Room Network.
     [[nodiscard]] const Network::RoomNetwork& GetRoomNetwork() const;
 
-    void SetExitLock(bool locked);
-    [[nodiscard]] bool GetExitLock() const;
+    void SetExitLocked(bool locked);
+    bool GetExitLocked() const;
+
+    void SetExitRequested(bool requested);
+    bool GetExitRequested() const;
 
     void SetApplicationProcessBuildID(const CurrentBuildProcessID& id);
     [[nodiscard]] const CurrentBuildProcessID& GetApplicationProcessBuildID() const;

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -340,7 +340,7 @@ void ISelfController::Exit(HLERequestContext& ctx) {
 void ISelfController::LockExit(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    system.SetExitLock(true);
+    system.SetExitLocked(true);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
@@ -349,10 +349,14 @@ void ISelfController::LockExit(HLERequestContext& ctx) {
 void ISelfController::UnlockExit(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    system.SetExitLock(false);
+    system.SetExitLocked(false);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
+
+    if (system.GetExitRequested()) {
+        system.Exit();
+    }
 }
 
 void ISelfController::EnterFatalSection(HLERequestContext& ctx) {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2010,8 +2010,16 @@ bool GMainWindow::OnShutdownBegin() {
 
     emit EmulationStopping();
 
+    int shutdown_time = 1000;
+
+    if (system->DebuggerEnabled()) {
+        shutdown_time = 0;
+    } else if (system->GetExitLocked()) {
+        shutdown_time = 5000;
+    }
+
     shutdown_timer.setSingleShot(true);
-    shutdown_timer.start(system->DebuggerEnabled() ? 0 : 5000);
+    shutdown_timer.start(shutdown_time);
     connect(&shutdown_timer, &QTimer::timeout, this, &GMainWindow::OnEmulationStopTimeExpired);
     connect(emu_thread.get(), &QThread::finished, this, &GMainWindow::OnEmulationStopped);
 
@@ -3261,7 +3269,7 @@ void GMainWindow::OnPauseContinueGame() {
 }
 
 void GMainWindow::OnStopGame() {
-    if (system->GetExitLock() && !ConfirmForceLockedExit()) {
+    if (system->GetExitLocked() && !ConfirmForceLockedExit()) {
         return;
     }
 
@@ -4513,6 +4521,8 @@ void GMainWindow::RequestGameExit() {
     auto applet_oe = sm.GetService<Service::AM::AppletOE>("appletOE");
     auto applet_ae = sm.GetService<Service::AM::AppletAE>("appletAE");
     bool has_signalled = false;
+
+    system->SetExitRequested(true);
 
     if (applet_oe != nullptr) {
         applet_oe->GetMessageQueue()->RequestExit();


### PR DESCRIPTION
This should make the "Closing software" dialog less of an agonizing wait and more in-line with hardware behavior.