### PR TITLE
 yuzu: Improve behavior when clicking on controller box in Controller applet

### DIFF
--- a/src/yuzu/applets/qt_controller.h
+++ b/src/yuzu/applets/qt_controller.h
@@ -100,6 +100,10 @@ private:
     // Updates the console mode.
     void UpdateDockedState(bool is_handheld);
 
+    // Enable preceding controllers or disable following ones
+    void PropagatePlayerNumberChanged(size_t player_index, bool checked,
+                                      bool reconnect_current = false);
+
     // Disables and disconnects unsupported players based on the given parameters.
     void DisableUnsupportedPlayers();
 

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -56,7 +56,9 @@ private:
     void UpdateDockedState(bool is_handheld);
     void UpdateAllInputDevices();
     void UpdateAllInputProfiles(std::size_t player_index);
-    void propagateMouseClickOnPlayers(size_t player_index, bool origin, bool checked);
+    // Enable preceding controllers or disable following ones
+    void PropagatePlayerNumberChanged(size_t player_index, bool checked,
+                                      bool reconnect_current = false);
 
     /// Load configuration settings.
     void LoadConfiguration();
@@ -71,7 +73,8 @@ private:
 
     std::array<ConfigureInputPlayer*, 8> player_controllers;
     std::array<QWidget*, 8> player_tabs;
-    std::array<QCheckBox*, 8> player_connected;
+    // Checkboxes representing the "Connected Controllers".
+    std::array<QCheckBox*, 8> connected_controller_checkboxes;
     ConfigureInputAdvanced* advanced;
 
     Core::System& system;

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -75,7 +75,7 @@ public:
     void ClearAll();
 
 signals:
-    /// Emitted when this controller is connected by the user.
+    /// Emitted when this controller is (dis)connected by the user.
     void Connected(bool connected);
     /// Emitted when the Handheld mode is selected (undocked with dual joycons attached).
     void HandheldStateChanged(bool is_handheld);
@@ -182,9 +182,6 @@ private:
 
     /// Stores a pair of "Connected Controllers" combobox index and Controller Type enum.
     std::vector<std::pair<int, Core::HID::NpadStyleIndex>> index_controller_type_pairs;
-
-    static constexpr int PLAYER_COUNT = 8;
-    std::array<QCheckBox*, PLAYER_COUNT> player_connected_checkbox;
 
     /// This will be the the setting function when an input is awaiting configuration.
     std::optional<std::function<void(const Common::ParamPackage&)>> input_setter;


### PR DESCRIPTION
- Apply changes on Controller configuration of commit 9524d70 to Controller applet
  - Fix regression of this previous commit: Enabling a controller in its tab did not activate previous controllers
  - Refactor to use same names in both classes