### PR TITLE
Revert "host_memory: Allocate virtual_base with MAP_NORESERVE"

### DIFF
--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -414,7 +414,15 @@ public:
                 throw std::bad_alloc{};
             }
         }
-#else
+#elif defined(ANDROID)
+        virtual_base = static_cast<u8*>(mmap(nullptr, virtual_size, PROT_NONE,
+                                             MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0));
+        if (virtual_base == MAP_FAILED) {
+            LOG_CRITICAL(HW_Memory, "mmap failed: {}", strerror(errno));
+            throw std::bad_alloc{};
+        }
+        madvise(virtual_base, virtual_size, MADV_HUGEPAGE);
+#else 
         virtual_base = static_cast<u8*>(mmap(nullptr, virtual_size, PROT_NONE,
                                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
         if (virtual_base == MAP_FAILED) {

--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -416,7 +416,7 @@ public:
         }
 #else
         virtual_base = static_cast<u8*>(mmap(nullptr, virtual_size, PROT_NONE,
-                                             MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0));
+                                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
         if (virtual_base == MAP_FAILED) {
             LOG_CRITICAL(HW_Memory, "mmap failed: {}", strerror(errno));
             throw std::bad_alloc{};


### PR DESCRIPTION
Prevents VK_ERROR_OUT_OF_DEVICE_MEMORY error when memory is full on AMD GPUs.

Fixes  #11132.
