### PR TITLE
[audio] Fix data source version 1 command looping

### DIFF
--- a/src/audio_core/renderer/command/data_source/adpcm.cpp
+++ b/src/audio_core/renderer/command/data_source/adpcm.cpp
@@ -20,6 +20,12 @@ void AdpcmDataSourceVersion1Command::Process(const AudioRenderer::CommandListPro
     auto out_buffer{processor.mix_buffers.subspan(output_index * processor.sample_count,
                                                   processor.sample_count)};
 
+    for (auto& wave_buffer : wave_buffers) {
+        wave_buffer.loop_start_offset = wave_buffer.start_offset;
+        wave_buffer.loop_end_offset = wave_buffer.end_offset;
+        wave_buffer.loop_count = wave_buffer.loop ? -1 : 0;
+    }
+
     DecodeFromWaveBuffersArgs args{
         .sample_format{SampleFormat::Adpcm},
         .output{out_buffer},

--- a/src/audio_core/renderer/command/data_source/pcm_float.cpp
+++ b/src/audio_core/renderer/command/data_source/pcm_float.cpp
@@ -21,6 +21,12 @@ void PcmFloatDataSourceVersion1Command::Process(
     auto out_buffer = processor.mix_buffers.subspan(output_index * processor.sample_count,
                                                     processor.sample_count);
 
+    for (auto& wave_buffer : wave_buffers) {
+        wave_buffer.loop_start_offset = wave_buffer.start_offset;
+        wave_buffer.loop_end_offset = wave_buffer.end_offset;
+        wave_buffer.loop_count = wave_buffer.loop ? -1 : 0;
+    }
+
     DecodeFromWaveBuffersArgs args{
         .sample_format{SampleFormat::PcmFloat},
         .output{out_buffer},

--- a/src/audio_core/renderer/command/data_source/pcm_int16.cpp
+++ b/src/audio_core/renderer/command/data_source/pcm_int16.cpp
@@ -23,6 +23,12 @@ void PcmInt16DataSourceVersion1Command::Process(
     auto out_buffer = processor.mix_buffers.subspan(output_index * processor.sample_count,
                                                     processor.sample_count);
 
+    for (auto& wave_buffer : wave_buffers) {
+        wave_buffer.loop_start_offset = wave_buffer.start_offset;
+        wave_buffer.loop_end_offset = wave_buffer.end_offset;
+        wave_buffer.loop_count = wave_buffer.loop ? -1 : 0;
+    }
+
     DecodeFromWaveBuffersArgs args{
         .sample_format{SampleFormat::PcmInt16},
         .output{out_buffer},


### PR DESCRIPTION
After a small change I made in #11428 to decode, audio was cutting out in XC2, and causing some issues in other games as well. 

After a bunch of investigation, I found an issue with version 1 of data source commands trying to loop. Version 2 of the data source commands added more looping control, and the decode function was updated to use them. Instead of splitting the decode function into an old and new for both version, instead they just passed the v2 struct, and the v1 commands initialise v2 wavebuffers using the v1 data.

I was not considering this properly, and wasn't correctly considering the new members when creating the v2 struct. This PR properly initialises those members which fixes v1 commands looping.

Closes #11462.