### PR TITLE
android: Fix URI parsing in native code

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
@@ -5,6 +5,7 @@ package org.yuzu.yuzu_emu
 
 import android.app.Dialog
 import android.content.DialogInterface
+import android.net.Uri
 import android.os.Bundle
 import android.text.Html
 import android.text.method.LinkMovementMethod
@@ -16,7 +17,7 @@ import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.lang.ref.WeakReference
 import org.yuzu.yuzu_emu.activities.EmulationActivity
-import org.yuzu.yuzu_emu.utils.DocumentsTree.Companion.isNativePath
+import org.yuzu.yuzu_emu.utils.DocumentsTree
 import org.yuzu.yuzu_emu.utils.FileUtil
 import org.yuzu.yuzu_emu.utils.Log
 import org.yuzu.yuzu_emu.utils.SerializableHelper.serializable
@@ -68,7 +69,7 @@ object NativeLibrary {
     @Keep
     @JvmStatic
     fun openContentUri(path: String?, openmode: String?): Int {
-        return if (isNativePath(path!!)) {
+        return if (DocumentsTree.isNativePath(path!!)) {
             YuzuApplication.documentsTree!!.openContentUri(path, openmode)
         } else {
             FileUtil.openContentUri(path, openmode)
@@ -78,7 +79,7 @@ object NativeLibrary {
     @Keep
     @JvmStatic
     fun getSize(path: String?): Long {
-        return if (isNativePath(path!!)) {
+        return if (DocumentsTree.isNativePath(path!!)) {
             YuzuApplication.documentsTree!!.getFileSize(path)
         } else {
             FileUtil.getFileSize(path)
@@ -88,7 +89,7 @@ object NativeLibrary {
     @Keep
     @JvmStatic
     fun exists(path: String?): Boolean {
-        return if (isNativePath(path!!)) {
+        return if (DocumentsTree.isNativePath(path!!)) {
             YuzuApplication.documentsTree!!.exists(path)
         } else {
             FileUtil.exists(path)
@@ -98,12 +99,30 @@ object NativeLibrary {
     @Keep
     @JvmStatic
     fun isDirectory(path: String?): Boolean {
-        return if (isNativePath(path!!)) {
+        return if (DocumentsTree.isNativePath(path!!)) {
             YuzuApplication.documentsTree!!.isDirectory(path)
         } else {
             FileUtil.isDirectory(path)
         }
     }
+
+    @Keep
+    @JvmStatic
+    fun getParentDirectory(path: String): String =
+        if (DocumentsTree.isNativePath(path)) {
+            YuzuApplication.documentsTree!!.getParentDirectory(path)
+        } else {
+            path
+        }
+
+    @Keep
+    @JvmStatic
+    fun getFilename(path: String): String =
+        if (DocumentsTree.isNativePath(path)) {
+            YuzuApplication.documentsTree!!.getFilename(path)
+        } else {
+            FileUtil.getFilename(Uri.parse(path))
+        }
 
     /**
      * Returns true if pro controller isn't available and handheld is

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
@@ -92,7 +92,7 @@ object NativeLibrary {
         return if (DocumentsTree.isNativePath(path!!)) {
             YuzuApplication.documentsTree!!.exists(path)
         } else {
-            FileUtil.exists(path)
+            FileUtil.exists(path, suppressLog = true)
         }
     }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
@@ -215,32 +215,6 @@ object NativeLibrary {
 
     external fun initGameIni(gameID: String?)
 
-    /**
-     * Gets the embedded icon within the given ROM.
-     *
-     * @param filename the file path to the ROM.
-     * @return a byte array containing the JPEG data for the icon.
-     */
-    external fun getIcon(filename: String): ByteArray
-
-    /**
-     * Gets the embedded title of the given ISO/ROM.
-     *
-     * @param filename The file path to the ISO/ROM.
-     * @return the embedded title of the ISO/ROM.
-     */
-    external fun getTitle(filename: String): String
-
-    external fun getDescription(filename: String): String
-
-    external fun getGameId(filename: String): String
-
-    external fun getRegions(filename: String): String
-
-    external fun getCompany(filename: String): String
-
-    external fun isHomebrew(filename: String): Boolean
-
     external fun setAppDirectory(directory: String)
 
     /**
@@ -292,11 +266,6 @@ object NativeLibrary {
      * Stops emulation.
      */
     external fun stopEmulation()
-
-    /**
-     * Resets the in-memory ROM metadata cache.
-     */
-    external fun resetRomMetadata()
 
     /**
      * Returns true if emulation is running (or is paused).

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/adapters/GameAdapter.kt
@@ -147,7 +147,7 @@ class GameAdapter(private val activity: AppCompatActivity) :
 
     private class DiffCallback : DiffUtil.ItemCallback<Game>() {
         override fun areItemsTheSame(oldItem: Game, newItem: Game): Boolean {
-            return oldItem.gameId == newItem.gameId
+            return oldItem.programId == newItem.programId
         }
 
         override fun areContentsTheSame(oldItem: Game, newItem: Game): Boolean {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/Game.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/Game.kt
@@ -12,15 +12,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 class Game(
     val title: String,
-    val description: String,
-    val regions: String,
     val path: String,
-    val gameId: String,
-    val company: String,
+    val programId: String,
+    val developer: String,
+    val version: String,
     val isHomebrew: Boolean
 ) : Parcelable {
-    val keyAddedToLibraryTime get() = "${gameId}_AddedToLibraryTime"
-    val keyLastPlayedTime get() = "${gameId}_LastPlayed"
+    val keyAddedToLibraryTime get() = "${programId}_AddedToLibraryTime"
+    val keyLastPlayedTime get() = "${programId}_LastPlayed"
 
     override fun equals(other: Any?): Boolean {
         if (other !is Game) {
@@ -32,11 +31,9 @@ class Game(
 
     override fun hashCode(): Int {
         var result = title.hashCode()
-        result = 31 * result + description.hashCode()
-        result = 31 * result + regions.hashCode()
         result = 31 * result + path.hashCode()
-        result = 31 * result + gameId.hashCode()
-        result = 31 * result + company.hashCode()
+        result = 31 * result + programId.hashCode()
+        result = 31 * result + developer.hashCode()
         result = 31 * result + isHomebrew.hashCode()
         return result
     }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/GamesViewModel.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/GamesViewModel.kt
@@ -14,15 +14,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.yuzu.yuzu_emu.NativeLibrary
 import org.yuzu.yuzu_emu.YuzuApplication
 import org.yuzu.yuzu_emu.utils.GameHelper
+import org.yuzu.yuzu_emu.utils.GameMetadata
 
-@OptIn(ExperimentalSerializationApi::class)
 class GamesViewModel : ViewModel() {
     val games: StateFlow<List<Game>> get() = _games
     private val _games = MutableStateFlow(emptyList<Game>())
@@ -58,7 +56,8 @@ class GamesViewModel : ViewModel() {
                         val game: Game
                         try {
                             game = Json.decodeFromString(it)
-                        } catch (e: MissingFieldException) {
+                        } catch (e: Exception) {
+                            // We don't care about any errors related to parsing the game cache
                             return@forEach
                         }
 
@@ -113,7 +112,7 @@ class GamesViewModel : ViewModel() {
 
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
-                NativeLibrary.resetRomMetadata()
+                GameMetadata.resetMetadata()
                 setGames(GameHelper.getGames())
                 _isReloading.value = false
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/DocumentsTree.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/DocumentsTree.kt
@@ -42,6 +42,23 @@ class DocumentsTree {
         return node != null && node.isDirectory
     }
 
+    fun getParentDirectory(filepath: String): String {
+        val node = resolvePath(filepath)!!
+        val parentNode = node.parent
+        if (parentNode != null && parentNode.isDirectory) {
+            return parentNode.uri!!.toString()
+        }
+        return node.uri!!.toString()
+    }
+
+    fun getFilename(filepath: String): String {
+        val node = resolvePath(filepath)
+        if (node != null) {
+            return node.name!!
+        }
+        return filepath
+    }
+
     private fun resolvePath(filepath: String): DocumentsNode? {
         val tokens = StringTokenizer(filepath, File.separator, false)
         var iterator = root

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/FileUtil.kt
@@ -144,7 +144,7 @@ object FileUtil {
      * @param path Native content uri path
      * @return bool
      */
-    fun exists(path: String?): Boolean {
+    fun exists(path: String?, suppressLog: Boolean = false): Boolean {
         var c: Cursor? = null
         try {
             val mUri = Uri.parse(path)
@@ -152,7 +152,9 @@ object FileUtil {
             c = context.contentResolver.query(mUri, columns, null, null, null)
             return c!!.count > 0
         } catch (e: Exception) {
-            Log.info("[FileUtil] Cannot find file from given path, error: " + e.message)
+            if (!suppressLog) {
+                Log.info("[FileUtil] Cannot find file from given path, error: " + e.message)
+            }
         } finally {
             closeQuietly(c)
         }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameHelper.kt
@@ -71,27 +71,26 @@ object GameHelper {
 
     fun getGame(uri: Uri, addedToLibrary: Boolean): Game {
         val filePath = uri.toString()
-        var name = NativeLibrary.getTitle(filePath)
+        var name = GameMetadata.getTitle(filePath)
 
         // If the game's title field is empty, use the filename.
         if (name.isEmpty()) {
             name = FileUtil.getFilename(uri)
         }
-        var gameId = NativeLibrary.getGameId(filePath)
+        var programId = GameMetadata.getProgramId(filePath)
 
         // If the game's ID field is empty, use the filename without extension.
-        if (gameId.isEmpty()) {
-            gameId = name.substring(0, name.lastIndexOf("."))
+        if (programId.isEmpty()) {
+            programId = name.substring(0, name.lastIndexOf("."))
         }
 
         val newGame = Game(
             name,
-            NativeLibrary.getDescription(filePath).replace("\n", " "),
-            NativeLibrary.getRegions(filePath),
             filePath,
-            gameId,
-            NativeLibrary.getCompany(filePath),
-            NativeLibrary.isHomebrew(filePath)
+            programId,
+            GameMetadata.getDeveloper(filePath),
+            GameMetadata.getVersion(filePath),
+            GameMetadata.getIsHomebrew(filePath)
         )
 
         if (addedToLibrary) {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameIconUtils.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameIconUtils.kt
@@ -18,7 +18,6 @@ import coil.key.Keyer
 import coil.memory.MemoryCache
 import coil.request.ImageRequest
 import coil.request.Options
-import org.yuzu.yuzu_emu.NativeLibrary
 import org.yuzu.yuzu_emu.R
 import org.yuzu.yuzu_emu.YuzuApplication
 import org.yuzu.yuzu_emu.model.Game
@@ -36,7 +35,7 @@ class GameIconFetcher(
     }
 
     private fun decodeGameIcon(uri: String): Bitmap? {
-        val data = NativeLibrary.getIcon(uri)
+        val data = GameMetadata.getIcon(uri)
         return BitmapFactory.decodeByteArray(
             data,
             0,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameMetadata.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameMetadata.kt
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.yuzu.yuzu_emu.utils
+
+object GameMetadata {
+    external fun getTitle(path: String): String
+
+    external fun getProgramId(path: String): String
+
+    external fun getDeveloper(path: String): String
+
+    external fun getVersion(path: String): String
+
+    external fun getIcon(path: String): ByteArray
+
+    external fun getIsHomebrew(path: String): Boolean
+
+    external fun resetMetadata()
+}

--- a/src/android/app/src/main/jni/CMakeLists.txt
+++ b/src/android/app/src/main/jni/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(yuzu-android SHARED
     id_cache.cpp
     id_cache.h
     native.cpp
+    native.h
     native_config.cpp
     uisettings.cpp
 )

--- a/src/android/app/src/main/jni/CMakeLists.txt
+++ b/src/android/app/src/main/jni/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(yuzu-android SHARED
     native.h
     native_config.cpp
     uisettings.cpp
+    game_metadata.cpp
 )
 
 set_property(TARGET yuzu-android PROPERTY IMPORTED_LOCATION ${FFmpeg_LIBRARY_DIR})

--- a/src/android/app/src/main/jni/game_metadata.cpp
+++ b/src/android/app/src/main/jni/game_metadata.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <core/core.h>
+#include <core/file_sys/patch_manager.h>
+#include <core/loader/nro.h>
+#include <jni.h>
+#include "core/loader/loader.h"
+#include "jni/android_common/android_common.h"
+#include "native.h"
+
+struct RomMetadata {
+    std::string title;
+    u64 programId;
+    std::string developer;
+    std::string version;
+    std::vector<u8> icon;
+    bool isHomebrew;
+};
+
+std::unordered_map<std::string, RomMetadata> m_rom_metadata_cache;
+
+RomMetadata CacheRomMetadata(const std::string& path) {
+    const auto file =
+        Core::GetGameFileFromPath(EmulationSession::GetInstance().System().GetFilesystem(), path);
+    auto loader = Loader::GetLoader(EmulationSession::GetInstance().System(), file, 0, 0);
+
+    RomMetadata entry;
+    loader->ReadTitle(entry.title);
+    loader->ReadProgramId(entry.programId);
+    loader->ReadIcon(entry.icon);
+
+    const FileSys::PatchManager pm{
+        entry.programId, EmulationSession::GetInstance().System().GetFileSystemController(),
+        EmulationSession::GetInstance().System().GetContentProvider()};
+    const auto control = pm.GetControlMetadata();
+
+    if (control.first != nullptr) {
+        entry.developer = control.first->GetDeveloperName();
+        entry.version = control.first->GetVersionString();
+    } else {
+        FileSys::NACP nacp;
+        if (loader->ReadControlData(nacp) == Loader::ResultStatus::Success) {
+            entry.developer = nacp.GetDeveloperName();
+        } else {
+            entry.developer = "";
+        }
+
+        entry.version = "1.0.0";
+    }
+
+    if (loader->GetFileType() == Loader::FileType::NRO) {
+        auto loader_nro = reinterpret_cast<Loader::AppLoader_NRO*>(loader.get());
+        entry.isHomebrew = loader_nro->IsHomebrew();
+    } else {
+        entry.isHomebrew = false;
+    }
+
+    m_rom_metadata_cache[path] = entry;
+
+    return entry;
+}
+
+RomMetadata GetRomMetadata(const std::string& path) {
+    if (auto search = m_rom_metadata_cache.find(path); search != m_rom_metadata_cache.end()) {
+        return search->second;
+    }
+
+    return CacheRomMetadata(path);
+}
+
+extern "C" {
+
+jstring Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getTitle(JNIEnv* env, jobject obj,
+                                                            jstring jpath) {
+    return ToJString(env, GetRomMetadata(GetJString(env, jpath)).title);
+}
+
+jstring Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getProgramId(JNIEnv* env, jobject obj,
+                                                                jstring jpath) {
+    return ToJString(env, std::to_string(GetRomMetadata(GetJString(env, jpath)).programId));
+}
+
+jstring Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getDeveloper(JNIEnv* env, jobject obj,
+                                                                jstring jpath) {
+    return ToJString(env, GetRomMetadata(GetJString(env, jpath)).developer);
+}
+
+jstring Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getVersion(JNIEnv* env, jobject obj,
+                                                              jstring jpath) {
+    return ToJString(env, GetRomMetadata(GetJString(env, jpath)).version);
+}
+
+jbyteArray Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getIcon(JNIEnv* env, jobject obj,
+                                                              jstring jpath) {
+    auto icon_data = GetRomMetadata(GetJString(env, jpath)).icon;
+    jbyteArray icon = env->NewByteArray(static_cast<jsize>(icon_data.size()));
+    env->SetByteArrayRegion(icon, 0, env->GetArrayLength(icon),
+                            reinterpret_cast<jbyte*>(icon_data.data()));
+    return icon;
+}
+
+jboolean Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getIsHomebrew(JNIEnv* env, jobject obj,
+                                                                  jstring jpath) {
+    return static_cast<jboolean>(GetRomMetadata(GetJString(env, jpath)).isHomebrew);
+}
+
+void Java_org_yuzu_yuzu_1emu_utils_GameMetadata_resetMetadata(JNIEnv* env, jobject obj) {
+    return m_rom_metadata_cache.clear();
+}
+
+} // extern "C"

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -558,10 +558,6 @@ void Java_org_yuzu_yuzu_1emu_NativeLibrary_stopEmulation(JNIEnv* env, jclass cla
     EmulationSession::GetInstance().HaltEmulation();
 }
 
-void Java_org_yuzu_yuzu_1emu_NativeLibrary_resetRomMetadata(JNIEnv* env, jclass clazz) {
-    EmulationSession::GetInstance().ResetRomMetadata();
-}
-
 jboolean Java_org_yuzu_yuzu_1emu_NativeLibrary_isRunning(JNIEnv* env, jclass clazz) {
     return static_cast<jboolean>(EmulationSession::GetInstance().IsRunning());
 }
@@ -665,46 +661,6 @@ void Java_org_yuzu_yuzu_1emu_NativeLibrary_onTouchReleased(JNIEnv* env, jclass c
     if (EmulationSession::GetInstance().IsRunning()) {
         EmulationSession::GetInstance().Window().OnTouchReleased(id);
     }
-}
-
-jbyteArray Java_org_yuzu_yuzu_1emu_NativeLibrary_getIcon(JNIEnv* env, jclass clazz,
-                                                         jstring j_filename) {
-    jauto icon_data = EmulationSession::GetInstance().GetRomIcon(GetJString(env, j_filename));
-    jbyteArray icon = env->NewByteArray(static_cast<jsize>(icon_data.size()));
-    env->SetByteArrayRegion(icon, 0, env->GetArrayLength(icon),
-                            reinterpret_cast<jbyte*>(icon_data.data()));
-    return icon;
-}
-
-jstring Java_org_yuzu_yuzu_1emu_NativeLibrary_getTitle(JNIEnv* env, jclass clazz,
-                                                       jstring j_filename) {
-    jauto title = EmulationSession::GetInstance().GetRomTitle(GetJString(env, j_filename));
-    return env->NewStringUTF(title.c_str());
-}
-
-jstring Java_org_yuzu_yuzu_1emu_NativeLibrary_getDescription(JNIEnv* env, jclass clazz,
-                                                             jstring j_filename) {
-    return j_filename;
-}
-
-jstring Java_org_yuzu_yuzu_1emu_NativeLibrary_getGameId(JNIEnv* env, jclass clazz,
-                                                        jstring j_filename) {
-    return j_filename;
-}
-
-jstring Java_org_yuzu_yuzu_1emu_NativeLibrary_getRegions(JNIEnv* env, jclass clazz,
-                                                         jstring j_filename) {
-    return env->NewStringUTF("");
-}
-
-jstring Java_org_yuzu_yuzu_1emu_NativeLibrary_getCompany(JNIEnv* env, jclass clazz,
-                                                         jstring j_filename) {
-    return env->NewStringUTF("");
-}
-
-jboolean Java_org_yuzu_yuzu_1emu_NativeLibrary_isHomebrew(JNIEnv* env, jclass clazz,
-                                                          jstring j_filename) {
-    return EmulationSession::GetInstance().GetIsHomebrew(GetJString(env, j_filename));
 }
 
 void Java_org_yuzu_yuzu_1emu_NativeLibrary_initializeEmulation(JNIEnv* env, jclass clazz) {

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <android/native_window_jni.h>
+#include "core/core.h"
+#include "core/perf_stats.h"
+#include "jni/emu_window/emu_window.h"
+#include "jni/applets/software_keyboard.h"
+#include "video_core/rasterizer_interface.h"
+#include "common/detached_tasks.h"
+#include "core/hle/service/acc/profile_manager.h"
+#include "core/file_sys/registered_cache.h"
+
+#pragma once
+
+class EmulationSession final {
+public:
+    explicit EmulationSession();
+    ~EmulationSession() = default;
+
+    static EmulationSession& GetInstance();
+    const Core::System& System() const;
+    Core::System& System();
+
+    const EmuWindow_Android& Window() const;
+    EmuWindow_Android& Window();
+    ANativeWindow* NativeWindow() const;
+    void SetNativeWindow(ANativeWindow* native_window);
+    void SurfaceChanged();
+
+    int InstallFileToNand(std::string filename, std::string file_extension);
+    void InitializeGpuDriver(const std::string& hook_lib_dir, const std::string& custom_driver_dir,
+                             const std::string& custom_driver_name,
+                             const std::string& file_redirect_dir);
+
+    bool IsRunning() const;
+    bool IsPaused() const;
+    void PauseEmulation();
+    void UnPauseEmulation();
+    void HaltEmulation();
+    void RunEmulation();
+    void ShutdownEmulation();
+
+    const Core::PerfStatsResults& PerfStats() const;
+    void ConfigureFilesystemProvider(const std::string& filepath);
+    Core::SystemResultStatus InitializeEmulation(const std::string& filepath);
+
+    bool IsHandheldOnly();
+    void SetDeviceType([[maybe_unused]] int index, int type);
+    void OnGamepadConnectEvent([[maybe_unused]] int index);
+    void OnGamepadDisconnectEvent([[maybe_unused]] int index);
+    SoftwareKeyboard::AndroidKeyboard* SoftwareKeyboard();
+
+private:
+    static void LoadDiskCacheProgress(VideoCore::LoadCallbackStage stage, int progress, int max);
+    static void OnEmulationStarted();
+    static void OnEmulationStopped(Core::SystemResultStatus result);
+
+private:
+    // Window management
+    std::unique_ptr<EmuWindow_Android> m_window;
+    ANativeWindow* m_native_window{};
+
+    // Core emulation
+    Core::System m_system;
+    InputCommon::InputSubsystem m_input_subsystem;
+    Common::DetachedTasks m_detached_tasks;
+    Core::PerfStatsResults m_perf_stats{};
+    std::shared_ptr<FileSys::VfsFilesystem> m_vfs;
+    Core::SystemResultStatus m_load_result{Core::SystemResultStatus::ErrorNotInitialized};
+    std::atomic<bool> m_is_running = false;
+    std::atomic<bool> m_is_paused = false;
+    SoftwareKeyboard::AndroidKeyboard* m_software_keyboard{};
+    std::unique_ptr<Service::Account::ProfileManager> m_profile_manager;
+    std::unique_ptr<FileSys::ManualContentProvider> m_manual_provider;
+
+    // GPU driver parameters
+    std::shared_ptr<Common::DynamicLibrary> m_vulkan_library;
+
+    // Synchronization
+    std::condition_variable_any m_cv;
+    mutable std::mutex m_perf_stats_mutex;
+    mutable std::mutex m_mutex;
+};

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <android/native_window_jni.h>
-#include "core/core.h"
-#include "core/perf_stats.h"
-#include "jni/emu_window/emu_window.h"
-#include "jni/applets/software_keyboard.h"
-#include "video_core/rasterizer_interface.h"
 #include "common/detached_tasks.h"
-#include "core/hle/service/acc/profile_manager.h"
+#include "core/core.h"
 #include "core/file_sys/registered_cache.h"
+#include "core/hle/service/acc/profile_manager.h"
+#include "core/perf_stats.h"
+#include "jni/applets/software_keyboard.h"
+#include "jni/emu_window/emu_window.h"
+#include "video_core/rasterizer_interface.h"
 
 #pragma once
 

--- a/src/common/fs/fs_android.cpp
+++ b/src/common/fs/fs_android.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/fs/fs_android.h"
+#include "common/string_util.h"
 
 namespace Common::FS::Android {
 
@@ -28,28 +29,35 @@ void RegisterCallbacks(JNIEnv* env, jclass clazz) {
     env->GetJavaVM(&g_jvm);
     native_library = clazz;
 
+#define FH(FunctionName, JMethodID, Caller, JMethodName, Signature)                                \
+    F(JMethodID, JMethodName, Signature)
 #define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature)                   \
     F(JMethodID, JMethodName, Signature)
 #define FS(FunctionName, ReturnValue, Parameters, JMethodID, JMethodName, Signature)               \
     F(JMethodID, JMethodName, Signature)
 #define F(JMethodID, JMethodName, Signature)                                                       \
     JMethodID = env->GetStaticMethodID(native_library, JMethodName, Signature);
+    ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(FH)
     ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(FR)
     ANDROID_STORAGE_FUNCTIONS(FS)
 #undef F
 #undef FS
 #undef FR
+#undef FH
 }
 
 void UnRegisterCallbacks() {
+#define FH(FunctionName, JMethodID, Caller, JMethodName, Signature) F(JMethodID)
 #define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature) F(JMethodID)
 #define FS(FunctionName, ReturnValue, Parameters, JMethodID, JMethodName, Signature) F(JMethodID)
 #define F(JMethodID) JMethodID = nullptr;
+    ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(FH)
     ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(FR)
     ANDROID_STORAGE_FUNCTIONS(FS)
 #undef F
 #undef FS
 #undef FR
+#undef FH
 }
 
 bool IsContentUri(const std::string& path) {
@@ -94,5 +102,30 @@ int OpenContentUri(const std::string& filepath, OpenMode openmode) {
 ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(FR)
 #undef F
 #undef FR
+
+#define FH(FunctionName, JMethodID, Caller, JMethodName, Signature)                                \
+    F(FunctionName, JMethodID, Caller)
+#define F(FunctionName, JMethodID, Caller)                                                         \
+    std::string FunctionName(const std::string& filepath) {                                        \
+        if (JMethodID == nullptr) {                                                                \
+            return 0;                                                                              \
+        }                                                                                          \
+        auto env = GetEnvForThread();                                                              \
+        jstring j_filepath = env->NewStringUTF(filepath.c_str());                                  \
+        jstring j_return =                                                                         \
+            static_cast<jstring>(env->Caller(native_library, JMethodID, j_filepath));              \
+        if (!j_return) {                                                                           \
+            return {};                                                                             \
+        }                                                                                          \
+        const jchar* jchars = env->GetStringChars(j_return, nullptr);                              \
+        const jsize length = env->GetStringLength(j_return);                                       \
+        const std::u16string_view string_view(reinterpret_cast<const char16_t*>(jchars), length);  \
+        const std::string converted_string = Common::UTF16ToUTF8(string_view);                     \
+        env->ReleaseStringChars(j_return, jchars);                                                 \
+        return converted_string;                                                                   \
+    }
+ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(FH)
+#undef F
+#undef FH
 
 } // namespace Common::FS::Android

--- a/src/common/fs/fs_android.h
+++ b/src/common/fs/fs_android.h
@@ -17,19 +17,28 @@
       "(Ljava/lang/String;)Z")                                                                     \
     V(Exists, bool, file_exists, CallStaticBooleanMethod, "exists", "(Ljava/lang/String;)Z")
 
+#define ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(V)                                                    \
+    V(GetParentDirectory, get_parent_directory, CallStaticObjectMethod, "getParentDirectory",      \
+      "(Ljava/lang/String;)Ljava/lang/String;")                                                    \
+    V(GetFilename, get_filename, CallStaticObjectMethod, "getFilename",                            \
+      "(Ljava/lang/String;)Ljava/lang/String;")
+
 namespace Common::FS::Android {
 
 static JavaVM* g_jvm = nullptr;
 static jclass native_library = nullptr;
 
+#define FH(FunctionName, JMethodID, Caller, JMethodName, Signature) F(JMethodID)
 #define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature) F(JMethodID)
 #define FS(FunctionName, ReturnValue, Parameters, JMethodID, JMethodName, Signature) F(JMethodID)
 #define F(JMethodID) static jmethodID JMethodID = nullptr;
+ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(FH)
 ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(FR)
 ANDROID_STORAGE_FUNCTIONS(FS)
 #undef F
 #undef FS
 #undef FR
+#undef FH
 
 enum class OpenMode {
     Read,
@@ -61,5 +70,11 @@ ANDROID_STORAGE_FUNCTIONS(FS)
 ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(FR)
 #undef F
 #undef FR
+
+#define FH(FunctionName, JMethodID, Caller, JMethodName, Signature) F(FunctionName)
+#define F(FunctionName) std::string FunctionName(const std::string& filepath);
+ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(FH)
+#undef F
+#undef FH
 
 } // namespace Common::FS::Android

--- a/src/common/fs/path_util.cpp
+++ b/src/common/fs/path_util.cpp
@@ -401,6 +401,16 @@ std::string SanitizePath(std::string_view path_, DirectorySeparator directory_se
 }
 
 std::string_view GetParentPath(std::string_view path) {
+    if (path.empty()) {
+        return path;
+    }
+
+#ifdef ANDROID
+    if (path[0] != '/') {
+        std::string path_string{path};
+        return FS::Android::GetParentDirectory(path_string);
+    }
+#endif
     const auto name_bck_index = path.rfind('\\');
     const auto name_fwd_index = path.rfind('/');
     std::size_t name_index;

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -14,6 +14,10 @@
 #include <windows.h>
 #endif
 
+#ifdef ANDROID
+#include <common/fs/fs_android.h>
+#endif
+
 namespace Common {
 
 /// Make a string lowercase
@@ -62,6 +66,14 @@ bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _
                std::string* _pExtension) {
     if (full_path.empty())
         return false;
+
+#ifdef ANDROID
+    if (full_path[0] != '/') {
+        *_pPath = Common::FS::Android::GetParentDirectory(full_path);
+        *_pFilename = Common::FS::Android::GetFilename(full_path);
+        return true;
+    }
+#endif
 
     std::size_t dir_end = full_path.find_last_of("/"
 // windows needs the : included for something like just "C:" to be considered a directory


### PR DESCRIPTION
We were getting logcat spam from incorrect assumptions about how android uri's worked. Here I add the hooks into Kotlin code that let us check for parent paths correctly and prevent the log spam we saw when loading the games list.

This does fix our previous assumption, but in the future I should create an all-encompassing solution where we keep track of each tree uri for the directories that we're allowed to search. We actually can't get the parent of a uri only with a single file's uri. For now if we want the parent of a uri, I just return the uri without changes.

This additionally has some fixes for game metadata parsing that get us all the information we need for a properties page.