### PR TITLE
android: Navigation drawer lock mode fix

### DIFF
--- a/src/android/app/src/main/res/layout/fragment_emulation.xml
+++ b/src/android/app/src/main/res/layout/fragment_emulation.xml
@@ -155,7 +155,7 @@
         android:id="@+id/in_game_menu"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_gravity="start|bottom"
+        android:layout_gravity="start"
         app:headerLayout="@layout/header_in_game"
         app:menu="@menu/menu_in_game"
         tools:visibility="gone" />

--- a/src/android/app/src/main/res/layout/fragment_emulation.xml
+++ b/src/android/app/src/main/res/layout/fragment_emulation.xml
@@ -32,7 +32,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:focusable="false">
+                android:focusable="false"
+                android:clickable="false">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/loading_layout"


### PR DESCRIPTION
Using the "bottom" attribute would break the navigation view and prevent things like rounded corners and lock modes from being applied properly. The attribute was used so that this would force the drawer to be on the bottom half of a foldable display when folded halfway. Since this behavior is broken and I can't test it, I will leave it as is for now.

This also fixes an issue where you could "click" the loading animation card and the ripple animation would appear.