### PR TITLE
opus: fix stereo stream count check in multistream decoder object

### DIFF
--- a/src/audio_core/adsp/apps/opus/opus_multistream_decode_object.cpp
+++ b/src/audio_core/adsp/apps/opus/opus_multistream_decode_object.cpp
@@ -12,7 +12,7 @@ bool IsValidChannelCount(u32 channel_count) {
 }
 
 bool IsValidStreamCounts(u32 total_stream_count, u32 stereo_stream_count) {
-    return total_stream_count > 0 && stereo_stream_count > 0 &&
+    return total_stream_count > 0 && static_cast<s32>(stereo_stream_count) >= 0 &&
            stereo_stream_count <= total_stream_count && IsValidChannelCount(total_stream_count);
 }
 } // namespace

--- a/src/audio_core/opus/decoder.cpp
+++ b/src/audio_core/opus/decoder.cpp
@@ -148,7 +148,7 @@ Result OpusDecoder::DecodeInterleavedForMultiStream(u32* out_data_size, u64* out
     auto* header_p{reinterpret_cast<const OpusPacketHeader*>(input_data.data())};
     OpusPacketHeader header{ReverseHeader(*header_p)};
 
-    LOG_ERROR(Service_Audio, "header size 0x{:X} input data size 0x{:X} in_data size 0x{:X}",
+    LOG_TRACE(Service_Audio, "header size 0x{:X} input data size 0x{:X} in_data size 0x{:X}",
               header.size, input_data.size_bytes(), in_data.size_bytes());
 
     R_UNLESS(in_data.size_bytes() >= header.size &&


### PR DESCRIPTION
This was regressed by #11460 and was _almost_ fixed by #11952, except the code was also duplicated in this location for some reason. At some point these blocks need to be deduplicated so that there is one place for validation.

Fixes Super Mario RPG background audio.