### PR TITLE
android: Content install lowercase fix

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
@@ -247,7 +247,12 @@ object NativeLibrary {
 
     external fun setAppDirectory(directory: String)
 
-    external fun installFileToNand(filename: String): Int
+    /**
+     * Installs a nsp or xci file to nand
+     * @param filename String representation of file uri
+     * @param extension Lowercase string representation of file extension without "."
+     */
+    external fun installFileToNand(filename: String, extension: String): Int
 
     external fun initializeGpuDriver(
         hookLibDir: String?,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
@@ -515,7 +515,7 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
         if (documents.isNotEmpty()) {
             IndeterminateProgressDialogFragment.newInstance(
                 this@MainActivity,
-                R.string.install_game_content
+                R.string.installing_game_content
             ) {
                 var installSuccess = 0
                 var installOverwrite = 0

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
@@ -523,7 +523,12 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 var errorExtension = 0
                 var errorOther = 0
                 documents.forEach {
-                    when (NativeLibrary.installFileToNand(it.toString())) {
+                    when (
+                        NativeLibrary.installFileToNand(
+                            it.toString(),
+                            FileUtil.getExtension(it)
+                        )
+                    ) {
                         NativeLibrary.InstallFileToNandResult.Success -> {
                             installSuccess += 1
                         }

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -102,7 +102,7 @@ public:
         m_native_window = native_window;
     }
 
-    int InstallFileToNand(std::string filename) {
+    int InstallFileToNand(std::string filename, std::string file_extension) {
         jconst copy_func = [](const FileSys::VirtualFile& src, const FileSys::VirtualFile& dest,
                               std::size_t block_size) {
             if (src == nullptr || dest == nullptr) {
@@ -134,12 +134,12 @@ public:
         m_system.GetFileSystemController().CreateFactories(*m_vfs);
 
         [[maybe_unused]] std::shared_ptr<FileSys::NSP> nsp;
-        if (filename.ends_with("nsp")) {
+        if (file_extension == "nsp") {
             nsp = std::make_shared<FileSys::NSP>(m_vfs->OpenFile(filename, FileSys::Mode::Read));
             if (nsp->IsExtractedType()) {
                 return InstallError;
             }
-        } else if (filename.ends_with("xci")) {
+        } else if (file_extension == "xci") {
             jconst xci =
                 std::make_shared<FileSys::XCI>(m_vfs->OpenFile(filename, FileSys::Mode::Read));
             nsp = xci->GetSecurePartitionNSP();
@@ -607,8 +607,10 @@ void Java_org_yuzu_yuzu_1emu_NativeLibrary_setAppDirectory(JNIEnv* env, jobject 
 }
 
 int Java_org_yuzu_yuzu_1emu_NativeLibrary_installFileToNand(JNIEnv* env, jobject instance,
-                                                            [[maybe_unused]] jstring j_file) {
-    return EmulationSession::GetInstance().InstallFileToNand(GetJString(env, j_file));
+                                                            jstring j_file,
+                                                            jstring j_file_extension) {
+    return EmulationSession::GetInstance().InstallFileToNand(GetJString(env, j_file),
+                                                             GetJString(env, j_file_extension));
 }
 
 void JNICALL Java_org_yuzu_yuzu_1emu_NativeLibrary_initializeGpuDriver(JNIEnv* env, jclass clazz,

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="share_log_missing">No log file found</string>
     <string name="install_game_content">Install game content</string>
     <string name="install_game_content_description">Install game updates or DLC</string>
+    <string name="installing_game_content">Installing content…</string>
     <string name="install_game_content_failure">Error installing file(s) to NAND</string>
     <string name="install_game_content_failure_description">Please ensure content(s) are valid and that the prod.keys file is installed.</string>
     <string name="install_game_content_failure_base">Installation of base games isn\'t permitted in order to avoid possible conflicts.</string>


### PR DESCRIPTION
The C++ side never made the filename lowercase when checking the extension. This just passes the pre-prepared extension to have it checked.
