### PR TITLE
Try to merge image mip levels

### DIFF
--- a/src/video_core/texture_cache/util.h
+++ b/src/video_core/texture_cache/util.h
@@ -111,6 +111,8 @@ void SwizzleImage(Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr, const Ima
                                  GPUVAddr candidate_addr, RelaxedOptions options, bool broken_views,
                                  bool native_bgr);
 
+[[nodiscard]] bool IsSubLevel(const ImageBase& image, const ImageBase& overlap);
+
 [[nodiscard]] bool IsSubCopy(const ImageInfo& candidate, const ImageBase& image,
                              GPUVAddr candidate_addr);
 


### PR DESCRIPTION
We currently have issues with merging single mip levels with their larger multi-level container. If we see the single mip level first, so it's added to the cache first, and then the larger full image with all levels after that, they're added as overlapping images with eachother, but we don't sync overlapping images at all. I tried adding that but it gets messy, because overlapping images also contains things which aren't valid mip levels and shouldn't be copied over.

This PR attempts to check if an incoming image is either a single mip level of an existing image, or a multi-level image that we already have a single mip for, and merge them.

A Sound Plan does just this, it first uses mip0 of a texture, which is drawn into, and then later tries to use an image at the same address but with 11 levels. We create 2 separate images here, but have no synchronisation between them. The single mip0 is drawn into, and then the 11 level image tries to be presented to the screen, which just remains blank as it's never written to. 

This PR fixes that issue, but is not complete, mipped images and mip levels are still a mess and still do not fully merge or add copy dependancies to eachother. All of our code here is just beyond a mess and needs to be completely re-done. It's a disaster.

For now, closes #11667.