### PR TITLE
GLSL: Use known cbuf sizes when possible

### DIFF
--- a/src/shader_recompiler/backend/glsl/glsl_emit_context.cpp
+++ b/src/shader_recompiler/backend/glsl/glsl_emit_context.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2021 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/div_ceil.h"
 #include "shader_recompiler/backend/bindings.h"
 #include "shader_recompiler/backend/glsl/glsl_emit_context.h"
 #include "shader_recompiler/frontend/ir/program.h"
@@ -431,9 +432,11 @@ void EmitContext::DefineConstantBuffers(Bindings& bindings) {
     }
     for (const auto& desc : info.constant_buffer_descriptors) {
         const auto cbuf_type{profile.has_gl_cbuf_ftou_bug ? "uvec4" : "vec4"};
+        const u32 cbuf_used_size{Common::DivCeil(info.constant_buffer_used_sizes[desc.index], 16U)};
+        const u32 cbuf_binding_size{info.uses_global_memory ? 0x1000U : cbuf_used_size};
         header += fmt::format("layout(std140,binding={}) uniform {}_cbuf_{}{{{} {}_cbuf{}[{}];}};",
                               bindings.uniform_buffer, stage_name, desc.index, cbuf_type,
-                              stage_name, desc.index, 4 * 1024);
+                              stage_name, desc.index, cbuf_binding_size);
         bindings.uniform_buffer += desc.count;
     }
 }


### PR DESCRIPTION
Use the known max size of the cbuf in the shader declaration when possible, rather than the maximum of 64KiB

This seems to help with shader compilation speed on Nvidia. 