### PR TITLE
nvnflinger: implement consumer abandonment

### DIFF
--- a/src/core/hle/service/nvnflinger/buffer_queue_consumer.h
+++ b/src/core/hle/service/nvnflinger/buffer_queue_consumer.h
@@ -32,6 +32,7 @@ public:
     Status AcquireBuffer(BufferItem* out_buffer, std::chrono::nanoseconds expected_present);
     Status ReleaseBuffer(s32 slot, u64 frame_number, const Fence& release_fence);
     Status Connect(std::shared_ptr<IConsumerListener> consumer_listener, bool controlled_by_app);
+    Status Disconnect();
     Status GetReleasedBuffers(u64* out_slot_mask);
 
 private:

--- a/src/core/hle/service/nvnflinger/buffer_queue_core.cpp
+++ b/src/core/hle/service/nvnflinger/buffer_queue_core.cpp
@@ -14,24 +14,12 @@ BufferQueueCore::BufferQueueCore() = default;
 
 BufferQueueCore::~BufferQueueCore() = default;
 
-void BufferQueueCore::NotifyShutdown() {
-    std::scoped_lock lock{mutex};
-
-    is_shutting_down = true;
-
-    SignalDequeueCondition();
-}
-
 void BufferQueueCore::SignalDequeueCondition() {
     dequeue_possible.store(true);
     dequeue_condition.notify_all();
 }
 
 bool BufferQueueCore::WaitForDequeueCondition(std::unique_lock<std::mutex>& lk) {
-    if (is_shutting_down) {
-        return false;
-    }
-
     dequeue_condition.wait(lk, [&] { return dequeue_possible.load(); });
     dequeue_possible.store(false);
 

--- a/src/core/hle/service/nvnflinger/buffer_queue_core.h
+++ b/src/core/hle/service/nvnflinger/buffer_queue_core.h
@@ -34,8 +34,6 @@ public:
     BufferQueueCore();
     ~BufferQueueCore();
 
-    void NotifyShutdown();
-
 private:
     void SignalDequeueCondition();
     bool WaitForDequeueCondition(std::unique_lock<std::mutex>& lk);
@@ -74,7 +72,6 @@ private:
     u32 transform_hint{};
     bool is_allocating{};
     mutable std::condition_variable_any is_allocating_condition;
-    bool is_shutting_down{};
 };
 
 } // namespace Service::android

--- a/src/core/hle/service/nvnflinger/consumer_base.h
+++ b/src/core/hle/service/nvnflinger/consumer_base.h
@@ -24,6 +24,7 @@ class BufferQueueConsumer;
 class ConsumerBase : public IConsumerListener, public std::enable_shared_from_this<ConsumerBase> {
 public:
     void Connect(bool controlled_by_app);
+    void Abandon();
 
 protected:
     explicit ConsumerBase(std::unique_ptr<BufferQueueConsumer> consumer_);
@@ -34,6 +35,7 @@ protected:
     void OnBuffersReleased() override;
     void OnSidebandStreamChanged() override;
 
+    void AbandonLocked();
     void FreeBufferLocked(s32 slot_index);
     Status AcquireBufferLocked(BufferItem* item, std::chrono::nanoseconds present_when);
     Status ReleaseBufferLocked(s32 slot, const std::shared_ptr<GraphicBuffer>& graphic_buffer);

--- a/src/core/hle/service/nvnflinger/nvnflinger.h
+++ b/src/core/hle/service/nvnflinger/nvnflinger.h
@@ -140,6 +140,8 @@ private:
 
     s32 swap_interval = 1;
 
+    bool is_abandoned = false;
+
     /// Event that handles screen composition.
     std::shared_ptr<Core::Timing::EventType> multi_composition_event;
     std::shared_ptr<Core::Timing::EventType> single_composition_event;


### PR DESCRIPTION
Companion PR to #11912. Graphic buffers get leaked on exit because of a reference cycle, and the way Android breaks this cycle is requiring the consumer to explicitly disconnect itself when the system is ready to shut down.