### PR TITLE
android: FPS counter adjustments

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -462,7 +462,6 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                     if (it.orientation == FoldingFeature.Orientation.HORIZONTAL) {
                         // Restrict emulation and overlays to the top of the screen
                         binding.emulationContainer.layoutParams.height = it.bounds.top
-                        binding.overlayContainer.layoutParams.height = it.bounds.top
                         // Restrict input and menu drawer to the bottom of the screen
                         binding.inputContainer.layoutParams.height = it.bounds.bottom
                         binding.inGameMenu.layoutParams.height = it.bounds.bottom
@@ -476,7 +475,6 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
         if (!isFolding) {
             binding.emulationContainer.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
             binding.inputContainer.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
-            binding.overlayContainer.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
             binding.inGameMenu.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
             isInFoldableLayout = false
             updateOrientation()
@@ -484,7 +482,6 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
         }
         binding.emulationContainer.requestLayout()
         binding.inputContainer.requestLayout()
-        binding.overlayContainer.requestLayout()
         binding.inGameMenu.requestLayout()
     }
 
@@ -710,24 +707,6 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             }
 
             v.setPadding(left, cutInsets.top, right, 0)
-
-            // Ensure FPS text doesn't get cut off by rounded display corners
-            val sidePadding = resources.getDimensionPixelSize(R.dimen.spacing_xtralarge)
-            if (cutInsets.left == 0) {
-                binding.showFpsText.setPadding(
-                    sidePadding,
-                    cutInsets.top,
-                    cutInsets.right,
-                    cutInsets.bottom
-                )
-            } else {
-                binding.showFpsText.setPadding(
-                    cutInsets.left,
-                    cutInsets.top,
-                    cutInsets.right,
-                    cutInsets.bottom
-                )
-            }
             windowInsets
         }
     }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -10,7 +10,6 @@ import android.content.DialogInterface
 import android.content.SharedPreferences
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
-import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
@@ -155,7 +154,6 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
         }
 
         binding.surfaceEmulation.holder.addCallback(this)
-        binding.showFpsText.setTextColor(Color.YELLOW)
         binding.doneControlConfig.setOnClickListener { stopConfiguringControls() }
 
         binding.drawerLayout.addDrawerListener(object : DrawerListener {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -414,12 +414,12 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             val FRAMETIME = 2
             val SPEED = 3
             perfStatsUpdater = {
-                if (emulationViewModel.emulationStarted.value == true) {
+                if (emulationViewModel.emulationStarted.value) {
                     val perfStats = NativeLibrary.getPerfStats()
-                    if (perfStats[FPS] > 0 && _binding != null) {
+                    if (_binding != null) {
                         binding.showFpsText.text = String.format("FPS: %.1f", perfStats[FPS])
                     }
-                    perfStatsUpdateHandler.postDelayed(perfStatsUpdater!!, 100)
+                    perfStatsUpdateHandler.postDelayed(perfStatsUpdater!!, 800)
                 }
             }
             perfStatsUpdateHandler.post(perfStatsUpdater!!)

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -199,8 +199,8 @@ bool EmulationSession::IsPaused() const {
     return m_is_running && m_is_paused;
 }
 
-const Core::PerfStatsResults& EmulationSession::PerfStats() const {
-    std::scoped_lock m_perf_stats_lock(m_perf_stats_mutex);
+const Core::PerfStatsResults& EmulationSession::PerfStats() {
+    m_perf_stats = m_system.GetAndResetPerfStats();
     return m_perf_stats;
 }
 
@@ -380,11 +380,6 @@ void EmulationSession::RunEmulation() {
                 // Emulation halted.
                 break;
             }
-        }
-        {
-            // Refresh performance stats.
-            std::scoped_lock m_perf_stats_lock(m_perf_stats_mutex);
-            m_perf_stats = m_system.GetAndResetPerfStats();
         }
     }
 }

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -41,7 +41,7 @@ public:
     void RunEmulation();
     void ShutdownEmulation();
 
-    const Core::PerfStatsResults& PerfStats() const;
+    const Core::PerfStatsResults& PerfStats();
     void ConfigureFilesystemProvider(const std::string& filepath);
     void InitializeSystem();
     Core::SystemResultStatus InitializeEmulation(const std::string& filepath);
@@ -80,6 +80,5 @@ private:
 
     // Synchronization
     std::condition_variable_any m_cv;
-    mutable std::mutex m_perf_stats_mutex;
     mutable std::mutex m_mutex;
 };

--- a/src/android/app/src/main/res/layout/fragment_emulation.xml
+++ b/src/android/app/src/main/res/layout/fragment_emulation.xml
@@ -134,16 +134,18 @@
         <FrameLayout
             android:id="@+id/overlay_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true">
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/show_fps_text"
+                style="@style/TextAppearance.Material3.BodyMedium"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="left"
                 android:clickable="false"
                 android:focusable="false"
-                android:shadowColor="@android:color/black"
+                android:paddingHorizontal="20dp"
                 android:textColor="@android:color/white"
                 android:textSize="12sp"
                 tools:ignore="RtlHardcoded" />


### PR DESCRIPTION
Just a few adjustments that @liamwhite and I wanted for the counter
- Always update the FPS counter regardless of pause state
- Recolor the text to white
- Simplify padding to just use its framelayout's `fitsSystemWindows` attribute and use the padding option directly in the xml view