### PR TITLE
kernel: fix incorrect calculation of used non system memory value

### DIFF
--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -149,7 +149,7 @@ u64 KProcess::GetTotalPhysicalMemoryUsed() {
 }
 
 u64 KProcess::GetTotalPhysicalMemoryUsedWithoutSystemResource() {
-    return this->GetTotalPhysicalMemoryUsed() - this->GetSystemResourceUsage();
+    return this->GetTotalPhysicalMemoryUsed() - this->GetSystemResourceSize();
 }
 
 bool KProcess::ReleaseUserException(KThread* thread) {


### PR DESCRIPTION
Fixes boot crash on Super Mario Bros Wonder