### PR TITLE
Add missing loop around compute FindBuffer calls

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1067,8 +1067,7 @@ void BufferCache<P>::BindHostComputeTextureBuffers() {
 
 template <class P>
 void BufferCache<P>::DoUpdateGraphicsBuffers(bool is_indexed) {
-    do {
-        channel_state->has_deleted_buffers = false;
+    BufferOperations([&]() {
         if (is_indexed) {
             UpdateIndexBuffer();
         }
@@ -1082,14 +1081,16 @@ void BufferCache<P>::DoUpdateGraphicsBuffers(bool is_indexed) {
         if (current_draw_indirect) {
             UpdateDrawIndirect();
         }
-    } while (channel_state->has_deleted_buffers);
+    });
 }
 
 template <class P>
 void BufferCache<P>::DoUpdateComputeBuffers() {
-    UpdateComputeUniformBuffers();
-    UpdateComputeStorageBuffers();
-    UpdateComputeTextureBuffers();
+    BufferOperations([&]() {
+        UpdateComputeUniformBuffers();
+        UpdateComputeStorageBuffers();
+        UpdateComputeTextureBuffers();
+    });
 }
 
 template <class P>

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -13,6 +13,7 @@
 #include "common/microprofile.h"
 #include "common/scope_exit.h"
 #include "common/settings.h"
+#include "video_core/buffer_cache/buffer_cache.h"
 #include "video_core/control/channel_state.h"
 #include "video_core/engines/draw_manager.h"
 #include "video_core/engines/kepler_compute.h"
@@ -285,6 +286,7 @@ void RasterizerVulkan::DrawTexture() {
 
     query_cache.NotifySegment(true);
 
+    std::scoped_lock l{texture_cache.mutex};
     texture_cache.SynchronizeGraphicsDescriptors();
     texture_cache.UpdateRenderTargets(false);
 


### PR DESCRIPTION
FindBuffer calls are required to be wrapped in a do/while loop due to the fact that existing buffers can be deleted on resize to accommodate a new overlapping range, which then invalidates the existing buffer ids in that range. When that happens, we need to loop and try to grab new buffer ids for all resources again. This is already done for graphics resources, but is missing for compute.

Also adds a cache lock in DrawTexture which seems to be missing.