### PR TITLE
yuzu: Display firmware version

### DIFF
--- a/src/core/hle/service/set/set_sys.h
+++ b/src/core/hle/service/set/set_sys.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/uuid.h"
+#include "core/hle/result.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/time/clock_types.h"
 
@@ -12,6 +13,29 @@ class System;
 }
 
 namespace Service::Set {
+enum class LanguageCode : u64;
+enum class GetFirmwareVersionType {
+    Version1,
+    Version2,
+};
+
+struct FirmwareVersionFormat {
+    u8 major;
+    u8 minor;
+    u8 micro;
+    INSERT_PADDING_BYTES(1);
+    u8 revision_major;
+    u8 revision_minor;
+    INSERT_PADDING_BYTES(2);
+    std::array<char, 0x20> platform;
+    std::array<u8, 0x40> version_hash;
+    std::array<char, 0x18> display_version;
+    std::array<char, 0x80> display_title;
+};
+static_assert(sizeof(FirmwareVersionFormat) == 0x100, "FirmwareVersionFormat is an invalid size");
+
+Result GetFirmwareVersionImpl(FirmwareVersionFormat& out_firmware, Core::System& system,
+                              GetFirmwareVersionType type);
 
 class SET_SYS final : public ServiceFramework<SET_SYS> {
 public:

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -47,6 +47,7 @@
 #include "core/hle/service/am/applet_ae.h"
 #include "core/hle/service/am/applet_oe.h"
 #include "core/hle/service/am/applets/applets.h"
+#include "core/hle/service/set/set_sys.h"
 #include "yuzu/multiplayer/state.h"
 #include "yuzu/util/controller_navigation.h"
 
@@ -1047,7 +1048,12 @@ void GMainWindow::InitializeWidgets() {
         statusBar()->addPermanentWidget(label);
     }
 
-    // TODO (flTobi): Add the widget when multiplayer is fully implemented
+    firmware_label = new QLabel();
+    firmware_label->setObjectName(QStringLiteral("FirmwareLabel"));
+    firmware_label->setVisible(false);
+    firmware_label->setFocusPolicy(Qt::NoFocus);
+    statusBar()->addPermanentWidget(firmware_label);
+
     statusBar()->addPermanentWidget(multiplayer_state->GetStatusText(), 0);
     statusBar()->addPermanentWidget(multiplayer_state->GetStatusIcon(), 0);
 
@@ -2160,6 +2166,10 @@ void GMainWindow::OnEmulationStopped() {
     game_fps_label->setVisible(false);
     emu_frametime_label->setVisible(false);
     renderer_status_button->setEnabled(!UISettings::values.has_broken_vulkan);
+
+    if (!firmware_label->text().isEmpty()) {
+        firmware_label->setVisible(true);
+    }
 
     current_game_path.clear();
 
@@ -4586,6 +4596,7 @@ void GMainWindow::UpdateStatusBar() {
     emu_speed_label->setVisible(!Settings::values.use_multi_core.GetValue());
     game_fps_label->setVisible(true);
     emu_frametime_label->setVisible(true);
+    firmware_label->setVisible(false);
 }
 
 void GMainWindow::UpdateGPUAccuracyButton() {
@@ -4803,6 +4814,8 @@ void GMainWindow::OnReinitializeKeys(ReinitializeKeyBehavior behavior) {
                "games."));
     }
 
+    SetFirmwareVersion();
+
     if (behavior == ReinitializeKeyBehavior::Warning) {
         game_list->PopulateAsync(UISettings::values.game_dirs);
     }
@@ -4830,7 +4843,7 @@ bool GMainWindow::CheckSystemArchiveDecryption() {
 }
 
 bool GMainWindow::CheckFirmwarePresence() {
-    constexpr u64 MiiEditId = 0x0100000000001009ull;
+    constexpr u64 MiiEditId = static_cast<u64>(Service::AM::Applets::AppletProgramId::MiiEdit);
 
     auto bis_system = system->GetFileSystemController().GetSystemNANDContents();
     if (!bis_system) {
@@ -4843,6 +4856,28 @@ bool GMainWindow::CheckFirmwarePresence() {
     }
 
     return true;
+}
+
+void GMainWindow::SetFirmwareVersion() {
+    Service::Set::FirmwareVersionFormat firmware_data{};
+    const auto result = Service::Set::GetFirmwareVersionImpl(
+        firmware_data, *system, Service::Set::GetFirmwareVersionType::Version2);
+
+    if (result.IsError() || !CheckFirmwarePresence()) {
+        LOG_INFO(Frontend, "Installed firmware: No firmware available");
+        firmware_label->setVisible(false);
+        return;
+    }
+
+    firmware_label->setVisible(true);
+
+    const std::string display_version(firmware_data.display_version.data());
+    const std::string display_title(firmware_data.display_title.data());
+
+    LOG_INFO(Frontend, "Installed firmware: {}", display_title);
+
+    firmware_label->setText(QString::fromStdString(display_version));
+    firmware_label->setToolTip(QString::fromStdString(display_title));
 }
 
 bool GMainWindow::SelectRomFSDumpTarget(const FileSys::ContentProvider& installed, u64 program_id,

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -457,6 +457,7 @@ private:
     bool CheckDarkMode();
     bool CheckSystemArchiveDecryption();
     bool CheckFirmwarePresence();
+    void SetFirmwareVersion();
     void ConfigureFilesystemProvider(const std::string& filepath);
     /**
      * Open (or not) the right confirm dialog based on current setting and game exit lock
@@ -511,6 +512,7 @@ private:
     QLabel* game_fps_label = nullptr;
     QLabel* emu_frametime_label = nullptr;
     QLabel* tas_label = nullptr;
+    QLabel* firmware_label = nullptr;
     QPushButton* gpu_accuracy_button = nullptr;
     QPushButton* renderer_status_button = nullptr;
     QPushButton* dock_status_button = nullptr;


### PR DESCRIPTION
Since FW version make a difference in system applets. It's actually useful now to display the current firmware version.

![image](https://github.com/yuzu-emu/yuzu/assets/5944268/26d2305c-09fe-4c71-8683-a4225bb26504)
