### PR TITLE
nvidia_flags: Enable GL Threaded optimizations

### DIFF
--- a/src/common/nvidia_flags.cpp
+++ b/src/common/nvidia_flags.cpp
@@ -25,6 +25,7 @@ void ConfigureNvidiaEnvironmentFlags() {
 
     void(_putenv(fmt::format("__GL_SHADER_DISK_CACHE_PATH={}", windows_path_string).c_str()));
     void(_putenv("__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1"));
+    void(_putenv("__GL_THREADED_OPTIMIZATIONS=1"));
 #endif
 }
 


### PR DESCRIPTION
Force enables the Nvidia OpenGL threaded optimizations using the environment variable flag