### PR TITLE
android: Update surface parameters on emulation start

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -312,6 +312,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                             ViewUtils.showView(binding.surfaceInputOverlay)
                             ViewUtils.hideView(binding.loadingIndicator)
 
+                            emulationState.updateSurface()
+
                             // Setup overlay
                             updateShowFpsOverlay()
                         }
@@ -801,6 +803,13 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             this.surface = surface
             if (this.surface != null) {
                 runWithValidSurface()
+            }
+        }
+
+        @Synchronized
+        fun updateSurface() {
+            if (surface != null) {
+                NativeLibrary.surfaceChanged(surface)
             }
         }
 


### PR DESCRIPTION
This adds a quick update that notifies the render surface if there was a change between surface creation and emulation starting.