### PR TITLE
Buffer Cache: Eliminate clears on Indirect buffers

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1192,11 +1192,6 @@ void BufferCache<P>::UpdateDrawIndirect() {
             .size = static_cast<u32>(size),
             .buffer_id = FindBuffer(*cpu_addr, static_cast<u32>(size)),
         };
-        VAddr cpu_addr_start = Common::AlignDown(*cpu_addr, 64);
-        VAddr cpu_addr_end = Common::AlignUp(*cpu_addr + size, 64);
-        IntervalType interval{cpu_addr_start, cpu_addr_end};
-        ClearDownload(interval);
-        common_ranges.subtract(interval);
     };
     if (current_draw_indirect->include_count) {
         update(current_draw_indirect->count_start_address, sizeof(u32),

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -268,7 +268,7 @@ size_t Maxwell3D::EstimateIndexBufferSize() {
                                                         std::numeric_limits<u32>::max()};
     const size_t byte_size = regs.index_buffer.FormatSizeInBytes();
     const size_t log2_byte_size = Common::Log2Ceil64(byte_size);
-    const size_t cap{GetMaxCurrentVertices() * 3 * byte_size};
+    const size_t cap{GetMaxCurrentVertices() * 4 * byte_size};
     const size_t lower_cap =
         std::min<size_t>(static_cast<size_t>(end_address - start_address), cap);
     return std::min<size_t>(


### PR DESCRIPTION
Fixes some regressions in Pokemon Scarlet.

thanks to @ameerj for figuring it out!