### PR TITLE
audio: fix shutdown deadlock in audio renderer

### DIFF
--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -204,6 +204,10 @@ void SinkStream::ProcessAudioOutAndRender(std::span<s16> output_buffer, std::siz
     // paused and we'll desync, so just play silence.
     if (system.IsPaused() || system.IsShuttingDown()) {
         if (system.IsShuttingDown()) {
+            {
+                std::scoped_lock lk{release_mutex};
+                queued_buffers.store(0);
+            }
             release_cv.notify_one();
         }
 


### PR DESCRIPTION
When in the process of shutting down, the sink callback signals release_cv to wake up the producer, but the producer is waiting for the number of queued buffers to be less than the maximum queue size. This sets the number of queued buffers to 0 every time the sink callback is invoked when shutting down, so that the producer can stop waiting.