### PR TITLE
query_cache: demote report synced unreachable to assert

### DIFF
--- a/src/video_core/query_cache/query_cache.h
+++ b/src/video_core/query_cache/query_cache.h
@@ -266,7 +266,7 @@ void QueryCacheBase<Traits>::CounterReport(GPUVAddr addr, QueryType counter_type
             return;
         }
         if (False(query_base->flags & QueryFlagBits::IsFinalValueSynced)) [[unlikely]] {
-            UNREACHABLE();
+            ASSERT(false);
             return;
         }
         query_base->value += streamer->GetAmmendValue();


### PR DESCRIPTION
This gets hits a lot on Turnip drivers, which causes a hard crash.