### PR TITLE
nvnflinger: use RAII container for map handles

### DIFF
--- a/src/core/hle/service/nvnflinger/buffer_queue_consumer.cpp
+++ b/src/core/hle/service/nvnflinger/buffer_queue_consumer.cpp
@@ -5,7 +5,6 @@
 // https://cs.android.com/android/platform/superproject/+/android-5.1.1_r38:frameworks/native/libs/gui/BufferQueueConsumer.cpp
 
 #include "common/logging/log.h"
-#include "core/hle/service/nvdrv/core/nvmap.h"
 #include "core/hle/service/nvnflinger/buffer_item.h"
 #include "core/hle/service/nvnflinger/buffer_queue_consumer.h"
 #include "core/hle/service/nvnflinger/buffer_queue_core.h"
@@ -14,9 +13,8 @@
 
 namespace Service::android {
 
-BufferQueueConsumer::BufferQueueConsumer(std::shared_ptr<BufferQueueCore> core_,
-                                         Service::Nvidia::NvCore::NvMap& nvmap_)
-    : core{std::move(core_)}, slots{core->slots}, nvmap(nvmap_) {}
+BufferQueueConsumer::BufferQueueConsumer(std::shared_ptr<BufferQueueCore> core_)
+    : core{std::move(core_)}, slots{core->slots} {}
 
 BufferQueueConsumer::~BufferQueueConsumer() = default;
 
@@ -135,8 +133,7 @@ Status BufferQueueConsumer::ReleaseBuffer(s32 slot, u64 frame_number, const Fenc
         }
 
         slots[slot].buffer_state = BufferState::Free;
-
-        nvmap.FreeHandle(slots[slot].graphic_buffer->BufferId(), true);
+        slots[slot].map_handle.reset();
 
         listener = core->connected_producer_listener;
 

--- a/src/core/hle/service/nvnflinger/buffer_queue_consumer.h
+++ b/src/core/hle/service/nvnflinger/buffer_queue_consumer.h
@@ -25,8 +25,7 @@ class IConsumerListener;
 
 class BufferQueueConsumer final {
 public:
-    explicit BufferQueueConsumer(std::shared_ptr<BufferQueueCore> core_,
-                                 Service::Nvidia::NvCore::NvMap& nvmap_);
+    explicit BufferQueueConsumer(std::shared_ptr<BufferQueueCore> core_);
     ~BufferQueueConsumer();
 
     Status AcquireBuffer(BufferItem* out_buffer, std::chrono::nanoseconds expected_present);
@@ -37,7 +36,6 @@ public:
 private:
     std::shared_ptr<BufferQueueCore> core;
     BufferQueueDefs::SlotsType& slots;
-    Service::Nvidia::NvCore::NvMap& nvmap;
 };
 
 } // namespace Service::android

--- a/src/core/hle/service/nvnflinger/buffer_slot.h
+++ b/src/core/hle/service/nvnflinger/buffer_slot.h
@@ -11,6 +11,10 @@
 #include "common/common_types.h"
 #include "core/hle/service/nvnflinger/ui/fence.h"
 
+namespace Service::Nvidia::NvCore {
+class NvMap;
+}
+
 namespace Service::android {
 
 struct GraphicBuffer;
@@ -22,10 +26,27 @@ enum class BufferState : u32 {
     Acquired = 3,
 };
 
+class MapHandle final {
+public:
+    MapHandle();
+    ~MapHandle();
+
+    MapHandle(const MapHandle& rhs) = delete;
+    MapHandle& operator=(const MapHandle& rhs);
+
+    void emplace(Service::Nvidia::NvCore::NvMap& nvmap, u32 nvmap_id);
+    void reset();
+
+private:
+    Service::Nvidia::NvCore::NvMap* m_nvmap;
+    u32 m_nvmap_id;
+};
+
 struct BufferSlot final {
-    constexpr BufferSlot() = default;
+    BufferSlot() = default;
 
     std::shared_ptr<GraphicBuffer> graphic_buffer;
+    MapHandle map_handle;
     BufferState buffer_state{BufferState::Free};
     bool request_buffer_called{};
     u64 frame_number{};

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -35,7 +35,7 @@ static BufferQueue CreateBufferQueue(KernelHelpers::ServiceContext& service_cont
     return {
         buffer_queue_core,
         std::make_unique<android::BufferQueueProducer>(service_context, buffer_queue_core, nvmap),
-        std::make_unique<android::BufferQueueConsumer>(buffer_queue_core, nvmap)};
+        std::make_unique<android::BufferQueueConsumer>(buffer_queue_core)};
 }
 
 Display::Display(u64 id, std::string name_,


### PR DESCRIPTION
Makes the compiler balance reference counts when processing slots. I wanted to use std::optional for this as well, but it actually ended up requiring more code to do that then just manually implement the optional functionality.