### PR TITLE
Implemented wheel event for volume control in VolumeButton

### DIFF
--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -8,6 +8,7 @@
 
 #include <QMainWindow>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QTimer>
 #include <QTranslator>
 
@@ -136,6 +137,28 @@ enum class ReinitializeKeyBehavior {
 namespace VkDeviceInfo {
 class Record;
 }
+
+class VolumeButton : public QPushButton {
+    Q_OBJECT
+public:
+    explicit VolumeButton(QWidget* parent = nullptr) : QPushButton(parent), scroll_multiplier(1) {
+        connect(&scroll_timer, &QTimer::timeout, this, &VolumeButton::ResetMultiplier);
+    }
+
+signals:
+    void VolumeChanged();
+
+protected:
+    void wheelEvent(QWheelEvent* event) override;
+
+private slots:
+    void ResetMultiplier();
+
+private:
+    int scroll_multiplier;
+    QTimer scroll_timer;
+    constexpr static int MaxMultiplier = 8;
+};
 
 class GMainWindow : public QMainWindow {
     Q_OBJECT
@@ -481,7 +504,7 @@ private:
     QPushButton* dock_status_button = nullptr;
     QPushButton* filter_status_button = nullptr;
     QPushButton* aa_status_button = nullptr;
-    QPushButton* volume_button = nullptr;
+    VolumeButton* volume_button = nullptr;
     QWidget* volume_popup = nullptr;
     QSlider* volume_slider = nullptr;
     QTimer status_bar_update_timer;


### PR DESCRIPTION
This simply adds a way of changing the volume by scrolling when hovering over the volume button in the UI without having to click it.
Volume changes faster with longer scroll duration up to a cap.

First time ever contributing to open source so any feedback welcome.