### PR TITLE
renderer_vulkan: exclude steam deck oled from force max clock setting

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -869,7 +869,8 @@ bool Device::ShouldBoostClocks() const {
         driver_id == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA ||
         driver_id == VK_DRIVER_ID_QUALCOMM_PROPRIETARY || driver_id == VK_DRIVER_ID_MESA_TURNIP;
 
-    const bool is_steam_deck = vendor_id == 0x1002 && device_id == 0x163F;
+    const bool is_steam_deck = (vendor_id == 0x1002 && device_id == 0x163F) ||
+                               (vendor_id == 0x1002 && device_id == 0x1435);
 
     const bool is_debugging = this->HasDebuggingToolAttached();
 


### PR DESCRIPTION
A gentle reminder that if you are on a power or thermally limited device, do not enable the option to force maximum clocks.