### PR TITLE
general: unbreak build on FreeBSD by disabling gamemode

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -386,7 +386,10 @@ if (NOT WIN32)
     target_include_directories(yuzu PRIVATE ${Qt${QT_MAJOR_VERSION}Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 if (UNIX AND NOT APPLE)
-    target_link_libraries(yuzu PRIVATE Qt${QT_MAJOR_VERSION}::DBus gamemode)
+    target_link_libraries(yuzu PRIVATE Qt${QT_MAJOR_VERSION}::DBus)
+endif()
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(yuzu PRIVATE gamemode)
 endif()
 
 target_compile_definitions(yuzu PRIVATE

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -17,6 +17,8 @@
 #ifdef __unix__
 #include <csignal>
 #include <sys/socket.h>
+#endif
+#ifdef __linux__
 #include "common/linux/gamemode.h"
 #endif
 
@@ -320,6 +322,8 @@ GMainWindow::GMainWindow(std::unique_ptr<QtConfig> config_, bool has_broken_vulk
       provider{std::make_unique<FileSys::ManualContentProvider>()} {
 #ifdef __unix__
     SetupSigInterrupts();
+#endif
+#ifdef __linux__
     SetGamemodeEnabled(Settings::values.enable_gamemode.GetValue());
 #endif
     system->Initialize();
@@ -2122,7 +2126,7 @@ void GMainWindow::OnEmulationStopped() {
 
     discord_rpc->Update();
 
-#ifdef __unix__
+#ifdef __linux__
     Common::Linux::StopGamemode();
 #endif
 
@@ -3509,7 +3513,7 @@ void GMainWindow::OnStartGame() {
 
     discord_rpc->Update();
 
-#ifdef __unix__
+#ifdef __linux__
     Common::Linux::StartGamemode();
 #endif
 }
@@ -3533,7 +3537,7 @@ void GMainWindow::OnPauseGame() {
     UpdateMenuState();
     AllowOSSleep();
 
-#ifdef __unix__
+#ifdef __linux__
     Common::Linux::StopGamemode();
 #endif
 }
@@ -3817,7 +3821,7 @@ void GMainWindow::OnConfigure() {
     const auto old_theme = UISettings::values.theme;
     const bool old_discord_presence = UISettings::values.enable_discord_presence.GetValue();
     const auto old_language_index = Settings::values.language_index.GetValue();
-#ifdef __unix__
+#ifdef __linux__
     const bool old_gamemode = Settings::values.enable_gamemode.GetValue();
 #endif
 
@@ -3881,7 +3885,7 @@ void GMainWindow::OnConfigure() {
     if (UISettings::values.enable_discord_presence.GetValue() != old_discord_presence) {
         SetDiscordEnabled(UISettings::values.enable_discord_presence.GetValue());
     }
-#ifdef __unix__
+#ifdef __linux__
     if (Settings::values.enable_gamemode.GetValue() != old_gamemode) {
         SetGamemodeEnabled(Settings::values.enable_gamemode.GetValue());
     }
@@ -5194,7 +5198,7 @@ void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {
     discord_rpc->Update();
 }
 
-#ifdef __unix__
+#ifdef __linux__
 void GMainWindow::SetGamemodeEnabled(bool state) {
     if (emulation_running) {
         Common::Linux::SetGamemodeState(state);

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -63,7 +63,7 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
 #endif
 
-#ifdef __unix__
+#ifdef __linux__
 #include "common/linux/gamemode.h"
 #endif
 
@@ -429,7 +429,7 @@ int main(int argc, char** argv) {
         exit(0);
     });
 
-#ifdef __unix__
+#ifdef __linux__
     Common::Linux::StartGamemode();
 #endif
 
@@ -444,7 +444,7 @@ int main(int argc, char** argv) {
     void(system.Pause());
     system.ShutdownMainProcess();
 
-#ifdef __unix__
+#ifdef __linux__
     Common::Linux::StopGamemode();
 #endif
 


### PR DESCRIPTION
Regressed by #12223 (partially). gamemode itself is Linux-only, so won't build on BSDs "as is".

Alternatively, gamemode can be converted into a CMake option (a la `USE_DISCORD_PRESENCE`) for easier testing disabled even on Linux.