### PR TITLE
core_timing: lock event queue access

### DIFF
--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -76,6 +76,7 @@ void CoreTiming::Initialize(std::function<void()>&& on_thread_init_) {
 }
 
 void CoreTiming::ClearPendingEvents() {
+    std::scoped_lock lock{basic_lock};
     event_queue.clear();
 }
 
@@ -113,6 +114,7 @@ bool CoreTiming::IsRunning() const {
 }
 
 bool CoreTiming::HasPendingEvents() const {
+    std::scoped_lock lock{basic_lock};
     return !(wait_set && event_queue.empty());
 }
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -161,7 +161,7 @@ private:
     std::shared_ptr<EventType> ev_lost;
     Common::Event event{};
     Common::Event pause_event{};
-    std::mutex basic_lock;
+    mutable std::mutex basic_lock;
     std::mutex advance_lock;
     std::unique_ptr<std::jthread> timer_thread;
     std::atomic<bool> paused{};


### PR DESCRIPTION
This fixes another shutdown crash. System calls ClearPendingEvents on shutdown, even though the timing thread may still be concurrently popping items from the event queue.