### PR TITLE
Fix mistaken usage of info.block instead of level_info.block

### DIFF
--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -885,7 +885,7 @@ boost::container::small_vector<BufferImageCopy, 16> UnswizzleImage(Tegra::Memory
         };
         const Extent3D num_tiles = AdjustTileSize(level_size, tile_size);
         const Extent3D block =
-            AdjustMipBlockSize(num_tiles, info.block, level, level_info.num_levels);
+            AdjustMipBlockSize(num_tiles, level_info.block, level, level_info.num_levels);
         const u32 stride_alignment = StrideAlignment(num_tiles, info.block, gob, bpp_log2);
         size_t guest_layer_offset = 0;
 
@@ -1062,7 +1062,7 @@ boost::container::small_vector<SwizzleParameters, 16> FullUploadSwizzles(const I
         const Extent3D level_size = AdjustMipSize(size, level);
         const Extent3D num_tiles = AdjustTileSize(level_size, tile_size);
         const Extent3D block =
-            AdjustMipBlockSize(num_tiles, info.block, level, level_info.num_levels);
+            AdjustMipBlockSize(num_tiles, level_info.block, level, level_info.num_levels);
         params[level] = SwizzleParameters{
             .num_tiles = num_tiles,
             .block = block,


### PR DESCRIPTION
Fixed an error on my part, in the last change I had mistakenly passed unadjusted block info into FullUploadSwizzles and UnswizzleImage

This reverts (my mistaken changing of) the construction of SwizzleParameters in UnswizzleImage and FullUploadSwizzles to use level_info.block instead of info.block. This ensures that the block information used in the swizzling process is correctly adjusted for each mip level.

This should close #11738 and negate the need for #11739