### PR TITLE
service: hid: Ensure resource manager is initialized

### DIFF
--- a/src/core/hle/service/hid/hid_server.cpp
+++ b/src/core/hle/service/hid/hid_server.cpp
@@ -1563,7 +1563,7 @@ void IHidServer::CreateActiveVibrationDeviceList(HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(ResultSuccess);
-    rb.PushIpcInterface<IActiveVibrationDeviceList>(system, resource_manager);
+    rb.PushIpcInterface<IActiveVibrationDeviceList>(system, GetResourceManager());
 }
 
 void IHidServer::PermitVibration(HLERequestContext& ctx) {


### PR DESCRIPTION
Ensures the proper initialization of the IActiveVibrationDeviceList. By using GetResourceManager() instead of resource_manager, we make sure that the IActiveVibrationDeviceListis initialized before it's used, preventing potential null issues.

Fixes #12088
Change suggested by @german77 