### PR TITLE
android: Remove settings interface specifically for audio mute

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
@@ -308,21 +308,6 @@ object NativeLibrary {
     external fun isPaused(): Boolean
 
     /**
-     * Mutes emulation sound
-     */
-    external fun muteAudio(): Boolean
-
-    /**
-     * Unmutes emulation sound
-     */
-    external fun unmuteAudio(): Boolean
-
-    /**
-     * Returns true if emulation audio is muted.
-     */
-    external fun isMuted(): Boolean
-
-    /**
      * Returns the performance stats for the current game
      */
     external fun getPerfStats(): DoubleArray

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
@@ -332,7 +332,7 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
             pictureInPictureActions.add(pauseRemoteAction)
         }
 
-        if (NativeLibrary.isMuted()) {
+        if (BooleanSetting.AUDIO_MUTED.boolean) {
             val unmuteIcon = Icon.createWithResource(
                 this@EmulationActivity,
                 R.drawable.ic_pip_unmute
@@ -389,9 +389,9 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
                 if (!NativeLibrary.isPaused()) NativeLibrary.pauseEmulation()
             }
             if (intent.action == actionUnmute) {
-                if (NativeLibrary.isMuted()) NativeLibrary.unmuteAudio()
+                if (BooleanSetting.AUDIO_MUTED.boolean) BooleanSetting.AUDIO_MUTED.setBoolean(false)
             } else if (intent.action == actionMute) {
-                if (!NativeLibrary.isMuted()) NativeLibrary.muteAudio()
+                if (!BooleanSetting.AUDIO_MUTED.boolean) BooleanSetting.AUDIO_MUTED.setBoolean(true)
             }
             buildPictureInPictureParams()
         }
@@ -417,7 +417,7 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
             } catch (ignored: Exception) {
             }
             // Always resume audio, since there is no UI button
-            if (NativeLibrary.isMuted()) NativeLibrary.unmuteAudio()
+            if (BooleanSetting.AUDIO_MUTED.boolean) BooleanSetting.AUDIO_MUTED.setBoolean(false)
         }
     }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/BooleanSetting.kt
@@ -10,6 +10,7 @@ enum class BooleanSetting(
     override val category: Settings.Category,
     override val androidDefault: Boolean? = null
 ) : AbstractBooleanSetting {
+    AUDIO_MUTED("audio_muted", Settings.Category.Audio),
     CPU_DEBUG_MODE("cpu_debug_mode", Settings.Category.Cpu),
     FASTMEM("cpuopt_fastmem", Settings.Category.Cpu),
     FASTMEM_EXCLUSIVES("cpuopt_fastmem_exclusives", Settings.Category.Cpu),

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -670,18 +670,6 @@ jboolean Java_org_yuzu_yuzu_1emu_NativeLibrary_isPaused(JNIEnv* env, jclass claz
     return static_cast<jboolean>(EmulationSession::GetInstance().IsPaused());
 }
 
-void Java_org_yuzu_yuzu_1emu_NativeLibrary_muteAduio(JNIEnv* env, jclass clazz) {
-    Settings::values.audio_muted = true;
-}
-
-void Java_org_yuzu_yuzu_1emu_NativeLibrary_unmuteAudio(JNIEnv* env, jclass clazz) {
-    Settings::values.audio_muted = false;
-}
-
-jboolean Java_org_yuzu_yuzu_1emu_NativeLibrary_isMuted(JNIEnv* env, jclass clazz) {
-    return static_cast<jboolean>(Settings::values.audio_muted.GetValue());
-}
-
 jboolean Java_org_yuzu_yuzu_1emu_NativeLibrary_isHandheldOnly(JNIEnv* env, jclass clazz) {
     return EmulationSession::GetInstance().IsHandheldOnly();
 }


### PR DESCRIPTION
Now just use the new settings interface provided by NativeConfig