### PR TITLE
roll back to fmt 8 for ubuntu 22.04 jammy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 # Enforce the search mode of non-required packages for better and shorter failure messages
 find_package(Boost 1.79.0 REQUIRED context)
 find_package(enet 1.3 MODULE)
-find_package(fmt 9 REQUIRED)
+find_package(fmt 8.0.1 REQUIRED)
 find_package(inih 52 MODULE COMPONENTS INIReader)
 find_package(LLVM 17.0.2 MODULE COMPONENTS Demangle)
 find_package(lz4 REQUIRED)


### PR DESCRIPTION
Ubuntu jammy is supported in the build instruction, but we can't build yuzu at the moment becaue of bumping version of fmt and zstd.
fmt is bumped from 8.0.1 to 9 from this pull request: https://github.com/yuzu-emu/yuzu/pull/6833, in which there is no need to bump fmt version.
zstd is bumped from 1.4.8 to 1.5 from this pull request: https://github.com/yuzu-emu/yuzu/pull/6348, which says `zstd 1.5.0 brings numerous performance improvements`. But this change will break build on ubuntu jammy.
If we want new version, just update libraries on system. It's not necessary to force people to update libraries on their old system.
I can build yuzu on ubuntu jammy after this patch with command:
```
cmake .. -GNinja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DYUZU_USE_QT_WEB_ENGINE=ON -DLINUX=1
```
cc @lioncash @abouvier 