### PR TITLE
core: hid: Signal color updates

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -96,18 +96,7 @@ void EmulatedController::ReloadFromSettings() {
     }
 
     controller.color_values = {};
-    controller.colors_state.fullkey = {
-        .body = GetNpadColor(player.body_color_left),
-        .button = GetNpadColor(player.button_color_left),
-    };
-    controller.colors_state.left = {
-        .body = GetNpadColor(player.body_color_left),
-        .button = GetNpadColor(player.button_color_left),
-    };
-    controller.colors_state.right = {
-        .body = GetNpadColor(player.body_color_right),
-        .button = GetNpadColor(player.button_color_right),
-    };
+    ReloadColorsFromSettings();
 
     ring_params[0] = Common::ParamPackage(Settings::values.ringcon_analogs);
 
@@ -126,6 +115,30 @@ void EmulatedController::ReloadFromSettings() {
     }
 
     ReloadInput();
+}
+
+void EmulatedController::ReloadColorsFromSettings() {
+    const auto player_index = NpadIdTypeToIndex(npad_id_type);
+    const auto& player = Settings::values.players.GetValue()[player_index];
+
+    // Avoid updating colors if overridden by physical controller
+    if (controller.color_values[LeftIndex].body != 0 &&
+        controller.color_values[RightIndex].body != 0) {
+        return;
+    }
+
+    controller.colors_state.fullkey = {
+        .body = GetNpadColor(player.body_color_left),
+        .button = GetNpadColor(player.button_color_left),
+    };
+    controller.colors_state.left = {
+        .body = GetNpadColor(player.body_color_left),
+        .button = GetNpadColor(player.button_color_left),
+    };
+    controller.colors_state.right = {
+        .body = GetNpadColor(player.body_color_right),
+        .button = GetNpadColor(player.button_color_right),
+    };
 }
 
 void EmulatedController::LoadDevices() {

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -253,6 +253,9 @@ public:
     /// Overrides current mapped devices with the stored configuration and reloads all input devices
     void ReloadFromSettings();
 
+    /// Updates current colors with the ones stored in the configuration
+    void ReloadColorsFromSettings();
+
     /// Saves the current mapped configuration
     void SaveCurrentConfig();
 

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -152,7 +152,7 @@ void ConfigureInput::Initialize(InputCommon::InputSubsystem* input_subsystem,
     connect(player_controllers[0], &ConfigureInputPlayer::HandheldStateChanged,
             [this](bool is_handheld) { UpdateDockedState(is_handheld); });
 
-    advanced = new ConfigureInputAdvanced(this);
+    advanced = new ConfigureInputAdvanced(hid_core, this);
     ui->tabAdvanced->setLayout(new QHBoxLayout(ui->tabAdvanced));
     ui->tabAdvanced->layout()->addWidget(advanced);
 

--- a/src/yuzu/configuration/configure_input_advanced.cpp
+++ b/src/yuzu/configuration/configure_input_advanced.cpp
@@ -4,11 +4,13 @@
 #include <QColorDialog>
 #include "common/settings.h"
 #include "core/core.h"
+#include "core/hid/emulated_controller.h"
+#include "core/hid/hid_core.h"
 #include "ui_configure_input_advanced.h"
 #include "yuzu/configuration/configure_input_advanced.h"
 
-ConfigureInputAdvanced::ConfigureInputAdvanced(QWidget* parent)
-    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInputAdvanced>()) {
+ConfigureInputAdvanced::ConfigureInputAdvanced(Core::HID::HIDCore& hid_core_, QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInputAdvanced>()), hid_core{hid_core_} {
     ui->setupUi(this);
 
     controllers_color_buttons = {{
@@ -123,6 +125,8 @@ void ConfigureInputAdvanced::ApplyConfiguration() {
         player.button_color_left = colors[1];
         player.body_color_right = colors[2];
         player.button_color_right = colors[3];
+
+        hid_core.GetEmulatedControllerByIndex(player_idx)->ReloadColorsFromSettings();
     }
 
     Settings::values.debug_pad_enabled = ui->debug_enabled->isChecked();

--- a/src/yuzu/configuration/configure_input_advanced.h
+++ b/src/yuzu/configuration/configure_input_advanced.h
@@ -14,11 +14,15 @@ namespace Ui {
 class ConfigureInputAdvanced;
 }
 
+namespace Core::HID {
+class HIDCore;
+} // namespace Core::HID
+
 class ConfigureInputAdvanced : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ConfigureInputAdvanced(QWidget* parent = nullptr);
+    explicit ConfigureInputAdvanced(Core::HID::HIDCore& hid_core_, QWidget* parent = nullptr);
     ~ConfigureInputAdvanced() override;
 
     void ApplyConfiguration();
@@ -44,4 +48,6 @@ private:
 
     std::array<std::array<QColor, 4>, 8> controllers_colors;
     std::array<std::array<QPushButton*, 4>, 8> controllers_color_buttons;
+
+    Core::HID::HIDCore& hid_core;
 };


### PR DESCRIPTION
Previously changing colors didn't take into effect until the configuration window was reopened. This allows to update colors when config is saved.