### PR TITLE
yuzu: Always ask when closing game with controller

### DIFF
--- a/src/yuzu/hotkeys.cpp
+++ b/src/yuzu/hotkeys.cpp
@@ -181,6 +181,10 @@ bool ControllerShortcut::IsEnabled() const {
     return is_enabled;
 }
 
+bool ControllerShortcut::IsActive() const {
+    return active;
+}
+
 void ControllerShortcut::ControllerUpdateEvent(Core::HID::ControllerTriggerType type) {
     if (!is_enabled) {
         return;

--- a/src/yuzu/hotkeys.h
+++ b/src/yuzu/hotkeys.h
@@ -39,6 +39,7 @@ public:
 
     void SetEnabled(bool enable);
     bool IsEnabled() const;
+    bool IsActive() const;
 
 Q_SIGNALS:
     void Activated();

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -98,7 +98,7 @@ struct Values {
         true,    true};
 
     SwitchableSetting<ConfirmStop> confirm_before_stopping{linkage,
-                                                           ConfirmStop::Ask_Always,
+                                                           ConfirmStop::Ask_Based_On_Game,
                                                            "confirmStop",
                                                            Category::UiGeneral,
                                                            Settings::Specialization::Default,


### PR DESCRIPTION
Probably a personal preference but I definitively hate that games always ask on close by default. This changes that back to only when game request. But it will always ask when using the controller hotkey.