### PR TITLE
romfs: fix extraction of single-directory root

### DIFF
--- a/src/core/file_sys/romfs.h
+++ b/src/core/file_sys/romfs.h
@@ -7,16 +7,9 @@
 
 namespace FileSys {
 
-enum class RomFSExtractionType {
-    Full,          // Includes data directory
-    Truncated,     // Traverses into data directory
-    SingleDiscard, // Traverses into the first subdirectory of root
-};
-
 // Converts a RomFS binary blob to VFS Filesystem
 // Returns nullptr on failure
-VirtualDir ExtractRomFS(VirtualFile file,
-                        RomFSExtractionType type = RomFSExtractionType::Truncated);
+VirtualDir ExtractRomFS(VirtualFile file);
 
 // Converts a VFS filesystem into a RomFS binary
 // Returns nullptr on failure

--- a/src/core/hle/service/am/applets/applet_web_browser.cpp
+++ b/src/core/hle/service/am/applets/applet_web_browser.cpp
@@ -330,8 +330,7 @@ void WebBrowser::ExtractOfflineRomFS() {
     LOG_DEBUG(Service_AM, "Extracting RomFS to {}",
               Common::FS::PathToUTF8String(offline_cache_dir));
 
-    const auto extracted_romfs_dir =
-        FileSys::ExtractRomFS(offline_romfs, FileSys::RomFSExtractionType::SingleDiscard);
+    const auto extracted_romfs_dir = FileSys::ExtractRomFS(offline_romfs);
 
     const auto temp_dir = system.GetFilesystem()->CreateDirectory(
         Common::FS::PathToUTF8String(offline_cache_dir), FileSys::Mode::ReadWrite);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2737,7 +2737,7 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
         return;
     }
 
-    const auto extracted = FileSys::ExtractRomFS(romfs, FileSys::RomFSExtractionType::Full);
+    const auto extracted = FileSys::ExtractRomFS(romfs);
     if (extracted == nullptr) {
         failed();
         return;


### PR DESCRIPTION
Fixes #8905. I've also gone ahead and removed the RomFSExtractionType enum as it would have only ever been used in error...