### PR TITLE
service: hid: Introduce firmware settings and update activate controller calls

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -523,6 +523,8 @@ add_library(core STATIC
     hle/service/hid/hid.h
     hle/service/hid/hid_debug_server.cpp
     hle/service/hid/hid_debug_server.h
+    hle/service/hid/hid_firmware_settings.cpp
+    hle/service/hid/hid_firmware_settings.h
     hle/service/hid/hid_server.cpp
     hle/service/hid/hid_server.h
     hle/service/hid/hid_system_server.cpp

--- a/src/core/hle/service/hid/controllers/controller_base.cpp
+++ b/src/core/hle/service/hid/controllers/controller_base.cpp
@@ -8,12 +8,17 @@ namespace Service::HID {
 ControllerBase::ControllerBase(Core::HID::HIDCore& hid_core_) : hid_core(hid_core_) {}
 ControllerBase::~ControllerBase() = default;
 
-void ControllerBase::ActivateController() {
+Result ControllerBase::Activate() {
     if (is_activated) {
-        return;
+        return ResultSuccess;
     }
     is_activated = true;
     OnInit();
+    return ResultSuccess;
+}
+
+Result ControllerBase::Activate(u64 aruid) {
+    return Activate();
 }
 
 void ControllerBase::DeactivateController() {

--- a/src/core/hle/service/hid/controllers/controller_base.h
+++ b/src/core/hle/service/hid/controllers/controller_base.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/common_types.h"
+#include "core/hle/result.h"
 
 namespace Core::Timing {
 class CoreTiming;
@@ -31,7 +32,8 @@ public:
     // When the controller is requesting a motion update for the shared memory
     virtual void OnMotionUpdate(const Core::Timing::CoreTiming& core_timing) {}
 
-    void ActivateController();
+    Result Activate();
+    Result Activate(u64 aruid);
 
     void DeactivateController();
 

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -86,6 +86,13 @@ public:
         Default = 3,
     };
 
+    enum class NpadRevision : u32 {
+        Revision0 = 0,
+        Revision1 = 1,
+        Revision2 = 2,
+        Revision3 = 3,
+    };
+
     void SetSupportedStyleSet(Core::HID::NpadStyleTag style_set);
     Core::HID::NpadStyleTag GetSupportedStyleSet() const;
 

--- a/src/core/hle/service/hid/controllers/palma.cpp
+++ b/src/core/hle/service/hid/controllers/palma.cpp
@@ -44,7 +44,7 @@ Result Controller_Palma::InitializePalma(const PalmaConnectionHandle& handle) {
     if (handle.npad_id != active_handle.npad_id) {
         return InvalidPalmaHandle;
     }
-    ActivateController();
+    Activate();
     return ResultSuccess;
 }
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -3,6 +3,7 @@
 
 #include "core/hle/service/hid/hid.h"
 #include "core/hle/service/hid/hid_debug_server.h"
+#include "core/hle/service/hid/hid_firmware_settings.h"
 #include "core/hle/service/hid/hid_server.h"
 #include "core/hle/service/hid/hid_system_server.h"
 #include "core/hle/service/hid/hidbus.h"
@@ -16,9 +17,11 @@ namespace Service::HID {
 void LoopProcess(Core::System& system) {
     auto server_manager = std::make_unique<ServerManager>(system);
     std::shared_ptr<ResourceManager> resouce_manager = std::make_shared<ResourceManager>(system);
+    std::shared_ptr<HidFirmwareSettings> firmware_settings =
+        std::make_shared<HidFirmwareSettings>();
 
-    server_manager->RegisterNamedService("hid",
-                                         std::make_shared<IHidServer>(system, resouce_manager));
+    server_manager->RegisterNamedService(
+        "hid", std::make_shared<IHidServer>(system, resouce_manager, firmware_settings));
     server_manager->RegisterNamedService(
         "hid:dbg", std::make_shared<IHidDebugServer>(system, resouce_manager));
     server_manager->RegisterNamedService(

--- a/src/core/hle/service/hid/hid_firmware_settings.cpp
+++ b/src/core/hle/service/hid/hid_firmware_settings.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "core/hle/service/hid/hid_firmware_settings.h"
+
+namespace Service::HID {
+
+HidFirmwareSettings::HidFirmwareSettings() {
+    LoadSettings(true);
+}
+
+void HidFirmwareSettings::Reload() {
+    LoadSettings(true);
+}
+
+void HidFirmwareSettings::LoadSettings(bool reload_config) {
+    if (is_initalized && !reload_config) {
+        return;
+    }
+
+    // TODO: Use nn::settings::fwdbg::GetSettingsItemValue to load config values
+
+    is_debug_pad_enabled = true;
+    is_device_managed = true;
+    is_touch_i2c_managed = is_device_managed;
+    is_future_devices_emulated = false;
+    is_mcu_hardware_error_emulated = false;
+    is_rail_enabled = true;
+    is_firmware_update_failure_emulated = false;
+    is_firmware_update_failure = {};
+    is_ble_disabled = false;
+    is_dscale_disabled = false;
+    is_handheld_forced = true;
+    features_per_id_disabled = {};
+    is_touch_firmware_auto_update_disabled = false;
+    is_initalized = true;
+}
+
+bool HidFirmwareSettings::IsDebugPadEnabled() {
+    LoadSettings(false);
+    return is_debug_pad_enabled;
+}
+
+bool HidFirmwareSettings::IsDeviceManaged() {
+    LoadSettings(false);
+    return is_device_managed;
+}
+
+bool HidFirmwareSettings::IsEmulateFutureDevice() {
+    LoadSettings(false);
+    return is_future_devices_emulated;
+}
+
+bool HidFirmwareSettings::IsTouchI2cManaged() {
+    LoadSettings(false);
+    return is_touch_i2c_managed;
+}
+
+bool HidFirmwareSettings::IsHandheldForced() {
+    LoadSettings(false);
+    return is_handheld_forced;
+}
+
+bool HidFirmwareSettings::IsRailEnabled() {
+    LoadSettings(false);
+    return is_rail_enabled;
+}
+
+bool HidFirmwareSettings::IsHardwareErrorEmulated() {
+    LoadSettings(false);
+    return is_mcu_hardware_error_emulated;
+}
+
+bool HidFirmwareSettings::IsBleDisabled() {
+    LoadSettings(false);
+    return is_ble_disabled;
+}
+
+bool HidFirmwareSettings::IsDscaleDisabled() {
+    LoadSettings(false);
+    return is_dscale_disabled;
+}
+
+bool HidFirmwareSettings::IsTouchAutoUpdateDisabled() {
+    LoadSettings(false);
+    return is_touch_firmware_auto_update_disabled;
+}
+
+HidFirmwareSettings::FirmwareSetting HidFirmwareSettings::GetFirmwareUpdateFailure() {
+    LoadSettings(false);
+    return is_firmware_update_failure;
+}
+
+HidFirmwareSettings::FeaturesPerId HidFirmwareSettings::FeaturesDisabledPerId() {
+    LoadSettings(false);
+    return features_per_id_disabled;
+}
+
+} // namespace Service::HID

--- a/src/core/hle/service/hid/hid_firmware_settings.h
+++ b/src/core/hle/service/hid/hid_firmware_settings.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Service::HID {
+
+/// Loads firmware config from nn::settings::fwdbg
+class HidFirmwareSettings {
+public:
+    using FirmwareSetting = std::array<u8, 4>;
+    using FeaturesPerId = std::array<bool, 0xA8>;
+
+    HidFirmwareSettings();
+
+    void Reload();
+    void LoadSettings(bool reload_config);
+
+    bool IsDebugPadEnabled();
+    bool IsDeviceManaged();
+    bool IsEmulateFutureDevice();
+    bool IsTouchI2cManaged();
+    bool IsHandheldForced();
+    bool IsRailEnabled();
+    bool IsHardwareErrorEmulated();
+    bool IsBleDisabled();
+    bool IsDscaleDisabled();
+    bool IsTouchAutoUpdateDisabled();
+
+    FirmwareSetting GetFirmwareUpdateFailure();
+    FeaturesPerId FeaturesDisabledPerId();
+
+private:
+    bool is_initalized{};
+
+    // Debug settings
+    bool is_debug_pad_enabled{};
+    bool is_device_managed{};
+    bool is_touch_i2c_managed{};
+    bool is_future_devices_emulated{};
+    bool is_mcu_hardware_error_emulated{};
+    bool is_rail_enabled{};
+    bool is_firmware_update_failure_emulated{};
+    bool is_ble_disabled{};
+    bool is_dscale_disabled{};
+    bool is_handheld_forced{};
+    bool is_touch_firmware_auto_update_disabled{};
+    FirmwareSetting is_firmware_update_failure{};
+    FeaturesPerId features_per_id_disabled{};
+};
+
+} // namespace Service::HID

--- a/src/core/hle/service/hid/hid_server.h
+++ b/src/core/hle/service/hid/hid_server.h
@@ -11,10 +11,12 @@ class System;
 
 namespace Service::HID {
 class ResourceManager;
+class HidFirmwareSettings;
 
 class IHidServer final : public ServiceFramework<IHidServer> {
 public:
-    explicit IHidServer(Core::System& system_, std::shared_ptr<ResourceManager> resource);
+    explicit IHidServer(Core::System& system_, std::shared_ptr<ResourceManager> resource,
+                        std::shared_ptr<HidFirmwareSettings> settings);
     ~IHidServer() override;
 
     std::shared_ptr<ResourceManager> GetResourceManager();
@@ -141,6 +143,7 @@ private:
     void IsFirmwareUpdateNeededForNotification(HLERequestContext& ctx);
 
     std::shared_ptr<ResourceManager> resource_manager;
+    std::shared_ptr<HidFirmwareSettings> firmware_settings;
 };
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/resource_manager.cpp
+++ b/src/core/hle/service/hid/resource_manager.cpp
@@ -59,8 +59,8 @@ void ResourceManager::Initialize() {
     MakeControllerWithServiceContext<Controller_Palma>(HidController::Palma, shared_memory);
 
     // Homebrew doesn't try to activate some controllers, so we activate them by default
-    GetController<Controller_NPad>(HidController::NPad).ActivateController();
-    GetController<Controller_Touchscreen>(HidController::Touchscreen).ActivateController();
+    GetController<Controller_NPad>(HidController::NPad).Activate();
+    GetController<Controller_Touchscreen>(HidController::Touchscreen).Activate();
 
     GetController<Controller_Stubbed>(HidController::HomeButton).SetCommonHeaderOffset(0x4C00);
     GetController<Controller_Stubbed>(HidController::SleepButton).SetCommonHeaderOffset(0x4E00);
@@ -71,14 +71,6 @@ void ResourceManager::Initialize() {
 
     system.HIDCore().ReloadInputDevices();
     is_initialized = true;
-}
-
-void ResourceManager::ActivateController(HidController controller) {
-    controllers[static_cast<size_t>(controller)]->ActivateController();
-}
-
-void ResourceManager::DeactivateController(HidController controller) {
-    controllers[static_cast<size_t>(controller)]->DeactivateController();
 }
 
 void ResourceManager::UpdateControllers(std::uintptr_t user_data,

--- a/src/core/hle/service/hid/resource_manager.h
+++ b/src/core/hle/service/hid/resource_manager.h
@@ -55,8 +55,6 @@ public:
     }
 
     void Initialize();
-    void ActivateController(HidController controller);
-    void DeactivateController(HidController controller);
 
     void UpdateControllers(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
     void UpdateNpad(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);


### PR DESCRIPTION
Next one on the list. Introduce hid firmware settings. To make use of the class I updated the activate calls to 16.0.0 for all hid types.  Right now there's no difference between managed and unmanaged config. But that will change as I keep updating the service.