### PR TITLE
translations: Add android translations to transifex config

### DIFF
--- a/dist/languages/.tx/config
+++ b/dist/languages/.tx/config
@@ -6,3 +6,8 @@ file_filter = <lang>.ts
 source_file = en.ts
 source_lang = en
 type = QT
+
+[o:yuzu-emulator:p:yuzu:r:yuzu-android]
+file_filter = ../../src/android/app/src/main/res/values-<lang>/strings.xml
+source_file = ../../src/android/app/src/main/res/values/strings.xml
+type = ANDROID


### PR DESCRIPTION
This should allow android strings to be automatically transferred between transifex and the app just like Qt