### PR TITLE
emit_spirv: fix incorrect use of descriptor index in image atomics

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -74,11 +74,6 @@ spv::ImageFormat GetImageFormat(ImageFormat format) {
     throw InvalidArgument("Invalid image format {}", format);
 }
 
-spv::ImageFormat GetImageFormatForBuffer(ImageFormat format) {
-    const auto spv_format = GetImageFormat(format);
-    return spv_format == spv::ImageFormat::Unknown ? spv::ImageFormat::R32ui : spv_format;
-}
-
 Id ImageType(EmitContext& ctx, const ImageDescriptor& desc) {
     const spv::ImageFormat format{GetImageFormat(desc.format)};
     const Id type{ctx.U32[1]};
@@ -1275,7 +1270,7 @@ void EmitContext::DefineImageBuffers(const Info& info, u32& binding) {
         if (desc.count != 1) {
             throw NotImplementedException("Array of image buffers");
         }
-        const spv::ImageFormat format{GetImageFormatForBuffer(desc.format)};
+        const spv::ImageFormat format{GetImageFormat(desc.format)};
         const Id image_type{TypeImage(U32[1], spv::Dim::Buffer, false, false, false, 2, format)};
         const Id pointer_type{TypePointer(spv::StorageClass::UniformConstant, image_type)};
         const Id id{AddGlobalVariable(pointer_type, spv::StorageClass::UniformConstant)};


### PR DESCRIPTION
Fixes #11559

The root cause of the problem in #11436 was performing atomic operations on a typeless image. However, given the constraints of how atomic operations are compiled, it is literally impossible for a typeless atomic to be emitted, and I did not pay close enough attention to that.

After debugging _why_ that happened, I found that this is just a bug where the SPIR-V code for atomics uses the _array layer of the image_ instead of the numeric value of the correct descriptor...

I fixed it and removed the previous workaround that sets typeless image buffers to R32UI (which is actually wrong because they may occur without atomics -- so they are supposed to be typeless in that case).

Fixes lighting in Pikmin 4.
Fixes #11487
Fixes https://github.com/yuzu-emu/yuzu/issues/11125.
Fixes https://github.com/yuzu-emu/yuzu/issues/10986.