### PR TITLE
Vulkan: Implement Depth Bias Control

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -350,6 +350,8 @@ struct Values {
         linkage, false, "disable_shader_loop_safety_checks", Category::RendererDebug};
     Setting<bool> enable_renderdoc_hotkey{linkage, false, "renderdoc_hotkey",
                                           Category::RendererDebug};
+    // TODO: remove this once AMDVLK supports VK_EXT_depth_bias_control
+    bool renderer_amdvlk_depth_bias_workaround{};
 
     // System
     SwitchableSetting<Language, true> language_index{linkage,

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -381,6 +381,10 @@ struct System::Impl {
             room_member->SendGameInfo(game_info);
         }
 
+        // Workarounds:
+        // Activate this in Super Smash Brothers Ultimate, it only affects AMD cards using AMDVLK
+        Settings::values.renderer_amdvlk_depth_bias_workaround = program_id == 0x1006A800016E000ULL;
+
         status = SystemResultStatus::Success;
         return status;
     }
@@ -439,6 +443,9 @@ struct System::Impl {
             Network::GameInfo game_info{};
             room_member->SendGameInfo(game_info);
         }
+
+        // Workarounds
+        Settings::values.renderer_amdvlk_depth_bias_workaround = false;
 
         LOG_DEBUG(Core, "Shutdown OK");
     }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1050,6 +1050,9 @@ void RasterizerVulkan::UpdateDepthBias(Tegra::Engines::Maxwell3D::Regs& regs) {
         if (device.IsExtDepthBiasControlSupported()) {
             return true;
         }
+        if (!Settings::values.renderer_amdvlk_depth_bias_workaround) {
+            return false;
+        }
         // the base formulas can be obtained from here:
         //   https://docs.microsoft.com/en-us/windows/win32/direct3d11/d3d10-graphics-programming-guide-output-merger-stage-depth-bias
         const double rescale_factor =

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1043,15 +1043,34 @@ void RasterizerVulkan::UpdateDepthBias(Tegra::Engines::Maxwell3D::Regs& regs) {
                         regs.zeta.format == Tegra::DepthFormat::X8Z24_UNORM ||
                         regs.zeta.format == Tegra::DepthFormat::S8Z24_UNORM ||
                         regs.zeta.format == Tegra::DepthFormat::V8Z24_UNORM;
-    if (is_d24 && !device.SupportsD24DepthBuffer()) {
+    bool force_unorm = ([&] {
+        if (!is_d24 || device.SupportsD24DepthBuffer()) {
+            return false;
+        }
+        if (device.IsExtDepthBiasControlSupported()) {
+            return true;
+        }
         // the base formulas can be obtained from here:
         //   https://docs.microsoft.com/en-us/windows/win32/direct3d11/d3d10-graphics-programming-guide-output-merger-stage-depth-bias
         const double rescale_factor =
             static_cast<double>(1ULL << (32 - 24)) / (static_cast<double>(0x1.ep+127));
         units = static_cast<float>(static_cast<double>(units) * rescale_factor);
-    }
+        return false;
+    })();
     scheduler.Record([constant = units, clamp = regs.depth_bias_clamp,
-                      factor = regs.slope_scale_depth_bias](vk::CommandBuffer cmdbuf) {
+                      factor = regs.slope_scale_depth_bias, force_unorm,
+                      precise = device.HasExactDepthBiasControl()](vk::CommandBuffer cmdbuf) {
+        if (force_unorm) {
+            VkDepthBiasRepresentationInfoEXT info{
+                .sType = VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT,
+                .pNext = nullptr,
+                .depthBiasRepresentation =
+                    VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT,
+                .depthBiasExact = precise ? VK_TRUE : VK_FALSE,
+            };
+            cmdbuf.SetDepthBias(constant, clamp, factor, &info);
+            return;
+        }
         cmdbuf.SetDepthBias(constant, clamp, factor);
     });
 }

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1051,6 +1051,13 @@ void Device::RemoveUnsuitableExtensions() {
     RemoveExtensionFeatureIfUnsuitable(extensions.custom_border_color, features.custom_border_color,
                                        VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
 
+    // VK_EXT_depth_bias_control
+    extensions.depth_bias_control =
+        features.depth_bias_control.depthBiasControl &&
+        features.depth_bias_control.leastRepresentableValueForceUnormRepresentation;
+    RemoveExtensionFeatureIfUnsuitable(extensions.depth_bias_control, features.depth_bias_control,
+                                       VK_EXT_DEPTH_BIAS_CONTROL_EXTENSION_NAME);
+
     // VK_EXT_depth_clip_control
     extensions.depth_clip_control = features.depth_clip_control.depthClipControl;
     RemoveExtensionFeatureIfUnsuitable(extensions.depth_clip_control, features.depth_clip_control,

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -456,8 +456,7 @@ public:
 
     /// Returns true if the device supports VK_EXT_depth_bias_control.
     bool IsExtDepthBiasControlSupported() const {
-        return extensions.depth_bias_control && features.depth_bias_control.depthBiasControl &&
-               features.depth_bias_control.leastRepresentableValueForceUnormRepresentation;
+        return extensions.depth_bias_control;
     }
 
     /// Returns true if the device supports VK_EXT_shader_viewport_index_layer.

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -41,6 +41,7 @@ VK_DEFINE_HANDLE(VmaAllocator)
 // Define all features which may be used by the implementation and require an extension here.
 #define FOR_EACH_VK_FEATURE_EXT(FEATURE)                                                           \
     FEATURE(EXT, CustomBorderColor, CUSTOM_BORDER_COLOR, custom_border_color)                      \
+    FEATURE(EXT, DepthBiasControl, DEPTH_BIAS_CONTROL, depth_bias_control)                         \
     FEATURE(EXT, DepthClipControl, DEPTH_CLIP_CONTROL, depth_clip_control)                         \
     FEATURE(EXT, ExtendedDynamicState, EXTENDED_DYNAMIC_STATE, extended_dynamic_state)             \
     FEATURE(EXT, ExtendedDynamicState2, EXTENDED_DYNAMIC_STATE_2, extended_dynamic_state2)         \
@@ -93,6 +94,7 @@ VK_DEFINE_HANDLE(VmaAllocator)
 // Define extensions where the absence of the extension may result in a degraded experience.
 #define FOR_EACH_VK_RECOMMENDED_EXTENSION(EXTENSION_NAME)                                          \
     EXTENSION_NAME(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME)                               \
+    EXTENSION_NAME(VK_EXT_DEPTH_BIAS_CONTROL_EXTENSION_NAME)                                       \
     EXTENSION_NAME(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME)                                 \
     EXTENSION_NAME(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME)                                   \
     EXTENSION_NAME(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME)                                 \
@@ -143,6 +145,9 @@ VK_DEFINE_HANDLE(VmaAllocator)
 // Define features where the absence of the feature may result in a degraded experience.
 #define FOR_EACH_VK_RECOMMENDED_FEATURE(FEATURE_NAME)                                              \
     FEATURE_NAME(custom_border_color, customBorderColors)                                          \
+    FEATURE_NAME(depth_bias_control, depthBiasControl)                                             \
+    FEATURE_NAME(depth_bias_control, leastRepresentableValueForceUnormRepresentation)              \
+    FEATURE_NAME(depth_bias_control, depthBiasExact)                                               \
     FEATURE_NAME(extended_dynamic_state, extendedDynamicState)                                     \
     FEATURE_NAME(index_type_uint8, indexTypeUint8)                                                 \
     FEATURE_NAME(primitive_topology_list_restart, primitiveTopologyListRestart)                    \
@@ -449,6 +454,12 @@ public:
         return extensions.depth_clip_control;
     }
 
+    /// Returns true if the device supports VK_EXT_depth_bias_control.
+    bool IsExtDepthBiasControlSupported() const {
+        return extensions.depth_bias_control && features.depth_bias_control.depthBiasControl &&
+               features.depth_bias_control.leastRepresentableValueForceUnormRepresentation;
+    }
+
     /// Returns true if the device supports VK_EXT_shader_viewport_index_layer.
     bool IsExtShaderViewportIndexLayerSupported() const {
         return extensions.shader_viewport_index_layer;
@@ -598,6 +609,10 @@ public:
 
     bool HasNullDescriptor() const {
         return features.robustness2.nullDescriptor;
+    }
+
+    bool HasExactDepthBiasControl() const {
+        return features.depth_bias_control.depthBiasExact;
     }
 
     u32 GetMaxVertexInputAttributes() const {

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -109,6 +109,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
     X(vkCmdPushDescriptorSetWithTemplateKHR);
     X(vkCmdSetBlendConstants);
     X(vkCmdSetDepthBias);
+    X(vkCmdSetDepthBias2EXT);
     X(vkCmdSetDepthBounds);
     X(vkCmdSetEvent);
     X(vkCmdSetScissor);

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -222,6 +222,7 @@ struct DeviceDispatch : InstanceDispatch {
     PFN_vkCmdSetBlendConstants vkCmdSetBlendConstants{};
     PFN_vkCmdSetCullModeEXT vkCmdSetCullModeEXT{};
     PFN_vkCmdSetDepthBias vkCmdSetDepthBias{};
+    PFN_vkCmdSetDepthBias2EXT vkCmdSetDepthBias2EXT{};
     PFN_vkCmdSetDepthBounds vkCmdSetDepthBounds{};
     PFN_vkCmdSetDepthBoundsTestEnableEXT vkCmdSetDepthBoundsTestEnableEXT{};
     PFN_vkCmdSetDepthCompareOpEXT vkCmdSetDepthCompareOpEXT{};
@@ -1313,6 +1314,18 @@ public:
 
     void SetDepthBias(float constant_factor, float clamp, float slope_factor) const noexcept {
         dld->vkCmdSetDepthBias(handle, constant_factor, clamp, slope_factor);
+    }
+
+    void SetDepthBias(float constant_factor, float clamp, float slope_factor,
+                      VkDepthBiasRepresentationInfoEXT* extra) const noexcept {
+        VkDepthBiasInfoEXT info{
+            .sType = VK_STRUCTURE_TYPE_DEPTH_BIAS_INFO_EXT,
+            .pNext = extra,
+            .depthBiasConstantFactor = constant_factor,
+            .depthBiasClamp = clamp,
+            .depthBiasSlopeFactor = slope_factor,
+        };
+        dld->vkCmdSetDepthBias2EXT(handle, &info);
     }
 
     void SetDepthBounds(float min_depth_bounds, float max_depth_bounds) const noexcept {


### PR DESCRIPTION
This should fix the z fighting in some games in AMD cards. So far only RADV supports the extension, hopefully, AMD's proprietary driver will in the future.

I'm leaving it as  a Draft as it needs testing.