### PR TITLE
Check that the Extent3D TileShift only operates on a 3D ASTC Texture …

### DIFF
--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -68,6 +68,7 @@ struct LevelInfo {
     Extent2D tile_size;
     u32 bpp_log2;
     u32 tile_width_spacing;
+    u32 num_levels;
 };
 
 [[nodiscard]] constexpr u32 AdjustTileSize(u32 shift, u32 unit_factor, u32 dimension) {
@@ -166,7 +167,7 @@ template <u32 GOB_EXTENT>
 }
 
 [[nodiscard]] constexpr Extent3D TileShift(const LevelInfo& info, u32 level) {
-    if (level == 0) {
+    if (level == 0 && info.num_levels == 1) {
         return Extent3D{
             .width = info.block.width,
             .height = info.block.height,
@@ -1294,9 +1295,9 @@ u32 MapSizeBytes(const ImageBase& image) {
 
 static_assert(CalculateLevelSize(LevelInfo{{1920, 1080, 1}, {0, 2, 0}, {1, 1}, 2, 0}, 0) ==
               0x7f8000);
-static_assert(CalculateLevelSize(LevelInfo{{32, 32, 1}, {0, 0, 4}, {1, 1}, 4, 0}, 0) == 0x40000);
+static_assert(CalculateLevelSize(LevelInfo{{32, 32, 1}, {0, 0, 4}, {1, 1}, 4, 0, 1}, 0) == 0x40000);
 
-static_assert(CalculateLevelSize(LevelInfo{{128, 8, 1}, {0, 4, 0}, {1, 1}, 4, 0}, 0) == 0x40000);
+static_assert(CalculateLevelSize(LevelInfo{{128, 8, 1}, {0, 4, 0}, {1, 1}, 4, 0, 1}, 0) == 0x40000);
 
 static_assert(CalculateLevelOffset(PixelFormat::R8_SINT, {1920, 1080, 1}, {0, 2, 0}, 0, 7) ==
               0x2afc00);

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -68,7 +68,7 @@ struct LevelInfo {
     Extent2D tile_size;
     u32 bpp_log2;
     u32 tile_width_spacing;
-    u32 num_levels;
+    s32 num_levels;
 };
 
 [[nodiscard]] constexpr u32 AdjustTileSize(u32 shift, u32 unit_factor, u32 dimension) {
@@ -258,7 +258,7 @@ template <u32 GOB_EXTENT>
 }
 
 [[nodiscard]] constexpr LevelInfo MakeLevelInfo(PixelFormat format, Extent3D size, Extent3D block,
-                                                u32 tile_width_spacing) {
+                                                u32 tile_width_spacing, const ImageInfo& info) {
     const u32 bytes_per_block = BytesPerBlock(format);
     return {
         .size =
@@ -271,16 +271,18 @@ template <u32 GOB_EXTENT>
         .tile_size = DefaultBlockSize(format),
         .bpp_log2 = BytesPerBlockLog2(bytes_per_block),
         .tile_width_spacing = tile_width_spacing,
+        .num_levels = info.resources.levels,
     };
 }
 
 [[nodiscard]] constexpr LevelInfo MakeLevelInfo(const ImageInfo& info) {
-    return MakeLevelInfo(info.format, info.size, info.block, info.tile_width_spacing);
+    return MakeLevelInfo(info.format, info.size, info.block, info.tile_width_spacing, info);
 }
 
 [[nodiscard]] constexpr u32 CalculateLevelOffset(PixelFormat format, Extent3D size, Extent3D block,
                                                  u32 tile_width_spacing, u32 level) {
-    const LevelInfo info = MakeLevelInfo(format, size, block, tile_width_spacing);
+    ImageInfo image_info{/* initialize fields here */};
+    const LevelInfo info = MakeLevelInfo(format, size, block, tile_width_spacing, image_info);
     u32 offset = 0;
     for (u32 current_level = 0; current_level < level; ++current_level) {
         offset += CalculateLevelSize(info, current_level);

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -68,7 +68,7 @@ struct LevelInfo {
     Extent2D tile_size;
     u32 bpp_log2;
     u32 tile_width_spacing;
-    s32 num_levels;
+    u32 num_levels;
 };
 
 [[nodiscard]] constexpr u32 AdjustTileSize(u32 shift, u32 unit_factor, u32 dimension) {
@@ -258,7 +258,7 @@ template <u32 GOB_EXTENT>
 }
 
 [[nodiscard]] constexpr LevelInfo MakeLevelInfo(PixelFormat format, Extent3D size, Extent3D block,
-                                                u32 tile_width_spacing, const ImageInfo& info) {
+                                                u32 tile_width_spacing, u32 num_levels) {
     const u32 bytes_per_block = BytesPerBlock(format);
     return {
         .size =
@@ -271,18 +271,18 @@ template <u32 GOB_EXTENT>
         .tile_size = DefaultBlockSize(format),
         .bpp_log2 = BytesPerBlockLog2(bytes_per_block),
         .tile_width_spacing = tile_width_spacing,
-        .num_levels = info.resources.levels,
+        .num_levels = num_levels,
     };
 }
 
 [[nodiscard]] constexpr LevelInfo MakeLevelInfo(const ImageInfo& info) {
-    return MakeLevelInfo(info.format, info.size, info.block, info.tile_width_spacing, info);
+    return MakeLevelInfo(info.format, info.size, info.block, info.tile_width_spacing,
+                         info.resources.levels);
 }
 
 [[nodiscard]] constexpr u32 CalculateLevelOffset(PixelFormat format, Extent3D size, Extent3D block,
                                                  u32 tile_width_spacing, u32 level) {
-    ImageInfo image_info{/* initialize fields here */};
-    const LevelInfo info = MakeLevelInfo(format, size, block, tile_width_spacing, image_info);
+    const LevelInfo info = MakeLevelInfo(format, size, block, tile_width_spacing, level);
     u32 offset = 0;
     for (u32 current_level = 0; current_level < level; ++current_level) {
         offset += CalculateLevelSize(info, current_level);

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -1293,7 +1293,7 @@ u32 MapSizeBytes(const ImageBase& image) {
     }
 }
 
-static_assert(CalculateLevelSize(LevelInfo{{1920, 1080, 1}, {0, 2, 0}, {1, 1}, 2, 0}, 0) ==
+static_assert(CalculateLevelSize(LevelInfo{{1920, 1080, 1}, {0, 2, 0}, {1, 1}, 2, 0, 1}, 0) ==
               0x7f8000);
 static_assert(CalculateLevelSize(LevelInfo{{32, 32, 1}, {0, 0, 4}, {1, 1}, 4, 0, 1}, 0) == 0x40000);
 


### PR DESCRIPTION
…by checking Mip count is 1.

It appears that previously the Extent3D Tileshift could apply to Mip 0 of 2D Textures in some cases, this is responsible for breaking Asterix and Obelix, ~~the Recall animation in TOTK(at scaled res)~~ and an older version of the Tanslation pack for Tsukihime -A Piece of Blue Glass Moon.

I'm open to someone with a better explanation for why these changes fix things, while not regressing TOTKs gloom.

Fixes #11252, #10456 