### PR TITLE
ci/linux: Upload separated debug symbols

### DIFF
--- a/.ci/scripts/common/pre-upload.sh
+++ b/.ci/scripts/common/pre-upload.sh
@@ -5,6 +5,6 @@
 
 GITDATE="`git show -s --date=short --format='%ad' | sed 's/-//g'`"
 GITREV="`git show -s --format='%h'`"
-ARTIFACTS_DIR="artifacts"
+ARTIFACTS_DIR="$PWD/artifacts"
 
 mkdir -p "${ARTIFACTS_DIR}/"

--- a/.ci/scripts/linux/docker.sh
+++ b/.ci/scripts/linux/docker.sh
@@ -42,7 +42,7 @@ for EXE in yuzu; do
     mv $EXE_PATH.out $EXE_PATH
 done
 # Strip debug symbols from all executables
-find -type f bin/ -not -regex '.*.debug' -exec strip -g {} ';'
+find bin/ -type f -not -regex '.*.debug' -exec strip -g {} ';'
 
 DESTDIR="$PWD/AppDir" ninja install
 rm -vf AppDir/usr/bin/yuzu-cmd AppDir/usr/bin/yuzu-tester

--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -59,4 +59,9 @@ if [ "${RELEASE_NAME}" = "mainline" ] || [ "${RELEASE_NAME}" = "early-access" ];
     cp "build/${APPIMAGE_NAME}" "${DIR_NAME}/yuzu-${RELEASE_NAME}.AppImage"
 fi
 
+# Copy debug symbols to artifacts
+cd build/bin
+tar $COMPRESSION_FLAGS "${ARTIFACTS_DIR}/${REV_NAME}-debug.tar.xz" *.debug
+cd -
+
 . .ci/scripts/common/post-upload.sh


### PR DESCRIPTION
Creates a new archive with a debug suffix that contains the debug symbols from compiling yuzu for mainline. The yuzu executable also gets a GNU debug link to the symbols file. ci/linux: Compile with debug symbols and upload separately

Currently only uploads for yuzu but yuzu-cmd or other future executables can be added to the for-loop's parameters.