### PR TITLE
common: add a compile time option to allow disabling portable mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ option(YUZU_ENABLE_LTO "Enable link-time optimization" OFF)
 
 option(YUZU_DOWNLOAD_TIME_ZONE_DATA "Always download time zone binaries" OFF)
 
+option(YUZU_ENABLE_PORTABLE "Allow yuzu to enable portable mode if a user folder is found in the CWD" ON)
+
 CMAKE_DEPENDENT_OPTION(YUZU_USE_FASTER_LD "Check if a faster linker is available" ON "NOT WIN32" OFF)
 
 CMAKE_DEPENDENT_OPTION(USE_SYSTEM_MOLTENVK "Use the system MoltenVK lib (instead of the bundled one)" OFF "APPLE" OFF)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -151,6 +151,10 @@ add_library(common STATIC
     zstd_compression.h
 )
 
+if (YUZU_ENABLE_PORTABLE)
+    add_compile_definitions(YUZU_ENABLE_PORTABLE)
+endif()
+
 if (WIN32)
   target_sources(common PRIVATE
     windows/timer_resolution.cpp

--- a/src/common/fs/path_util.cpp
+++ b/src/common/fs/path_util.cpp
@@ -88,8 +88,9 @@ public:
         fs::path yuzu_path_config;
 
 #ifdef _WIN32
+#ifdef YUZU_ENABLE_PORTABLE
         yuzu_path = GetExeDirectory() / PORTABLE_DIR;
-
+#endif
         if (!IsDir(yuzu_path)) {
             yuzu_path = GetAppDataRoamingDirectory() / YUZU_DIR;
         }
@@ -101,8 +102,9 @@ public:
         yuzu_path_cache = yuzu_path / CACHE_DIR;
         yuzu_path_config = yuzu_path / CONFIG_DIR;
 #else
+#ifdef YUZU_ENABLE_PORTABLE
         yuzu_path = GetCurrentDir() / PORTABLE_DIR;
-
+#endif
         if (Exists(yuzu_path) && IsDir(yuzu_path)) {
             yuzu_path_cache = yuzu_path / CACHE_DIR;
             yuzu_path_config = yuzu_path / CONFIG_DIR;


### PR DESCRIPTION
yuzu checks for a `user` folder in the current working directory on non-windows and non-android platforms. At least on linux, the CWD will default to `~` if ran through an application launcher, and a folder at `~/user` will enable portable mode.

As installations with a package manager will not make use of portable mode, we should expose a compile time option to allow package maintainers disable this undesirable behavior.

closes #11441 