### PR TITLE
android: Return the correct status code on emulation stop

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -327,12 +327,13 @@ public:
             m_system.ShutdownMainProcess();
             m_detached_tasks.WaitForAllTasks();
             m_load_result = Core::SystemResultStatus::ErrorNotInitialized;
+            m_window.reset();
+            OnEmulationStopped(Core::SystemResultStatus::Success);
+            return;
         }
 
         // Tear down the render window.
         m_window.reset();
-
-        OnEmulationStopped(m_load_result);
     }
 
     void PauseEmulation() {


### PR DESCRIPTION
When trying to avoid closing the emulation activity if there was a message that needed to be displayed (Ex. Invalid ROM), I accidentally prevented the emulation activity from getting the right message by running the OnEmulationStopped callback after the `m_load_result` state was reset. This behavior is corrected now.