### PR TITLE
android: Prevent nav bar shade from laying out across screen

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsActivity.kt
@@ -181,12 +181,14 @@ class SettingsActivity : AppCompatActivity() {
     private fun setInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(
             binding.navigationBarShade
-        ) { view: View, windowInsets: WindowInsetsCompat ->
+        ) { _: View, windowInsets: WindowInsetsCompat ->
             val barInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
 
-            val mlpShade = view.layoutParams as MarginLayoutParams
-            mlpShade.height = barInsets.bottom
-            view.layoutParams = mlpShade
+            // The only situation where we care to have a nav bar shade is when it's at the bottom
+            // of the screen where scrolling list elements can go behind it.
+            val mlpNavShade = binding.navigationBarShade.layoutParams as MarginLayoutParams
+            mlpNavShade.height = barInsets.bottom
+            binding.navigationBarShade.layoutParams = mlpNavShade
 
             windowInsets
         }

--- a/src/android/app/src/main/res/layout/activity_settings.xml
+++ b/src/android/app/src/main/res/layout/activity_settings.xml
@@ -22,7 +22,7 @@
 
     <View
         android:id="@+id/navigation_bar_shade"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="1px"
         android:background="@android:color/transparent"
         android:clickable="false"


### PR DESCRIPTION
Fixes an issue where the settings activity could appear dim while using 3 button navigation and landscape.