### PR TITLE
renderer_vulkan: Implement MSAA image copies

### DIFF
--- a/src/video_core/host_shaders/convert_msaa_to_non_msaa.comp
+++ b/src/video_core/host_shaders/convert_msaa_to_non_msaa.comp
@@ -15,11 +15,14 @@ void main() {
 
     // TODO: Specialization constants for num_samples?
     const int num_samples = imageSamples(msaa_in);
+    const ivec3 msaa_size = imageSize(msaa_in);
+    const ivec3 out_size = imageSize(output_img);
+    const ivec3 scale = out_size / msaa_size;
     for (int curr_sample = 0; curr_sample < num_samples; ++curr_sample) {
         const vec4 pixel = imageLoad(msaa_in, coords, curr_sample);
 
-        const int single_sample_x = 2 * coords.x + (curr_sample & 1);
-        const int single_sample_y = 2 * coords.y + ((curr_sample / 2) & 1);
+        const int single_sample_x = scale.x * coords.x + (curr_sample & 1);
+        const int single_sample_y = scale.y * coords.y + ((curr_sample / 2) & 1);
         const ivec3 dest_coords = ivec3(single_sample_x, single_sample_y, coords.z);
 
         if (any(greaterThanEqual(dest_coords, imageSize(output_img)))) {

--- a/src/video_core/host_shaders/convert_non_msaa_to_msaa.comp
+++ b/src/video_core/host_shaders/convert_non_msaa_to_msaa.comp
@@ -15,9 +15,12 @@ void main() {
 
     // TODO: Specialization constants for num_samples?
     const int num_samples = imageSamples(output_msaa);
+    const ivec3 msaa_size = imageSize(output_msaa);
+    const ivec3 out_size = imageSize(img_in);
+    const ivec3 scale = out_size / msaa_size;
     for (int curr_sample = 0; curr_sample < num_samples; ++curr_sample) {
-        const int single_sample_x = 2 * coords.x + (curr_sample & 1);
-        const int single_sample_y = 2 * coords.y + ((curr_sample / 2) & 1);
+        const int single_sample_x = scale.x * coords.x + (curr_sample & 1);
+        const int single_sample_y = scale.y * coords.y + ((curr_sample / 2) & 1);
         const ivec3 single_coords = ivec3(single_sample_x, single_sample_y, coords.z);
 
         if (any(greaterThanEqual(single_coords, imageSize(img_in)))) {

--- a/src/video_core/renderer_vulkan/vk_compute_pass.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.h
@@ -11,6 +11,7 @@
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_vulkan/vk_descriptor_pool.h"
 #include "video_core/renderer_vulkan/vk_update_descriptor.h"
+#include "video_core/texture_cache/types.h"
 #include "video_core/vulkan_common/vulkan_memory_allocator.h"
 #include "video_core/vulkan_common/vulkan_wrapper.h"
 
@@ -128,6 +129,24 @@ private:
     StagingBufferPool& staging_buffer_pool;
     ComputePassDescriptorQueue& compute_pass_descriptor_queue;
     MemoryAllocator& memory_allocator;
+};
+
+class MSAACopyPass final : public ComputePass {
+public:
+    explicit MSAACopyPass(const Device& device_, Scheduler& scheduler_,
+                          DescriptorPool& descriptor_pool_, StagingBufferPool& staging_buffer_pool_,
+                          ComputePassDescriptorQueue& compute_pass_descriptor_queue_);
+    ~MSAACopyPass();
+
+    void CopyImage(Image& dst_image, Image& src_image,
+                   std::span<const VideoCommon::ImageCopy> copies, bool msaa_to_non_msaa);
+
+private:
+    Scheduler& scheduler;
+    StagingBufferPool& staging_buffer_pool;
+    ComputePassDescriptorQueue& compute_pass_descriptor_queue;
+    std::array<vk::ShaderModule, 2> modules;
+    std::array<vk::Pipeline, 2> pipelines;
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -117,6 +117,7 @@ public:
     BlitImageHelper& blit_image_helper;
     RenderPassCache& render_pass_cache;
     std::optional<ASTCDecoderPass> astc_decoder_pass;
+    std::unique_ptr<MSAACopyPass> msaa_copy_pass;
     const Settings::ResolutionScalingInfo& resolution;
     std::array<std::vector<VkFormat>, VideoCore::Surface::MaxPixelFormat> view_formats;
 
@@ -161,14 +162,12 @@ public:
         return aspect_mask;
     }
 
-    [[nodiscard]] VkImageView StorageImageView(s32 level) const noexcept {
-        return *storage_image_views[level];
-    }
-
     /// Returns true when the image is already initialized and mark it as initialized
     [[nodiscard]] bool ExchangeInitialization() noexcept {
         return std::exchange(initialized, true);
     }
+
+    VkImageView StorageImageView(s32 level) noexcept;
 
     bool IsRescaled() const noexcept;
 

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -324,6 +324,11 @@ public:
         return features.shader_float16_int8.shaderInt8;
     }
 
+    /// Returns true if the device supports binding multisample images as storage images.
+    bool IsStorageImageMultisampleSupported() const {
+        return features.features.shaderStorageImageMultisample;
+    }
+
     /// Returns true if the device warp size can potentially be bigger than guest's warp size.
     bool IsWarpSizePotentiallyBiggerThanGuest() const {
         return is_warp_potentially_bigger;


### PR DESCRIPTION
Implementation of https://github.com/yuzu-emu/yuzu/pull/9746 for vulkan for the image copy part. I didn't implement uploads because I couldn't find much information about the layout of MSAA images and games I tested do not upload anything meaningful anyway. Fixes graphics in Sonic Forces as mentioned in the PR and also in Mortal Kombat 1

yuzu (master) | yuzu (PR)
-|-
![master](https://github.com/yuzu-emu/yuzu/assets/47210458/d8fc40e9-948e-4d3a-ae32-74f035edd049) | ![pr](https://github.com/yuzu-emu/yuzu/assets/47210458/076c5254-61ed-4f1a-81e7-93c46b99c4af)
