### PR TITLE
renderer_vulkan: Correct component order for A4B4G4R4_UNORM

### DIFF
--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -185,7 +185,7 @@ struct FormatTuple {
     {VK_FORMAT_BC2_SRGB_BLOCK},                                // BC2_SRGB
     {VK_FORMAT_BC3_SRGB_BLOCK},                                // BC3_SRGB
     {VK_FORMAT_BC7_SRGB_BLOCK},                                // BC7_SRGB
-    {VK_FORMAT_R4G4B4A4_UNORM_PACK16},                         // A4B4G4R4_UNORM
+    {VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT},                     // A4B4G4R4_UNORM
     {VK_FORMAT_R4G4_UNORM_PACK8},                              // G4R4_UNORM
     {VK_FORMAT_ASTC_4x4_SRGB_BLOCK},                           // ASTC_2D_4X4_SRGB
     {VK_FORMAT_ASTC_8x8_SRGB_BLOCK},                           // ASTC_2D_8X8_SRGB

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -76,6 +76,11 @@ constexpr std::array VK_FORMAT_R32G32B32_SFLOAT{
     VK_FORMAT_UNDEFINED,
 };
 
+constexpr std::array VK_FORMAT_A4B4G4R4_UNORM_PACK16{
+    VK_FORMAT_R4G4B4A4_UNORM_PACK16,
+    VK_FORMAT_UNDEFINED,
+};
+
 } // namespace Alternatives
 
 enum class NvidiaArchitecture {
@@ -110,6 +115,8 @@ constexpr const VkFormat* GetFormatAlternatives(VkFormat format) {
         return Alternatives::R8G8B8_SSCALED.data();
     case VK_FORMAT_R32G32B32_SFLOAT:
         return Alternatives::VK_FORMAT_R32G32B32_SFLOAT.data();
+    case VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT:
+        return Alternatives::VK_FORMAT_A4B4G4R4_UNORM_PACK16.data();
     default:
         return nullptr;
     }
@@ -238,6 +245,7 @@ std::unordered_map<VkFormat, VkFormatProperties> GetFormatProperties(vk::Physica
         VK_FORMAT_R32_SINT,
         VK_FORMAT_R32_UINT,
         VK_FORMAT_R4G4B4A4_UNORM_PACK16,
+        VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT,
         VK_FORMAT_R4G4_UNORM_PACK8,
         VK_FORMAT_R5G5B5A1_UNORM_PACK16,
         VK_FORMAT_R5G6B5_UNORM_PACK16,

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -45,6 +45,7 @@ VK_DEFINE_HANDLE(VmaAllocator)
     FEATURE(EXT, ExtendedDynamicState, EXTENDED_DYNAMIC_STATE, extended_dynamic_state)             \
     FEATURE(EXT, ExtendedDynamicState2, EXTENDED_DYNAMIC_STATE_2, extended_dynamic_state2)         \
     FEATURE(EXT, ExtendedDynamicState3, EXTENDED_DYNAMIC_STATE_3, extended_dynamic_state3)         \
+    FEATURE(EXT, 4444Formats, 4444_FORMATS, format_a4b4g4r4)                                       \
     FEATURE(EXT, IndexTypeUint8, INDEX_TYPE_UINT8, index_type_uint8)                               \
     FEATURE(EXT, LineRasterization, LINE_RASTERIZATION, line_rasterization)                        \
     FEATURE(EXT, PrimitiveTopologyListRestart, PRIMITIVE_TOPOLOGY_LIST_RESTART,                    \
@@ -97,6 +98,7 @@ VK_DEFINE_HANDLE(VmaAllocator)
     EXTENSION_NAME(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME)                                   \
     EXTENSION_NAME(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME)                                 \
     EXTENSION_NAME(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME)                                 \
+    EXTENSION_NAME(VK_EXT_4444_FORMATS_EXTENSION_NAME)                                             \
     EXTENSION_NAME(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME)                                       \
     EXTENSION_NAME(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)                                             \
     EXTENSION_NAME(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME)                               \
@@ -144,6 +146,7 @@ VK_DEFINE_HANDLE(VmaAllocator)
 #define FOR_EACH_VK_RECOMMENDED_FEATURE(FEATURE_NAME)                                              \
     FEATURE_NAME(custom_border_color, customBorderColors)                                          \
     FEATURE_NAME(extended_dynamic_state, extendedDynamicState)                                     \
+    FEATURE_NAME(format_a4b4g4r4, formatA4B4G4R4)                                                  \
     FEATURE_NAME(index_type_uint8, indexTypeUint8)                                                 \
     FEATURE_NAME(primitive_topology_list_restart, primitiveTopologyListRestart)                    \
     FEATURE_NAME(provoking_vertex, provokingVertexLast)                                            \
@@ -486,6 +489,11 @@ public:
     /// Returns true if the device supports VK_EXT_extended_dynamic_state3.
     bool IsExtExtendedDynamicState3Supported() const {
         return extensions.extended_dynamic_state3;
+    }
+
+    /// Returns true if the device supports VK_EXT_4444_formats.
+    bool IsExt4444FormatsSupported() const {
+        return features.format_a4b4g4r4.formatA4B4G4R4;
     }
 
     /// Returns true if the device supports VK_EXT_extended_dynamic_state3.


### PR DESCRIPTION
Some games use this format for text rendering but because the component order was not correct it would show up all wrong. So instead we use VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT which has the order we want. If that format is not available then it is emulated using a swizzle.

yuzu (master) | yuzu (PR)
-|-
![master](https://github.com/yuzu-emu/yuzu/assets/47210458/b88758d4-303a-4b4e-8853-0c7a5a1dd43d) | ![pr](https://github.com/yuzu-emu/yuzu/assets/47210458/5406e7b1-21f7-4a81-a329-7d3d164a5bc7)

Fixes https://github.com/yuzu-emu/yuzu/issues/11550