### PR TITLE
yuzu: Add desktop shortcut support for Windows (continuation of #11344)

### DIFF
--- a/src/common/fs/fs_paths.h
+++ b/src/common/fs/fs_paths.h
@@ -22,6 +22,7 @@
 #define SDMC_DIR "sdmc"
 #define SHADER_DIR "shader"
 #define TAS_DIR "tas"
+#define ICONS_DIR "icons"
 
 // yuzu-specific files
 

--- a/src/common/fs/path_util.cpp
+++ b/src/common/fs/path_util.cpp
@@ -128,6 +128,7 @@ public:
         GenerateYuzuPath(YuzuPath::SDMCDir, yuzu_path / SDMC_DIR);
         GenerateYuzuPath(YuzuPath::ShaderDir, yuzu_path / SHADER_DIR);
         GenerateYuzuPath(YuzuPath::TASDir, yuzu_path / TAS_DIR);
+        GenerateYuzuPath(YuzuPath::IconsDir, yuzu_path / ICONS_DIR);
     }
 
 private:

--- a/src/common/fs/path_util.h
+++ b/src/common/fs/path_util.h
@@ -24,6 +24,7 @@ enum class YuzuPath {
     SDMCDir,        // Where the emulated SDMC is stored.
     ShaderDir,      // Where shaders are stored.
     TASDir,         // Where TAS scripts are stored.
+    IconsDir,       // Where Icons for Windows shortcuts are stored.
 };
 
 /**

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -560,9 +560,9 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     QAction* verify_integrity = context_menu.addAction(tr("Verify Integrity"));
     QAction* copy_tid = context_menu.addAction(tr("Copy Title ID to Clipboard"));
     QAction* navigate_to_gamedb_entry = context_menu.addAction(tr("Navigate to GameDB entry"));
-#ifndef WIN32
     QMenu* shortcut_menu = context_menu.addMenu(tr("Create Shortcut"));
     QAction* create_desktop_shortcut = shortcut_menu->addAction(tr("Add to Desktop"));
+#ifndef WIN32
     QAction* create_applications_menu_shortcut =
         shortcut_menu->addAction(tr("Add to Applications Menu"));
 #endif
@@ -638,10 +638,10 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     connect(navigate_to_gamedb_entry, &QAction::triggered, [this, program_id]() {
         emit NavigateToGamedbEntryRequested(program_id, compatibility_list);
     });
-#ifndef WIN32
     connect(create_desktop_shortcut, &QAction::triggered, [this, program_id, path]() {
         emit CreateShortcut(program_id, path, GameListShortcutTarget::Desktop);
     });
+#ifndef WIN32
     connect(create_applications_menu_shortcut, &QAction::triggered, [this, program_id, path]() {
         emit CreateShortcut(program_id, path, GameListShortcutTarget::Applications);
     });

--- a/src/yuzu/util/util.cpp
+++ b/src/yuzu/util/util.cpp
@@ -5,6 +5,10 @@
 #include <cmath>
 #include <QPainter>
 #include "yuzu/util/util.h"
+#ifdef _WIN32
+#include <windows.h>
+#include "common/fs/file.h"
+#endif
 
 QFont GetMonospaceFont() {
     QFont font(QStringLiteral("monospace"));
@@ -36,4 +40,77 @@ QPixmap CreateCirclePixmapFromColor(const QColor& color) {
     painter.setBrush(color);
     painter.drawEllipse({circle_pixmap.width() / 2.0, circle_pixmap.height() / 2.0}, 7.0, 7.0);
     return circle_pixmap;
+}
+
+bool SaveIconToFile(const std::string_view path, const QImage& image) {
+#if defined(WIN32)
+#pragma pack(push, 2)
+    struct IconDir {
+        WORD id_reserved;
+        WORD id_type;
+        WORD id_count;
+    };
+
+    struct IconDirEntry {
+        BYTE width;
+        BYTE height;
+        BYTE color_count;
+        BYTE reserved;
+        WORD planes;
+        WORD bit_count;
+        DWORD bytes_in_res;
+        DWORD image_offset;
+    };
+#pragma pack(pop)
+
+    QImage source_image = image.convertToFormat(QImage::Format_RGB32);
+    constexpr int bytes_per_pixel = 4;
+    const int image_size = source_image.width() * source_image.height() * bytes_per_pixel;
+
+    BITMAPINFOHEADER info_header{};
+    info_header.biSize = sizeof(BITMAPINFOHEADER), info_header.biWidth = source_image.width(),
+    info_header.biHeight = source_image.height() * 2, info_header.biPlanes = 1,
+    info_header.biBitCount = bytes_per_pixel * 8, info_header.biCompression = BI_RGB;
+
+    const IconDir icon_dir{.id_reserved = 0, .id_type = 1, .id_count = 1};
+    const IconDirEntry icon_entry{.width = static_cast<BYTE>(source_image.width()),
+                                  .height = static_cast<BYTE>(source_image.height() * 2),
+                                  .color_count = 0,
+                                  .reserved = 0,
+                                  .planes = 1,
+                                  .bit_count = bytes_per_pixel * 8,
+                                  .bytes_in_res =
+                                      static_cast<DWORD>(sizeof(BITMAPINFOHEADER) + image_size),
+                                  .image_offset = sizeof(IconDir) + sizeof(IconDirEntry)};
+
+    Common::FS::IOFile icon_file(path, Common::FS::FileAccessMode::Write,
+                                 Common::FS::FileType::BinaryFile);
+    if (!icon_file.IsOpen()) {
+        return false;
+    }
+
+    if (!icon_file.Write(icon_dir)) {
+        return false;
+    }
+    if (!icon_file.Write(icon_entry)) {
+        return false;
+    }
+    if (!icon_file.Write(info_header)) {
+        return false;
+    }
+
+    for (int y = 0; y < image.height(); y++) {
+        const auto* line = source_image.scanLine(source_image.height() - 1 - y);
+        std::vector<u8> line_data(source_image.width() * bytes_per_pixel);
+        std::memcpy(line_data.data(), line, line_data.size());
+        if (!icon_file.Write(line_data)) {
+            return false;
+        }
+    }
+    icon_file.Close();
+
+    return true;
+#else
+    return false;
+#endif
 }

--- a/src/yuzu/util/util.h
+++ b/src/yuzu/util/util.h
@@ -7,14 +7,22 @@
 #include <QString>
 
 /// Returns a QFont object appropriate to use as a monospace font for debugging widgets, etc.
-QFont GetMonospaceFont();
+[[nodiscard]] QFont GetMonospaceFont();
 
 /// Convert a size in bytes into a readable format (KiB, MiB, etc.)
-QString ReadableByteSize(qulonglong size);
+[[nodiscard]] QString ReadableByteSize(qulonglong size);
 
 /**
  * Creates a circle pixmap from a specified color
  * @param color The color the pixmap shall have
  * @return QPixmap circle pixmap
  */
-QPixmap CreateCirclePixmapFromColor(const QColor& color);
+[[nodiscard]] QPixmap CreateCirclePixmapFromColor(const QColor& color);
+
+/**
+ * Saves a windows icon to a file
+ * @param path The icons path
+ * @param image The image to save
+ * @return bool If the operation succeeded
+ */
+[[nodiscard]] bool SaveIconToFile(const std::string_view path, const QImage& image);


### PR DESCRIPTION
Allows creating desktop shortcuts with icons for yuzu games.

This is a continuation of https://github.com/yuzu-emu/yuzu/pull/11344 with some minor changes and its review comments addressed.