### PR TITLE
service: am: Implement ISelfController::SaveCurrentScreenshot

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -31,6 +31,7 @@
 #include "core/hle/service/apm/apm_controller.h"
 #include "core/hle/service/apm/apm_interface.h"
 #include "core/hle/service/bcat/backend/backend.h"
+#include "core/hle/service/caps/caps_su.h"
 #include "core/hle/service/caps/caps_types.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/ipc_helpers.h"
@@ -702,9 +703,17 @@ void ISelfController::SetAlbumImageTakenNotificationEnabled(HLERequestContext& c
 void ISelfController::SaveCurrentScreenshot(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
 
-    const auto album_report_option = rp.PopEnum<Capture::AlbumReportOption>();
+    const auto report_option = rp.PopEnum<Capture::AlbumReportOption>();
 
-    LOG_WARNING(Service_AM, "(STUBBED) called. album_report_option={}", album_report_option);
+    LOG_INFO(Service_AM, "called, report_option={}", report_option);
+
+    const auto screenshot_service =
+        system.ServiceManager().GetService<Service::Capture::IScreenShotApplicationService>(
+            "caps:su");
+
+    if (screenshot_service) {
+        screenshot_service->CaptureAndSaveScreenshot(report_option);
+    }
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);

--- a/src/core/hle/service/caps/caps_manager.cpp
+++ b/src/core/hle/service/caps/caps_manager.cpp
@@ -228,12 +228,14 @@ Result AlbumManager::LoadAlbumScreenShotThumbnail(
 
 Result AlbumManager::SaveScreenShot(ApplicationAlbumEntry& out_entry,
                                     const ScreenShotAttribute& attribute,
-                                    std::span<const u8> image_data, u64 aruid) {
-    return SaveScreenShot(out_entry, attribute, {}, image_data, aruid);
+                                    AlbumReportOption report_option, std::span<const u8> image_data,
+                                    u64 aruid) {
+    return SaveScreenShot(out_entry, attribute, report_option, {}, image_data, aruid);
 }
 
 Result AlbumManager::SaveScreenShot(ApplicationAlbumEntry& out_entry,
                                     const ScreenShotAttribute& attribute,
+                                    AlbumReportOption report_option,
                                     const ApplicationData& app_data, std::span<const u8> image_data,
                                     u64 aruid) {
     const u64 title_id = system.GetApplicationProcessProgramID();
@@ -407,10 +409,14 @@ Result AlbumManager::LoadImage(std::span<u8> out_image, const std::filesystem::p
     return ResultSuccess;
 }
 
-static void PNGToMemory(void* context, void* png, int len) {
+void AlbumManager::FlipVerticallyOnWrite(bool flip) {
+    stbi_flip_vertically_on_write(flip);
+}
+
+static void PNGToMemory(void* context, void* data, int len) {
     std::vector<u8>* png_image = static_cast<std::vector<u8>*>(context);
-    png_image->reserve(len);
-    std::memcpy(png_image->data(), png, len);
+    unsigned char* png = static_cast<unsigned char*>(data);
+    png_image->insert(png_image->end(), png, png + len);
 }
 
 Result AlbumManager::SaveImage(ApplicationAlbumEntry& out_entry, std::span<const u8> image,

--- a/src/core/hle/service/caps/caps_manager.h
+++ b/src/core/hle/service/caps/caps_manager.h
@@ -59,13 +59,16 @@ public:
                                         const ScreenShotDecodeOption& decoder_options) const;
 
     Result SaveScreenShot(ApplicationAlbumEntry& out_entry, const ScreenShotAttribute& attribute,
-                          std::span<const u8> image_data, u64 aruid);
-    Result SaveScreenShot(ApplicationAlbumEntry& out_entry, const ScreenShotAttribute& attribute,
-                          const ApplicationData& app_data, std::span<const u8> image_data,
+                          AlbumReportOption report_option, std::span<const u8> image_data,
                           u64 aruid);
+    Result SaveScreenShot(ApplicationAlbumEntry& out_entry, const ScreenShotAttribute& attribute,
+                          AlbumReportOption report_option, const ApplicationData& app_data,
+                          std::span<const u8> image_data, u64 aruid);
     Result SaveEditedScreenShot(ApplicationAlbumEntry& out_entry,
                                 const ScreenShotAttribute& attribute, const AlbumFileId& file_id,
                                 std::span<const u8> image_data);
+
+    void FlipVerticallyOnWrite(bool flip);
 
 private:
     static constexpr std::size_t NandAlbumFileLimit = 1000;

--- a/src/core/hle/service/caps/caps_ss.cpp
+++ b/src/core/hle/service/caps/caps_ss.cpp
@@ -34,7 +34,7 @@ void IScreenShotService::SaveScreenShotEx0(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     struct Parameters {
         ScreenShotAttribute attribute{};
-        u32 report_option{};
+        AlbumReportOption report_option{};
         INSERT_PADDING_BYTES(0x4);
         u64 applet_resource_user_id{};
     };
@@ -49,13 +49,16 @@ void IScreenShotService::SaveScreenShotEx0(HLERequestContext& ctx) {
              parameters.applet_resource_user_id);
 
     ApplicationAlbumEntry entry{};
-    const auto result = manager->SaveScreenShot(entry, parameters.attribute, image_data_buffer,
-                                                parameters.applet_resource_user_id);
+    manager->FlipVerticallyOnWrite(false);
+    const auto result =
+        manager->SaveScreenShot(entry, parameters.attribute, parameters.report_option,
+                                image_data_buffer, parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 10};
     rb.Push(result);
     rb.PushRaw(entry);
 }
+
 void IScreenShotService::SaveEditedScreenShotEx1(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     struct Parameters {
@@ -83,6 +86,7 @@ void IScreenShotService::SaveEditedScreenShotEx1(HLERequestContext& ctx) {
              image_data_buffer.size(), thumbnail_image_data_buffer.size());
 
     ApplicationAlbumEntry entry{};
+    manager->FlipVerticallyOnWrite(false);
     const auto result = manager->SaveEditedScreenShot(entry, parameters.attribute,
                                                       parameters.file_id, image_data_buffer);
 

--- a/src/core/hle/service/caps/caps_su.h
+++ b/src/core/hle/service/caps/caps_su.h
@@ -10,6 +10,7 @@ class System;
 }
 
 namespace Service::Capture {
+enum class AlbumReportOption : s32;
 class AlbumManager;
 
 class IScreenShotApplicationService final : public ServiceFramework<IScreenShotApplicationService> {
@@ -18,10 +19,18 @@ public:
                                            std::shared_ptr<AlbumManager> album_manager);
     ~IScreenShotApplicationService() override;
 
+    void CaptureAndSaveScreenshot(AlbumReportOption report_option);
+
 private:
+    static constexpr std::size_t screenshot_width = 1280;
+    static constexpr std::size_t screenshot_height = 720;
+    static constexpr std::size_t bytes_per_pixel = 4;
+
     void SetShimLibraryVersion(HLERequestContext& ctx);
     void SaveScreenShotEx0(HLERequestContext& ctx);
     void SaveScreenShotEx1(HLERequestContext& ctx);
+
+    std::array<u8, screenshot_width * screenshot_height * bytes_per_pixel> image_data;
 
     std::shared_ptr<AlbumManager> manager;
 };


### PR DESCRIPTION
Fixes the regression caused by #11880 and implements `SaveCurrentScreenshot`. This function is a bit more complicated from the others since the game doesn't provide the image data. This allows to take screenshots on `Pokémon Scarlet` on the latest game update.

![0100a3d008c5c000_2023-10-26_17-15-17-000](https://github.com/yuzu-emu/yuzu/assets/5944268/6506027a-496c-494c-8611-82ad791d07ca)
