### PR TITLE
Transition MSAA images to general layout without uploading data

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -118,6 +118,8 @@ public:
 
     void InsertUploadMemoryBarrier();
 
+    void TransitionImageLayout(Image& image) {}
+
     FormatProperties FormatInfo(VideoCommon::ImageType type, GLenum internal_format) const;
 
     bool HasNativeBgr() const noexcept {

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -92,6 +92,8 @@ public:
 
     void InsertUploadMemoryBarrier() {}
 
+    void TransitionImageLayout(Image& image);
+
     bool HasBrokenTextureViewFormats() const noexcept {
         // No known Vulkan driver has broken image views
         return false;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1016,6 +1016,7 @@ void TextureCache<P>::RefreshContents(Image& image, ImageId image_id) {
 
     if (image.info.num_samples > 1 && !runtime.CanUploadMSAA()) {
         LOG_WARNING(HW_GPU, "MSAA image uploads are not implemented");
+        runtime.TransitionImageLayout(image);
         return;
     }
     if (True(image.flags & ImageFlagBits::AsynchronousDecode)) {


### PR DESCRIPTION
We have an implicit dependance on RefreshContents uploading an image's memory on creation, and the barrier for it transitioning the image to a general layout. For MSAA iamges we don't support uploading its data and return early, which ends up leaving the iamge in its default undefined layout. This then causes render passes using these as render targets to fail to draw. 

This PR just adds an explicit transition for multisampled images to get them into a general layout. Gets rid of a validation error, and is needed to fix some games rendering, though some still have issues to due memory tracking.