### PR TITLE
Allocate resources for test window before getting system info

### DIFF
--- a/src/yuzu/vk_device_info.cpp
+++ b/src/yuzu/vk_device_info.cpp
@@ -31,6 +31,7 @@ void PopulateRecords(std::vector<Record>& records, QWindow* window) try {
     // Create a test window with a Vulkan surface type for checking present modes.
     QWindow test_window(window);
     test_window.setSurfaceType(QWindow::VulkanSurface);
+    test_window.create();
     auto wsi = QtCommon::GetWindowSystemInfo(&test_window);
 
     vk::InstanceDispatch dld;


### PR DESCRIPTION
Allocate resources for `test_window` to avoid setting `wsi.render_surface` as nullptr, which causes a crash in Wayland as per [#11941](https://github.com/yuzu-emu/yuzu/issues/11941#issuecomment-1795920846)

Fixes #11941.