### PR TITLE
hwopus: Implement GetWorkBufferSizeExEx

### DIFF
--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -267,6 +267,10 @@ void HwOpus::GetWorkBufferSizeEx(HLERequestContext& ctx) {
     GetWorkBufferSize(ctx);
 }
 
+void HwOpus::GetWorkBufferSizeExEx(HLERequestContext& ctx) {
+    GetWorkBufferSizeEx(ctx);
+}
+
 void HwOpus::GetWorkBufferSizeForMultiStreamEx(HLERequestContext& ctx) {
     OpusMultiStreamParametersEx param;
     std::memcpy(&param, ctx.ReadBuffer().data(), ctx.GetReadBufferSize());
@@ -409,7 +413,7 @@ HwOpus::HwOpus(Core::System& system_) : ServiceFramework{system_, "hwopus"} {
         {6, &HwOpus::OpenHardwareOpusDecoderForMultiStreamEx,
          "OpenHardwareOpusDecoderForMultiStreamEx"},
         {7, &HwOpus::GetWorkBufferSizeForMultiStreamEx, "GetWorkBufferSizeForMultiStreamEx"},
-        {8, nullptr, "GetWorkBufferSizeExEx"},
+        {8, &HwOpus::GetWorkBufferSizeExEx, "GetWorkBufferSizeExEx"},
         {9, nullptr, "GetWorkBufferSizeForMultiStreamExEx"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/audio/hwopus.h
+++ b/src/core/hle/service/audio/hwopus.h
@@ -34,6 +34,7 @@ private:
     void OpenHardwareOpusDecoderForMultiStreamEx(HLERequestContext& ctx);
     void GetWorkBufferSize(HLERequestContext& ctx);
     void GetWorkBufferSizeEx(HLERequestContext& ctx);
+    void GetWorkBufferSizeExEx(HLERequestContext& ctx);
     void GetWorkBufferSizeForMultiStreamEx(HLERequestContext& ctx);
 };
 


### PR DESCRIPTION
Allows Sea of Stars to boot.

Fixes https://github.com/yuzu-emu/yuzu/issues/11415.