### PR TITLE
Create shortcuts on Windows

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -538,6 +538,13 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     QAction* start_game = context_menu.addAction(tr("Start Game"));
     QAction* start_game_global =
         context_menu.addAction(tr("Start Game without Custom Configuration"));
+    QAction* create_desktop_shortcut = context_menu.addAction(tr("Create Shortcut"));
+#ifndef WIN32
+    QMenu* shortcut_menu = context_menu.addMenu(tr("Create Shortcut"));
+    QAction* create_desktop_shortcut = shortcut_menu->addAction(tr("Add to Desktop"));
+    QAction* create_applications_menu_shortcut =
+        shortcut_menu->addAction(tr("Add to Applications Menu"));
+#endif
     context_menu.addSeparator();
     QAction* open_save_location = context_menu.addAction(tr("Open Save Data Location"));
     QAction* open_mod_location = context_menu.addAction(tr("Open Mod Data Location"));
@@ -560,12 +567,6 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     QAction* verify_integrity = context_menu.addAction(tr("Verify Integrity"));
     QAction* copy_tid = context_menu.addAction(tr("Copy Title ID to Clipboard"));
     QAction* navigate_to_gamedb_entry = context_menu.addAction(tr("Navigate to GameDB entry"));
-#ifndef WIN32
-    QMenu* shortcut_menu = context_menu.addMenu(tr("Create Shortcut"));
-    QAction* create_desktop_shortcut = shortcut_menu->addAction(tr("Add to Desktop"));
-    QAction* create_applications_menu_shortcut =
-        shortcut_menu->addAction(tr("Add to Applications Menu"));
-#endif
     context_menu.addSeparator();
     QAction* properties = context_menu.addAction(tr("Properties"));
 
@@ -636,10 +637,10 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     connect(navigate_to_gamedb_entry, &QAction::triggered, [this, program_id]() {
         emit NavigateToGamedbEntryRequested(program_id, compatibility_list);
     });
-#ifndef WIN32
     connect(create_desktop_shortcut, &QAction::triggered, [this, program_id, path]() {
         emit CreateShortcut(program_id, path, GameListShortcutTarget::Desktop);
     });
+#ifndef WIN32
     connect(create_applications_menu_shortcut, &QAction::triggered, [this, program_id, path]() {
         emit CreateShortcut(program_id, path, GameListShortcutTarget::Applications);
     });

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -404,7 +404,7 @@ private:
     void ConfigureFilesystemProvider(const std::string& filepath);
 
     QString GetTasStateDescription() const;
-    bool CreateShortcut(const std::string& shortcut_path, const std::string& title,
+    bool CreateShortcut(const std::wstring& shortcut_path, const std::string& title,
                         const std::string& comment, const std::string& icon_path,
                         const std::string& command, const std::string& arguments,
                         const std::string& categories, const std::string& keywords);


### PR DESCRIPTION
Add the ability to create a shortcut in Windows.
Use ffmpeg to convert PNG to ICO, however you need to include ffmpeg.exe in the yuzu directory, or find another solution to convert.
![print](https://github.com/yuzu-emu/yuzu/assets/28203966/0aa1941c-450d-4342-b988-5d2b2923d798)
