### PR TITLE
nvnflinger: fix reporting and freeing of preallocated buffers

### DIFF
--- a/src/core/hle/service/nvnflinger/buffer_queue_core.cpp
+++ b/src/core/hle/service/nvnflinger/buffer_queue_core.cpp
@@ -41,7 +41,7 @@ bool BufferQueueCore::WaitForDequeueCondition(std::unique_lock<std::mutex>& lk) 
 s32 BufferQueueCore::GetMinUndequeuedBufferCountLocked(bool async) const {
     // If DequeueBuffer is allowed to error out, we don't have to add an extra buffer.
     if (!use_async_buffer) {
-        return max_acquired_buffer_count;
+        return 0;
     }
 
     if (dequeue_buffer_cannot_block || async) {
@@ -52,7 +52,7 @@ s32 BufferQueueCore::GetMinUndequeuedBufferCountLocked(bool async) const {
 }
 
 s32 BufferQueueCore::GetMinMaxBufferCountLocked(bool async) const {
-    return GetMinUndequeuedBufferCountLocked(async) + 1;
+    return GetMinUndequeuedBufferCountLocked(async);
 }
 
 s32 BufferQueueCore::GetMaxBufferCountLocked(bool async) const {
@@ -61,7 +61,7 @@ s32 BufferQueueCore::GetMaxBufferCountLocked(bool async) const {
 
     if (override_max_buffer_count != 0) {
         ASSERT(override_max_buffer_count >= min_buffer_count);
-        max_buffer_count = override_max_buffer_count;
+        return override_max_buffer_count;
     }
 
     // Any buffers that are dequeued by the producer or sitting in the queue waiting to be consumed


### PR DESCRIPTION
Super Mario Bros Wonder switches between double and triple buffered presentation modes in-game and in the world map.

Decreasing the buffer count would almost always freeze, because we would end up freeing a preallocated buffer slot beyond the new max buffer count. This caused the game to continuously retry to dequeue that slot and fail.

This ensures we don't free preallocated slots, and fixes buffer count tracking, preventing the game from freezing when transitioning.