### PR TITLE
qt: ensure worker cancellation is complete before clearing

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -826,11 +826,12 @@ void GameList::PopulateAsync(QVector<UISettings::GameDir>& game_dirs) {
     tree_view->setColumnHidden(COLUMN_SIZE, !UISettings::values.show_size);
     tree_view->setColumnHidden(COLUMN_PLAY_TIME, !UISettings::values.show_play_time);
 
+    // Before deleting rows, cancel the worker so that it is not using them
+    emit ShouldCancelWorker();
+
     // Delete any rows that might already exist if we're repopulating
     item_model->removeRows(0, item_model->rowCount());
     search_field->clear();
-
-    emit ShouldCancelWorker();
 
     GameListWorker* worker =
         new GameListWorker(vfs, provider, game_dirs, compatibility_list, play_time_manager, system);

--- a/src/yuzu/game_list_worker.h
+++ b/src/yuzu/game_list_worker.h
@@ -12,6 +12,7 @@
 #include <QRunnable>
 #include <QString>
 
+#include "common/thread.h"
 #include "yuzu/compatibility_list.h"
 #include "yuzu/play_time_manager.h"
 
@@ -82,7 +83,9 @@ private:
     const PlayTime::PlayTimeManager& play_time_manager;
 
     QStringList watch_list;
-    std::atomic_bool stop_processing;
+
+    Common::Event processing_completed;
+    std::atomic_bool stop_requested = false;
 
     Core::System& system;
 };


### PR DESCRIPTION
The item model in GameList takes ownership of GameListDir objects while they are being processed. However, the list can be cleared while the worker may still have live references to GameListDir objects. This prevents use-after-free in GameListWorker, by forcing processing to complete before clearing the list.