### PR TITLE
vulkan_common: use highest API version

### DIFF
--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -522,7 +522,7 @@ Instance Instance::Create(u32 version, Span<const char*> layers, Span<const char
         .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
         .pEngineName = "yuzu Emulator",
         .engineVersion = VK_MAKE_VERSION(0, 1, 0),
-        .apiVersion = version,
+        .apiVersion = VK_API_VERSION_1_3,
     };
     const VkInstanceCreateInfo ci{
         .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,


### PR DESCRIPTION
https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkApplicationInfo.html
> Vulkan 1.0 implementations were required to return `VK_ERROR_INCOMPATIBLE_DRIVER` if `apiVersion` was larger than 1.0. Implementations that support Vulkan 1.1 or later **must** not return `VK_ERROR_INCOMPATIBLE_DRIVER` for any value of `apiVersion`.
...
> The Khronos validation layers will treat `apiVersion` as the highest API version the application targets, and will validate API usage against the minimum of that version and the implementation version (instance or device, depending on context). If an application tries to use functionality from a greater version than this, a validation error will be triggered.


We support features from Vulkan 1.3, and attempt to use them with the logical device, but 1.1 loaders would reject our calls and crash. This should fix all Android devices that should have been able to use Turnip not working with it.