### PR TITLE
Revoke https://github.com/yuzu-emu/yuzu/pull/10433 as a temp solution to fix OLD texture error

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,9 @@
 name: 'yuzu verify'
 
 on:
+  push:
+    branches: [master]
+    tags: ["*"]
   pull_request:
     branches: [ master ]
 env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,9 +4,6 @@
 name: 'yuzu verify'
 
 on:
-  push:
-    branches: [master]
-    tags: ["*"]
   pull_request:
     branches: [ master ]
 env:

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -122,9 +122,7 @@ template <u32 GOB_EXTENT>
     return {
         .width = AdjustMipBlockSize<GOB_SIZE_X>(num_tiles.width, block_size.width, level),
         .height = AdjustMipBlockSize<GOB_SIZE_Y>(num_tiles.height, block_size.height, level),
-        .depth = level == 0
-                     ? block_size.depth
-                     : AdjustMipBlockSize<GOB_SIZE_Z>(num_tiles.depth, block_size.depth, level),
+        .depth = AdjustMipBlockSize<GOB_SIZE_Z>(num_tiles.depth, block_size.depth, level),
     };
 }
 
@@ -166,13 +164,6 @@ template <u32 GOB_EXTENT>
 }
 
 [[nodiscard]] constexpr Extent3D TileShift(const LevelInfo& info, u32 level) {
-    if (level == 0) {
-        return Extent3D{
-            .width = info.block.width,
-            .height = info.block.height,
-            .depth = info.block.depth,
-        };
-    }
     const Extent3D blocks = NumLevelBlocks(info, level);
     return Extent3D{
         .width = AdjustTileSize(info.block.width, GOB_SIZE_X, blocks.width),
@@ -1294,9 +1285,7 @@ u32 MapSizeBytes(const ImageBase& image) {
 
 static_assert(CalculateLevelSize(LevelInfo{{1920, 1080, 1}, {0, 2, 0}, {1, 1}, 2, 0}, 0) ==
               0x7f8000);
-static_assert(CalculateLevelSize(LevelInfo{{32, 32, 1}, {0, 0, 4}, {1, 1}, 4, 0}, 0) == 0x40000);
-
-static_assert(CalculateLevelSize(LevelInfo{{128, 8, 1}, {0, 4, 0}, {1, 1}, 4, 0}, 0) == 0x40000);
+static_assert(CalculateLevelSize(LevelInfo{{32, 32, 1}, {0, 0, 4}, {1, 1}, 4, 0}, 0) == 0x4000);
 
 static_assert(CalculateLevelOffset(PixelFormat::R8_SINT, {1920, 1080, 1}, {0, 2, 0}, 0, 7) ==
               0x2afc00);


### PR DESCRIPTION
Revoke https://github.com/yuzu-emu/yuzu/pull/10433 as a temp solution to fix OLD texture error in multiple games, especially for Android player who start to play ns games after yuzu for Android released since old versions before mainline 1441 don't have the same issue.

This is ONLY a TEMP solution to fix those issues and I will close this pull request AT ONCE there is a solution found to solve the problem.

Just for those eager players.

Fixed https://github.com/yuzu-emu/yuzu/issues/10456 (tested) and maybe so on. Find artifacts in Actions or my fork.