### PR TITLE
shader_recompiler: always declare image format for image buffers

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -74,6 +74,11 @@ spv::ImageFormat GetImageFormat(ImageFormat format) {
     throw InvalidArgument("Invalid image format {}", format);
 }
 
+spv::ImageFormat GetImageFormatForBuffer(ImageFormat format) {
+    const auto spv_format = GetImageFormat(format);
+    return spv_format == spv::ImageFormat::Unknown ? spv::ImageFormat::R32ui : spv_format;
+}
+
 Id ImageType(EmitContext& ctx, const ImageDescriptor& desc) {
     const spv::ImageFormat format{GetImageFormat(desc.format)};
     const Id type{ctx.U32[1]};
@@ -1271,7 +1276,7 @@ void EmitContext::DefineImageBuffers(const Info& info, u32& binding) {
         if (desc.count != 1) {
             throw NotImplementedException("Array of image buffers");
         }
-        const spv::ImageFormat format{GetImageFormat(desc.format)};
+        const spv::ImageFormat format{GetImageFormatForBuffer(desc.format)};
         const Id image_type{TypeImage(U32[1], spv::Dim::Buffer, false, false, false, 2, format)};
         const Id pointer_type{TypePointer(spv::StorageClass::UniformConstant, image_type)};
         const Id id{AddGlobalVariable(pointer_type, spv::StorageClass::UniformConstant)};


### PR DESCRIPTION
This fixes a NIR validation error that is not yet added as a Vulkan validation error. [The spec says:](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap15.html#interfaces-resources-descset)
> The `Image Format` of an `OpTypeImage` declaration **must not** be **Unknown**, for variables which are used for `OpAtomic*` operations.

Since the image's sampled type is set to u32x1, the result on most(?) drivers with the previous is that the atomic will be performed as a 32-bit operation. This makes that behavior explicit.