### PR TITLE
vk_buffer_cache: Respect max vertex bindings in BindVertexBuffers

### DIFF
--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -529,17 +529,20 @@ void BufferCacheRuntime::BindVertexBuffers(VideoCommon::HostBindings<Buffer>& bi
         buffer_handles.push_back(handle);
     }
     if (device.IsExtExtendedDynamicStateSupported()) {
-        scheduler.Record([bindings_ = std::move(bindings),
+        scheduler.Record([this, bindings_ = std::move(bindings),
                           buffer_handles_ = std::move(buffer_handles)](vk::CommandBuffer cmdbuf) {
             cmdbuf.BindVertexBuffers2EXT(bindings_.min_index,
-                                         bindings_.max_index - bindings_.min_index,
+                                         std::min(bindings_.max_index - bindings_.min_index,
+                                                  device.GetMaxVertexInputBindings()),
                                          buffer_handles_.data(), bindings_.offsets.data(),
                                          bindings_.sizes.data(), bindings_.strides.data());
         });
     } else {
-        scheduler.Record([bindings_ = std::move(bindings),
+        scheduler.Record([this, bindings_ = std::move(bindings),
                           buffer_handles_ = std::move(buffer_handles)](vk::CommandBuffer cmdbuf) {
-            cmdbuf.BindVertexBuffers(bindings_.min_index, bindings_.max_index - bindings_.min_index,
+            cmdbuf.BindVertexBuffers(bindings_.min_index,
+                                     std::min(bindings_.max_index - bindings_.min_index,
+                                              device.GetMaxVertexInputBindings()),
                                      buffer_handles_.data(), bindings_.offsets.data());
         });
     }


### PR DESCRIPTION
https://github.com/yuzu-emu/yuzu/pull/10668 added a new path for binding vertex buffers, but without the fix of https://github.com/yuzu-emu/yuzu/pull/6688 which causes crashing in all games with older Bifrost Mali GPUs as these do not expose 32 vertex bindings (only 16). Applying this fix here as well allows games to boot as they did before.