### PR TITLE
android: Add option to bundle validation layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ option(YUZU_TESTS "Compile tests" "${BUILD_TESTING}")
 
 option(YUZU_USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 
+option(YUZU_DOWNLOAD_ANDROID_VVL "Download validation layer binary for android" ON)
+
 CMAKE_DEPENDENT_OPTION(YUZU_ROOM "Compile LDN room server" ON "NOT ANDROID" OFF)
 
 CMAKE_DEPENDENT_OPTION(YUZU_CRASH_DUMPS "Compile Windows crash dump (Minidump) support" OFF "WIN32" OFF)
@@ -76,6 +78,24 @@ if (ANDROID OR WIN32 OR APPLE)
     set(DEFAULT_ENABLE_OPENSSL OFF)
 endif()
 option(ENABLE_OPENSSL "Enable OpenSSL backend for ISslConnection" ${DEFAULT_ENABLE_OPENSSL})
+
+if (ANDROID AND YUZU_DOWNLOAD_ANDROID_VVL)
+    set(vvl_version "sdk-1.3.261.1")
+    set(vvl_zip_file "${CMAKE_BINARY_DIR}/externals/vvl-android.zip")
+    if (NOT EXISTS "${vvl_zip_file}")
+        # Download and extract validation layer release to externals directory
+        set(vvl_base_url "https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases/download")
+        file(DOWNLOAD "${vvl_base_url}/${vvl_version}/android-binaries-${vvl_version}-android.zip"
+            "${vvl_zip_file}" SHOW_PROGRESS)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${vvl_zip_file}"
+                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/externals")
+    endif()
+
+    # Copy the arm64 binary to src/android/app/main/jniLibs
+    set(vvl_lib_path "${CMAKE_CURRENT_SOURCE_DIR}/src/android/app/src/main/jniLibs/arm64-v8a/")
+    file(COPY "${CMAKE_BINARY_DIR}/externals/android-binaries-${vvl_version}/arm64-v8a/libVkLayer_khronos_validation.so"
+            DESTINATION "${vvl_lib_path}")
+endif()
 
 # On Android, fetch and compile libcxx before doing anything else
 if (ANDROID)

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -35,8 +35,6 @@ class GPU;
 
 namespace Vulkan {
 
-using DebugCallback = std::variant<vk::DebugUtilsMessenger, vk::DebugReportCallback>;
-
 Device CreateDevice(const vk::Instance& instance, const vk::InstanceDispatch& dld,
                     VkSurfaceKHR surface);
 
@@ -75,7 +73,7 @@ private:
     vk::InstanceDispatch dld;
 
     vk::Instance instance;
-    DebugCallback debug_callback;
+    vk::DebugUtilsMessenger debug_messenger;
     vk::SurfaceKHR surface;
 
     ScreenInfo screen_info;

--- a/src/video_core/vulkan_common/vulkan_debug_callback.cpp
+++ b/src/video_core/vulkan_common/vulkan_debug_callback.cpp
@@ -63,22 +63,6 @@ VkBool32 DebugUtilCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
     return VK_FALSE;
 }
 
-VkBool32 DebugReportCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType,
-                             uint64_t object, size_t location, int32_t messageCode,
-                             const char* pLayerPrefix, const char* pMessage, void* pUserData) {
-    const VkDebugReportFlagBitsEXT severity = static_cast<VkDebugReportFlagBitsEXT>(flags);
-    const std::string_view message{pMessage};
-    if (severity & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
-        LOG_CRITICAL(Render_Vulkan, "{}", message);
-    } else if (severity & VK_DEBUG_REPORT_WARNING_BIT_EXT) {
-        LOG_WARNING(Render_Vulkan, "{}", message);
-    } else if (severity & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) {
-        LOG_INFO(Render_Vulkan, "{}", message);
-    } else if (severity & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
-        LOG_DEBUG(Render_Vulkan, "{}", message);
-    }
-    return VK_FALSE;
-}
 } // Anonymous namespace
 
 vk::DebugUtilsMessenger CreateDebugUtilsCallback(const vk::Instance& instance) {
@@ -94,17 +78,6 @@ vk::DebugUtilsMessenger CreateDebugUtilsCallback(const vk::Instance& instance) {
                        VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
                        VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT,
         .pfnUserCallback = DebugUtilCallback,
-        .pUserData = nullptr,
-    });
-}
-
-vk::DebugReportCallback CreateDebugReportCallback(const vk::Instance& instance) {
-    return instance.CreateDebugReportCallback({
-        .sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
-        .pNext = nullptr,
-        .flags = VK_DEBUG_REPORT_DEBUG_BIT_EXT | VK_DEBUG_REPORT_INFORMATION_BIT_EXT |
-                 VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT,
-        .pfnCallback = DebugReportCallback,
         .pUserData = nullptr,
     });
 }

--- a/src/video_core/vulkan_common/vulkan_debug_callback.h
+++ b/src/video_core/vulkan_common/vulkan_debug_callback.h
@@ -9,6 +9,4 @@ namespace Vulkan {
 
 vk::DebugUtilsMessenger CreateDebugUtilsCallback(const vk::Instance& instance);
 
-vk::DebugReportCallback CreateDebugReportCallback(const vk::Instance& instance);
-
 } // namespace Vulkan

--- a/src/video_core/vulkan_common/vulkan_instance.cpp
+++ b/src/video_core/vulkan_common/vulkan_instance.cpp
@@ -76,11 +76,9 @@ namespace {
         extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
     }
 #endif
-    if (enable_validation) {
-        const bool debug_utils =
-            AreExtensionsSupported(dld, std::array{VK_EXT_DEBUG_UTILS_EXTENSION_NAME});
-        extensions.push_back(debug_utils ? VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-                                         : VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+    if (enable_validation &&
+        AreExtensionsSupported(dld, std::array{VK_EXT_DEBUG_UTILS_EXTENSION_NAME})) {
+        extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     }
     return extensions;
 }


### PR DESCRIPTION
The graphics debugging option on android is currently not very useful as validation layers are not available to the android app. So this PR adds a cmake option to automatically download the validation layers android binary from the vvl github and copy it to jniLibs directory.

In addition I've removed support for VK_EXT_debug_report as newer versions of vvl implement VK_EXT_debug_utils. I have tested it on my Samsung Note 9 and validation works as expected.