### PR TITLE
configure_graphics: Fix handling of broken Vulkan

### DIFF
--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -493,7 +493,7 @@ void ConfigureGraphics::RetrieveVulkanDevices() {
 }
 
 Settings::RendererBackend ConfigureGraphics::GetCurrentGraphicsBackend() const {
-    const auto selected_backend = [=]() {
+    const auto selected_backend = [&]() {
         if (!Settings::IsConfiguringGlobal() && !api_restore_global_button->isEnabled()) {
             return Settings::values.renderer_backend.GetValue(true);
         }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -442,7 +442,11 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
                                 "#yuzu-starts-with-the-error-broken-vulkan-installation-detected'>"
                                 "here for instructions to fix the issue</a>."));
 
+#ifdef HAS_OPENGL
         Settings::values.renderer_backend = Settings::RendererBackend::OpenGL;
+#else
+        Settings::values.renderer_backend = Settings::RendererBackend::Null;
+#endif
 
         UpdateAPIText();
         renderer_status_button->setDisabled(true);
@@ -3771,10 +3775,14 @@ void GMainWindow::OnToggleAdaptingFilter() {
 
 void GMainWindow::OnToggleGraphicsAPI() {
     auto api = Settings::values.renderer_backend.GetValue();
-    if (api == Settings::RendererBackend::OpenGL) {
+    if (api != Settings::RendererBackend::Vulkan) {
         api = Settings::RendererBackend::Vulkan;
     } else {
+#ifdef HAS_OPENGL
         api = Settings::RendererBackend::OpenGL;
+#else
+        api = Settings::RendererBackend::Null;
+#endif
     }
     Settings::values.renderer_backend.SetValue(api);
     renderer_status_button->setChecked(api == Settings::RendererBackend::Vulkan);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -444,6 +444,7 @@ GMainWindow::GMainWindow(std::unique_ptr<Config> config_, bool has_broken_vulkan
 
         Settings::values.renderer_backend = Settings::RendererBackend::OpenGL;
 
+        UpdateAPIText();
         renderer_status_button->setDisabled(true);
         renderer_status_button->setChecked(false);
     } else {


### PR DESCRIPTION
The VSync combobox wouldn't populate if there was no Vulkan device, which caused issues with trying to set VSync on other backends.

This also adds another layer to GetCurrentGraphicsBackend to check for broken Vulkan and return OpenGL instead of Vulkan.

Closes #11445