### PR TITLE
service: caps: Fix GetAlbumFileList3AaeAruid and GetAlbumFileList0AafeAruidDeprecated

### DIFF
--- a/src/core/hle/service/caps/caps.cpp
+++ b/src/core/hle/service/caps/caps.cpp
@@ -16,7 +16,7 @@ namespace Service::Capture {
 
 void LoopProcess(Core::System& system) {
     auto server_manager = std::make_unique<ServerManager>(system);
-    auto album_manager = std::make_shared<AlbumManager>();
+    auto album_manager = std::make_shared<AlbumManager>(system);
 
     server_manager->RegisterNamedService(
         "caps:a", std::make_shared<IAlbumAccessorService>(system, album_manager));

--- a/src/core/hle/service/caps/caps_manager.h
+++ b/src/core/hle/service/caps/caps_manager.h
@@ -37,7 +37,7 @@ namespace Service::Capture {
 
 class AlbumManager {
 public:
-    explicit AlbumManager();
+    explicit AlbumManager(Core::System& system_);
     ~AlbumManager();
 
     Result DeleteAlbumFile(const AlbumFileId& file_id);
@@ -45,6 +45,9 @@ public:
     Result GetAlbumFileList(std::vector<AlbumEntry>& out_entries, AlbumStorage storage,
                             u8 flags) const;
     Result GetAlbumFileList(std::vector<ApplicationAlbumFileEntry>& out_entries,
+                            ContentType contex_type, s64 start_posix_time, s64 end_posix_time,
+                            u64 aruid) const;
+    Result GetAlbumFileList(std::vector<ApplicationAlbumEntry>& out_entries,
                             ContentType contex_type, AlbumFileDateTime start_date,
                             AlbumFileDateTime end_date, u64 aruid) const;
     Result GetAutoSavingStorage(bool& out_is_autosaving) const;
@@ -65,8 +68,12 @@ private:
     Result LoadImage(std::span<u8> out_image, const std::filesystem::path& path, int width,
                      int height, ScreenShotDecoderFlag flag) const;
 
+    AlbumFileDateTime ConvertToAlbumDateTime(u64 posix_time) const;
+
     bool is_mounted{};
     std::unordered_map<AlbumFileId, std::filesystem::path> album_files;
+
+    Core::System& system;
 };
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_types.h
+++ b/src/core/hle/service/caps/caps_types.h
@@ -41,13 +41,13 @@ enum class ScreenShotDecoderFlag : u64 {
 
 // This is nn::capsrv::AlbumFileDateTime
 struct AlbumFileDateTime {
-    u16 year{};
-    u8 month{};
-    u8 day{};
-    u8 hour{};
-    u8 minute{};
-    u8 second{};
-    u8 unique_id{};
+    s16 year{};
+    s8 month{};
+    s8 day{};
+    s8 hour{};
+    s8 minute{};
+    s8 second{};
+    s8 unique_id{};
 
     friend constexpr bool operator==(const AlbumFileDateTime&, const AlbumFileDateTime&) = default;
     friend constexpr bool operator>(const AlbumFileDateTime& a, const AlbumFileDateTime& b) {


### PR DESCRIPTION
I made too many mistakes here. First of all in parameters where wrong. Secondly `GetAlbumFileList3AaeAruid` returns a  `ApplicationAlbumEntry` list. Finally these should auto mount.

I also fully implemented GetAlbumFileList0AafeAruidDeprecated so it will now use the correct date range.

Fixes SSBU replays menu.