### PR TITLE
fsmitm_romfsbuild: avoid unnecessary copies of vfs pointers

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -116,11 +116,8 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
             }
         }
 
-        if (concat.empty()) {
-            return nullptr;
-        }
-
-        return FileSys::ConcatenatedVfsFile::MakeConcatenatedFile(concat, dir->GetName());
+        return FileSys::ConcatenatedVfsFile::MakeConcatenatedFile(dir->GetName(),
+                                                                  std::move(concat));
     }
 
     if (Common::FS::IsDir(path)) {

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -377,16 +377,16 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
 
         auto romfs_dir = FindSubdirectoryCaseless(subdir, "romfs");
         if (romfs_dir != nullptr)
-            layers.push_back(std::make_shared<CachedVfsDirectory>(romfs_dir));
+            layers.emplace_back(std::make_shared<CachedVfsDirectory>(std::move(romfs_dir)));
 
         auto ext_dir = FindSubdirectoryCaseless(subdir, "romfs_ext");
         if (ext_dir != nullptr)
-            layers_ext.push_back(std::make_shared<CachedVfsDirectory>(ext_dir));
+            layers_ext.emplace_back(std::make_shared<CachedVfsDirectory>(std::move(ext_dir)));
 
         if (type == ContentRecordType::HtmlDocument) {
             auto manual_dir = FindSubdirectoryCaseless(subdir, "manual_html");
             if (manual_dir != nullptr)
-                layers.push_back(std::make_shared<CachedVfsDirectory>(manual_dir));
+                layers.emplace_back(std::make_shared<CachedVfsDirectory>(std::move(manual_dir)));
         }
     }
 
@@ -400,7 +400,7 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
         return;
     }
 
-    layers.push_back(std::move(extracted));
+    layers.emplace_back(std::move(extracted));
 
     auto layered = LayeredVfsDirectory::MakeLayeredDirectory(std::move(layers));
     if (layered == nullptr) {

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -322,7 +322,8 @@ VirtualFile RegisteredCache::OpenFileOrDirectoryConcat(const VirtualDir& open_di
         return nullptr;
     }
 
-    return ConcatenatedVfsFile::MakeConcatenatedFile(concat, concat.front()->GetName());
+    auto name = concat.front()->GetName();
+    return ConcatenatedVfsFile::MakeConcatenatedFile(std::move(name), std::move(concat));
 }
 
 VirtualFile RegisteredCache::GetFileAtID(NcaID id) const {

--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -133,7 +133,7 @@ VirtualDir ExtractRomFS(VirtualFile file, RomFSExtractionType type) {
         out = out->GetSubdirectories().front();
     }
 
-    return std::make_shared<CachedVfsDirectory>(out);
+    return std::make_shared<CachedVfsDirectory>(std::move(out));
 }
 
 VirtualFile CreateRomFS(VirtualDir dir, VirtualDir ext) {
@@ -141,8 +141,7 @@ VirtualFile CreateRomFS(VirtualDir dir, VirtualDir ext) {
         return nullptr;
 
     RomFSBuildContext ctx{dir, ext};
-    auto file_map = ctx.Build();
-    return ConcatenatedVfsFile::MakeConcatenatedFile(0, file_map, dir->GetName());
+    return ConcatenatedVfsFile::MakeConcatenatedFile(0, dir->GetName(), ctx.Build());
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/vfs_cached.cpp
+++ b/src/core/file_sys/vfs_cached.cpp
@@ -6,13 +6,13 @@
 
 namespace FileSys {
 
-CachedVfsDirectory::CachedVfsDirectory(VirtualDir& source_dir)
+CachedVfsDirectory::CachedVfsDirectory(VirtualDir&& source_dir)
     : name(source_dir->GetName()), parent(source_dir->GetParentDirectory()) {
     for (auto& dir : source_dir->GetSubdirectories()) {
-        dirs.emplace(dir->GetName(), std::make_shared<CachedVfsDirectory>(dir));
+        dirs.emplace(dir->GetName(), std::make_shared<CachedVfsDirectory>(std::move(dir)));
     }
     for (auto& file : source_dir->GetFiles()) {
-        files.emplace(file->GetName(), file);
+        files.emplace(file->GetName(), std::move(file));
     }
 }
 

--- a/src/core/file_sys/vfs_cached.h
+++ b/src/core/file_sys/vfs_cached.h
@@ -11,7 +11,7 @@ namespace FileSys {
 
 class CachedVfsDirectory : public ReadOnlyVfsDirectory {
 public:
-    CachedVfsDirectory(VirtualDir& source_directory);
+    CachedVfsDirectory(VirtualDir&& source_directory);
 
     ~CachedVfsDirectory() override;
     VirtualFile GetFile(std::string_view file_name) const override;

--- a/src/core/file_sys/vfs_concat.h
+++ b/src/core/file_sys/vfs_concat.h
@@ -24,22 +24,20 @@ private:
     };
     using ConcatenationMap = std::vector<ConcatenationEntry>;
 
-    explicit ConcatenatedVfsFile(std::vector<ConcatenationEntry>&& concatenation_map,
-                                 std::string&& name);
+    explicit ConcatenatedVfsFile(std::string&& name,
+                                 std::vector<ConcatenationEntry>&& concatenation_map);
     bool VerifyContinuity() const;
 
 public:
     ~ConcatenatedVfsFile() override;
 
     /// Wrapper function to allow for more efficient handling of files.size() == 0, 1 cases.
-    static VirtualFile MakeConcatenatedFile(const std::vector<VirtualFile>& files,
-                                            std::string&& name);
+    static VirtualFile MakeConcatenatedFile(std::string&& name, std::vector<VirtualFile>&& files);
 
     /// Convenience function that turns a map of offsets to files into a concatenated file, filling
     /// gaps with a given filler byte.
-    static VirtualFile MakeConcatenatedFile(u8 filler_byte,
-                                            const std::multimap<u64, VirtualFile>& files,
-                                            std::string&& name);
+    static VirtualFile MakeConcatenatedFile(u8 filler_byte, std::string&& name,
+                                            std::multimap<u64, VirtualFile>&& files);
 
     std::string GetName() const override;
     std::size_t GetSize() const override;

--- a/src/core/file_sys/vfs_layered.cpp
+++ b/src/core/file_sys/vfs_layered.cpp
@@ -38,7 +38,7 @@ VirtualDir LayeredVfsDirectory::GetDirectoryRelative(std::string_view path) cons
     for (const auto& layer : dirs) {
         auto dir = layer->GetDirectoryRelative(path);
         if (dir != nullptr) {
-            out.push_back(std::move(dir));
+            out.emplace_back(std::move(dir));
         }
     }
 
@@ -62,11 +62,11 @@ std::vector<VirtualFile> LayeredVfsDirectory::GetFiles() const {
     std::set<std::string, std::less<>> out_names;
 
     for (const auto& layer : dirs) {
-        for (const auto& file : layer->GetFiles()) {
+        for (auto& file : layer->GetFiles()) {
             auto file_name = file->GetName();
             if (!out_names.contains(file_name)) {
                 out_names.emplace(std::move(file_name));
-                out.push_back(file);
+                out.emplace_back(std::move(file));
             }
         }
     }
@@ -86,7 +86,7 @@ std::vector<VirtualDir> LayeredVfsDirectory::GetSubdirectories() const {
     std::vector<VirtualDir> out;
     out.reserve(names.size());
     for (const auto& subdir : names)
-        out.push_back(GetSubdirectory(subdir));
+        out.emplace_back(GetSubdirectory(subdir));
 
     return out;
 }


### PR DESCRIPTION
Somewhat improves romfs build performance due to code refactoring that gets rid of unnecessary string copying. Also fixes #11724 (circular reference formed in RomFSBuildContext).