### PR TITLE
cmake: unbreak build on FreeBSD by re-enabling gamemode

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -189,7 +189,7 @@ if (ANDROID)
    endif()
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (UNIX AND NOT APPLE)
     add_subdirectory(gamemode)
 endif()
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -174,7 +174,7 @@ if(ANDROID)
     )
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (UNIX AND NOT APPLE)
   target_sources(common PRIVATE
     linux/gamemode.cpp
     linux/gamemode.h


### PR DESCRIPTION
Regressed by #12223. gamemode itself is Linux-only but yuzu doesn't bundle gamemode. Avoid extra conditionals by keeping the support even if it will never be used.