### PR TITLE
android: Remove "auto" region option

### DIFF
--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -2,7 +2,6 @@
 <resources>
 
     <string-array name="regionNames">
-        <item>@string/auto</item>
         <item>@string/region_australia</item>
         <item>@string/region_china</item>
         <item>@string/region_europe</item>
@@ -13,7 +12,6 @@
     </string-array>
 
     <integer-array name="regionValues">
-        <item>-1</item>
         <item>3</item>
         <item>4</item>
         <item>2</item>


### PR DESCRIPTION
This doesn't exist and if you clicked it, your region would be set to Taiwan.