### PR TITLE
renderer_vulkan: fix viewport swizzle dirty state tracking

### DIFF
--- a/src/video_core/renderer_vulkan/vk_state_tracker.cpp
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.cpp
@@ -190,7 +190,7 @@ void SetupDirtySpecialOps(Tables& tables) {
 void SetupDirtyViewportSwizzles(Tables& tables) {
     static constexpr size_t swizzle_offset = 6;
     for (size_t index = 0; index < Regs::NumViewports; ++index) {
-        tables[0][OFF(viewport_transform) + index * NUM(viewport_transform[0]) + swizzle_offset] =
+        tables[1][OFF(viewport_transform) + index * NUM(viewport_transform[0]) + swizzle_offset] =
             ViewportSwizzles;
     }
 }


### PR DESCRIPTION
When swizzle is invalidated we need to update the whole viewport state, but we were clobbering the viewport dirty state in this case. Moving these to the second table ensures we track the invalidation correctly.

Fixes #9368
Fixes #8839