### PR TITLE
renderer_vulkan: add workaround for broken occlusion queries on turnip

### DIFF
--- a/src/video_core/query_cache/query_cache_base.h
+++ b/src/video_core/query_cache/query_cache_base.h
@@ -53,7 +53,8 @@ public:
     };
 
     explicit QueryCacheBase(Tegra::GPU& gpu, VideoCore::RasterizerInterface& rasterizer_,
-                            Core::Memory::Memory& cpu_memory_, RuntimeType& runtime_);
+                            Core::Memory::Memory& cpu_memory_, RuntimeType& runtime_,
+                            bool has_broken_occlusion_query_);
 
     ~QueryCacheBase();
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -174,7 +174,7 @@ RasterizerVulkan::RasterizerVulkan(Core::Frontend::EmuWindow& emu_window_, Tegra
       buffer_cache(*this, cpu_memory_, buffer_cache_runtime),
       query_cache_runtime(this, cpu_memory_, buffer_cache, device, memory_allocator, scheduler,
                           staging_pool, compute_pass_descriptor_queue, descriptor_pool),
-      query_cache(gpu, *this, cpu_memory_, query_cache_runtime),
+      query_cache(gpu, *this, cpu_memory_, query_cache_runtime, device.HasBrokenOcclusionQuery()),
       pipeline_cache(*this, device, scheduler, descriptor_pool, guest_descriptor_queue,
                      render_pass_cache, buffer_cache, texture_cache, gpu.ShaderNotify()),
       accelerate_dma(buffer_cache, texture_cache, scheduler),

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -513,6 +513,11 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
 #endif
     }
 
+    if (is_turnip) {
+        LOG_WARNING(Render_Vulkan, "Turnip drivers have broken occlusion queries");
+        has_broken_occlusion_query = true;
+    }
+
     if (is_arm) {
         must_emulate_scaled_formats = true;
 

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -599,6 +599,10 @@ public:
         return has_broken_cube_compatibility;
     }
 
+    bool HasBrokenOcclusionQuery() const {
+        return has_broken_occlusion_query;
+    }
+
     /// Returns the vendor name reported from Vulkan.
     std::string_view GetVendorName() const {
         return properties.driver.driverName;
@@ -794,6 +798,7 @@ private:
     bool is_non_gpu{};                         ///< Is SoftwareRasterizer, FPGA, non-GPU device.
     bool has_broken_compute{};                 ///< Compute shaders can cause crashes
     bool has_broken_cube_compatibility{};      ///< Has broken cube compatibility bit
+    bool has_broken_occlusion_query{};         ///< Has broken occlusion queries
     bool has_renderdoc{};                      ///< Has RenderDoc attached
     bool has_nsight_graphics{};                ///< Has Nsight Graphics attached
     bool supports_d24_depth{};                 ///< Supports D24 depth buffers.


### PR DESCRIPTION
Fixes #11958

Discovered to be a driver bug in turnip during a joint debugging session with @t895. Calling vkCmdBeginQuery will instantly cause a device loss on a730-badged devices, but a6xx and a740 are not affected (nor are proprietary drivers). I do not have the means to further debug why this would happen, so a report to mesa still needs to be made.