### PR TITLE
android: Select recently played games by default in search tab

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/Game.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/Game.kt
@@ -18,8 +18,8 @@ class Game(
     val version: String = "",
     val isHomebrew: Boolean = false
 ) : Parcelable {
-    val keyAddedToLibraryTime get() = "${programId}_AddedToLibraryTime"
-    val keyLastPlayedTime get() = "${programId}_LastPlayed"
+    val keyAddedToLibraryTime get() = "${path}_AddedToLibraryTime"
+    val keyLastPlayedTime get() = "${path}_LastPlayed"
 
     override fun equals(other: Any?): Boolean {
         if (other !is Game) {

--- a/src/android/app/src/main/res/layout/fragment_search.xml
+++ b/src/android/app/src/main/res/layout/fragment_search.xml
@@ -127,6 +127,7 @@
             android:layout_height="wrap_content"
             android:clipToPadding="false"
             android:paddingVertical="4dp"
+            app:checkedChip="@id/chip_recently_played"
             app:chipSpacingHorizontal="12dp"
             app:singleLine="true"
             app:singleSelection="true">


### PR DESCRIPTION
Additionally fixes an issue where all homebrew apps would appear in the recently played list even though you only played one