### PR TITLE
service: hid: Implement ApplyNpadSystemCommonPolicy

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -1508,6 +1508,31 @@ Core::HID::NpadButton Controller_NPad::GetAndResetPressState() {
     return static_cast<Core::HID::NpadButton>(press_state.exchange(0));
 }
 
+void Controller_NPad::ApplyNpadSystemCommonPolicy() {
+    Core::HID::NpadStyleTag styletag{};
+    styletag.fullkey.Assign(1);
+    styletag.handheld.Assign(1);
+    styletag.joycon_dual.Assign(1);
+    styletag.system_ext.Assign(1);
+    styletag.system.Assign(1);
+    SetSupportedStyleSet(styletag);
+
+    SetNpadHandheldActivationMode(NpadHandheldActivationMode::Dual);
+
+    supported_npad_id_types.clear();
+    supported_npad_id_types.resize(10);
+    supported_npad_id_types[0] = Core::HID::NpadIdType::Player1;
+    supported_npad_id_types[1] = Core::HID::NpadIdType::Player2;
+    supported_npad_id_types[2] = Core::HID::NpadIdType::Player3;
+    supported_npad_id_types[3] = Core::HID::NpadIdType::Player4;
+    supported_npad_id_types[4] = Core::HID::NpadIdType::Player5;
+    supported_npad_id_types[5] = Core::HID::NpadIdType::Player6;
+    supported_npad_id_types[6] = Core::HID::NpadIdType::Player7;
+    supported_npad_id_types[7] = Core::HID::NpadIdType::Player8;
+    supported_npad_id_types[8] = Core::HID::NpadIdType::Other;
+    supported_npad_id_types[9] = Core::HID::NpadIdType::Handheld;
+}
+
 bool Controller_NPad::IsControllerSupported(Core::HID::NpadStyleIndex controller) const {
     if (controller == Core::HID::NpadStyleIndex::Handheld) {
         const bool support_handheld =

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -190,6 +190,8 @@ public:
     // Specifically for cheat engine and other features.
     Core::HID::NpadButton GetAndResetPressState();
 
+    void ApplyNpadSystemCommonPolicy();
+
     static bool IsNpadIdValid(Core::HID::NpadIdType npad_id);
     static Result IsDeviceHandleValid(const Core::HID::VibrationDeviceHandle& device_handle);
     static Result VerifyValidSixAxisSensorHandle(

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -95,7 +95,7 @@ private:
 
 class Hid final : public ServiceFramework<Hid> {
 public:
-    explicit Hid(Core::System& system_);
+    explicit Hid(Core::System& system_, std::shared_ptr<IAppletResource> applet_resource_);
     ~Hid() override;
 
     std::shared_ptr<IAppletResource> GetAppletResource();


### PR DESCRIPTION
AppletResource should be actually shared between hid services. Someone put `// We already do this for homebrew so we can just stub it out` well this is a lie so in this PR we actually implement this function.