### PR TITLE
Frontend: Remove ability to install xci files

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -139,10 +139,6 @@ public:
             if (nsp->IsExtractedType()) {
                 return InstallError;
             }
-        } else if (file_extension == "xci") {
-            jconst xci =
-                std::make_shared<FileSys::XCI>(m_vfs->OpenFile(filename, FileSys::Mode::Read));
-            nsp = xci->GetSecurePartitionNSP();
         } else {
             return ErrorFilenameExtension;
         }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3113,10 +3113,9 @@ void GMainWindow::OnMenuInstallToNAND() {
         QFuture<InstallResult> future;
         InstallResult result;
 
-        if (file.endsWith(QStringLiteral("xci"), Qt::CaseInsensitive) ||
-            file.endsWith(QStringLiteral("nsp"), Qt::CaseInsensitive)) {
+        if (file.endsWith(QStringLiteral("nsp"), Qt::CaseInsensitive)) {
 
-            future = QtConcurrent::run([this, &file] { return InstallNSPXCI(file); });
+            future = QtConcurrent::run([this, &file] { return InstallNSP(file); });
 
             while (!future.isFinished()) {
                 QCoreApplication::processEvents();
@@ -3175,7 +3174,7 @@ void GMainWindow::OnMenuInstallToNAND() {
     ui->action_Install_File_NAND->setEnabled(true);
 }
 
-InstallResult GMainWindow::InstallNSPXCI(const QString& filename) {
+InstallResult GMainWindow::InstallNSP(const QString& filename) {
     const auto qt_raw_copy = [this](const FileSys::VirtualFile& src,
                                     const FileSys::VirtualFile& dest, std::size_t block_size) {
         if (src == nullptr || dest == nullptr) {
@@ -3209,9 +3208,7 @@ InstallResult GMainWindow::InstallNSPXCI(const QString& filename) {
             return InstallResult::Failure;
         }
     } else {
-        const auto xci = std::make_shared<FileSys::XCI>(
-            vfs->OpenFile(filename.toStdString(), FileSys::Mode::Read));
-        nsp = xci->GetSecurePartitionNSP();
+        return InstallResult::Failure;
     }
 
     if (nsp->GetStatus() != Loader::ResultStatus::Success) {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -387,7 +387,7 @@ private:
     void RemoveCacheStorage(u64 program_id);
     bool SelectRomFSDumpTarget(const FileSys::ContentProvider&, u64 program_id,
                                u64* selected_title_id, u8* selected_content_record_type);
-    InstallResult InstallNSPXCI(const QString& filename);
+    InstallResult InstallNSP(const QString& filename);
     InstallResult InstallNCA(const QString& filename);
     void MigrateConfigFiles();
     void UpdateWindowTitle(std::string_view title_name = {}, std::string_view title_version = {},


### PR DESCRIPTION
Just talked with @liamwhite about how you can still install these. Figured we should remove the ability to since XCIs are usually application containers and will fail on installation.