### PR TITLE
shader_recompiler: skip sampler for buffer textures

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -204,9 +204,7 @@ Id TextureImage(EmitContext& ctx, IR::TextureInstInfo info, const IR::Value& ind
         if (def.count > 1) {
             throw NotImplementedException("Indirect texture sample");
         }
-        const Id sampler_id{def.id};
-        const Id id{ctx.OpLoad(ctx.sampled_texture_buffer_type, sampler_id)};
-        return ctx.OpImage(ctx.image_buffer_type, id);
+        return ctx.OpLoad(ctx.image_buffer_type, def.id);
     } else {
         const TextureDefinition& def{ctx.textures.at(info.descriptor_index)};
         if (def.count > 1) {

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1242,9 +1242,8 @@ void EmitContext::DefineTextureBuffers(const Info& info, u32& binding) {
     }
     const spv::ImageFormat format{spv::ImageFormat::Unknown};
     image_buffer_type = TypeImage(F32[1], spv::Dim::Buffer, 0U, false, false, 1, format);
-    sampled_texture_buffer_type = TypeSampledImage(image_buffer_type);
 
-    const Id type{TypePointer(spv::StorageClass::UniformConstant, sampled_texture_buffer_type)};
+    const Id type{TypePointer(spv::StorageClass::UniformConstant, image_buffer_type)};
     texture_buffers.reserve(info.texture_buffer_descriptors.size());
     for (const TextureBufferDescriptor& desc : info.texture_buffer_descriptors) {
         if (desc.count != 1) {

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -206,7 +206,6 @@ public:
     Id output_u32{};
 
     Id image_buffer_type{};
-    Id sampled_texture_buffer_type{};
     Id image_u32{};
 
     std::array<UniformDefinitions, Info::MAX_CBUFS> cbufs{};


### PR DESCRIPTION
Fixes Pikmin 4 crashing on recent versions of Mesa (probably, debug builds have a NIR validation failure in the same shader that I couldn't get past, even on versions predating when they added the check for this SPIR-V validation issue).

Khronos removed (!) the ability to declare an OpTypeSampledImage for images with the Buffer dim declaration in SPIR-V 1.6. There appear to be no public notes for why they removed it completely instead of just marking it as a deprecation, and this removal makes it more inconvenient to work with buffer textures in a uniform way when stored alongside other samplers.

They also forgot to remove the SampledBuffer capability, which is now useless.