### PR TITLE
common: use SetThreadDescription API for thread names

### DIFF
--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -11,6 +11,7 @@
 #include <mach/mach.h>
 #elif defined(_WIN32)
 #include <windows.h>
+#include "common/string_util.h"
 #else
 #if defined(__Bitrig__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <pthread_np.h>
@@ -82,29 +83,8 @@ void SetCurrentThreadPriority(ThreadPriority new_priority) {
 #ifdef _MSC_VER
 
 // Sets the debugger-visible name of the current thread.
-// Uses trick documented in:
-// https://docs.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code
 void SetCurrentThreadName(const char* name) {
-    static const DWORD MS_VC_EXCEPTION = 0x406D1388;
-
-#pragma pack(push, 8)
-    struct THREADNAME_INFO {
-        DWORD dwType;     // must be 0x1000
-        LPCSTR szName;    // pointer to name (in user addr space)
-        DWORD dwThreadID; // thread ID (-1=caller thread)
-        DWORD dwFlags;    // reserved for future use, must be zero
-    } info;
-#pragma pack(pop)
-
-    info.dwType = 0x1000;
-    info.szName = name;
-    info.dwThreadID = std::numeric_limits<DWORD>::max();
-    info.dwFlags = 0;
-
-    __try {
-        RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
-    } __except (EXCEPTION_CONTINUE_EXECUTION) {
-    }
+    SetThreadDescription(GetCurrentThread(), UTF8ToUTF16W(name).data());
 }
 
 #else // !MSVC_VER, so must be POSIX threads


### PR DESCRIPTION
Available in Windows 10 1607+, and our minimum requirement is already 1809+