### PR TITLE
texture_cache: skip accelerate path for blit source

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1574,9 +1574,6 @@ std::optional<typename TextureCache<P>::BlitImages> TextureCache<P>::GetBlitImag
                 if (!src_id && !dst_id) {
                     return std::nullopt;
                 }
-                if (src_id && True(slot_images[src_id].flags & ImageFlagBits::GpuModified)) {
-                    break;
-                }
                 if (dst_id && True(slot_images[dst_id].flags & ImageFlagBits::GpuModified)) {
                     break;
                 }


### PR DESCRIPTION
While this never affected Intel or AMD drivers on Linux, it seems to be a huge pessimization on Windows and also a huge pessimization for mobile drivers. 3DAS launcher perf goes from 20 fps to 60 fps on Windows and from 10 fps to 40 on Turnip with an Adreno 618.

Fixes #8343