### PR TITLE
android: Use measured size of view for input overlay bounds

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/overlay/InputOverlay.kt
@@ -352,7 +352,7 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
     }
 
     private fun addOverlayControls(layout: String) {
-        val windowSize = getSafeScreenSize(context)
+        val windowSize = getSafeScreenSize(context, Pair(measuredWidth, measuredHeight))
         if (preferences.getBoolean(Settings.PREF_BUTTON_A, true)) {
             overlayButtons.add(
                 initializeOverlayButton(
@@ -593,7 +593,7 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
     }
 
     private fun saveControlPosition(prefId: String, x: Int, y: Int, layout: String) {
-        val windowSize = getSafeScreenSize(context)
+        val windowSize = getSafeScreenSize(context, Pair(measuredWidth, measuredHeight))
         val min = windowSize.first
         val max = windowSize.second
         PreferenceManager.getDefaultSharedPreferences(YuzuApplication.appContext).edit()
@@ -968,14 +968,17 @@ class InputOverlay(context: Context, attrs: AttributeSet?) :
          * @return A pair of points, the first being the top left corner of the safe area,
          *                  the second being the bottom right corner of the safe area
          */
-        private fun getSafeScreenSize(context: Context): Pair<Point, Point> {
+        private fun getSafeScreenSize(
+            context: Context,
+            screenSize: Pair<Int, Int>
+        ): Pair<Point, Point> {
             // Get screen size
             val windowMetrics = WindowMetricsCalculator.getOrCreate()
                 .computeCurrentWindowMetrics(context as Activity)
-            var maxY = windowMetrics.bounds.height().toFloat()
-            var maxX = windowMetrics.bounds.width().toFloat()
-            var minY = 0
+            var maxX = screenSize.first.toFloat()
+            var maxY = screenSize.second.toFloat()
             var minX = 0
+            var minY = 0
 
             // If we have API access, calculate the safe area to draw the overlay
             var cutoutLeft = 0


### PR DESCRIPTION
Even after updating the androidx window library, this did not fix the issue for all devices. This ensures that the measured size of the overlay will be used instead of a potentially larger one seen by androidx.