### PR TITLE
input_common: joycon: Move vibrations to a queue

### DIFF
--- a/src/input_common/helpers/joycon_driver.h
+++ b/src/input_common/helpers/joycon_driver.h
@@ -9,6 +9,7 @@
 #include <span>
 #include <thread>
 
+#include "common/threadsafe_queue.h"
 #include "input_common/helpers/joycon_protocol/joycon_types.h"
 
 namespace Common::Input {
@@ -151,6 +152,10 @@ private:
     SerialNumber serial_number{};        // Serial number reported by controller
     SerialNumber handle_serial_number{}; // Serial number type reported by hidapi
     SupportedFeatures supported_features{};
+
+    /// Queue of vibration request to controllers
+    Common::Input::DriverResult last_vibration_result{Common::Input::DriverResult::Success};
+    Common::SPSCQueue<VibrationValue> vibration_queue;
 
     // Thread related
     mutable std::mutex mutex;


### PR DESCRIPTION
Currently switch controllers need to wait for the reply of the controller. This takes time. Games like Mario Wonder love vibration. So you start feeling those little stutters from vibration. We can avoid this by using a queue and just returning a delayed vibration result.