### PR TITLE
Revert "android: Allow save imports always"

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/ImportExportSavesFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/ImportExportSavesFragment.kt
@@ -65,20 +65,25 @@ class ImportExportSavesFragment : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val builder = MaterialAlertDialogBuilder(requireContext())
-            .setTitle(R.string.manage_save_data)
-            .setPositiveButton(R.string.import_saves) { _, _ ->
-                documentPicker.launch(arrayOf("application/zip"))
-            }
-            .setNeutralButton(android.R.string.cancel, null)
-
-        if (savesFolderRoot != "") {
-            builder.setNegativeButton(R.string.export_saves) { _, _ ->
-                exportSave()
-            }
+        return if (savesFolderRoot == "") {
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.manage_save_data)
+                .setMessage(R.string.import_export_saves_no_profile)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
+        } else {
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.manage_save_data)
+                .setMessage(R.string.manage_save_data_description)
+                .setNegativeButton(R.string.export_saves) { _, _ ->
+                    exportSave()
+                }
+                .setPositiveButton(R.string.import_saves) { _, _ ->
+                    documentPicker.launch(arrayOf("application/zip"))
+                }
+                .setNeutralButton(android.R.string.cancel, null)
+                .show()
         }
-
-        return builder.show()
     }
 
     /**

--- a/src/android/app/src/main/res/values-de/strings.xml
+++ b/src/android/app/src/main/res/values-de/strings.xml
@@ -77,7 +77,9 @@
     <string name="notification_no_directory_link">yuzu-Verzeichnis konnte nicht geöffnet werden</string>
     <string name="notification_no_directory_link_description">Bitte suche den Benutzerordner manuell über die Seitenleiste des Dateimanagers.</string>
     <string name="manage_save_data">Speicherdaten verwalten</string>
+    <string name="manage_save_data_description">Speicherdaten gefunden. Bitte wähle unten eine Option aus.</string>
     <string name="import_export_saves_description">Speicherdaten importieren oder exportieren</string>
+    <string name="import_export_saves_no_profile">Keine Speicherdaten gefunden. Bitte starte ein Spiel und versuche es erneut.</string>
     <string name="save_file_imported_success">Erfolgreich importiert</string>
     <string name="save_file_invalid_zip_structure">Ungültige Speicherverzeichnisstruktur</string>
     <string name="save_file_invalid_zip_structure_description">Der erste Unterordnername muss die Titel-ID des Spiels sein.</string>

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">No se pudo abrir la carpeta yuzu</string>
     <string name="notification_no_directory_link_description">Por favor, busque la carpeta user con el panel lateral del explorador de archivos de forma manual.</string>
     <string name="manage_save_data">Administrar datos de guardado</string>
+    <string name="manage_save_data_description">Guardar los datos encontrados. Por favor, seleccione una opción de abajo.</string>
     <string name="import_export_saves_description">Importar o exportar archivos de guardado</string>
+    <string name="import_export_saves_no_profile">No se han encontrado datos de guardado. Por favor, ejecute un juego y vuelva a intentarlo.</string>
     <string name="save_file_imported_success">Importado correctamente</string>
     <string name="save_file_invalid_zip_structure">Estructura del directorio de guardado no válido</string>
     <string name="save_file_invalid_zip_structure_description">El nombre de la primera subcarpeta debe ser el Title ID del juego.</string>

--- a/src/android/app/src/main/res/values-fr/strings.xml
+++ b/src/android/app/src/main/res/values-fr/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">Impossible d\'ouvrir le répertoire de yuzu</string>
     <string name="notification_no_directory_link_description">Veuillez localiser manuellement le dossier utilisateur avec le panneau latéral du gestionnaire de fichiers.</string>
     <string name="manage_save_data">Gérer les données de sauvegarde</string>
+    <string name="manage_save_data_description">Données de sauvegarde trouvées. Veuillez sélectionner une option ci-dessous.</string>
     <string name="import_export_saves_description">Importer ou exporter des fichiers de sauvegarde</string>
+    <string name="import_export_saves_no_profile">Aucune données de sauvegarde trouvées. Veuillez lancer un jeu et réessayer.</string>
     <string name="save_file_imported_success">Importé avec succès</string>
     <string name="save_file_invalid_zip_structure">Structure de répertoire de sauvegarde non valide</string>
     <string name="save_file_invalid_zip_structure_description">Le nom du premier sous-dossier doit être l\'identifiant du titre du jeu.</string>

--- a/src/android/app/src/main/res/values-it/strings.xml
+++ b/src/android/app/src/main/res/values-it/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">Impossibile aprire la cartella di yuzu</string>
     <string name="notification_no_directory_link_description">Per favore individua la cartella dell\'utente manualmente con il pannello laterale del file manager.</string>
     <string name="manage_save_data">Gestisci i salvataggi</string>
+    <string name="manage_save_data_description">Salvataggio non trovato. Seleziona un\'opzione di seguito.</string>
     <string name="import_export_saves_description">Importa o esporta i salvataggi</string>
+    <string name="import_export_saves_no_profile">Nessun salvataggio trovato. Avvia un gioco e riprova.</string>
     <string name="save_file_imported_success">Importato con successo</string>
     <string name="save_file_invalid_zip_structure">La struttura della cartella dei salvataggi è invalida</string>
     <string name="save_file_invalid_zip_structure_description">La prima sotto cartella <b>deve</b> chiamarsi come l\'ID del titolo del gioco.</string>

--- a/src/android/app/src/main/res/values-ja/strings.xml
+++ b/src/android/app/src/main/res/values-ja/strings.xml
@@ -78,7 +78,9 @@
     <string name="notification_no_directory_link">yuzuのディレクトリを開けません</string>
     <string name="notification_no_directory_link_description">ファイルマネージャのサイドパネルでユーザーフォルダを手動で探してください。</string>
     <string name="manage_save_data">セーブデータを管理</string>
+    <string name="manage_save_data_description">セーブデータが見つかりました。以下のオプションから選択してください。</string>
     <string name="import_export_saves_description">セーブファイルをインポート/エクスポート</string>
+    <string name="import_export_saves_no_profile">セーブデータがありません。ゲームを起動してから再度お試しください。</string>
     <string name="save_file_imported_success">インポートが完了しました</string>
     <string name="save_file_invalid_zip_structure">セーブデータのディレクトリ構造が無効です</string>
     <string name="save_file_invalid_zip_structure_description">最初のサブフォルダ名は、ゲームのタイトルIDである必要があります。</string>

--- a/src/android/app/src/main/res/values-ko/strings.xml
+++ b/src/android/app/src/main/res/values-ko/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">yuzu 디렉토리를 열 수 없음</string>
     <string name="notification_no_directory_link_description">파일 관리자의 사이드 패널에서 사용자 폴더를 수동으로 찾아주세요.</string>
     <string name="manage_save_data">저장 데이터 관리</string>
+    <string name="manage_save_data_description">데이터를 저장했습니다. 아래에서 옵션을 선택하세요.</string>
     <string name="import_export_saves_description">저장 파일 가져오기 또는 내보내기</string>
+    <string name="import_export_saves_no_profile">저장 데이터를 찾을 수 없습니다. 게임을 실행한 후 다시 시도하세요.</string>
     <string name="save_file_imported_success">가져오기 성공</string>
     <string name="save_file_invalid_zip_structure">저장 디렉터리 구조가 잘못됨</string>
     <string name="save_file_invalid_zip_structure_description">첫 번째 하위 폴더 이름은 게임의 타이틀 ID여야 합니다.</string>

--- a/src/android/app/src/main/res/values-nb/strings.xml
+++ b/src/android/app/src/main/res/values-nb/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">Kunne ikke åpne yuzu-katalogen</string>
     <string name="notification_no_directory_link_description">Finn brukermappen manuelt med filbehandlingens sidepanel.</string>
     <string name="manage_save_data">Administrere lagringsdata</string>
+    <string name="manage_save_data_description">Lagringsdata funnet. Velg et alternativ nedenfor.</string>
     <string name="import_export_saves_description">Importer eller eksporter lagringsfiler</string>
+    <string name="import_export_saves_no_profile">Ingen lagringsdata funnet. Start et nytt spill og prøv på nytt.</string>
     <string name="save_file_imported_success">Vellykket import</string>
     <string name="save_file_invalid_zip_structure">Ugyldig struktur for lagringskatalog</string>
     <string name="save_file_invalid_zip_structure_description">Det første undermappenavnet må være spillets tittel-ID.</string>

--- a/src/android/app/src/main/res/values-pl/strings.xml
+++ b/src/android/app/src/main/res/values-pl/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">Nie można otworzyć folderu emulatora</string>
     <string name="notification_no_directory_link_description">Proszę wybrać ręcznie folder z pomocą panelu bocznego menedżera plików.</string>
     <string name="manage_save_data">Zarządzaj plikami zapisów gier</string>
+    <string name="manage_save_data_description">Znaleziono pliki zapisów gier. Wybierz opcję poniżej.</string>
     <string name="import_export_saves_description">Importuj lub wyeksportuj pliki zapisów</string>
+    <string name="import_export_saves_no_profile">Nie znaleziono plików zapisów. Uruchom grę i spróbuj ponownie.</string>
     <string name="save_file_imported_success">Zaimportowano pomyślnie</string>
     <string name="save_file_invalid_zip_structure">Niepoprawna struktura folderów</string>
     <string name="save_file_invalid_zip_structure_description">Pierwszy podkatalog musi zawierać w nazwie numer ID tytułu gry.</string>

--- a/src/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/src/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">Impossível abrir pasta Yuzu</string>
     <string name="notification_no_directory_link_description">Localiza a pasta de utilizador manualmente com o painel lateral do gestor de ficheiros.</string>
     <string name="manage_save_data">Gerir dados guardados</string>
+    <string name="manage_save_data_description">Dados não encontrados. Por favor seleciona uma opção abaixo.</string>
     <string name="import_export_saves_description">Importa ou exporta dados guardados</string>
+    <string name="import_export_saves_no_profile">Dados não encontrados. Por favor lança o jogo e tenta novamente.</string>
     <string name="save_file_imported_success">Importado com sucesso</string>
     <string name="save_file_invalid_zip_structure">Estrutura de diretório de dados invalida</string>
     <string name="save_file_invalid_zip_structure_description">O nome da primeira sub pasta tem de ser a ID do jogo.</string>

--- a/src/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/src/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">Impossível abrir pasta Yuzu</string>
     <string name="notification_no_directory_link_description">Localiza a pasta de utilizador manualmente com o painel lateral do gestor de ficheiros.</string>
     <string name="manage_save_data">Gerir dados guardados</string>
+    <string name="manage_save_data_description">Dados não encontrados. Por favor seleciona uma opção abaixo.</string>
     <string name="import_export_saves_description">Importa ou exporta dados guardados</string>
+    <string name="import_export_saves_no_profile">Dados não encontrados. Por favor lança o jogo e tenta novamente.</string>
     <string name="save_file_imported_success">Importado com sucesso</string>
     <string name="save_file_invalid_zip_structure">Estrutura de diretório de dados invalida</string>
     <string name="save_file_invalid_zip_structure_description">O nome da primeira sub pasta tem de ser a ID do jogo.</string>

--- a/src/android/app/src/main/res/values-ru/strings.xml
+++ b/src/android/app/src/main/res/values-ru/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">Не удалось открыть папку yuzu</string>
     <string name="notification_no_directory_link_description">Пожалуйста, найдите папку пользователя с помощью боковой панели файлового менеджера вручную.</string>
     <string name="manage_save_data">Управление данными сохранений</string>
+    <string name="manage_save_data_description">Найдено данные сохранений. Пожалуйста, выберите вариант ниже.</string>
     <string name="import_export_saves_description">Импорт или экспорт файлов сохранения</string>
+    <string name="import_export_saves_no_profile">Данные сохранений не найдены. Пожалуйста, запустите игру и повторите попытку.</string>
     <string name="save_file_imported_success">Успешно импортировано</string>
     <string name="save_file_invalid_zip_structure">Недопустимая структура папки сохранения</string>
     <string name="save_file_invalid_zip_structure_description">Название первой вложенной папки должно быть идентификатором игры.</string>

--- a/src/android/app/src/main/res/values-uk/strings.xml
+++ b/src/android/app/src/main/res/values-uk/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">Не вдалося відкрити папку yuzu</string>
     <string name="notification_no_directory_link_description">Будь ласка, знайдіть папку користувача за допомогою бічної панелі файлового менеджера вручну.</string>
     <string name="manage_save_data">Керування даними збережень</string>
+    <string name="manage_save_data_description">Знайдено дані збережень. Будь ласка, виберіть варіант нижче.</string>
     <string name="import_export_saves_description">Імпорт або експорт файлів збереження</string>
+    <string name="import_export_saves_no_profile">Дані збережень не знайдено. Будь ласка, запустіть гру та повторіть спробу.</string>
     <string name="save_file_imported_success">Успішно імпортовано</string>
     <string name="save_file_invalid_zip_structure">Неприпустима структура папки збереження</string>
     <string name="save_file_invalid_zip_structure_description">Назва першої вкладеної папки має бути ідентифікатором гри.</string>

--- a/src/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">无法打开 yuzu 文件夹</string>
     <string name="notification_no_directory_link_description">请使用文件管理器的侧部面板手动定位用户文件夹。</string>
     <string name="manage_save_data">管理存档数据</string>
+    <string name="manage_save_data_description">已找到存档数据，请选择下方的选项。</string>
     <string name="import_export_saves_description">导入或导出存档</string>
+    <string name="import_export_saves_no_profile">找不到存档数据，请启动游戏并重试。</string>
     <string name="save_file_imported_success">已成功导入存档</string>
     <string name="save_file_invalid_zip_structure">无效的存档目录</string>
     <string name="save_file_invalid_zip_structure_description">第一个子文件夹名称必须为当前游戏的 ID。</string>

--- a/src/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/src/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -79,7 +79,9 @@
     <string name="notification_no_directory_link">無法開啟 yuzu 目錄</string>
     <string name="notification_no_directory_link_description">請使用檔案管理員的側邊面板手動定位到使用者資料夾。</string>
     <string name="manage_save_data">管理儲存資料</string>
+    <string name="manage_save_data_description">已找到儲存資料，請選取下方的選項。</string>
     <string name="import_export_saves_description">匯入或匯出儲存檔案</string>
+    <string name="import_export_saves_no_profile">找不到儲存資料，請啟動遊戲並重試。</string>
     <string name="save_file_imported_success">已成功匯入</string>
     <string name="save_file_invalid_zip_structure">無效的儲存目錄結構</string>
     <string name="save_file_invalid_zip_structure_description">首個子資料夾名稱必須為遊戲標題 ID。</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -88,7 +88,9 @@
     <string name="notification_no_directory_link">Could not open yuzu directory</string>
     <string name="notification_no_directory_link_description">Please locate the user folder with the file manager\'s side panel manually.</string>
     <string name="manage_save_data">Manage save data</string>
+    <string name="manage_save_data_description">Save data found. Please select an option below.</string>
     <string name="import_export_saves_description">Import or export save files</string>
+    <string name="import_export_saves_no_profile">No save data found. Please launch a game and retry.</string>
     <string name="save_file_imported_success">Imported successfully</string>
     <string name="save_file_invalid_zip_structure">Invalid save directory structure</string>
     <string name="save_file_invalid_zip_structure_description">The first subfolder name must be the title ID of the game.</string>


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#11551 due to an oversight in the user profile folder generation. Will be reintroduced later with a proper solution.