### PR TITLE
core: hid: Fix wrong battery values

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -1091,30 +1091,30 @@ void EmulatedController::SetBattery(const Common::Input::CallbackStatus& callbac
 
     bool is_charging = false;
     bool is_powered = false;
-    NpadBatteryLevel battery_level = 0;
+    NpadBatteryLevel battery_level = NpadBatteryLevel::Empty;
     switch (controller.battery_values[index]) {
     case Common::Input::BatteryLevel::Charging:
         is_charging = true;
         is_powered = true;
-        battery_level = 6;
+        battery_level = NpadBatteryLevel::Full;
         break;
     case Common::Input::BatteryLevel::Medium:
-        battery_level = 6;
+        battery_level = NpadBatteryLevel::High;
         break;
     case Common::Input::BatteryLevel::Low:
-        battery_level = 4;
+        battery_level = NpadBatteryLevel::Low;
         break;
     case Common::Input::BatteryLevel::Critical:
-        battery_level = 2;
+        battery_level = NpadBatteryLevel::Critical;
         break;
     case Common::Input::BatteryLevel::Empty:
-        battery_level = 0;
+        battery_level = NpadBatteryLevel::Empty;
         break;
     case Common::Input::BatteryLevel::None:
     case Common::Input::BatteryLevel::Full:
     default:
         is_powered = true;
-        battery_level = 8;
+        battery_level = NpadBatteryLevel::Full;
         break;
     }
 

--- a/src/core/hid/hid_types.h
+++ b/src/core/hid/hid_types.h
@@ -302,6 +302,15 @@ enum class TouchScreenModeForNx : u8 {
     Heat2,
 };
 
+// This is nn::hid::system::NpadBatteryLevel
+enum class NpadBatteryLevel : u32 {
+    Empty,
+    Critical,
+    Low,
+    High,
+    Full,
+};
+
 // This is nn::hid::NpadStyleTag
 struct NpadStyleTag {
     union {
@@ -385,16 +394,12 @@ struct NpadGcTriggerState {
 };
 static_assert(sizeof(NpadGcTriggerState) == 0x10, "NpadGcTriggerState is an invalid size");
 
-// This is nn::hid::system::NpadBatteryLevel
-using NpadBatteryLevel = u32;
-static_assert(sizeof(NpadBatteryLevel) == 0x4, "NpadBatteryLevel is an invalid size");
-
 // This is nn::hid::system::NpadPowerInfo
 struct NpadPowerInfo {
     bool is_powered{};
     bool is_charging{};
     INSERT_PADDING_BYTES(0x6);
-    NpadBatteryLevel battery_level{8};
+    NpadBatteryLevel battery_level{NpadBatteryLevel::Full};
 };
 static_assert(sizeof(NpadPowerInfo) == 0xC, "NpadPowerInfo is an invalid size");
 

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -1108,9 +1108,9 @@ Result Controller_NPad::DisconnectNpad(Core::HID::NpadIdType npad_id) {
     shared_memory->sixaxis_dual_right_properties.raw = 0;
     shared_memory->sixaxis_left_properties.raw = 0;
     shared_memory->sixaxis_right_properties.raw = 0;
-    shared_memory->battery_level_dual = 0;
-    shared_memory->battery_level_left = 0;
-    shared_memory->battery_level_right = 0;
+    shared_memory->battery_level_dual = Core::HID::NpadBatteryLevel::Empty;
+    shared_memory->battery_level_left = Core::HID::NpadBatteryLevel::Empty;
+    shared_memory->battery_level_right = Core::HID::NpadBatteryLevel::Empty;
     shared_memory->fullkey_color = {
         .attribute = ColorAttribute::NoController,
         .fullkey = {},


### PR DESCRIPTION
While implementing applets a function called `nn::hid::detail::GetNpadPowerInfo` this will throw `nn::detail::UnexpectedDefaultImpl` on any battery value higher than 4. Fix this property by using the apropiarte range.