### PR TITLE
cmake: include externals before qt/sdl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,8 @@ if(ENABLE_QT6 AND Qt6_LOCATION)
     list(APPEND CMAKE_PREFIX_PATH "${Qt6_LOCATION}")
 endif()
 
+add_subdirectory(externals)
+
 function(set_yuzu_qt_components)
     # Best practice is to ask for all components at once, so they are from the same version
     set(YUZU_QT_COMPONENTS2 Core Widgets Concurrent)
@@ -689,7 +691,6 @@ if (YUZU_USE_FASTER_LD AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-add_subdirectory(externals)
 add_subdirectory(src)
 
 # Set yuzu project or yuzu-cmd project as default StartUp Project in Visual Studio depending on whether QT is enabled or not


### PR DESCRIPTION
My system version of Qt6 is configured with Vulkan support and looks for the target Vulkan::Headers when included, which it will be able to find the system package for. But we want to use the newest version of Vulkan Headers from externals, and without changing the order of when externals are included, I get this:
```
CMake Error at externals/vcpkg/scripts/buildsystems/vcpkg.cmake:633 (_add_library):
  _add_library cannot create ALIAS target "Vulkan::Headers" because another
  target with the same name already exists.
Call Stack (most recent call first):
  externals/Vulkan-Headers/CMakeLists.txt:47 (add_library)
```