### PR TITLE
android: Use suspend function for creating dynamic shortcuts

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameIconUtils.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/GameIconUtils.kt
@@ -8,9 +8,9 @@ import android.graphics.BitmapFactory
 import android.widget.ImageView
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.drawable.toDrawable
+import androidx.lifecycle.LifecycleOwner
 import coil.ImageLoader
 import coil.decode.DataSource
-import coil.executeBlocking
 import coil.fetch.DrawableResult
 import coil.fetch.FetchResult
 import coil.fetch.Fetcher
@@ -76,12 +76,13 @@ object GameIconUtils {
         imageLoader.enqueue(request)
     }
 
-    fun getGameIcon(game: Game): Bitmap {
+    suspend fun getGameIcon(lifecycleOwner: LifecycleOwner, game: Game): Bitmap {
         val request = ImageRequest.Builder(YuzuApplication.appContext)
             .data(game)
+            .lifecycle(lifecycleOwner)
             .error(R.drawable.default_icon)
             .build()
-        return imageLoader.executeBlocking(request)
+        return imageLoader.execute(request)
             .drawable!!.toBitmap(config = Bitmap.Config.ARGB_8888)
     }
 }


### PR DESCRIPTION
If the coil loader ever got stuck when creating a dynamic shortcut icon, the app would freeze. This would happen most notably when booting nca format games. This pushes that process to a separate coroutine that can be cancelled by the main activity's lifecycle.