### PR TITLE
host1x/codecs: enable CUDA on Linux

### DIFF
--- a/src/video_core/host1x/codecs/codec.cpp
+++ b/src/video_core/host1x/codecs/codec.cpp
@@ -137,16 +137,6 @@ bool Codec::CreateGpuAvDevice() {
                 break;
             }
             if ((config->methods & HW_CONFIG_METHOD) != 0 && config->device_type == type) {
-#if defined(__unix__)
-                // Some linux decoding backends are reported to crash with this config method
-                // TODO(ameerj): Properly support this method
-                if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_FRAMES_CTX) != 0) {
-                    // skip zero-copy decoders, we don't currently support them
-                    LOG_DEBUG(Service_NVDRV, "Skipping decoder {} with unsupported capability {}.",
-                              av_hwdevice_get_type_name(type), config->methods);
-                    continue;
-                }
-#endif
                 LOG_INFO(Service_NVDRV, "Using {} GPU decoder", av_hwdevice_get_type_name(type));
                 av_codec_ctx->pix_fmt = config->pix_fmt;
                 return true;


### PR DESCRIPTION
The code in question disabled use of CUDA/NVDEC hardware decoder on all Linux machines, including those where it works just fine. The only known setup where this caused problems and led to inclusion of this code is having two NVIDIA+AMD GPUs installed, which is a fairly uncommon case that with this change only requires user to select "CPU Video Decoding" for NVDEC emulation.

I've confirmed that this allows GPU decoding to work on my Linux+Nvidia setup.