### PR TITLE
android: Support intents to emulation activity

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -66,6 +66,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
                 <data android:mimeType="application/octet-stream" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:mimeType="application/octet-stream"
+                    android:scheme="content"/>
+            </intent-filter>
+
             <meta-data
                 android:name="android.nfc.action.TECH_DISCOVERED"
                 android:resource="@xml/nfc_tech_filter" />

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameHelper.kt
@@ -63,13 +63,13 @@ object GameHelper {
                 )
             } else {
                 if (Game.extensions.contains(FileUtil.getExtension(it.uri))) {
-                    games.add(getGame(it.uri))
+                    games.add(getGame(it.uri, true))
                 }
             }
         }
     }
 
-    private fun getGame(uri: Uri): Game {
+    fun getGame(uri: Uri, addedToLibrary: Boolean): Game {
         val filePath = uri.toString()
         var name = NativeLibrary.getTitle(filePath)
 
@@ -94,11 +94,13 @@ object GameHelper {
             NativeLibrary.isHomebrew(filePath)
         )
 
-        val addedTime = preferences.getLong(newGame.keyAddedToLibraryTime, 0L)
-        if (addedTime == 0L) {
-            preferences.edit()
-                .putLong(newGame.keyAddedToLibraryTime, System.currentTimeMillis())
-                .apply()
+        if (addedToLibrary) {
+            val addedTime = preferences.getLong(newGame.keyAddedToLibraryTime, 0L)
+            if (addedTime == 0L) {
+                preferences.edit()
+                    .putLong(newGame.keyAddedToLibraryTime, System.currentTimeMillis())
+                    .apply()
+            }
         }
 
         return newGame

--- a/src/android/app/src/main/res/navigation/emulation_navigation.xml
+++ b/src/android/app/src/main/res/navigation/emulation_navigation.xml
@@ -12,7 +12,9 @@
         tools:layout="@layout/fragment_emulation" >
         <argument
             android:name="game"
-            app:argType="org.yuzu.yuzu_emu.model.Game" />
+            app:argType="org.yuzu.yuzu_emu.model.Game"
+            app:nullable="true"
+            android:defaultValue="@null" />
     </fragment>
 
 </navigation>

--- a/src/android/app/src/main/res/navigation/home_navigation.xml
+++ b/src/android/app/src/main/res/navigation/home_navigation.xml
@@ -62,7 +62,9 @@
         android:label="EmulationActivity">
         <argument
             android:name="game"
-            app:argType="org.yuzu.yuzu_emu.model.Game" />
+            app:argType="org.yuzu.yuzu_emu.model.Game"
+            app:nullable="true"
+            android:defaultValue="@null" />
     </activity>
 
     <action


### PR DESCRIPTION
Added a view action to the emulation activity so that you can launch games in yuzu from other apps like Daijishō

Demo - 
![daijishobruh](https://github.com/yuzu-emu/yuzu/assets/14132249/988a62db-3154-4f8d-913c-9c4e37211e6e)
