### PR TITLE
android: Disable PiP by default

### DIFF
--- a/src/android/app/src/main/jni/uisettings.h
+++ b/src/android/app/src/main/jni/uisettings.h
@@ -13,7 +13,7 @@ struct Values {
     Settings::Linkage linkage;
 
     // Android
-    Settings::Setting<bool> picture_in_picture{linkage, true, "picture_in_picture",
+    Settings::Setting<bool> picture_in_picture{linkage, false, "picture_in_picture",
                                                Settings::Category::Android};
     Settings::Setting<s32> screen_layout{linkage,
                                          5,


### PR DESCRIPTION
After getting several complaints from devs and users alike, this is being disabled by default on new configs