### PR TITLE
Do not set rescaled flag when rescaling is disabled

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -1048,6 +1048,10 @@ void Image::Scale(bool up_scale) {
 }
 
 bool Image::ScaleUp(bool ignore) {
+    const auto& resolution = runtime->resolution;
+    if (!resolution.active) {
+        return false;
+    }
     if (True(flags & ImageFlagBits::Rescaled)) {
         return false;
     }
@@ -1060,9 +1064,6 @@ bool Image::ScaleUp(bool ignore) {
         return false;
     }
     flags |= ImageFlagBits::Rescaled;
-    if (!runtime->resolution.active) {
-        return false;
-    }
     has_scaled = true;
     if (ignore) {
         current_texture = upscaled_backup.handle;
@@ -1073,13 +1074,14 @@ bool Image::ScaleUp(bool ignore) {
 }
 
 bool Image::ScaleDown(bool ignore) {
+    const auto& resolution = runtime->resolution;
+    if (!resolution.active) {
+        return false;
+    }
     if (False(flags & ImageFlagBits::Rescaled)) {
         return false;
     }
     flags &= ~ImageFlagBits::Rescaled;
-    if (!runtime->resolution.active) {
-        return false;
-    }
     if (ignore) {
         current_texture = texture.handle;
         return true;

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1530,15 +1530,15 @@ bool Image::IsRescaled() const noexcept {
 }
 
 bool Image::ScaleUp(bool ignore) {
+    const auto& resolution = runtime->resolution;
+    if (!resolution.active) {
+        return false;
+    }
     if (True(flags & ImageFlagBits::Rescaled)) {
         return false;
     }
     ASSERT(info.type != ImageType::Linear);
     flags |= ImageFlagBits::Rescaled;
-    const auto& resolution = runtime->resolution;
-    if (!resolution.active) {
-        return false;
-    }
     has_scaled = true;
     if (!scaled_image) {
         const bool is_2d = info.type == ImageType::e2D;
@@ -1567,15 +1567,15 @@ bool Image::ScaleUp(bool ignore) {
 }
 
 bool Image::ScaleDown(bool ignore) {
+    const auto& resolution = runtime->resolution;
+    if (!resolution.active) {
+        return false;
+    }
     if (False(flags & ImageFlagBits::Rescaled)) {
         return false;
     }
     ASSERT(info.type != ImageType::Linear);
     flags &= ~ImageFlagBits::Rescaled;
-    const auto& resolution = runtime->resolution;
-    if (!resolution.active) {
-        return false;
-    }
     current_image = *original_image;
     if (ignore) {
         return true;


### PR DESCRIPTION
If resolution scaling is disabled, we shouldn't set the Rescaled flag as if it was active. This leads to weird issues/different paths taken where some images can be marked as rescaled and get compared with other images which are not rescaled. I've seen it throw this assert for instance: https://github.com/yuzu-emu/yuzu/blob/master/src/video_core/texture_cache/texture_cache.h#L2326