### PR TITLE
Manually robust on Maxwell and earlier

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -64,6 +64,42 @@ struct UniformDefinitions {
     Id F32{};
     Id U32x2{};
     Id U32x4{};
+
+    constexpr static size_t NumElements(Id UniformDefinitions::*member_ptr) {
+        if (member_ptr == &UniformDefinitions::U8) {
+            return 1;
+        }
+        if (member_ptr == &UniformDefinitions::S8) {
+            return 1;
+        }
+        if (member_ptr == &UniformDefinitions::U16) {
+            return 1;
+        }
+        if (member_ptr == &UniformDefinitions::S16) {
+            return 1;
+        }
+        if (member_ptr == &UniformDefinitions::U32) {
+            return 1;
+        }
+        if (member_ptr == &UniformDefinitions::F32) {
+            return 1;
+        }
+        if (member_ptr == &UniformDefinitions::U32x2) {
+            return 2;
+        }
+        if (member_ptr == &UniformDefinitions::U32x4) {
+            return 4;
+        }
+        ASSERT(false);
+        return 1;
+    }
+
+    constexpr static bool IsFloat(Id UniformDefinitions::*member_ptr) {
+        if (member_ptr == &UniformDefinitions::F32) {
+            return true;
+        }
+        return false;
+    }
 };
 
 struct StorageTypeDefinition {

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -9,7 +9,6 @@ namespace Shader {
 
 struct Profile {
     u32 supported_spirv{0x00010000};
-
     bool unified_descriptor_binding{};
     bool support_descriptor_aliasing{};
     bool support_int8{};
@@ -82,6 +81,9 @@ struct Profile {
     bool has_broken_spirv_subgroup_mask_vector_extract_dynamic{};
 
     u32 gl_max_compute_smem_size{};
+
+    /// Maxwell and earlier nVidia architectures have broken robust support
+    bool has_broken_robust{};
 };
 
 } // namespace Shader

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -356,7 +356,11 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .has_broken_fp16_float_controls = driver_id == VK_DRIVER_ID_NVIDIA_PROPRIETARY,
         .ignore_nan_fp_comparisons = false,
         .has_broken_spirv_subgroup_mask_vector_extract_dynamic =
-            driver_id == VK_DRIVER_ID_QUALCOMM_PROPRIETARY};
+            driver_id == VK_DRIVER_ID_QUALCOMM_PROPRIETARY,
+        .has_broken_robust =
+            device.IsNvidia() && device.GetNvidiaArch() <= NvidiaArchitecture::Arch_Maxwell,
+    };
+
     host_info = Shader::HostTranslateInfo{
         .support_float64 = device.IsFloat64Supported(),
         .support_float16 = device.IsFloat16Supported(),

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -177,6 +177,15 @@ enum class FormatType { Linear, Optimal, Buffer };
 /// Subgroup size of the guest emulated hardware (Nvidia has 32 threads per subgroup).
 const u32 GuestWarpSize = 32;
 
+enum class NvidiaArchitecture {
+    Arch_KeplerOrOlder,
+    Arch_Maxwell,
+    Arch_Pascal,
+    Arch_Volta,
+    Arch_Turing,
+    Arch_AmpereOrNewer,
+};
+
 /// Handles data specific to a physical device.
 class Device {
 public:
@@ -670,6 +679,14 @@ public:
         return false;
     }
 
+    bool IsNvidia() const noexcept {
+        return properties.driver.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY;
+    }
+
+    NvidiaArchitecture GetNvidiaArch() const noexcept {
+        return nvidia_arch;
+    }
+
 private:
     /// Checks if the physical device is suitable and configures the object state
     /// with all necessary info about its properties.
@@ -788,6 +805,7 @@ private:
     bool supports_conditional_barriers{};      ///< Allows barriers in conditional control flow.
     u64 device_access_memory{};                ///< Total size of device local memory in bytes.
     u32 sets_per_pool{};                       ///< Sets per Description Pool
+    NvidiaArchitecture nvidia_arch{NvidiaArchitecture::Arch_AmpereOrNewer};
 
     // Telemetry parameters
     std::set<std::string, std::less<>> supported_extensions; ///< Reported Vulkan extensions.


### PR DESCRIPTION
Unfortunately it seems like Maxwell and Pascal cards have broken robust support, or something else strange is happening in Yuzu preventing it from working correctly. Crash Team Racing Nitro Fueled uses wildly invalid buffer indexes (values like 0x3D00001C), and they should just return 0 with robust enabled on the device, but Maxwell seems to instead just % the index with the buffer size, or & it with at least 0x10000 or something, and is returning "valid" results even with large indexes. 0x3D00001C returns the same value as 0x1C. No bits above bit 16 affect the returned result, so 0x20000 and above.

This PR also changes the arithmetic shifts to logical, since we don't want negative indexes, which also affects CTR.

I feel like there's something else strange going on in our shaders or their setup, or in how we enable robust or something which is causing it to fail. Ryujinx doesn't seem to suffer this issue, and the load does return 0, though that may be coincidence or something to do with our 16k buffer size their 4k, not sure. If anyone wants to investigate further, please do.

This should close #8215 and #6731.