### PR TITLE
service: nfc: Validate mii data

### DIFF
--- a/src/core/hle/service/am/applets/applet_cabinet.cpp
+++ b/src/core/hle/service/am/applets/applet_cabinet.cpp
@@ -130,7 +130,7 @@ void Cabinet::DisplayCompleted(bool apply_changes, std::string_view amiibo_name)
         nfp_device->DeleteApplicationArea();
         break;
     case Service::NFP::CabinetMode::StartRestorer:
-        nfp_device->RestoreAmiibo();
+        nfp_device->Restore();
         break;
     case Service::NFP::CabinetMode::StartFormatter:
         nfp_device->Format();

--- a/src/core/hle/service/mii/types/ver3_store_data.cpp
+++ b/src/core/hle/service/mii/types/ver3_store_data.cpp
@@ -98,7 +98,7 @@ void Ver3StoreData::BuildToStoreData(StoreData& out_store_data) const {
 }
 
 void Ver3StoreData::BuildFromStoreData(const StoreData& store_data) {
-    version = 1;
+    version = 3;
     mii_information.gender.Assign(static_cast<u8>(store_data.GetGender()));
     mii_information.favorite_color.Assign(static_cast<u8>(store_data.GetFavoriteColor()));
     height = store_data.GetHeight();

--- a/src/core/hle/service/nfc/common/device.h
+++ b/src/core/hle/service/nfc/common/device.h
@@ -68,7 +68,6 @@ public:
 
     Result DeleteRegisterInfo();
     Result SetRegisterInfoPrivate(const NFP::RegisterInfoPrivate& register_info);
-    Result RestoreAmiibo();
     Result Format();
 
     Result OpenApplicationArea(u32 access_id);


### PR DESCRIPTION
Games like SSBU crash if you load an amiibo with invalid mii data. Since mii service is implemented now we can actually check the integrity of the mii. This change returns a corrupted error if mii is invalid. If a backup exist you can use the applet to restore it to be functional again.

I also deleted a duplicated function. Probably a leftover from a rebase. 

Big **WARNING** I made a huge mistake. All mii amiibo registered on yuzu in the last few months are considered corrupted. Should be fixable by using the restore function on the amiibo applet.