### PR TITLE
core: check for thread dpc before eret

### DIFF
--- a/src/core/arm/arm_interface.cpp
+++ b/src/core/arm/arm_interface.cpp
@@ -153,6 +153,14 @@ void ARM_Interface::Run() {
         Kernel::KThread* current_thread{Kernel::GetCurrentThreadPointer(system.Kernel())};
         HaltReason hr{};
 
+        // If the thread is scheduled for termination, exit the thread.
+        if (current_thread->HasDpc()) {
+            if (current_thread->IsTerminationRequested()) {
+                current_thread->Exit();
+                UNREACHABLE();
+            }
+        }
+
         // Notify the debugger and go to sleep if a step was performed
         // and this thread has been scheduled again.
         if (current_thread->GetStepState() == StepState::StepPerformed) {
@@ -173,14 +181,6 @@ void ARM_Interface::Run() {
             hr = RunJit();
         }
         system.ExitCPUProfile();
-
-        // If the thread is scheduled for termination, exit the thread.
-        if (current_thread->HasDpc()) {
-            if (current_thread->IsTerminationRequested()) {
-                current_thread->Exit();
-                UNREACHABLE();
-            }
-        }
 
         // Notify the debugger and go to sleep if a breakpoint was hit,
         // or if the thread is unable to continue for any reason.


### PR DESCRIPTION
The process for shutting down a process involves the following, for each thread:
- Mark it as termination requested and apply the DPC flags, and if it is runnable, send an interrupt to all cores with the thread's affinity
- Wait for the thread to exit, if needed

Threads which are runnable and marked as termination-requested are not removed from the scheduling PQ, so they can get scheduled again during termination, despite the core having already cleared the interrupt when a previous thread was terminated. This implies a subtle but important rule that the DPC flags must be checked _before_ returning to user code, or a thread might not get terminated, and cause a deadlock on shutdown.