### PR TITLE
Don't send a double focus change message

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -2094,9 +2094,6 @@ void IApplicationFunctions::PrepareForJit(HLERequestContext& ctx) {
 
 void LoopProcess(Nvnflinger::Nvnflinger& nvnflinger, Core::System& system) {
     auto message_queue = std::make_shared<AppletMessageQueue>(system);
-    // Needed on game boot
-    message_queue->PushMessage(AppletMessageQueue::AppletMessage::FocusStateChanged);
-
     auto server_manager = std::make_unique<ServerManager>(system);
 
     server_manager->RegisterNamedService(


### PR DESCRIPTION
Regression from #11569, FocusStateChanged is pushed twice, once in LoopProcess when setting up the services, and then it's set again when ICommonStateGetter is created as added by #11569. Removing the one in LoopProcess fixes a hang on boot.

Closes #11624