### PR TITLE
core: Close all KEvents

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -796,7 +796,9 @@ ILockAccessor::ILockAccessor(Core::System& system_)
     lock_event = service_context.CreateEvent("ILockAccessor::LockEvent");
 }
 
-ILockAccessor::~ILockAccessor() = default;
+ILockAccessor::~ILockAccessor() {
+    service_context.CloseEvent(lock_event);
+};
 
 void ILockAccessor::TryLock(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
@@ -909,7 +911,9 @@ ICommonStateGetter::ICommonStateGetter(Core::System& system_,
     msg_queue->PushMessage(AppletMessageQueue::AppletMessage::ChangeIntoForeground);
 }
 
-ICommonStateGetter::~ICommonStateGetter() = default;
+ICommonStateGetter::~ICommonStateGetter() {
+    service_context.CloseEvent(sleep_lock_event);
+};
 
 void ICommonStateGetter::GetBootMode(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");

--- a/src/core/hle/service/am/applets/applet_cabinet.cpp
+++ b/src/core/hle/service/am/applets/applet_cabinet.cpp
@@ -25,7 +25,9 @@ Cabinet::Cabinet(Core::System& system_, LibraryAppletMode applet_mode_,
         service_context.CreateEvent("CabinetApplet:AvailabilityChangeEvent");
 }
 
-Cabinet::~Cabinet() = default;
+Cabinet::~Cabinet() {
+    service_context.CloseEvent(availability_change_event);
+};
 
 void Cabinet::Initialize() {
     Applet::Initialize();

--- a/src/core/hle/service/hid/controllers/palma.cpp
+++ b/src/core/hle/service/hid/controllers/palma.cpp
@@ -19,7 +19,9 @@ Controller_Palma::Controller_Palma(Core::HID::HIDCore& hid_core_, u8* raw_shared
     operation_complete_event = service_context.CreateEvent("hid:PalmaOperationCompleteEvent");
 }
 
-Controller_Palma::~Controller_Palma() = default;
+Controller_Palma::~Controller_Palma() {
+    service_context.CloseEvent(operation_complete_event);
+};
 
 void Controller_Palma::OnInit() {}
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -2757,6 +2757,10 @@ public:
         joy_detach_event = service_context.CreateEvent("HidSys::JoyDetachEvent");
     }
 
+    ~HidSys() {
+        service_context.CloseEvent(joy_detach_event);
+    };
+
 private:
     void ApplyNpadSystemCommonPolicy(HLERequestContext& ctx) {
         LOG_WARNING(Service_HID, "called");

--- a/src/core/hle/service/hid/hidbus/hidbus_base.cpp
+++ b/src/core/hle/service/hid/hidbus/hidbus_base.cpp
@@ -13,7 +13,10 @@ HidbusBase::HidbusBase(Core::System& system_, KernelHelpers::ServiceContext& ser
     : system(system_), service_context(service_context_) {
     send_command_async_event = service_context.CreateEvent("hidbus:SendCommandAsyncEvent");
 }
-HidbusBase::~HidbusBase() = default;
+
+HidbusBase::~HidbusBase() {
+    service_context.CloseEvent(send_command_async_event);
+};
 
 void HidbusBase::ActivateDevice() {
     if (is_activated) {

--- a/src/core/hle/service/pctl/pctl_module.cpp
+++ b/src/core/hle/service/pctl/pctl_module.cpp
@@ -141,6 +141,12 @@ public:
             service_context.CreateEvent("IParentalControlService::RequestSuspensionEvent");
     }
 
+    ~IParentalControlService() {
+        service_context.CloseEvent(synchronization_event);
+        service_context.CloseEvent(unlinked_event);
+        service_context.CloseEvent(request_suspension_event);
+    };
+
 private:
     bool CheckFreeCommunicationPermissionImpl() const {
         if (states.temporary_unlocked) {


### PR DESCRIPTION
While testing applets I noticed we run out of handles. Make sure to close all KEvents on all services.