### PR TITLE
settings_setting: Read audio engine

### DIFF
--- a/src/common/settings_setting.h
+++ b/src/common/settings_setting.h
@@ -187,6 +187,8 @@ public:
                 this->SetValue(input == "true");
             } else if constexpr (std::is_same_v<Type, float>) {
                 this->SetValue(std::stof(input));
+            } else if constexpr (std::is_same_v<Type, AudioEngine>) {
+                this->SetValue(ToEnum<AudioEngine>(input));
             } else {
                 this->SetValue(static_cast<Type>(std::stoll(input)));
             }


### PR DESCRIPTION
This was mysteriously missing, likely from when I ported Citra fixes semi-recently.