### PR TITLE
service: hle: Allow to access read buffer A and X directly

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -400,13 +400,13 @@ protected:
         IPC::RequestParser rp{ctx};
         const auto base = rp.PopRaw<ProfileBase>();
 
-        const auto user_data = ctx.ReadBuffer();
-        const auto image_data = ctx.ReadBuffer(1);
+        const auto image_data = ctx.ReadBufferA(0);
+        const auto user_data = ctx.ReadBufferX(0);
 
-        LOG_DEBUG(Service_ACC, "called, username='{}', timestamp={:016X}, uuid=0x{}",
-                  Common::StringFromFixedZeroTerminatedBuffer(
-                      reinterpret_cast<const char*>(base.username.data()), base.username.size()),
-                  base.timestamp, base.user_uuid.RawString());
+        LOG_INFO(Service_ACC, "called, username='{}', timestamp={:016X}, uuid=0x{}",
+                 Common::StringFromFixedZeroTerminatedBuffer(
+                     reinterpret_cast<const char*>(base.username.data()), base.username.size()),
+                 base.timestamp, base.user_uuid.RawString());
 
         if (user_data.size() < sizeof(UserData)) {
             LOG_ERROR(Service_ACC, "UserData buffer too small!");

--- a/src/core/hle/service/hle_ipc.h
+++ b/src/core/hle/service/hle_ipc.h
@@ -253,6 +253,12 @@ public:
         return domain_message_header.has_value();
     }
 
+    /// Helper function to get a span of a buffer using the buffer descriptor A
+    [[nodiscard]] std::span<const u8> ReadBufferA(std::size_t buffer_index = 0) const;
+
+    /// Helper function to get a span of a buffer using the buffer descriptor X
+    [[nodiscard]] std::span<const u8> ReadBufferX(std::size_t buffer_index = 0) const;
+
     /// Helper function to get a span of a buffer using the appropriate buffer descriptor
     [[nodiscard]] std::span<const u8> ReadBuffer(std::size_t buffer_index = 0) const;
 

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -58,14 +58,8 @@ private:
         IPC::RequestParser rp{ctx};
         const auto process_id = rp.PopRaw<u64>();
 
-        const auto data1 = ctx.ReadBuffer(0);
-        const auto data2 = [&ctx] {
-            if (ctx.CanReadBuffer(1)) {
-                return ctx.ReadBuffer(1);
-            }
-
-            return std::span<const u8>{};
-        }();
+        const auto data1 = ctx.ReadBufferA(0);
+        const auto data2 = ctx.ReadBufferX(0);
 
         LOG_DEBUG(Service_PREPO,
                   "called, type={:02X}, process_id={:016X}, data1_size={:016X}, data2_size={:016X}",
@@ -85,14 +79,8 @@ private:
         const auto user_id = rp.PopRaw<u128>();
         const auto process_id = rp.PopRaw<u64>();
 
-        const auto data1 = ctx.ReadBuffer(0);
-        const auto data2 = [&ctx] {
-            if (ctx.CanReadBuffer(1)) {
-                return ctx.ReadBuffer(1);
-            }
-
-            return std::span<const u8>{};
-        }();
+        const auto data1 = ctx.ReadBufferA(0);
+        const auto data2 = ctx.ReadBufferX(0);
 
         LOG_DEBUG(Service_PREPO,
                   "called, type={:02X}, user_id={:016X}{:016X}, process_id={:016X}, "
@@ -137,14 +125,8 @@ private:
         IPC::RequestParser rp{ctx};
         const auto title_id = rp.PopRaw<u64>();
 
-        const auto data1 = ctx.ReadBuffer(0);
-        const auto data2 = [&ctx] {
-            if (ctx.CanReadBuffer(1)) {
-                return ctx.ReadBuffer(1);
-            }
-
-            return std::span<const u8>{};
-        }();
+        const auto data1 = ctx.ReadBufferA(0);
+        const auto data2 = ctx.ReadBufferX(0);
 
         LOG_DEBUG(Service_PREPO, "called, title_id={:016X}, data1_size={:016X}, data2_size={:016X}",
                   title_id, data1.size(), data2.size());
@@ -161,14 +143,8 @@ private:
         const auto user_id = rp.PopRaw<u128>();
         const auto title_id = rp.PopRaw<u64>();
 
-        const auto data1 = ctx.ReadBuffer(0);
-        const auto data2 = [&ctx] {
-            if (ctx.CanReadBuffer(1)) {
-                return ctx.ReadBuffer(1);
-            }
-
-            return std::span<const u8>{};
-        }();
+        const auto data1 = ctx.ReadBufferA(0);
+        const auto data2 = ctx.ReadBufferX(0);
 
         LOG_DEBUG(Service_PREPO,
                   "called, user_id={:016X}{:016X}, title_id={:016X}, data1_size={:016X}, "


### PR DESCRIPTION
In some rare cases both buffer descriptors A and X are available under the same index. This was the case with `StoreWithImage` and `SaveReportWithUser`.

This PR addresses this issue by letting them be accessed directly. I also added a warning log to help identify this issue on the rest of the codebase as it's probably an error.