### PR TITLE
pfs: Fix reading filenames past the buffer end

### DIFF
--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -47,6 +47,7 @@ PartitionFilesystem::PartitionFilesystem(VirtualFile file) {
     // Actually read in now...
     std::vector<u8> file_data = file->ReadBytes(metadata_size);
     const std::size_t total_size = file_data.size();
+    file_data.push_back(0);
 
     if (total_size != metadata_size) {
         status = Loader::ResultStatus::ErrorIncorrectPFSFileSize;


### PR DESCRIPTION
Can't say it applies to many games but in my case `Luigi's Mansion 3` couldn't load and instead caused Yuzu to segfault randomly. The log says:
```
[   0.446392] Service.FS <Warning> core/file_sys/submission_package.cpp:ReadNCAs:245: NCA with ID 0fe8c30f50fa8d12c9b9b85045fe6473.nca is listed in content metadata, but cannot be found in PFS. NSP appears to be corrupted.
[   0.446601] Loader <Debug> core/loader/loader.cpp:GetLoader:265: Loading file Luigis Mansion 3 [0100DCA0064A6000][v0] (6.35 GB).nsp as NSP...
[   0.446647] Crypto <Debug> core/crypto/key_manager.cpp:AddTicket:1366: Skipping parsing title key from ticket for known rights ID 080000000000000000604A06A0DC0001.
[   0.446811] Service.FS <Warning> core/file_sys/submission_package.cpp:ReadNCAs:245: NCA with ID 0fe8c30f50fa8d12c9b9b85045fe6473.nca is listed in content metadata, but cannot be found in PFS. NSP appears to be corrupted.
[   0.446918] Crypto <Debug> core/crypto/key_manager.cpp:AddTicket:1366: Skipping parsing title key from ticket for known rights ID 080000000000000000604A06A0DC0001.
[   0.447073] Service.FS <Warning> core/file_sys/submission_package.cpp:ReadNCAs:245: NCA with ID 0fe8c30f50fa8d12c9b9b85045fe6473.nca is listed in content metadata, but cannot be found in PFS. NSP appears to be corrupted.
[   0.447302] Crypto <Debug> core/crypto/key_manager.cpp:AddTicket:1366: Skipping parsing title key from ticket for known rights ID 080000000000000000604A06A0DC0001.
[   0.447456] Service.FS <Warning> core/file_sys/submission_package.cpp:ReadNCAs:245: NCA with ID 0fe8c30f50fa8d12c9b9b85045fe6473.nca is listed in content metadata, but cannot be found in PFS. NSP appears to be corrupted.
[   0.447657] Crypto <Debug> core/crypto/key_manager.cpp:AddTicket:1366: Skipping parsing title key from ticket for known rights ID 080000000000000000604A06A0DC0001.
[   0.447817] Service.FS <Warning> core/file_sys/submission_package.cpp:ReadNCAs:245: NCA with ID 0fe8c30f50fa8d12c9b9b85045fe6473.nca is listed in content metadata, but cannot be found in PFS. NSP appears to be corrupted.
[   0.448018] Loader <Debug> core/loader/loader.cpp:GetLoader:265: Loading file Luigis Mansion 3 [0100DCA0064A6000][v0] (6.35 GB).nsp as NSP...
[   0.448061] Crypto <Debug> core/crypto/key_manager.cpp:AddTicket:1366: Skipping parsing title key from ticket for known rights ID 080000000000000000604A06A0DC0001.
[   0.448225] Service.FS <Warning> core/file_sys/submission_package.cpp:ReadNCAs:245: NCA with ID 0fe8c30f50fa8d12c9b9b85045fe6473.nca is listed in content metadata, but cannot be found in PFS. NSP appears to be corrupted.
```
But apparently the file was there because *sometimes* it worked. Since this one file couldn't be found it caused the `second_loader` variable in `nsp.cpp` not to be initialized and the program eventually crashed because it was null.

Further investigation revealed that the file name had a random garbage suffix when Yuzu segfaulted and looked fine when it worked okay. This garbage prevented the file from being found in the other parts of the code. Apparently this particular file name is located at the very end of the header and if the memory after the `std::vector<u8> file_data` contains random non-zero data, `std::string name(reinterpret_cast<const char*>(&file_data[strtab_offset + entry.strtab_offset]));` reads too much. But if it's all zero the name reads just fine. Adding that zero to the vector explicitly fixes the bug and Yuzu no longer randomly crashes on game launch.