### PR TITLE
android: Adjust valid user data check

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
@@ -664,7 +664,8 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 checkStream.use { stream ->
                     var ze: ZipEntry? = null
                     while (stream.nextEntry?.also { ze = it } != null) {
-                        if (ze!!.name.trim() == "/config/config.ini") {
+                        val itemName = ze!!.name.trim()
+                        if (itemName == "/config/config.ini" || itemName == "config/config.ini") {
                             isYuzuBackup = true
                             return@use
                         }


### PR DESCRIPTION
If you wanted to manually back up your user data from an older version and then import it into a newer version, sometimes it would fail because of how your compression tool would create the zip file.