### PR TITLE
am: mii_edit: Implement DB operations

### DIFF
--- a/src/core/hle/service/am/applets/applet_mii_edit.h
+++ b/src/core/hle/service/am/applets/applet_mii_edit.h
@@ -11,6 +11,11 @@ namespace Core {
 class System;
 } // namespace Core
 
+namespace Service::Mii {
+struct DatabaseSessionMetadata;
+class MiiManager;
+} // namespace Service::Mii
+
 namespace Service::AM::Applets {
 
 class MiiEdit final : public Applet {
@@ -40,6 +45,8 @@ private:
     MiiEditAppletInputV4 applet_input_v4{};
 
     bool is_complete{false};
+    std::shared_ptr<Mii::MiiManager> manager = nullptr;
+    Mii::DatabaseSessionMetadata metadata{};
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/mii/mii.h
+++ b/src/core/hle/service/mii/mii.h
@@ -3,11 +3,29 @@
 
 #pragma once
 
+#include "core/hle/service/service.h"
+
 namespace Core {
 class System;
 }
 
 namespace Service::Mii {
+class MiiManager;
+
+class MiiDBModule final : public ServiceFramework<MiiDBModule> {
+public:
+    explicit MiiDBModule(Core::System& system_, const char* name_,
+                         std::shared_ptr<MiiManager> mii_manager, bool is_system_);
+    ~MiiDBModule() override;
+
+    std::shared_ptr<MiiManager> GetMiiManager();
+
+private:
+    void GetDatabaseService(HLERequestContext& ctx);
+
+    std::shared_ptr<MiiManager> manager = nullptr;
+    bool is_system{};
+};
 
 void LoopProcess(Core::System& system);
 

--- a/src/core/hle/service/mii/mii_manager.cpp
+++ b/src/core/hle/service/mii/mii_manager.cpp
@@ -130,11 +130,11 @@ Result MiiManager::GetIndex(const DatabaseSessionMetadata& metadata, const CharI
     }
 
     s32 index{};
-    Result result = {};
-    // FindIndex(index);
+    const bool is_special = metadata.magic == MiiMagic;
+    const auto result = database_manager.FindIndex(index, char_info.GetCreateId(), is_special);
 
     if (result.IsError()) {
-        return ResultNotFound;
+        index = -1;
     }
 
     if (index == -1) {

--- a/src/core/hle/service/mii/types/char_info.cpp
+++ b/src/core/hle/service/mii/types/char_info.cpp
@@ -37,7 +37,7 @@ void CharInfo::SetFromStoreData(const StoreData& store_data) {
     eyebrow_aspect = store_data.GetEyebrowAspect();
     eyebrow_rotate = store_data.GetEyebrowRotate();
     eyebrow_x = store_data.GetEyebrowX();
-    eyebrow_y = store_data.GetEyebrowY() + 3;
+    eyebrow_y = store_data.GetEyebrowY();
     nose_type = store_data.GetNoseType();
     nose_scale = store_data.GetNoseScale();
     nose_y = store_data.GetNoseY();

--- a/src/core/hle/service/mii/types/core_data.cpp
+++ b/src/core/hle/service/mii/types/core_data.cpp
@@ -171,7 +171,7 @@ void CoreData::BuildRandom(Age age, Gender gender, Race race) {
     u8 glasses_type{};
     while (glasses_type_start < glasses_type_info.values[glasses_type]) {
         if (++glasses_type >= glasses_type_info.values_count) {
-            ASSERT(false);
+            glasses_type = 0;
             break;
         }
     }
@@ -179,6 +179,7 @@ void CoreData::BuildRandom(Age age, Gender gender, Race race) {
     SetGlassType(static_cast<GlassType>(glasses_type));
     SetGlassColor(RawData::GetGlassColorFromVer3(0));
     SetGlassScale(4);
+    SetGlassY(static_cast<u8>(axis_y + 10));
 
     SetMoleType(MoleType::None);
     SetMoleScale(4);

--- a/src/core/hle/service/mii/types/raw_data.cpp
+++ b/src/core/hle/service/mii/types/raw_data.cpp
@@ -1716,18 +1716,18 @@ const std::array<RandomMiiData4, 18> RandomMiiMouthType{
 const std::array<RandomMiiData2, 3> RandomMiiGlassType{
     RandomMiiData2{
         .arg_1 = 0,
-        .values_count = 9,
-        .values = {90, 94, 96, 100, 0, 0, 0, 0, 0},
+        .values_count = 4,
+        .values = {90, 94, 96, 100},
     },
     RandomMiiData2{
         .arg_1 = 1,
-        .values_count = 9,
-        .values = {83, 86, 90, 93, 94, 96, 98, 100, 0},
+        .values_count = 8,
+        .values = {83, 86, 90, 93, 94, 96, 98, 100},
     },
     RandomMiiData2{
         .arg_1 = 2,
-        .values_count = 9,
-        .values = {78, 83, 0, 93, 0, 0, 98, 100, 0},
+        .values_count = 8,
+        .values = {78, 83, 0, 93, 0, 0, 98, 100},
     },
 };
 


### PR DESCRIPTION
Allows our HLE implementation of mii edit to create mii. This PR also fixes random mii generation, makes the mii manager shared across sessions as well implements GetIndex which somehow wasn't implemented by previous PR.

With this change creating a mii from any game won't result in any crash. Instead it will automatically generate a random mii.

Fixes: #3587

![01006a800016e000_2023-09-21_10-52-35-326](https://github.com/yuzu-emu/yuzu/assets/5944268/3c92fa63-cb95-48cc-a5ab-a53bc9b1d01c)
