### PR TITLE
externals: Update SDL to 2.28.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,7 +524,7 @@ if (ENABLE_SDL2)
     if (YUZU_USE_BUNDLED_SDL2)
         # Detect toolchain and platform
         if ((MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1940) AND ARCHITECTURE_x86_64)
-            set(SDL2_VER "SDL2-2.28.1")
+            set(SDL2_VER "SDL2-2.28.2")
         else()
             message(FATAL_ERROR "No bundled SDL2 binaries for your toolchain. Disable YUZU_USE_BUNDLED_SDL2 and provide your own.")
         endif()


### PR DESCRIPTION
This version allows to disable WGI however I had to disable it with cmake flags since we can't use that feature yet on some systems until they update to 2.28.2. This mainly solves crashes when opening yuzu with specific controllers. Depends on https://github.com/yuzu-emu/ext-windows-bin/pull/47

- Fixed Xbox controller trigger motion events on Windows
- Fixed Xbox controller rumble in the background on Windows
- Fixed 8BitDo gamepad mapping when in XInput mode on Linux
- Fixed controller lockup initializing some unofficial PS4 replica controllers

closes #11296 