### PR TITLE
fsp-srv: enable auto save data creation on init

### DIFF
--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -855,6 +855,9 @@ FSP_SRV::FSP_SRV(Core::System& system_)
     if (Settings::values.enable_fs_access_log) {
         access_log_mode = AccessLogMode::SdCard;
     }
+
+    // This should be true on creation
+    fsc.SetAutoSaveDataCreation(true);
 }
 
 FSP_SRV::~FSP_SRV() = default;


### PR DESCRIPTION
The MiiEdit applet disables automatic save data creation, which is persisted global state(!)

This caused games that need automatic save data creation to crash when booting, so reset the state every time fsp-srv is re-inited.