### PR TITLE
OpenGL: Implement async downloads in buffer and texture caches

### DIFF
--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -146,8 +146,12 @@ StagingBufferMap BufferCacheRuntime::UploadStagingBuffer(size_t size) {
     return staging_buffer_pool.RequestUploadBuffer(size);
 }
 
-StagingBufferMap BufferCacheRuntime::DownloadStagingBuffer(size_t size) {
-    return staging_buffer_pool.RequestDownloadBuffer(size);
+StagingBufferMap BufferCacheRuntime::DownloadStagingBuffer(size_t size, bool deferred) {
+    return staging_buffer_pool.RequestDownloadBuffer(size, deferred);
+}
+
+void BufferCacheRuntime::FreeDeferredStagingBuffer(StagingBufferMap& buffer) {
+    staging_buffer_pool.FreeDeferredStagingBuffer(buffer.index);
 }
 
 u64 BufferCacheRuntime::GetDeviceMemoryUsage() const {

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -151,7 +151,7 @@ StagingBufferMap BufferCacheRuntime::DownloadStagingBuffer(size_t size, bool def
 }
 
 void BufferCacheRuntime::FreeDeferredStagingBuffer(StagingBufferMap& buffer) {
-    staging_buffer_pool.FreeDeferredStagingBuffer(buffer.index);
+    staging_buffer_pool.FreeDeferredStagingBuffer(buffer);
 }
 
 u64 BufferCacheRuntime::GetDeviceMemoryUsage() const {

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -64,7 +64,9 @@ public:
 
     [[nodiscard]] StagingBufferMap UploadStagingBuffer(size_t size);
 
-    [[nodiscard]] StagingBufferMap DownloadStagingBuffer(size_t size);
+    [[nodiscard]] StagingBufferMap DownloadStagingBuffer(size_t size, bool deferred = false);
+
+    void FreeDeferredStagingBuffer(StagingBufferMap& buffer);
 
     void CopyBuffer(GLuint dst_buffer, GLuint src_buffer,
                     std::span<const VideoCommon::BufferCopy> copies, bool barrier = true);
@@ -233,7 +235,7 @@ struct BufferCacheParams {
     static constexpr bool NEEDS_BIND_STORAGE_INDEX = true;
     static constexpr bool USE_MEMORY_MAPS = true;
     static constexpr bool SEPARATE_IMAGE_BUFFER_BINDINGS = true;
-    static constexpr bool IMPLEMENTS_ASYNC_DOWNLOADS = false;
+    static constexpr bool IMPLEMENTS_ASYNC_DOWNLOADS = true;
 
     // TODO: Investigate why OpenGL seems to perform worse with persistently mapped buffer uploads
     static constexpr bool USE_MEMORY_MAPS_FOR_UPLOADS = false;

--- a/src/video_core/renderer_opengl/gl_staging_buffer_pool.cpp
+++ b/src/video_core/renderer_opengl/gl_staging_buffer_pool.cpp
@@ -45,6 +45,7 @@ StagingBufferMap StagingBuffers::RequestMap(size_t requested_size, bool insert_f
 }
 
 void StagingBuffers::FreeDeferredStagingBuffer(size_t index) {
+    ASSERT(allocs[index].deferred);
     allocs[index].deferred = false;
 }
 
@@ -152,8 +153,8 @@ StagingBufferMap StagingBufferPool::RequestDownloadBuffer(size_t size, bool defe
     return download_buffers.RequestMap(size, false, deferred);
 }
 
-void StagingBufferPool::FreeDeferredStagingBuffer(size_t index) {
-    download_buffers.FreeDeferredStagingBuffer(index);
+void StagingBufferPool::FreeDeferredStagingBuffer(StagingBufferMap& buffer) {
+    download_buffers.FreeDeferredStagingBuffer(buffer.index);
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer_pool.h
+++ b/src/video_core/renderer_opengl/gl_staging_buffer_pool.h
@@ -38,11 +38,14 @@ struct StagingBuffers {
 
     std::optional<size_t> FindBuffer(size_t requested_size);
 
-    std::vector<OGLSync> syncs;
-    std::vector<OGLBuffer> buffers;
-    std::vector<u8*> maps;
-    std::vector<size_t> sizes;
-    std::vector<size_t> sync_indices;
+    struct StagingBufferAlloc {
+        OGLSync sync;
+        OGLBuffer buffer;
+        u8* map;
+        size_t size;
+        size_t sync_index;
+    };
+    std::vector<StagingBufferAlloc> allocs;
     GLenum storage_flags;
     GLenum map_flags;
     size_t current_sync_index = 0;

--- a/src/video_core/renderer_opengl/gl_staging_buffer_pool.h
+++ b/src/video_core/renderer_opengl/gl_staging_buffer_pool.h
@@ -26,13 +26,16 @@ struct StagingBufferMap {
     size_t offset = 0;
     OGLSync* sync;
     GLuint buffer;
+    size_t index;
 };
 
 struct StagingBuffers {
     explicit StagingBuffers(GLenum storage_flags_, GLenum map_flags_);
     ~StagingBuffers();
 
-    StagingBufferMap RequestMap(size_t requested_size, bool insert_fence);
+    StagingBufferMap RequestMap(size_t requested_size, bool insert_fence, bool deferred = false);
+
+    void FreeDeferredStagingBuffer(size_t index);
 
     size_t RequestBuffer(size_t requested_size);
 
@@ -44,6 +47,7 @@ struct StagingBuffers {
         u8* map;
         size_t size;
         size_t sync_index;
+        bool deferred;
     };
     std::vector<StagingBufferAlloc> allocs;
     GLenum storage_flags;
@@ -88,7 +92,8 @@ public:
     ~StagingBufferPool() = default;
 
     StagingBufferMap RequestUploadBuffer(size_t size);
-    StagingBufferMap RequestDownloadBuffer(size_t size);
+    StagingBufferMap RequestDownloadBuffer(size_t size, bool deferred = false);
+    void FreeDeferredStagingBuffer(size_t index);
 
 private:
     StagingBuffers upload_buffers{GL_MAP_WRITE_BIT, GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT};

--- a/src/video_core/renderer_opengl/gl_staging_buffer_pool.h
+++ b/src/video_core/renderer_opengl/gl_staging_buffer_pool.h
@@ -93,7 +93,7 @@ public:
 
     StagingBufferMap RequestUploadBuffer(size_t size);
     StagingBufferMap RequestDownloadBuffer(size_t size, bool deferred = false);
-    void FreeDeferredStagingBuffer(size_t index);
+    void FreeDeferredStagingBuffer(StagingBufferMap& buffer);
 
 private:
     StagingBuffers upload_buffers{GL_MAP_WRITE_BIT, GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT};

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -557,8 +557,12 @@ StagingBufferMap TextureCacheRuntime::UploadStagingBuffer(size_t size) {
     return staging_buffer_pool.RequestUploadBuffer(size);
 }
 
-StagingBufferMap TextureCacheRuntime::DownloadStagingBuffer(size_t size) {
-    return staging_buffer_pool.RequestDownloadBuffer(size);
+StagingBufferMap TextureCacheRuntime::DownloadStagingBuffer(size_t size, bool deferred) {
+    return staging_buffer_pool.RequestDownloadBuffer(size, deferred);
+}
+
+void TextureCacheRuntime::FreeDeferredStagingBuffer(StagingBufferMap& buffer) {
+    staging_buffer_pool.FreeDeferredStagingBuffer(buffer);
 }
 
 u64 TextureCacheRuntime::GetDeviceMemoryUsage() const {

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -74,7 +74,9 @@ public:
 
     StagingBufferMap UploadStagingBuffer(size_t size);
 
-    StagingBufferMap DownloadStagingBuffer(size_t size);
+    StagingBufferMap DownloadStagingBuffer(size_t size, bool deferred = false);
+
+    void FreeDeferredStagingBuffer(StagingBufferMap& buffer);
 
     u64 GetDeviceLocalMemory() const {
         return device_access_memory;
@@ -359,7 +361,7 @@ struct TextureCacheParams {
     static constexpr bool FRAMEBUFFER_BLITS = true;
     static constexpr bool HAS_EMULATED_COPIES = true;
     static constexpr bool HAS_DEVICE_MEMORY_INFO = true;
-    static constexpr bool IMPLEMENTS_ASYNC_DOWNLOADS = false;
+    static constexpr bool IMPLEMENTS_ASYNC_DOWNLOADS = true;
 
     using Runtime = OpenGL::TextureCacheRuntime;
     using Image = OpenGL::Image;
@@ -367,7 +369,7 @@ struct TextureCacheParams {
     using ImageView = OpenGL::ImageView;
     using Sampler = OpenGL::Sampler;
     using Framebuffer = OpenGL::Framebuffer;
-    using AsyncBuffer = u32;
+    using AsyncBuffer = OpenGL::StagingBufferMap;
     using BufferType = GLuint;
 };
 


### PR DESCRIPTION
This brings the OpenGL caches closer to feature parity with the Vulkan renderer. 

This should boost perf but I don't know which titles abuse these paths and would see the benefit. Testing would be appreciated.