### PR TITLE
Do not consider voice commands in time estimation, fix adpcm estimate

### DIFF
--- a/src/audio_core/renderer/command/command_processing_time_estimator.cpp
+++ b/src/audio_core/renderer/command/command_processing_time_estimator.cpp
@@ -27,12 +27,12 @@ u32 CommandProcessingTimeEstimatorVersion1::Estimate(
 
 u32 CommandProcessingTimeEstimatorVersion1::Estimate(
     const AdpcmDataSourceVersion1Command& command) const {
-    return static_cast<u32>(command.pitch * 0.25f * 1.2f);
+    return static_cast<u32>(command.pitch * 0.46f * 1.2f);
 }
 
 u32 CommandProcessingTimeEstimatorVersion1::Estimate(
     const AdpcmDataSourceVersion2Command& command) const {
-    return static_cast<u32>(command.pitch * 0.25f * 1.2f);
+    return static_cast<u32>(command.pitch * 0.46f * 1.2f);
 }
 
 u32 CommandProcessingTimeEstimatorVersion1::Estimate(


### PR DESCRIPTION
Fixes a bug with time estimation and the dropping of voices. In New Super Marios Bros U's final level, the music can randomly cut out, which happens due to the music getting dropped when the command buffer goes over its time estimate with too many commands. NSMBU has a specific case where it runs into situations needing to drop *some* voices, but not drop so many that it gets to the music track.

The starting point for time estimation is meant to begin after voice generation rather than before, so all voice commands aren't counted, which results in a smaller estimation, and fewer commands need to be dropped to fit into the time limit. Also a small fix to the ADPCM estimate from a bad copy/paste. That file is a nightmare.