### PR TITLE
android: Adjust log lifecycle

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
@@ -462,12 +462,12 @@ object NativeLibrary {
     }
 
     fun setEmulationActivity(emulationActivity: EmulationActivity?) {
-        Log.verbose("[NativeLibrary] Registering EmulationActivity.")
+        Log.debug("[NativeLibrary] Registering EmulationActivity.")
         sEmulationActivity = WeakReference(emulationActivity)
     }
 
     fun clearEmulationActivity() {
-        Log.verbose("[NativeLibrary] Unregistering EmulationActivity.")
+        Log.debug("[NativeLibrary] Unregistering EmulationActivity.")
         sEmulationActivity.clear()
     }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
@@ -47,6 +47,7 @@ import org.yuzu.yuzu_emu.model.EmulationViewModel
 import org.yuzu.yuzu_emu.model.Game
 import org.yuzu.yuzu_emu.utils.ForegroundService
 import org.yuzu.yuzu_emu.utils.InputHandler
+import org.yuzu.yuzu_emu.utils.Log
 import org.yuzu.yuzu_emu.utils.MemoryUtil
 import org.yuzu.yuzu_emu.utils.NfcReader
 import org.yuzu.yuzu_emu.utils.ThemeHelper
@@ -80,6 +81,7 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Log.gameLaunched = true
         ThemeHelper.setTheme(this)
 
         super.onCreate(savedInstanceState)

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/Log.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/Log.kt
@@ -3,38 +3,14 @@
 
 package org.yuzu.yuzu_emu.utils
 
-import android.util.Log
-import org.yuzu.yuzu_emu.BuildConfig
-
-/**
- * Contains methods that call through to [android.util.Log], but
- * with the same TAG automatically provided. Also no-ops VERBOSE and DEBUG log
- * levels in release builds.
- */
 object Log {
-    private const val TAG = "Yuzu Frontend"
+    external fun debug(message: String)
 
-    fun verbose(message: String) {
-        if (BuildConfig.DEBUG) {
-            Log.v(TAG, message)
-        }
-    }
+    external fun warning(message: String)
 
-    fun debug(message: String) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, message)
-        }
-    }
+    external fun info(message: String)
 
-    fun info(message: String) {
-        Log.i(TAG, message)
-    }
+    external fun error(message: String)
 
-    fun warning(message: String) {
-        Log.w(TAG, message)
-    }
-
-    fun error(message: String) {
-        Log.e(TAG, message)
-    }
+    external fun critical(message: String)
 }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/Log.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/Log.kt
@@ -4,6 +4,9 @@
 package org.yuzu.yuzu_emu.utils
 
 object Log {
+    // Tracks whether we should share the old log or the current log
+    var gameLaunched = false
+
     external fun debug(message: String)
 
     external fun warning(message: String)

--- a/src/android/app/src/main/jni/CMakeLists.txt
+++ b/src/android/app/src/main/jni/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(yuzu-android SHARED
     native_config.cpp
     uisettings.cpp
     game_metadata.cpp
+    native_log.cpp
 )
 
 set_property(TARGET yuzu-android PROPERTY IMPORTED_LOCATION ${FFmpeg_LIBRARY_DIR})

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -248,6 +248,11 @@ void EmulationSession::ConfigureFilesystemProvider(const std::string& filepath) 
 }
 
 void EmulationSession::InitializeSystem() {
+    // Initialize logging system
+    Common::Log::Initialize();
+    Common::Log::SetColorConsoleBackendEnabled(true);
+    Common::Log::Start();
+
     // Initialize filesystem.
     m_system.SetFilesystem(m_vfs);
     m_system.GetUserChannel().clear();
@@ -462,10 +467,6 @@ void EmulationSession::OnEmulationStopped(Core::SystemResultStatus result) {
 }
 
 static Core::SystemResultStatus RunEmulation(const std::string& filepath) {
-    Common::Log::Initialize();
-    Common::Log::SetColorConsoleBackendEnabled(true);
-    Common::Log::Start();
-
     MicroProfileOnThreadCreate("EmuThread");
     SCOPE_EXIT({ MicroProfileShutdown(); });
 

--- a/src/android/app/src/main/jni/native_log.cpp
+++ b/src/android/app/src/main/jni/native_log.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <common/logging/log.h>
+#include <jni.h>
+
+#include "android_common/android_common.h"
+
+extern "C" {
+
+void Java_org_yuzu_yuzu_1emu_utils_Log_debug(JNIEnv* env, jobject obj, jstring jmessage) {
+    LOG_DEBUG(Frontend, "{}", GetJString(env, jmessage));
+}
+
+void Java_org_yuzu_yuzu_1emu_utils_Log_warning(JNIEnv* env, jobject obj, jstring jmessage) {
+    LOG_WARNING(Frontend, "{}", GetJString(env, jmessage));
+}
+
+void Java_org_yuzu_yuzu_1emu_utils_Log_info(JNIEnv* env, jobject obj, jstring jmessage) {
+    LOG_INFO(Frontend, "{}", GetJString(env, jmessage));
+}
+
+void Java_org_yuzu_yuzu_1emu_utils_Log_error(JNIEnv* env, jobject obj, jstring jmessage) {
+    LOG_ERROR(Frontend, "{}", GetJString(env, jmessage));
+}
+
+void Java_org_yuzu_yuzu_1emu_utils_Log_critical(JNIEnv* env, jobject obj, jstring jmessage) {
+    LOG_CRITICAL(Frontend, "{}", GetJString(env, jmessage));
+}
+
+} // extern "C"


### PR DESCRIPTION
Begin logging when the frontend starts like qt and forward all calls to the Log object in the android frontend to the yuzu logging system so we can get information in the yuzu_log.txt file.

 This also ensures that the user shares the correct log based on context. If a user has booted a game, closed it, and went to share the log, the most recent log will be shared. If a user had a game crash and goes to share the log, the old log will be shared.