### PR TITLE
audio_core: ignore renderer wait when stream is paused

### DIFF
--- a/src/audio_core/sink/cubeb_sink.cpp
+++ b/src/audio_core/sink/cubeb_sink.cpp
@@ -146,7 +146,7 @@ public:
             return;
         }
 
-        paused = true;
+        SignalPause();
         if (cubeb_stream_stop(stream_backend) != CUBEB_OK) {
             LOG_CRITICAL(Audio_Sink, "Error stopping cubeb stream");
         }

--- a/src/audio_core/sink/sdl2_sink.cpp
+++ b/src/audio_core/sink/sdl2_sink.cpp
@@ -111,7 +111,7 @@ public:
         if (device == 0 || paused) {
             return;
         }
-        paused = true;
+        SignalPause();
         SDL_PauseAudioDevice(device, 1);
     }
 

--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -282,11 +282,19 @@ u64 SinkStream::GetExpectedPlayedSampleCount() {
 void SinkStream::WaitFreeSpace(std::stop_token stop_token) {
     std::unique_lock lk{release_mutex};
     release_cv.wait_for(lk, std::chrono::milliseconds(5),
-                        [this]() { return queued_buffers < max_queue_size; });
+                        [this]() { return paused || queued_buffers < max_queue_size; });
     if (queued_buffers > max_queue_size + 3) {
         Common::CondvarWait(release_cv, lk, stop_token,
-                            [this] { return queued_buffers < max_queue_size; });
+                            [this] { return paused || queued_buffers < max_queue_size; });
     }
+}
+
+void SinkStream::SignalPause() {
+    {
+        std::scoped_lock lk{release_mutex};
+        paused = true;
+    }
+    release_cv.notify_one();
 }
 
 } // namespace AudioCore::Sink

--- a/src/audio_core/sink/sink_stream.h
+++ b/src/audio_core/sink/sink_stream.h
@@ -214,6 +214,12 @@ public:
     void WaitFreeSpace(std::stop_token stop_token);
 
 protected:
+    /**
+     * Unblocks the ADSP if the stream is paused.
+     */
+    void SignalPause();
+
+protected:
     /// Core system
     Core::System& system;
     /// Type of this stream


### PR DESCRIPTION
On finalization, sink callbacks can get paused with a bunch of stream data still queued. Once the sink callbacks are stopped and will not be called anymore, the renderer might then block forever and prevent shutdown. This fixes a persistent shutdown deadlock on Android.