### PR TITLE
qt: fix game list shutdown crash

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -380,7 +380,6 @@ void GameList::UnloadController() {
 
 GameList::~GameList() {
     UnloadController();
-    emit ShouldCancelWorker();
 }
 
 void GameList::SetFilterFocus() {
@@ -395,6 +394,10 @@ void GameList::SetFilterVisible(bool visibility) {
 
 void GameList::ClearFilter() {
     search_field->clear();
+}
+
+void GameList::WorkerEvent() {
+    current_worker->ProcessEvents(this);
 }
 
 void GameList::AddDirEntry(GameListDir* entry_items) {
@@ -826,28 +829,21 @@ void GameList::PopulateAsync(QVector<UISettings::GameDir>& game_dirs) {
     tree_view->setColumnHidden(COLUMN_SIZE, !UISettings::values.show_size);
     tree_view->setColumnHidden(COLUMN_PLAY_TIME, !UISettings::values.show_play_time);
 
-    // Before deleting rows, cancel the worker so that it is not using them
-    emit ShouldCancelWorker();
+    // Cancel any existing worker.
+    current_worker.reset();
 
     // Delete any rows that might already exist if we're repopulating
     item_model->removeRows(0, item_model->rowCount());
     search_field->clear();
 
-    GameListWorker* worker =
-        new GameListWorker(vfs, provider, game_dirs, compatibility_list, play_time_manager, system);
+    current_worker = std::make_unique<GameListWorker>(vfs, provider, game_dirs, compatibility_list,
+                                                      play_time_manager, system);
 
-    connect(worker, &GameListWorker::EntryReady, this, &GameList::AddEntry, Qt::QueuedConnection);
-    connect(worker, &GameListWorker::DirEntryReady, this, &GameList::AddDirEntry,
+    // Get events from the worker as data becomes available
+    connect(current_worker.get(), &GameListWorker::DataAvailable, this, &GameList::WorkerEvent,
             Qt::QueuedConnection);
-    connect(worker, &GameListWorker::Finished, this, &GameList::DonePopulating,
-            Qt::QueuedConnection);
-    // Use DirectConnection here because worker->Cancel() is thread-safe and we want it to
-    // cancel without delay.
-    connect(this, &GameList::ShouldCancelWorker, worker, &GameListWorker::Cancel,
-            Qt::DirectConnection);
 
-    QThreadPool::globalInstance()->start(worker);
-    current_worker = std::move(worker);
+    QThreadPool::globalInstance()->start(current_worker.get());
 }
 
 void GameList::SaveInterfaceLayout() {

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -109,7 +109,6 @@ signals:
     void BootGame(const QString& game_path, u64 program_id, std::size_t program_index,
                   StartGameType type, AmLaunchType launch_type);
     void GameChosen(const QString& game_path, const u64 title_id = 0);
-    void ShouldCancelWorker();
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target,
                              const std::string& game_path);
     void OpenTransferableShaderCacheRequested(u64 program_id);
@@ -138,10 +137,15 @@ private slots:
     void OnUpdateThemedIcons();
 
 private:
+    friend class GameListWorker;
+    void WorkerEvent();
+
     void AddDirEntry(GameListDir* entry_items);
     void AddEntry(const QList<QStandardItem*>& entry_items, GameListDir* parent);
-    void ValidateEntry(const QModelIndex& item);
     void DonePopulating(const QStringList& watch_list);
+
+private:
+    void ValidateEntry(const QModelIndex& item);
 
     void RefreshGameDirectory();
 
@@ -165,7 +169,7 @@ private:
     QVBoxLayout* layout = nullptr;
     QTreeView* tree_view = nullptr;
     QStandardItemModel* item_model = nullptr;
-    GameListWorker* current_worker = nullptr;
+    std::unique_ptr<GameListWorker> current_worker;
     QFileSystemWatcher* watcher = nullptr;
     ControllerNavigation* controller_navigation = nullptr;
     CompatibilityList compatibility_list;


### PR DESCRIPTION
I experienced seemingly random shutdown crashes about 10% of the time and seemingly duplicated objects in the game list when shutting down games more than 50% of the time. This is another result of the play time PR, which fully reloads the game list on shutdown.

It turns out there is a really annoying behavior of Qt: when an object is disconnected or destroyed, any messages from that object which are still queued in slots (but not yet delivered) will still get delivered. This led to messages from the game list worker, which had just been canceled and destroyed, sending invalid data references to the game list, which would then try to process them and crash.

Unfortunately it is not possible to ensure the signal queue for any given object is empty in Qt, so we change the strategy by signaling the _availability_ of game list data instead of the data itself, and then requiring the game list to go fetch the events from the worker instance it knows is the current one.

This ensures that even if we receive spurious events from a worker which we just destroyed, we will check a non-destroyed worker reference for events and end up doing nothing instead of crashing.