### PR TITLE
service: hid: Implement last active Npad and fix some errors.

### DIFF
--- a/src/core/hid/hid_core.cpp
+++ b/src/core/hid/hid_core.cpp
@@ -154,6 +154,14 @@ NpadIdType HIDCore::GetFirstDisconnectedNpadId() const {
     return NpadIdType::Player1;
 }
 
+void HIDCore::SetLastActiveController(NpadIdType npad_id) {
+    last_active_controller = npad_id;
+}
+
+NpadIdType HIDCore::GetLastActiveController() const {
+    return last_active_controller;
+}
+
 void HIDCore::EnableAllControllerConfiguration() {
     player_1->EnableConfiguration();
     player_2->EnableConfiguration();

--- a/src/core/hid/hid_core.h
+++ b/src/core/hid/hid_core.h
@@ -48,6 +48,12 @@ public:
     /// Returns the first disconnected npad id
     NpadIdType GetFirstDisconnectedNpadId() const;
 
+    /// Sets the npad id of the last active controller
+    void SetLastActiveController(NpadIdType npad_id);
+
+    /// Returns the npad id of the last controller that pushed a button
+    NpadIdType GetLastActiveController() const;
+
     /// Sets all emulated controllers into configuring mode.
     void EnableAllControllerConfiguration();
 
@@ -77,6 +83,7 @@ private:
     std::unique_ptr<EmulatedConsole> console;
     std::unique_ptr<EmulatedDevices> devices;
     NpadStyleTag supported_style_tag{NpadStyleSet::All};
+    NpadIdType last_active_controller{NpadIdType::Handheld};
 };
 
 } // namespace Core::HID

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -476,6 +476,10 @@ void Controller_NPad::RequestPadStateUpdate(Core::HID::NpadIdType npad_id) {
         pad_entry.npad_buttons.l.Assign(button_state.zl);
         pad_entry.npad_buttons.r.Assign(button_state.zr);
     }
+
+    if (pad_entry.npad_buttons.raw != Core::HID::NpadButton::None) {
+        hid_core.SetLastActiveController(npad_id);
+    }
 }
 
 void Controller_NPad::OnUpdate(const Core::Timing::CoreTiming& core_timing) {

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -193,7 +193,7 @@ void Controller_NPad::InitNewlyAddedController(Core::HID::NpadIdType npad_id) {
         shared_memory->system_properties.use_minus.Assign(1);
         shared_memory->system_properties.is_charging_joy_dual.Assign(
             battery_level.dual.is_charging);
-        shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::SwitchProController;
+        shared_memory->applet_footer_type = AppletFooterUiType::SwitchProController;
         shared_memory->sixaxis_fullkey_properties.is_newly_assigned.Assign(1);
         break;
     case Core::HID::NpadStyleIndex::Handheld:
@@ -216,8 +216,7 @@ void Controller_NPad::InitNewlyAddedController(Core::HID::NpadIdType npad_id) {
         shared_memory->system_properties.is_charging_joy_right.Assign(
             battery_level.right.is_charging);
         shared_memory->assignment_mode = NpadJoyAssignmentMode::Dual;
-        shared_memory->applet_nfc_xcd.applet_footer.type =
-            AppletFooterUiType::HandheldJoyConLeftJoyConRight;
+        shared_memory->applet_footer_type = AppletFooterUiType::HandheldJoyConLeftJoyConRight;
         shared_memory->sixaxis_handheld_properties.is_newly_assigned.Assign(1);
         break;
     case Core::HID::NpadStyleIndex::JoyconDual:
@@ -247,19 +246,19 @@ void Controller_NPad::InitNewlyAddedController(Core::HID::NpadIdType npad_id) {
         shared_memory->assignment_mode = NpadJoyAssignmentMode::Dual;
 
         if (controller.is_dual_left_connected && controller.is_dual_right_connected) {
-            shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::JoyDual;
+            shared_memory->applet_footer_type = AppletFooterUiType::JoyDual;
             shared_memory->fullkey_color.fullkey = body_colors.left;
             shared_memory->battery_level_dual = battery_level.left.battery_level;
             shared_memory->system_properties.is_charging_joy_dual.Assign(
                 battery_level.left.is_charging);
         } else if (controller.is_dual_left_connected) {
-            shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::JoyDualLeftOnly;
+            shared_memory->applet_footer_type = AppletFooterUiType::JoyDualLeftOnly;
             shared_memory->fullkey_color.fullkey = body_colors.left;
             shared_memory->battery_level_dual = battery_level.left.battery_level;
             shared_memory->system_properties.is_charging_joy_dual.Assign(
                 battery_level.left.is_charging);
         } else {
-            shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::JoyDualRightOnly;
+            shared_memory->applet_footer_type = AppletFooterUiType::JoyDualRightOnly;
             shared_memory->fullkey_color.fullkey = body_colors.right;
             shared_memory->battery_level_dual = battery_level.right.battery_level;
             shared_memory->system_properties.is_charging_joy_dual.Assign(
@@ -278,7 +277,7 @@ void Controller_NPad::InitNewlyAddedController(Core::HID::NpadIdType npad_id) {
         shared_memory->system_properties.use_minus.Assign(1);
         shared_memory->system_properties.is_charging_joy_left.Assign(
             battery_level.left.is_charging);
-        shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::JoyLeftHorizontal;
+        shared_memory->applet_footer_type = AppletFooterUiType::JoyLeftHorizontal;
         shared_memory->sixaxis_left_properties.is_newly_assigned.Assign(1);
         break;
     case Core::HID::NpadStyleIndex::JoyconRight:
@@ -293,7 +292,7 @@ void Controller_NPad::InitNewlyAddedController(Core::HID::NpadIdType npad_id) {
         shared_memory->system_properties.use_plus.Assign(1);
         shared_memory->system_properties.is_charging_joy_right.Assign(
             battery_level.right.is_charging);
-        shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::JoyRightHorizontal;
+        shared_memory->applet_footer_type = AppletFooterUiType::JoyRightHorizontal;
         shared_memory->sixaxis_right_properties.is_newly_assigned.Assign(1);
         break;
     case Core::HID::NpadStyleIndex::GameCube:
@@ -314,12 +313,12 @@ void Controller_NPad::InitNewlyAddedController(Core::HID::NpadIdType npad_id) {
     case Core::HID::NpadStyleIndex::SNES:
         shared_memory->style_tag.lucia.Assign(1);
         shared_memory->device_type.fullkey.Assign(1);
-        shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::Lucia;
+        shared_memory->applet_footer_type = AppletFooterUiType::Lucia;
         break;
     case Core::HID::NpadStyleIndex::N64:
         shared_memory->style_tag.lagoon.Assign(1);
         shared_memory->device_type.fullkey.Assign(1);
-        shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::Lagon;
+        shared_memory->applet_footer_type = AppletFooterUiType::Lagon;
         break;
     case Core::HID::NpadStyleIndex::SegaGenesis:
         shared_memory->style_tag.lager.Assign(1);
@@ -1120,7 +1119,7 @@ Result Controller_NPad::DisconnectNpad(Core::HID::NpadIdType npad_id) {
         .left = {},
         .right = {},
     };
-    shared_memory->applet_nfc_xcd.applet_footer.type = AppletFooterUiType::None;
+    shared_memory->applet_footer_type = AppletFooterUiType::None;
 
     controller.is_dual_left_connected = true;
     controller.is_dual_right_connected = true;

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -360,7 +360,7 @@ private:
     enum class AppletFooterUiType : u8 {
         None = 0,
         HandheldNone = 1,
-        HandheldJoyConLeftOnly = 1,
+        HandheldJoyConLeftOnly = 2,
         HandheldJoyConRightOnly = 3,
         HandheldJoyConLeftJoyConRight = 4,
         JoyDual = 5,
@@ -381,13 +381,6 @@ private:
         Verification = 20,
         Lagon = 21,
     };
-
-    struct AppletFooterUi {
-        AppletFooterUiAttributes attributes{};
-        AppletFooterUiType type{AppletFooterUiType::None};
-        INSERT_PADDING_BYTES(0x5B); // Reserved
-    };
-    static_assert(sizeof(AppletFooterUi) == 0x60, "AppletFooterUi is an invalid size");
 
     // This is nn::hid::NpadLarkType
     enum class NpadLarkType : u32 {
@@ -419,13 +412,6 @@ private:
         U,
     };
 
-    struct AppletNfcXcd {
-        union {
-            AppletFooterUi applet_footer{};
-            Lifo<NfcXcdDeviceHandleStateImpl, 0x2> nfc_xcd_device_lifo;
-        };
-    };
-
     // This is nn::hid::detail::NpadInternalState
     struct NpadInternalState {
         Core::HID::NpadStyleTag style_tag{Core::HID::NpadStyleSet::None};
@@ -452,7 +438,9 @@ private:
         Core::HID::NpadBatteryLevel battery_level_dual{};
         Core::HID::NpadBatteryLevel battery_level_left{};
         Core::HID::NpadBatteryLevel battery_level_right{};
-        AppletNfcXcd applet_nfc_xcd{};
+        AppletFooterUiAttributes applet_footer_attributes{};
+        AppletFooterUiType applet_footer_type{AppletFooterUiType::None};
+        INSERT_PADDING_BYTES(0x5B); // Reserved
         INSERT_PADDING_BYTES(0x20); // Unknown
         Lifo<NpadGcTriggerState, hid_entry_count> gc_trigger_lifo{};
         NpadLarkType lark_type_l_and_main{};

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -2768,7 +2768,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
-        rb.PushEnum(Core::HID::NpadIdType::Handheld);
+        rb.PushEnum(system.HIDCore().GetLastActiveController());
     }
 
     void GetUniquePadsFromNpad(HLERequestContext& ctx) {


### PR DESCRIPTION
Implement get last active Npad since the stub was causing issues with controllers not being detected. Removes deprecated field from the Npad struct since this will never be used anymore. And lastly we had a nasty bug where the controller could be connected but not supported. So double check both the emulated and the service are connected if not try to fix it.