### PR TITLE
android: Various play store fixes

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -304,6 +304,10 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
+        if (_binding == null) {
+            return
+        }
+
         updateScreenLayout()
         if (emulationActivity?.isInPictureInPictureMode == true) {
             if (binding.drawerLayout.isOpen) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -310,19 +310,13 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                 binding.drawerLayout.close()
             }
             if (EmulationMenuSettings.showOverlay) {
-                binding.surfaceInputOverlay.post {
-                    binding.surfaceInputOverlay.visibility = View.INVISIBLE
-                }
+                binding.surfaceInputOverlay.visibility = View.INVISIBLE
             }
         } else {
             if (EmulationMenuSettings.showOverlay && emulationViewModel.emulationStarted.value) {
-                binding.surfaceInputOverlay.post {
-                    binding.surfaceInputOverlay.visibility = View.VISIBLE
-                }
+                binding.surfaceInputOverlay.visibility = View.VISIBLE
             } else {
-                binding.surfaceInputOverlay.post {
-                    binding.surfaceInputOverlay.visibility = View.INVISIBLE
-                }
+                binding.surfaceInputOverlay.visibility = View.INVISIBLE
             }
             if (!isInFoldableLayout) {
                 if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -17,6 +17,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.*
 import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.content.res.ResourcesCompat
@@ -53,6 +54,7 @@ import org.yuzu.yuzu_emu.model.Game
 import org.yuzu.yuzu_emu.model.EmulationViewModel
 import org.yuzu.yuzu_emu.overlay.InputOverlay
 import org.yuzu.yuzu_emu.utils.*
+import java.lang.NullPointerException
 
 class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     private lateinit var preferences: SharedPreferences
@@ -104,10 +106,21 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                 null
             }
         }
-        game = if (args.game != null) {
-            args.game!!
-        } else {
-            intentGame ?: error("[EmulationFragment] No bootable game present!")
+
+        try {
+            game = if (args.game != null) {
+                args.game!!
+            } else {
+                intentGame!!
+            }
+        } catch (e: NullPointerException) {
+            Toast.makeText(
+                requireContext(),
+                R.string.no_game_present,
+                Toast.LENGTH_SHORT
+            ).show()
+            requireActivity().finish()
+            return
         }
 
         // So this fragment doesn't restart on configuration changes; i.e. rotation.
@@ -131,6 +144,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     // This is using the correct scope, lint is just acting up
     @SuppressLint("UnsafeRepeatOnLifecycleDetector")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        if (requireActivity().isFinishing) {
+            return
+        }
+
         binding.surfaceEmulation.holder.addCallback(this)
         binding.showFpsText.setTextColor(Color.YELLOW)
         binding.doneControlConfig.setOnClickListener { stopConfiguringControls() }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/SetupFragment.kt
@@ -295,8 +295,10 @@ class SetupFragment : Fragment() {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putBoolean(KEY_NEXT_VISIBILITY, binding.buttonNext.isVisible)
-        outState.putBoolean(KEY_BACK_VISIBILITY, binding.buttonBack.isVisible)
+        if (_binding != null) {
+            outState.putBoolean(KEY_NEXT_VISIBILITY, binding.buttonNext.isVisible)
+            outState.putBoolean(KEY_BACK_VISIBILITY, binding.buttonBack.isVisible)
+        }
         outState.putBooleanArray(KEY_HAS_BEEN_WARNED, hasBeenWarned)
     }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/SetupFragment.kt
@@ -355,11 +355,15 @@ class SetupFragment : Fragment() {
     }
 
     fun pageForward() {
-        binding.viewPager2.currentItem = binding.viewPager2.currentItem + 1
+        if (_binding != null) {
+            binding.viewPager2.currentItem += 1
+        }
     }
 
     fun pageBackward() {
-        binding.viewPager2.currentItem = binding.viewPager2.currentItem - 1
+        if (_binding != null) {
+            binding.viewPager2.currentItem -= 1
+        }
     }
 
     fun setPageWarned(page: Int) {

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -294,6 +294,7 @@
     <string name="performance_warning">Turning off this setting will significantly reduce emulation performance! For the best experience, it is recommended that you leave this setting enabled.</string>
     <string name="device_memory_inadequate">Device RAM: %1$s\nRecommended: %2$s</string>
     <string name="memory_formatted">%1$s %2$s</string>
+    <string name="no_game_present">No bootable game present!</string>
 
     <!-- Region Names -->
     <string name="region_japan">Japan</string>


### PR DESCRIPTION
Was looking at play store stats and noticed a few crashes that I could fix quickly.

Fixes an issue where the app would crash if the emulation activity doesn't have a game.
Fixes an issue where we tried to update invalid views in the emulation fragment.
Fixes a couple issues where we tried to update invalid views in the setup fragment.

Additionally don't wait for post callback to update input overlay visibility.