### PR TITLE
input_common: udp: Avoid crash when trying to map motion before client is ready

### DIFF
--- a/src/input_common/drivers/udp_client.cpp
+++ b/src/input_common/drivers/udp_client.cpp
@@ -338,6 +338,7 @@ void UDPClient::StartCommunication(std::size_t client, const std::string& host, 
     for (std::size_t index = 0; index < PADS_PER_CLIENT; ++index) {
         const PadIdentifier identifier = GetPadIdentifier(client * PADS_PER_CLIENT + index);
         PreSetController(identifier);
+        PreSetMotion(identifier, 0);
     }
 }
 


### PR DESCRIPTION
CemuHook can take a while to connect. So it's very likely you can start trying to map motion before the client is ready. To avoid mapping to undefined axis we need to preset the motion input beforehand. 