### PR TITLE
service: acc: Ensure proper profile size

### DIFF
--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -306,10 +306,10 @@ void ConfigureProfileManager::SetUserImage() {
         return;
     }
 
-    // Some games crash when the profile image is too big. Resize any image bigger than 256x256
+    // Profile image must be 256x256
     QImage image(image_path);
-    if (image.width() > 256 || image.height() > 256) {
-        image = image.scaled(256, 256, Qt::KeepAspectRatio);
+    if (image.width() != 256 || image.height() != 256) {
+        image = image.scaled(256, 256, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
         if (!image.save(image_path)) {
             QMessageBox::warning(this, tr("Error resizing user image"),
                                  tr("Unable to resize image"));


### PR DESCRIPTION
Turns out system applets only allow 256x256 images any other size will result in a corrupted image. Resize all image profiles on frontend side as well on core side. Ensuring that the image will be always displayed properly even when the stored image is wrong.

![image](https://github.com/yuzu-emu/yuzu/assets/5944268/8328d9bd-257b-47e1-a5b6-dc0f15b1a93a)

closes #11968 