### PR TITLE
yuzu: Improve behavior when clicking on controller box in Control configuration

### DIFF
--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -56,6 +56,7 @@ private:
     void UpdateDockedState(bool is_handheld);
     void UpdateAllInputDevices();
     void UpdateAllInputProfiles(std::size_t player_index);
+    void propagateMouseClickOnPlayers(size_t player_index, bool origin, bool checked);
 
     /// Load configuration settings.
     void LoadConfiguration();


### PR DESCRIPTION
When reducing the number of Connecter Controllers, keep the one clicked if it was not the last one of the list.

I find it more intuitive to click on the number of players we want, being for increasing or reducing. With the current behavior, if 4 controllers are set and we want to reduce it to 2, we need to click on "3", or to click on "2" two times.