### PR TITLE
Improvement in Directory Path Detection for Shortcuts

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2884,7 +2884,7 @@ if (target == GameListShortcutTarget::Desktop) {
                 .arg(QString::fromStdString(target_directory.generic_string())),
             QMessageBox::StandardButton::Ok);
         return;
-     }
+    }
 } else if (target == GameListShortcutTarget::Applications) {
  #if defined(__linux__)
     QString applicationsPath =

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2875,7 +2875,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     // Determine target directory for shortcut
     if (target == GameListShortcutTarget::Desktop) {
         const auto desktop_path = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-        target_directory = desktopPath.toUtf8().toStdString();
+        target_directory = desktop_path.toUtf8().toStdString();
         const QDir dir(QString::fromStdString(target_directory.generic_string()));
         if (!dir.exists()) {
             QMessageBox::critical(

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2874,7 +2874,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 
     // Determine target directory for shortcut
     if (target == GameListShortcutTarget::Desktop) {
-        QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+        const auto desktop_path = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
         target_directory = desktopPath.toUtf8().toStdString();
         QDir dir(QString::fromStdString(target_directory.generic_string()));
         if (!dir.exists()) {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2872,36 +2872,36 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 
     std::filesystem::path target_directory{};
 
-// Determine target directory for shortcut
-if (target == GameListShortcutTarget::Desktop) {
-    QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-    target_directory = desktopPath.toUtf8().toStdString();
-    QDir dir(QString::fromStdString(target_directory.generic_string()));
-    if (!dir.exists()) {
-        QMessageBox::critical(
-            this, tr("Create Shortcut"),
-            tr("Cannot create shortcut on desktop. Path \"%1\" does not exist.")
-                .arg(QString::fromStdString(target_directory.generic_string())),
-            QMessageBox::StandardButton::Ok);
-        return;
+    // Determine target directory for shortcut
+    if (target == GameListShortcutTarget::Desktop) {
+        QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+        target_directory = desktopPath.toUtf8().toStdString();
+        QDir dir(QString::fromStdString(target_directory.generic_string()));
+        if (!dir.exists()) {
+            QMessageBox::critical(
+                this, tr("Create Shortcut"),
+                tr("Cannot create shortcut on desktop. Path \"%1\" does not exist.")
+                    .arg(QString::fromStdString(target_directory.generic_string())),
+                QMessageBox::StandardButton::Ok);
+            return;
+        }
+    } else if (target == GameListShortcutTarget::Applications) {
+#if defined(__linux__)
+        QString applicationsPath =
+            QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
+        target_directory = applicationsPath.toUtf8().toStdString();
+        QDir dir(QString::fromStdString(target_directory.generic_string()));
+        if (!dir.exists()) {
+            QMessageBox::critical(
+                this, tr("Create Shortcut"),
+                tr("Cannot create shortcut in applications menu. Path \"%1\" "
+                   "does not exist and cannot be created.")
+                    .arg(QString::fromStdString(target_directory.generic_string())),
+                QMessageBox::StandardButton::Ok);
+            return;
+        }
+#endif
     }
-} else if (target == GameListShortcutTarget::Applications) {
- #if defined(__linux__)
-    QString applicationsPath =
-        QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
-    target_directory = applicationsPath.toUtf8().toStdString();
-    QDir dir(QString::fromStdString(target_directory.generic_string()));
-    if (!dir.exists()) {
-        QMessageBox::critical(
-            this, tr("Create Shortcut"),
-            tr("Cannot create shortcut in applications menu. Path \"%1\" "
-               "does not exist and cannot be created.")
-                .arg(QString::fromStdString(target_directory.generic_string())),
-            QMessageBox::StandardButton::Ok);
-        return;
-    }
- #endif
-}
 
     const std::string game_file_name = std::filesystem::path(game_path).filename().string();
     // Determine full paths for icon and shortcut

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2913,7 +2913,8 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     const char* xdg_data_home = std::getenv("XDG_DATA_HOME");
 
     std::filesystem::path system_icons_path =
-        (xdg_data_home == nullptr ? home_path / ".local/share/" : std::filesystem::path(xdg_data_home)) /
+        (xdg_data_home == nullptr ? home_path / ".local/share/"
+                                  : std::filesystem::path(xdg_data_home)) /
         "icons/hicolor/256x256";
     if (!Common::FS::CreateDirs(system_icons_path)) {
         QMessageBox::critical(

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2908,8 +2908,12 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     const std::string game_file_name = std::filesystem::path(game_path).filename().string();
     // Determine full paths for icon and shortcut
 #if defined(__linux__) || defined(__FreeBSD__)
+    const char* home = std::getenv("HOME");
+    const std::filesystem::path home_path = (home == nullptr ? "~" : home);
+    const char* xdg_data_home = std::getenv("XDG_DATA_HOME");
+
     std::filesystem::path system_icons_path =
-        (xdg_data_home == nullptr ? home_path / ".local/share/" : xdg_data_home) /
+        (xdg_data_home == nullptr ? home_path / ".local/share/" : std::filesystem::path(xdg_data_home)) /
         "icons/hicolor/256x256";
     if (!Common::FS::CreateDirs(system_icons_path)) {
         QMessageBox::critical(

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2874,15 +2874,15 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 
     switch (target) {
     case GameListShortcutTarget::Desktop: {
-        const QString desktop_Path =
+        const QString desktop_path =
             QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-        target_directory = desktop_Path.toUtf8().toStdString();
+        target_directory = desktop_path.toUtf8().toStdString();
         break;
     }
     case GameListShortcutTarget::Applications: {
-        const QString applications_Path =
+        const QString applications_path =
             QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
-        target_directory = applications_Path.toUtf8().toStdString();
+        target_directory = applications_path.toUtf8().toStdString();
         break;
     }
     default:

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2872,36 +2872,31 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 
     std::filesystem::path target_directory{};
 
-    // Determine target directory for shortcut
-    if (target == GameListShortcutTarget::Desktop) {
-        const auto desktop_path = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-        target_directory = desktop_path.toUtf8().toStdString();
-        const QDir dir(QString::fromStdString(target_directory.generic_string()));
-        if (!dir.exists()) {
-            QMessageBox::critical(
-                this, tr("Create Shortcut"),
-                tr("Cannot create shortcut on desktop. Path \"%1\" does not exist.")
-                    .arg(QString::fromStdString(target_directory.generic_string())),
-                QMessageBox::StandardButton::Ok);
-            return;
-        }
-    } else if (target == GameListShortcutTarget::Applications) {
-#if defined(__linux__)
-        QString applicationsPath =
-            QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
-        target_directory = applicationsPath.toUtf8().toStdString();
-        QDir dir(QString::fromStdString(target_directory.generic_string()));
-        if (!dir.exists()) {
-            QMessageBox::critical(
-                this, tr("Create Shortcut"),
-                tr("Cannot create shortcut in applications menu. Path \"%1\" "
-                   "does not exist and cannot be created.")
-                    .arg(QString::fromStdString(target_directory.generic_string())),
-                QMessageBox::StandardButton::Ok);
-            return;
-        }
-#endif
-    }
+switch (target) {
+   case GameListShortcutTarget::Desktop: {
+       const QString desktopPath =
+           QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+       target_directory = desktopPath.toUtf8().toStdString();
+       break;
+   }
+   case GameListShortcutTarget::Applications: {
+       const QString applicationsPath =
+           QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
+       target_directory = applicationsPath.toUtf8().toStdString();
+       break;
+   }
+   default:
+       return;
+   }
+
+   const QDir dir(QString::fromStdString(target_directory.generic_string()));
+   if (!dir.exists()) {
+      QMessageBox::critical(this, tr("Create Shortcut"),
+                            tr("Cannot create shortcut. Path \"%1\" does not exist.")
+                                .arg(QString::fromStdString(target_directory.generic_string())),
+                            QMessageBox::StandardButton::Ok);
+      return;
+   }
 
     const std::string game_file_name = std::filesystem::path(game_path).filename().string();
     // Determine full paths for icon and shortcut

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2882,7 +2882,14 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     case GameListShortcutTarget::Applications: {
         const QString applications_path =
             QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
-        target_directory = applications_path.toUtf8().toStdString();
+        if (applications_path.isEmpty()) {
+            const char* home = std::getenv("HOME");
+            if (home != nullptr) {
+                target_directory = std::filesystem::path(home) / ".local/share/applications";
+            }
+        } else {
+            target_directory = applications_path.toUtf8().toStdString();
+        }
         break;
     }
     default:

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2872,22 +2872,22 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 
     std::filesystem::path target_directory{};
 
-switch (target) {
-   case GameListShortcutTarget::Desktop: {
-       const QString desktopPath =
-           QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-       target_directory = desktopPath.toUtf8().toStdString();
-       break;
-   }
-   case GameListShortcutTarget::Applications: {
-       const QString applicationsPath =
-           QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
-       target_directory = applicationsPath.toUtf8().toStdString();
-       break;
-   }
-   default:
-       return;
-   }
+    switch (target) {
+    case GameListShortcutTarget::Desktop: {
+        const QString desktop_Path =
+            QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+        target_directory = desktop_Path.toUtf8().toStdString();
+        break;
+    }
+    case GameListShortcutTarget::Applications: {
+        const QString applications_Path =
+            QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
+        target_directory = applications_Path.toUtf8().toStdString();
+        break;
+    }
+    default:
+        return;
+    }
 
    const QDir dir(QString::fromStdString(target_directory.generic_string()));
    if (!dir.exists()) {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2876,7 +2876,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     if (target == GameListShortcutTarget::Desktop) {
         const auto desktop_path = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
         target_directory = desktopPath.toUtf8().toStdString();
-        QDir dir(QString::fromStdString(target_directory.generic_string()));
+        const QDir dir(QString::fromStdString(target_directory.generic_string()));
         if (!dir.exists()) {
             QMessageBox::critical(
                 this, tr("Create Shortcut"),

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -67,6 +67,7 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #define QT_NO_OPENGL
 #include <QClipboard>
 #include <QDesktopServices>
+#include <QDir>
 #include <QFile>
 #include <QFileDialog>
 #include <QInputDialog>
@@ -76,13 +77,12 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #include <QPushButton>
 #include <QScreen>
 #include <QShortcut>
+#include <QStandardPaths>
 #include <QStatusBar>
 #include <QString>
 #include <QSysInfo>
 #include <QUrl>
 #include <QtConcurrent/QtConcurrent>
-#include <QStandardPaths>
-#include <QDir>
 
 #ifdef HAVE_SDL2
 #include <SDL.h> // For SDL ScreenSaver functions
@@ -2889,14 +2889,14 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
         return;
     }
 
-   const QDir dir(QString::fromStdString(target_directory.generic_string()));
-   if (!dir.exists()) {
-      QMessageBox::critical(this, tr("Create Shortcut"),
-                            tr("Cannot create shortcut. Path \"%1\" does not exist.")
-                                .arg(QString::fromStdString(target_directory.generic_string())),
-                            QMessageBox::StandardButton::Ok);
-      return;
-   }
+    const QDir dir(QString::fromStdString(target_directory.generic_string()));
+    if (!dir.exists()) {
+        QMessageBox::critical(this, tr("Create Shortcut"),
+                              tr("Cannot create shortcut. Path \"%1\" does not exist.")
+                                  .arg(QString::fromStdString(target_directory.generic_string())),
+                              QMessageBox::StandardButton::Ok);
+        return;
+    }
 
     const std::string game_file_name = std::filesystem::path(game_path).filename().string();
     // Determine full paths for icon and shortcut


### PR DESCRIPTION
![image](https://github.com/yuzu-emu/yuzu/assets/28203966/7b213fc4-4604-47ba-b5d5-40015885215f)

This pull request updates how the directory path for shortcuts is determined. The main changes are:

1. Replaced the use of environment variables to determine the path of the desktop and applications menu with `QStandardPaths::writableLocation`. This change addresses an issue where the desktop path was not correctly identified when its location was customized, as shown in the attached screenshot.

2. Added conversion from `QString` to `std::string` using `toUtf8()`, which correctly handles non-ASCII characters in directory paths. This change ensures that directory paths containing Portuguese words like "área de trabalho" are supported.

3. Replaced directory checking using `Common::FS::IsDir()` with `QDir::exists()`.

These changes should improve cross-platform compatibility and code robustness. Because it couldn't locate my desktop, which wasn't on the C drive, but on the F, and even though localization wouldn't work because it was setting it to find the 'Desktop' folder and in the computer's language it says 'Área de trabalho', that will fix for other languages too.

Thanks for the idea suggested in 'issues' https://github.com/yuzu-emu/yuzu/issues/11737