### PR TITLE
shared_translation: Call tr more directly

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -252,6 +252,7 @@ file(GLOB_RECURSE THEMES ${PROJECT_SOURCE_DIR}/dist/qt_themes/*)
 if (ENABLE_QT_TRANSLATION)
     set(YUZU_QT_LANGUAGES "${PROJECT_SOURCE_DIR}/dist/languages" CACHE PATH "Path to the translation bundle for the Qt frontend")
     option(GENERATE_QT_TRANSLATION "Generate en.ts as the translation source file" OFF)
+    option(WORKAROUND_BROKEN_LUPDATE "Run lupdate directly through CMake if Qt's convenience wrappers don't work" OFF)
 
     # Update source TS file if enabled
     if (GENERATE_QT_TRANSLATION)
@@ -259,19 +260,51 @@ if (ENABLE_QT_TRANSLATION)
         # these calls to qt_create_translation also creates a rule to generate en.qm which conflicts with providing english plurals
         # so we have to set a OUTPUT_LOCATION so that we don't have multiple rules to generate en.qm
         set_source_files_properties(${YUZU_QT_LANGUAGES}/en.ts PROPERTIES OUTPUT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/translations")
-        qt_create_translation(QM_FILES
-            ${SRCS}
-            ${UIS}
-            ${YUZU_QT_LANGUAGES}/en.ts
-        OPTIONS
-            -source-language en_US
-            -target-language en_US
-        )
+        if (WORKAROUND_BROKEN_LUPDATE)
+            add_custom_command(OUTPUT ${YUZU_QT_LANGUAGES}/en.ts
+                COMMAND lupdate
+                    -source-language en_US
+                    -target-language en_US
+                    ${SRCS}
+                    ${UIS}
+                    -ts ${YUZU_QT_LANGUAGES}/en.ts
+                DEPENDS
+                    ${SRCS}
+                    ${UIS}
+                WORKING_DIRECTORY
+                    ${CMAKE_CURRENT_SOURCE_DIR}
+            )
+        else()
+            qt_create_translation(QM_FILES
+                ${SRCS}
+                ${UIS}
+                ${YUZU_QT_LANGUAGES}/en.ts
+            OPTIONS
+                -source-language en_US
+                -target-language en_US
+            )
+        endif()
 
         # Generate plurals into dist/english_plurals/generated_en.ts so it can be used to revise dist/english_plurals/en.ts
         set(GENERATED_PLURALS_FILE ${PROJECT_SOURCE_DIR}/dist/english_plurals/generated_en.ts)
         set_source_files_properties(${GENERATED_PLURALS_FILE} PROPERTIES OUTPUT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/plurals")
-        qt_create_translation(QM_FILES ${SRCS} ${UIS} ${GENERATED_PLURALS_FILE} OPTIONS -pluralonly -source-language en_US -target-language en_US)
+        if (WORKAROUND_BROKEN_LUPDATE)
+            add_custom_command(OUTPUT ${GENERATED_PLURALS_FILE}
+                COMMAND lupdate
+                    -source-language en_US
+                    -target-language en_US
+                    ${SRCS}
+                    ${UIS}
+                    -ts ${GENERATED_PLURALS_FILE}
+                DEPENDS
+                    ${SRCS}
+                    ${UIS}
+                WORKING_DIRECTORY
+                    ${CMAKE_CURRENT_SOURCE_DIR}
+            )
+        else()
+            qt_create_translation(QM_FILES ${SRCS} ${UIS} ${GENERATED_PLURALS_FILE} OPTIONS -pluralonly -source-language en_US -target-language en_US)
+        endif()
 
         add_custom_target(translation ALL DEPENDS ${YUZU_QT_LANGUAGES}/en.ts ${GENERATED_PLURALS_FILE})
     endif()

--- a/src/yuzu/configuration/shared_translation.cpp
+++ b/src/yuzu/configuration/shared_translation.cpp
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "common/time_zone.h"
 #include "yuzu/configuration/shared_translation.h"
 
 #include <map>
 #include <memory>
 #include <tuple>
 #include <utility>
+#include <QCoreApplication>
 #include <QWidget>
 #include "common/settings.h"
 #include "common/settings_enums.h"
 #include "common/settings_setting.h"
+#include "common/time_zone.h"
 #include "yuzu/uisettings.h"
 
 namespace ConfigurationShared {
@@ -21,123 +22,135 @@ std::unique_ptr<TranslationMap> InitializeTranslations(QWidget* parent) {
     const auto& tr = [parent](const char* text) -> QString { return parent->tr(text); };
 
 #define INSERT(SETTINGS, ID, NAME, TOOLTIP)                                                        \
-    translations->insert(std::pair{SETTINGS::values.ID.Id(), std::pair{tr((NAME)), tr((TOOLTIP))}})
+    translations->insert(std::pair{SETTINGS::values.ID.Id(), std::pair{(NAME), (TOOLTIP)}})
 
     // A setting can be ignored by giving it a blank name
 
     // Audio
-    INSERT(Settings, sink_id, "Output Engine:", "");
-    INSERT(Settings, audio_output_device_id, "Output Device:", "");
-    INSERT(Settings, audio_input_device_id, "Input Device:", "");
-    INSERT(Settings, audio_muted, "Mute audio", "");
-    INSERT(Settings, volume, "Volume:", "");
-    INSERT(Settings, dump_audio_commands, "", "");
-    INSERT(UISettings, mute_when_in_background, "Mute audio when in background", "");
+    INSERT(Settings, sink_id, tr("Output Engine:"), QStringLiteral());
+    INSERT(Settings, audio_output_device_id, tr("Output Device:"), QStringLiteral());
+    INSERT(Settings, audio_input_device_id, tr("Input Device:"), QStringLiteral());
+    INSERT(Settings, audio_muted, tr("Mute audio"), QStringLiteral());
+    INSERT(Settings, volume, tr("Volume:"), QStringLiteral());
+    INSERT(Settings, dump_audio_commands, QStringLiteral(), QStringLiteral());
+    INSERT(UISettings, mute_when_in_background, tr("Mute audio when in background"),
+           QStringLiteral());
 
     // Core
-    INSERT(Settings, use_multi_core, "Multicore CPU Emulation", "");
-    INSERT(Settings, memory_layout_mode, "Memory Layout", "");
-    INSERT(Settings, use_speed_limit, "", "");
-    INSERT(Settings, speed_limit, "Limit Speed Percent", "");
+    INSERT(Settings, use_multi_core, tr("Multicore CPU Emulation"), QStringLiteral());
+    INSERT(Settings, memory_layout_mode, tr("Memory Layout"), QStringLiteral());
+    INSERT(Settings, use_speed_limit, QStringLiteral(), QStringLiteral());
+    INSERT(Settings, speed_limit, tr("Limit Speed Percent"), QStringLiteral());
 
     // Cpu
-    INSERT(Settings, cpu_accuracy, "Accuracy:", "");
+    INSERT(Settings, cpu_accuracy, tr("Accuracy:"), QStringLiteral());
 
     // Cpu Debug
 
     // Cpu Unsafe
-    INSERT(Settings, cpuopt_unsafe_unfuse_fma,
-           "Unfuse FMA (improve performance on CPUs without FMA)",
-           "This option improves speed by reducing accuracy of fused-multiply-add instructions on "
-           "CPUs without native FMA support.");
-    INSERT(Settings, cpuopt_unsafe_reduce_fp_error, "Faster FRSQRTE and FRECPE",
-           "This option improves the speed of some approximate floating-point functions by using "
-           "less accurate native approximations.");
-    INSERT(Settings, cpuopt_unsafe_ignore_standard_fpcr, "Faster ASIMD instructions (32 bits only)",
-           "This option improves the speed of 32 bits ASIMD floating-point functions by running "
-           "with incorrect rounding modes.");
-    INSERT(Settings, cpuopt_unsafe_inaccurate_nan, "Inaccurate NaN handling",
-           "This option improves speed by removing NaN checking. Please note this also reduces "
-           "accuracy of certain floating-point instructions.");
     INSERT(
-        Settings, cpuopt_unsafe_fastmem_check, "Disable address space checks",
-        "This option improves speed by eliminating a safety check before every memory read/write "
-        "in guest. Disabling it may allow a game to read/write the emulator's memory.");
-    INSERT(Settings, cpuopt_unsafe_ignore_global_monitor, "Ignore global monitor",
-           "This option improves speed by relying only on the semantics of cmpxchg to ensure "
+        Settings, cpuopt_unsafe_unfuse_fma,
+        tr("Unfuse FMA (improve performance on CPUs without FMA)"),
+        tr("This option improves speed by reducing accuracy of fused-multiply-add instructions on "
+           "CPUs without native FMA support."));
+    INSERT(
+        Settings, cpuopt_unsafe_reduce_fp_error, tr("Faster FRSQRTE and FRECPE"),
+        tr("This option improves the speed of some approximate floating-point functions by using "
+           "less accurate native approximations."));
+    INSERT(Settings, cpuopt_unsafe_ignore_standard_fpcr,
+           tr("Faster ASIMD instructions (32 bits only)"),
+           tr("This option improves the speed of 32 bits ASIMD floating-point functions by running "
+              "with incorrect rounding modes."));
+    INSERT(Settings, cpuopt_unsafe_inaccurate_nan, tr("Inaccurate NaN handling"),
+           tr("This option improves speed by removing NaN checking. Please note this also reduces "
+              "accuracy of certain floating-point instructions."));
+    INSERT(Settings, cpuopt_unsafe_fastmem_check, tr("Disable address space checks"),
+           tr("This option improves speed by eliminating a safety check before every memory "
+              "read/write "
+              "in guest. Disabling it may allow a game to read/write the emulator's memory."));
+    INSERT(
+        Settings, cpuopt_unsafe_ignore_global_monitor, tr("Ignore global monitor"),
+        tr("This option improves speed by relying only on the semantics of cmpxchg to ensure "
            "safety of exclusive access instructions. Please note this may result in deadlocks and "
-           "other race conditions.");
+           "other race conditions."));
 
     // Renderer
-    INSERT(Settings, renderer_backend, "API:", "");
-    INSERT(Settings, vulkan_device, "Device:", "");
-    INSERT(Settings, shader_backend, "Shader Backend:", "");
-    INSERT(Settings, resolution_setup, "Resolution:", "");
-    INSERT(Settings, scaling_filter, "Window Adapting Filter:", "");
-    INSERT(Settings, fsr_sharpening_slider, "FSR Sharpness:", "");
-    INSERT(Settings, anti_aliasing, "Anti-Aliasing Method:", "");
-    INSERT(Settings, fullscreen_mode, "Fullscreen Mode:", "");
-    INSERT(Settings, aspect_ratio, "Aspect Ratio:", "");
-    INSERT(Settings, use_disk_shader_cache, "Use disk pipeline cache", "");
-    INSERT(Settings, use_asynchronous_gpu_emulation, "Use asynchronous GPU emulation", "");
-    INSERT(Settings, nvdec_emulation, "NVDEC emulation:", "");
-    INSERT(Settings, accelerate_astc, "ASTC Decoding Method:", "");
-    INSERT(Settings, astc_recompression, "ASTC Recompression Method:", "");
-    INSERT(Settings, vsync_mode, "VSync Mode:",
-           "FIFO (VSync) does not drop frames or exhibit tearing but is limited by the screen "
+    INSERT(Settings, renderer_backend, tr("API:"), QStringLiteral());
+    INSERT(Settings, vulkan_device, tr("Device:"), QStringLiteral());
+    INSERT(Settings, shader_backend, tr("Shader Backend:"), QStringLiteral());
+    INSERT(Settings, resolution_setup, tr("Resolution:"), QStringLiteral());
+    INSERT(Settings, scaling_filter, tr("Window Adapting Filter:"), QStringLiteral());
+    INSERT(Settings, fsr_sharpening_slider, tr("FSR Sharpness:"), QStringLiteral());
+    INSERT(Settings, anti_aliasing, tr("Anti-Aliasing Method:"), QStringLiteral());
+    INSERT(Settings, fullscreen_mode, tr("Fullscreen Mode:"), QStringLiteral());
+    INSERT(Settings, aspect_ratio, tr("Aspect Ratio:"), QStringLiteral());
+    INSERT(Settings, use_disk_shader_cache, tr("Use disk pipeline cache"), QStringLiteral());
+    INSERT(Settings, use_asynchronous_gpu_emulation, tr("Use asynchronous GPU emulation"),
+           QStringLiteral());
+    INSERT(Settings, nvdec_emulation, tr("NVDEC emulation:"), QStringLiteral());
+    INSERT(Settings, accelerate_astc, tr("ASTC Decoding Method:"), QStringLiteral());
+    INSERT(Settings, astc_recompression, tr("ASTC Recompression Method:"), QStringLiteral());
+    INSERT(
+        Settings, vsync_mode, tr("VSync Mode:"),
+        tr("FIFO (VSync) does not drop frames or exhibit tearing but is limited by the screen "
            "refresh rate.\nFIFO Relaxed is similar to FIFO but allows tearing as it recovers from "
            "a slow down.\nMailbox can have lower latency than FIFO and does not tear but may drop "
            "frames.\nImmediate (no synchronization) just presents whatever is available and can "
-           "exhibit tearing.");
-    INSERT(Settings, bg_red, "", "");
-    INSERT(Settings, bg_green, "", "");
-    INSERT(Settings, bg_blue, "", "");
+           "exhibit tearing."));
+    INSERT(Settings, bg_red, QStringLiteral(), QStringLiteral());
+    INSERT(Settings, bg_green, QStringLiteral(), QStringLiteral());
+    INSERT(Settings, bg_blue, QStringLiteral(), QStringLiteral());
 
     // Renderer (Advanced Graphics)
-    INSERT(Settings, async_presentation, "Enable asynchronous presentation (Vulkan only)", "");
-    INSERT(Settings, renderer_force_max_clock, "Force maximum clocks (Vulkan only)",
-           "Runs work in the background while waiting for graphics commands to keep the GPU from "
-           "lowering its clock speed.");
-    INSERT(Settings, max_anisotropy, "Anisotropic Filtering:", "");
-    INSERT(Settings, gpu_accuracy, "Accuracy Level:", "");
-    INSERT(Settings, use_asynchronous_shaders, "Use asynchronous shader building (Hack)",
-           "Enables asynchronous shader compilation, which may reduce shader stutter. This feature "
-           "is experimental.");
-    INSERT(Settings, use_fast_gpu_time, "Use Fast GPU Time (Hack)",
-           "Enables Fast GPU Time. This option will force most games to run at their highest "
-           "native resolution.");
-    INSERT(Settings, use_vulkan_driver_pipeline_cache, "Use Vulkan pipeline cache",
-           "Enables GPU vendor-specific pipeline cache. This option can improve shader loading "
-           "time significantly in cases where the Vulkan driver does not store pipeline cache "
-           "files internally.");
-    INSERT(Settings, enable_compute_pipelines, "Enable Compute Pipelines (Intel Vulkan Only)",
-           "Enable compute pipelines, required by some games.\nThis setting only exists for Intel "
+    INSERT(Settings, async_presentation, tr("Enable asynchronous presentation (Vulkan only)"),
+           QStringLiteral());
+    INSERT(
+        Settings, renderer_force_max_clock, tr("Force maximum clocks (Vulkan only)"),
+        tr("Runs work in the background while waiting for graphics commands to keep the GPU from "
+           "lowering its clock speed."));
+    INSERT(Settings, max_anisotropy, tr("Anisotropic Filtering:"), QStringLiteral());
+    INSERT(Settings, gpu_accuracy, tr("Accuracy Level:"), QStringLiteral());
+    INSERT(
+        Settings, use_asynchronous_shaders, tr("Use asynchronous shader building (Hack)"),
+        tr("Enables asynchronous shader compilation, which may reduce shader stutter. This feature "
+           "is experimental."));
+    INSERT(Settings, use_fast_gpu_time, tr("Use Fast GPU Time (Hack)"),
+           tr("Enables Fast GPU Time. This option will force most games to run at their highest "
+              "native resolution."));
+    INSERT(Settings, use_vulkan_driver_pipeline_cache, tr("Use Vulkan pipeline cache"),
+           tr("Enables GPU vendor-specific pipeline cache. This option can improve shader loading "
+              "time significantly in cases where the Vulkan driver does not store pipeline cache "
+              "files internally."));
+    INSERT(
+        Settings, enable_compute_pipelines, tr("Enable Compute Pipelines (Intel Vulkan Only)"),
+        tr("Enable compute pipelines, required by some games.\nThis setting only exists for Intel "
            "proprietary drivers, and may crash if enabled.\nCompute pipelines are always enabled "
-           "on all other drivers.");
-    INSERT(Settings, use_reactive_flushing, "Enable Reactive Flushing",
-           "Uses reactive flushing instead of predictive flushing, allowing more accurate memory "
-           "syncing.");
-    INSERT(Settings, use_video_framerate, "Sync to framerate of video playback",
-           "Run the game at normal speed during video playback, even when the framerate is "
-           "unlocked.");
-    INSERT(Settings, barrier_feedback_loops, "Barrier feedback loops",
-           "Improves rendering of transparency effects in specific games.");
+           "on all other drivers."));
+    INSERT(
+        Settings, use_reactive_flushing, tr("Enable Reactive Flushing"),
+        tr("Uses reactive flushing instead of predictive flushing, allowing more accurate memory "
+           "syncing."));
+    INSERT(Settings, use_video_framerate, tr("Sync to framerate of video playback"),
+           tr("Run the game at normal speed during video playback, even when the framerate is "
+              "unlocked."));
+    INSERT(Settings, barrier_feedback_loops, tr("Barrier feedback loops"),
+           tr("Improves rendering of transparency effects in specific games."));
 
     // Renderer (Debug)
 
     // System
-    INSERT(Settings, rng_seed, "RNG Seed", "");
-    INSERT(Settings, rng_seed_enabled, "", "");
-    INSERT(Settings, device_name, "Device Name", "");
-    INSERT(Settings, custom_rtc, "Custom RTC", "");
-    INSERT(Settings, custom_rtc_enabled, "", "");
-    INSERT(Settings, language_index,
-           "Language:", "Note: this can be overridden when region setting is auto-select");
-    INSERT(Settings, region_index, "Region:", "");
-    INSERT(Settings, time_zone_index, "Time Zone:", "");
-    INSERT(Settings, sound_index, "Sound Output Mode:", "");
-    INSERT(Settings, use_docked_mode, "Console Mode:", "");
-    INSERT(Settings, current_user, "", "");
+    INSERT(Settings, rng_seed, tr("RNG Seed"), QStringLiteral());
+    INSERT(Settings, rng_seed_enabled, QStringLiteral(), QStringLiteral());
+    INSERT(Settings, device_name, tr("Device Name"), QStringLiteral());
+    INSERT(Settings, custom_rtc, tr("Custom RTC"), QStringLiteral());
+    INSERT(Settings, custom_rtc_enabled, QStringLiteral(), QStringLiteral());
+    INSERT(Settings, language_index, tr("Language:"),
+           tr("Note: this can be overridden when region setting is auto-select"));
+    INSERT(Settings, region_index, tr("Region:"), QStringLiteral());
+    INSERT(Settings, time_zone_index, tr("Time Zone:"), QStringLiteral());
+    INSERT(Settings, sound_index, tr("Sound Output Mode:"), QStringLiteral());
+    INSERT(Settings, use_docked_mode, tr("Console Mode:"), QStringLiteral());
+    INSERT(Settings, current_user, QStringLiteral(), QStringLiteral());
 
     // Controls
 
@@ -154,11 +167,14 @@ std::unique_ptr<TranslationMap> InitializeTranslations(QWidget* parent) {
     // Ui
 
     // Ui General
-    INSERT(UISettings, select_user_on_boot, "Prompt for user on game boot", "");
-    INSERT(UISettings, pause_when_in_background, "Pause emulation when in background", "");
-    INSERT(UISettings, confirm_before_stopping, "Confirm before stopping emulation", "");
-    INSERT(UISettings, hide_mouse, "Hide mouse on inactivity", "");
-    INSERT(UISettings, controller_applet_disabled, "Disable controller applet", "");
+    INSERT(UISettings, select_user_on_boot, tr("Prompt for user on game boot"), QStringLiteral());
+    INSERT(UISettings, pause_when_in_background, tr("Pause emulation when in background"),
+           QStringLiteral());
+    INSERT(UISettings, confirm_before_stopping, tr("Confirm before stopping emulation"),
+           QStringLiteral());
+    INSERT(UISettings, hide_mouse, tr("Hide mouse on inactivity"), QStringLiteral());
+    INSERT(UISettings, controller_applet_disabled, tr("Disable controller applet"),
+           QStringLiteral());
 
     // Ui Debugging
 
@@ -178,140 +194,141 @@ std::unique_ptr<ComboboxTranslationMap> ComboboxEnumeration(QWidget* parent) {
         return parent->tr(text, context);
     };
 
-#define PAIR(ENUM, VALUE, TRANSLATION)                                                             \
-    { static_cast<u32>(Settings::ENUM::VALUE), tr(TRANSLATION) }
-#define CTX_PAIR(ENUM, VALUE, TRANSLATION, CONTEXT)                                                \
-    { static_cast<u32>(Settings::ENUM::VALUE), tr(TRANSLATION, CONTEXT) }
+#define PAIR(ENUM, VALUE, TRANSLATION) {static_cast<u32>(Settings::ENUM::VALUE), (TRANSLATION)}
 
     // Intentionally skipping VSyncMode to let the UI fill that one out
 
     translations->insert({Settings::EnumMetadata<Settings::AstcDecodeMode>::Index(),
                           {
-                              PAIR(AstcDecodeMode, Cpu, "CPU"),
-                              PAIR(AstcDecodeMode, Gpu, "GPU"),
-                              PAIR(AstcDecodeMode, CpuAsynchronous, "CPU Asynchronous"),
+                              PAIR(AstcDecodeMode, Cpu, tr("CPU")),
+                              PAIR(AstcDecodeMode, Gpu, tr("GPU")),
+                              PAIR(AstcDecodeMode, CpuAsynchronous, tr("CPU Asynchronous")),
                           }});
-    translations->insert({Settings::EnumMetadata<Settings::AstcRecompression>::Index(),
-                          {
-                              PAIR(AstcRecompression, Uncompressed, "Uncompressed (Best quality)"),
-                              PAIR(AstcRecompression, Bc1, "BC1 (Low quality)"),
-                              PAIR(AstcRecompression, Bc3, "BC3 (Medium quality)"),
-                          }});
+    translations->insert(
+        {Settings::EnumMetadata<Settings::AstcRecompression>::Index(),
+         {
+             PAIR(AstcRecompression, Uncompressed, tr("Uncompressed (Best quality)")),
+             PAIR(AstcRecompression, Bc1, tr("BC1 (Low quality)")),
+             PAIR(AstcRecompression, Bc3, tr("BC3 (Medium quality)")),
+         }});
     translations->insert({Settings::EnumMetadata<Settings::RendererBackend>::Index(),
                           {
 #ifdef HAS_OPENGL
-                              PAIR(RendererBackend, OpenGL, "OpenGL"),
+                              PAIR(RendererBackend, OpenGL, tr("OpenGL")),
 #endif
-                              PAIR(RendererBackend, Vulkan, "Vulkan"),
-                              PAIR(RendererBackend, Null, "Null"),
+                              PAIR(RendererBackend, Vulkan, tr("Vulkan")),
+                              PAIR(RendererBackend, Null, tr("Null")),
                           }});
-    translations->insert({Settings::EnumMetadata<Settings::ShaderBackend>::Index(),
-                          {
-                              PAIR(ShaderBackend, Glsl, "GLSL"),
-                              PAIR(ShaderBackend, Glasm, "GLASM (Assembly Shaders, NVIDIA Only)"),
-                              PAIR(ShaderBackend, SpirV, "SPIR-V (Experimental, Mesa Only)"),
-                          }});
+    translations->insert(
+        {Settings::EnumMetadata<Settings::ShaderBackend>::Index(),
+         {
+             PAIR(ShaderBackend, Glsl, tr("GLSL")),
+             PAIR(ShaderBackend, Glasm, tr("GLASM (Assembly Shaders, NVIDIA Only)")),
+             PAIR(ShaderBackend, SpirV, tr("SPIR-V (Experimental, Mesa Only)")),
+         }});
     translations->insert({Settings::EnumMetadata<Settings::GpuAccuracy>::Index(),
                           {
-                              PAIR(GpuAccuracy, Normal, "Normal"),
-                              PAIR(GpuAccuracy, High, "High"),
-                              PAIR(GpuAccuracy, Extreme, "Extreme"),
+                              PAIR(GpuAccuracy, Normal, tr("Normal")),
+                              PAIR(GpuAccuracy, High, tr("High")),
+                              PAIR(GpuAccuracy, Extreme, tr("Extreme")),
                           }});
-    translations->insert({Settings::EnumMetadata<Settings::CpuAccuracy>::Index(),
-                          {
-                              PAIR(CpuAccuracy, Auto, "Auto"),
-                              PAIR(CpuAccuracy, Accurate, "Accurate"),
-                              PAIR(CpuAccuracy, Unsafe, "Unsafe"),
-                              PAIR(CpuAccuracy, Paranoid, "Paranoid (disables most optimizations)"),
-                          }});
+    translations->insert(
+        {Settings::EnumMetadata<Settings::CpuAccuracy>::Index(),
+         {
+             PAIR(CpuAccuracy, Auto, tr("Auto")),
+             PAIR(CpuAccuracy, Accurate, tr("Accurate")),
+             PAIR(CpuAccuracy, Unsafe, tr("Unsafe")),
+             PAIR(CpuAccuracy, Paranoid, tr("Paranoid (disables most optimizations)")),
+         }});
     translations->insert({Settings::EnumMetadata<Settings::FullscreenMode>::Index(),
                           {
-                              PAIR(FullscreenMode, Borderless, "Borderless Windowed"),
-                              PAIR(FullscreenMode, Exclusive, "Exclusive Fullscreen"),
+                              PAIR(FullscreenMode, Borderless, tr("Borderless Windowed")),
+                              PAIR(FullscreenMode, Exclusive, tr("Exclusive Fullscreen")),
                           }});
     translations->insert({Settings::EnumMetadata<Settings::NvdecEmulation>::Index(),
                           {
-                              PAIR(NvdecEmulation, Off, "No Video Output"),
-                              PAIR(NvdecEmulation, Cpu, "CPU Video Decoding"),
-                              PAIR(NvdecEmulation, Gpu, "GPU Video Decoding (Default)"),
+                              PAIR(NvdecEmulation, Off, tr("No Video Output")),
+                              PAIR(NvdecEmulation, Cpu, tr("CPU Video Decoding")),
+                              PAIR(NvdecEmulation, Gpu, tr("GPU Video Decoding (Default)")),
                           }});
-    translations->insert({Settings::EnumMetadata<Settings::ResolutionSetup>::Index(),
-                          {
-                              PAIR(ResolutionSetup, Res1_2X, "0.5X (360p/540p) [EXPERIMENTAL]"),
-                              PAIR(ResolutionSetup, Res3_4X, "0.75X (540p/810p) [EXPERIMENTAL]"),
-                              PAIR(ResolutionSetup, Res1X, "1X (720p/1080p)"),
-                              PAIR(ResolutionSetup, Res3_2X, "1.5X (1080p/1620p) [EXPERIMENTAL]"),
-                              PAIR(ResolutionSetup, Res2X, "2X (1440p/2160p)"),
-                              PAIR(ResolutionSetup, Res3X, "3X (2160p/3240p)"),
-                              PAIR(ResolutionSetup, Res4X, "4X (2880p/4320p)"),
-                              PAIR(ResolutionSetup, Res5X, "5X (3600p/5400p)"),
-                              PAIR(ResolutionSetup, Res6X, "6X (4320p/6480p)"),
-                              PAIR(ResolutionSetup, Res7X, "7X (5040p/7560p)"),
-                              PAIR(ResolutionSetup, Res8X, "8X (5760p/8640p)"),
-                          }});
+    translations->insert(
+        {Settings::EnumMetadata<Settings::ResolutionSetup>::Index(),
+         {
+             PAIR(ResolutionSetup, Res1_2X, tr("0.5X (360p/540p) [EXPERIMENTAL]")),
+             PAIR(ResolutionSetup, Res3_4X, tr("0.75X (540p/810p) [EXPERIMENTAL]")),
+             PAIR(ResolutionSetup, Res1X, tr("1X (720p/1080p)")),
+             PAIR(ResolutionSetup, Res3_2X, tr("1.5X (1080p/1620p) [EXPERIMENTAL]")),
+             PAIR(ResolutionSetup, Res2X, tr("2X (1440p/2160p)")),
+             PAIR(ResolutionSetup, Res3X, tr("3X (2160p/3240p)")),
+             PAIR(ResolutionSetup, Res4X, tr("4X (2880p/4320p)")),
+             PAIR(ResolutionSetup, Res5X, tr("5X (3600p/5400p)")),
+             PAIR(ResolutionSetup, Res6X, tr("6X (4320p/6480p)")),
+             PAIR(ResolutionSetup, Res7X, tr("7X (5040p/7560p)")),
+             PAIR(ResolutionSetup, Res8X, tr("8X (5760p/8640p)")),
+         }});
     translations->insert({Settings::EnumMetadata<Settings::ScalingFilter>::Index(),
                           {
-                              PAIR(ScalingFilter, NearestNeighbor, "Nearest Neighbor"),
-                              PAIR(ScalingFilter, Bilinear, "Bilinear"),
-                              PAIR(ScalingFilter, Bicubic, "Bicubic"),
-                              PAIR(ScalingFilter, Gaussian, "Gaussian"),
-                              PAIR(ScalingFilter, ScaleForce, "ScaleForce"),
-                              PAIR(ScalingFilter, Fsr, "AMD FidelityFX™️ Super Resolution"),
+                              PAIR(ScalingFilter, NearestNeighbor, tr("Nearest Neighbor")),
+                              PAIR(ScalingFilter, Bilinear, tr("Bilinear")),
+                              PAIR(ScalingFilter, Bicubic, tr("Bicubic")),
+                              PAIR(ScalingFilter, Gaussian, tr("Gaussian")),
+                              PAIR(ScalingFilter, ScaleForce, tr("ScaleForce")),
+                              PAIR(ScalingFilter, Fsr, tr("AMD FidelityFX™️ Super Resolution")),
                           }});
     translations->insert({Settings::EnumMetadata<Settings::AntiAliasing>::Index(),
                           {
-                              PAIR(AntiAliasing, None, "None"),
-                              PAIR(AntiAliasing, Fxaa, "FXAA"),
-                              PAIR(AntiAliasing, Smaa, "SMAA"),
+                              PAIR(AntiAliasing, None, tr("None")),
+                              PAIR(AntiAliasing, Fxaa, tr("FXAA")),
+                              PAIR(AntiAliasing, Smaa, tr("SMAA")),
                           }});
     translations->insert({Settings::EnumMetadata<Settings::AspectRatio>::Index(),
                           {
-                              PAIR(AspectRatio, R16_9, "Default (16:9)"),
-                              PAIR(AspectRatio, R4_3, "Force 4:3"),
-                              PAIR(AspectRatio, R21_9, "Force 21:9"),
-                              PAIR(AspectRatio, R16_10, "Force 16:10"),
-                              PAIR(AspectRatio, Stretch, "Stretch to Window"),
+                              PAIR(AspectRatio, R16_9, tr("Default (16:9)")),
+                              PAIR(AspectRatio, R4_3, tr("Force 4:3")),
+                              PAIR(AspectRatio, R21_9, tr("Force 21:9")),
+                              PAIR(AspectRatio, R16_10, tr("Force 16:10")),
+                              PAIR(AspectRatio, Stretch, tr("Stretch to Window")),
                           }});
     translations->insert({Settings::EnumMetadata<Settings::AnisotropyMode>::Index(),
                           {
-                              PAIR(AnisotropyMode, Automatic, "Automatic"),
-                              PAIR(AnisotropyMode, Default, "Default"),
-                              PAIR(AnisotropyMode, X2, "2x"),
-                              PAIR(AnisotropyMode, X4, "4x"),
-                              PAIR(AnisotropyMode, X8, "8x"),
-                              PAIR(AnisotropyMode, X16, "16x"),
+                              PAIR(AnisotropyMode, Automatic, tr("Automatic")),
+                              PAIR(AnisotropyMode, Default, tr("Default")),
+                              PAIR(AnisotropyMode, X2, tr("2x")),
+                              PAIR(AnisotropyMode, X4, tr("4x")),
+                              PAIR(AnisotropyMode, X8, tr("8x")),
+                              PAIR(AnisotropyMode, X16, tr("16x")),
                           }});
     translations->insert(
         {Settings::EnumMetadata<Settings::Language>::Index(),
          {
-             PAIR(Language, Japanese, "Japanese (日本語)"),
-             PAIR(Language, EnglishAmerican, "American English"),
-             PAIR(Language, French, "French (français)"),
-             PAIR(Language, German, "German (Deutsch)"),
-             PAIR(Language, Italian, "Italian (italiano)"),
-             PAIR(Language, Spanish, "Spanish (español)"),
-             PAIR(Language, Chinese, "Chinese"),
-             PAIR(Language, Korean, "Korean (한국어)"),
-             PAIR(Language, Dutch, "Dutch (Nederlands)"),
-             PAIR(Language, Portuguese, "Portuguese (português)"),
-             PAIR(Language, Russian, "Russian (Русский)"),
-             PAIR(Language, Taiwanese, "Taiwanese"),
-             PAIR(Language, EnglishBritish, "British English"),
-             PAIR(Language, FrenchCanadian, "Canadian French"),
-             PAIR(Language, SpanishLatin, "Latin American Spanish"),
-             PAIR(Language, ChineseSimplified, "Simplified Chinese"),
-             PAIR(Language, ChineseTraditional, "Traditional Chinese (正體中文)"),
-             PAIR(Language, PortugueseBrazilian, "Brazilian Portuguese (português do Brasil)"),
+             PAIR(Language, Japanese, tr("Japanese (日本語)")),
+             PAIR(Language, EnglishAmerican, tr("American English")),
+             PAIR(Language, French, tr("French (français)")),
+             PAIR(Language, German, tr("German (Deutsch)")),
+             PAIR(Language, Italian, tr("Italian (italiano)")),
+             PAIR(Language, Spanish, tr("Spanish (español)")),
+             PAIR(Language, Chinese, tr("Chinese")),
+             PAIR(Language, Korean, tr("Korean (한국어)")),
+             PAIR(Language, Dutch, tr("Dutch (Nederlands)")),
+             PAIR(Language, Portuguese, tr("Portuguese (português)")),
+             PAIR(Language, Russian, tr("Russian (Русский)")),
+             PAIR(Language, Taiwanese, tr("Taiwanese")),
+             PAIR(Language, EnglishBritish, tr("British English")),
+             PAIR(Language, FrenchCanadian, tr("Canadian French")),
+             PAIR(Language, SpanishLatin, tr("Latin American Spanish")),
+             PAIR(Language, ChineseSimplified, tr("Simplified Chinese")),
+             PAIR(Language, ChineseTraditional, tr("Traditional Chinese (正體中文)")),
+             PAIR(Language, PortugueseBrazilian, tr("Brazilian Portuguese (português do Brasil)")),
          }});
     translations->insert({Settings::EnumMetadata<Settings::Region>::Index(),
                           {
-                              PAIR(Region, Japan, "Japan"),
-                              PAIR(Region, Usa, "USA"),
-                              PAIR(Region, Europe, "Europe"),
-                              PAIR(Region, Australia, "Australia"),
-                              PAIR(Region, China, "China"),
-                              PAIR(Region, Korea, "Korea"),
-                              PAIR(Region, Taiwan, "Taiwan"),
+                              PAIR(Region, Japan, tr("Japan")),
+                              PAIR(Region, Usa, tr("USA")),
+                              PAIR(Region, Europe, tr("Europe")),
+                              PAIR(Region, Australia, tr("Australia")),
+                              PAIR(Region, China, tr("China")),
+                              PAIR(Region, Korea, tr("Korea")),
+                              PAIR(Region, Taiwan, tr("Taiwan")),
                           }});
     translations->insert(
         {Settings::EnumMetadata<Settings::TimeZone>::Index(),
@@ -323,72 +340,74 @@ std::unique_ptr<ComboboxTranslationMap> ComboboxEnumeration(QWidget* parent) {
              {static_cast<u32>(Settings::TimeZone::Default),
               tr("Default (%1)", "Default time zone")
                   .arg(QString::fromStdString(Common::TimeZone::GetDefaultTimeZone()))},
-             PAIR(TimeZone, Cet, "CET"),
-             PAIR(TimeZone, Cst6Cdt, "CST6CDT"),
-             PAIR(TimeZone, Cuba, "Cuba"),
-             PAIR(TimeZone, Eet, "EET"),
-             PAIR(TimeZone, Egypt, "Egypt"),
-             PAIR(TimeZone, Eire, "Eire"),
-             PAIR(TimeZone, Est, "EST"),
-             PAIR(TimeZone, Est5Edt, "EST5EDT"),
-             PAIR(TimeZone, Gb, "GB"),
-             PAIR(TimeZone, GbEire, "GB-Eire"),
-             PAIR(TimeZone, Gmt, "GMT"),
-             PAIR(TimeZone, GmtPlusZero, "GMT+0"),
-             PAIR(TimeZone, GmtMinusZero, "GMT-0"),
-             PAIR(TimeZone, GmtZero, "GMT0"),
-             PAIR(TimeZone, Greenwich, "Greenwich"),
-             PAIR(TimeZone, Hongkong, "Hongkong"),
-             PAIR(TimeZone, Hst, "HST"),
-             PAIR(TimeZone, Iceland, "Iceland"),
-             PAIR(TimeZone, Iran, "Iran"),
-             PAIR(TimeZone, Israel, "Israel"),
-             PAIR(TimeZone, Jamaica, "Jamaica"),
-             PAIR(TimeZone, Japan, "Japan"),
-             PAIR(TimeZone, Kwajalein, "Kwajalein"),
-             PAIR(TimeZone, Libya, "Libya"),
-             PAIR(TimeZone, Met, "MET"),
-             PAIR(TimeZone, Mst, "MST"),
-             PAIR(TimeZone, Mst7Mdt, "MST7MDT"),
-             PAIR(TimeZone, Navajo, "Navajo"),
-             PAIR(TimeZone, Nz, "NZ"),
-             PAIR(TimeZone, NzChat, "NZ-CHAT"),
-             PAIR(TimeZone, Poland, "Poland"),
-             PAIR(TimeZone, Portugal, "Portugal"),
-             PAIR(TimeZone, Prc, "PRC"),
-             PAIR(TimeZone, Pst8Pdt, "PST8PDT"),
-             PAIR(TimeZone, Roc, "ROC"),
-             PAIR(TimeZone, Rok, "ROK"),
-             PAIR(TimeZone, Singapore, "Singapore"),
-             PAIR(TimeZone, Turkey, "Turkey"),
-             PAIR(TimeZone, Uct, "UCT"),
-             PAIR(TimeZone, Universal, "Universal"),
-             PAIR(TimeZone, Utc, "UTC"),
-             PAIR(TimeZone, WSu, "W-SU"),
-             PAIR(TimeZone, Wet, "WET"),
-             PAIR(TimeZone, Zulu, "Zulu"),
+             PAIR(TimeZone, Cet, tr("CET")),
+             PAIR(TimeZone, Cst6Cdt, tr("CST6CDT")),
+             PAIR(TimeZone, Cuba, tr("Cuba")),
+             PAIR(TimeZone, Eet, tr("EET")),
+             PAIR(TimeZone, Egypt, tr("Egypt")),
+             PAIR(TimeZone, Eire, tr("Eire")),
+             PAIR(TimeZone, Est, tr("EST")),
+             PAIR(TimeZone, Est5Edt, tr("EST5EDT")),
+             PAIR(TimeZone, Gb, tr("GB")),
+             PAIR(TimeZone, GbEire, tr("GB-Eire")),
+             PAIR(TimeZone, Gmt, tr("GMT")),
+             PAIR(TimeZone, GmtPlusZero, tr("GMT+0")),
+             PAIR(TimeZone, GmtMinusZero, tr("GMT-0")),
+             PAIR(TimeZone, GmtZero, tr("GMT0")),
+             PAIR(TimeZone, Greenwich, tr("Greenwich")),
+             PAIR(TimeZone, Hongkong, tr("Hongkong")),
+             PAIR(TimeZone, Hst, tr("HST")),
+             PAIR(TimeZone, Iceland, tr("Iceland")),
+             PAIR(TimeZone, Iran, tr("Iran")),
+             PAIR(TimeZone, Israel, tr("Israel")),
+             PAIR(TimeZone, Jamaica, tr("Jamaica")),
+             PAIR(TimeZone, Japan, tr("Japan")),
+             PAIR(TimeZone, Kwajalein, tr("Kwajalein")),
+             PAIR(TimeZone, Libya, tr("Libya")),
+             PAIR(TimeZone, Met, tr("MET")),
+             PAIR(TimeZone, Mst, tr("MST")),
+             PAIR(TimeZone, Mst7Mdt, tr("MST7MDT")),
+             PAIR(TimeZone, Navajo, tr("Navajo")),
+             PAIR(TimeZone, Nz, tr("NZ")),
+             PAIR(TimeZone, NzChat, tr("NZ-CHAT")),
+             PAIR(TimeZone, Poland, tr("Poland")),
+             PAIR(TimeZone, Portugal, tr("Portugal")),
+             PAIR(TimeZone, Prc, tr("PRC")),
+             PAIR(TimeZone, Pst8Pdt, tr("PST8PDT")),
+             PAIR(TimeZone, Roc, tr("ROC")),
+             PAIR(TimeZone, Rok, tr("ROK")),
+             PAIR(TimeZone, Singapore, tr("Singapore")),
+             PAIR(TimeZone, Turkey, tr("Turkey")),
+             PAIR(TimeZone, Uct, tr("UCT")),
+             PAIR(TimeZone, Universal, tr("Universal")),
+             PAIR(TimeZone, Utc, tr("UTC")),
+             PAIR(TimeZone, WSu, tr("W-SU")),
+             PAIR(TimeZone, Wet, tr("WET")),
+             PAIR(TimeZone, Zulu, tr("Zulu")),
          }});
     translations->insert({Settings::EnumMetadata<Settings::AudioMode>::Index(),
                           {
-                              PAIR(AudioMode, Mono, "Mono"),
-                              PAIR(AudioMode, Stereo, "Stereo"),
-                              PAIR(AudioMode, Surround, "Surround"),
+                              PAIR(AudioMode, Mono, tr("Mono")),
+                              PAIR(AudioMode, Stereo, tr("Stereo")),
+                              PAIR(AudioMode, Surround, tr("Surround")),
                           }});
     translations->insert({Settings::EnumMetadata<Settings::MemoryLayout>::Index(),
                           {
-                              PAIR(MemoryLayout, Memory_4Gb, "4GB DRAM (Default)"),
-                              PAIR(MemoryLayout, Memory_6Gb, "6GB DRAM (Unsafe)"),
-                              PAIR(MemoryLayout, Memory_8Gb, "8GB DRAM (Unsafe)"),
+                              PAIR(MemoryLayout, Memory_4Gb, tr("4GB DRAM (Default)")),
+                              PAIR(MemoryLayout, Memory_6Gb, tr("6GB DRAM (Unsafe)")),
+                              PAIR(MemoryLayout, Memory_8Gb, tr("8GB DRAM (Unsafe)")),
                           }});
-    translations->insert(
-        {Settings::EnumMetadata<Settings::ConsoleMode>::Index(),
-         {PAIR(ConsoleMode, Docked, "Docked"), PAIR(ConsoleMode, Handheld, "Handheld")}});
+    translations->insert({Settings::EnumMetadata<Settings::ConsoleMode>::Index(),
+                          {
+                              PAIR(ConsoleMode, Docked, tr("Docked")),
+                              PAIR(ConsoleMode, Handheld, tr("Handheld")),
+                          }});
     translations->insert(
         {Settings::EnumMetadata<Settings::ConfirmStop>::Index(),
          {
-             PAIR(ConfirmStop, Ask_Always, "Always ask (Default)"),
-             PAIR(ConfirmStop, Ask_Based_On_Game, "Only if game specifies not to stop"),
-             PAIR(ConfirmStop, Ask_Never, "Never ask"),
+             PAIR(ConfirmStop, Ask_Always, tr("Always ask (Default)")),
+             PAIR(ConfirmStop, Ask_Based_On_Game, tr("Only if game specifies not to stop")),
+             PAIR(ConfirmStop, Ask_Never, tr("Never ask")),
          }});
 
 #undef PAIR


### PR DESCRIPTION
Qt can't parse tr called within a macro, so we must call it on each string. Qt still seems unhappy with the way I called tr, but it's getting the strings now nevertheless.

To figure this out, I had to create a workaround so that lupdate would run on my system. The path I created results in a number of warnings across the Qt frontend. I have no ability to tell if these were existing already or not, or if this is an issue with the way I'm calling lupdate.