### PR TITLE
Allow GPUs without rebar to open multiple RenderDoc captures

### DIFF
--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
@@ -90,6 +90,9 @@ private:
     void ReleaseCache(MemoryUsage usage);
 
     void ReleaseLevel(StagingBuffersCache& cache, size_t log2);
+    size_t Region(size_t iter) const noexcept {
+        return iter / region_size;
+    }
 
     const Device& device;
     MemoryAllocator& memory_allocator;
@@ -97,6 +100,8 @@ private:
 
     vk::Buffer stream_buffer;
     std::span<u8> stream_pointer;
+    VkDeviceSize stream_buffer_size;
+    VkDeviceSize region_size;
 
     size_t iterator = 0;
     size_t used_iterator = 0;


### PR DESCRIPTION
As in the comments, GPUs without rebar support have a very limited host/device heap size, which gets very full in a frame. This prevents RenderDoc from being able to open 2 captures at the same time, since if 200/256MB of the heap is full in a capture, opening a second then fails as the region is out of memory. RenderDoc cannot migrate or move allocations to other heaps, they have to be where they were originally. This PR removes non-stream allocations from the shared heap, and also limits the size of the stream buffer to 40% of max, so 2 can be opened.

Also removes HOST_ACCESS flags from our DeviceLocal allocations, as we always call copy functions on device local memory, so there's no need to try and allocate them into host visible regions. May give a performance increase.