### PR TITLE
internal_network: cancel pending socket operations on application process termination

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -404,6 +404,7 @@ struct System::Impl {
             gpu_core->NotifyShutdown();
         }
 
+        Network::CancelPendingSocketOperations();
         kernel.SuspendApplication(true);
         if (services) {
             services->KillNVNFlinger();
@@ -425,6 +426,7 @@ struct System::Impl {
         debugger.reset();
         kernel.Shutdown();
         memory.Reset();
+        Network::RestartSocketOperations();
 
         if (auto room_member = room_network.GetRoomMember().lock()) {
             Network::GameInfo game_info{};

--- a/src/core/internal_network/network.cpp
+++ b/src/core/internal_network/network.cpp
@@ -201,7 +201,10 @@ void InterruptSocketOperations() {
 
 void AcknowledgeInterrupt() {
     u8 value = 0;
-    read(interrupt_pipe_fd[0], &value, sizeof(value));
+    ssize_t ret = read(interrupt_pipe_fd[0], &value, sizeof(value));
+    if (ret != 1 && errno != EAGAIN && errno != EWOULDBLOCK) {
+        LOG_ERROR(Network, "Failed to acknowledge interrupt on shutdown");
+    }
 }
 
 SOCKET GetInterruptSocket() {

--- a/src/core/internal_network/network.h
+++ b/src/core/internal_network/network.h
@@ -96,6 +96,9 @@ public:
     ~NetworkInstance();
 };
 
+void CancelPendingSocketOperations();
+void RestartSocketOperations();
+
 #ifdef _WIN32
 constexpr IPv4Address TranslateIPv4(in_addr addr) {
     auto& bytes = addr.S_un.S_un_b;


### PR DESCRIPTION
The [TCP logger](https://github.com/skyline-dev/skyline/blob/master/source/skyline/logger/TcpLogger.cpp#L41) here has a blocking accept call that gets converted to a host accept call. This ends up blocking forever until a host is actually accepted. However, when terminating the application, we want this to get shut down right away, and not require forcibly killing the emulator.