### PR TITLE
renderer_vulkan: exclude more qcom drivers from extensions

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -892,10 +892,6 @@ void RasterizerVulkan::UpdateDynamicStates() {
         UpdateFrontFace(regs);
         UpdateStencilOp(regs);
 
-        if (device.IsExtVertexInputDynamicStateSupported()) {
-            UpdateVertexInput(regs);
-        }
-
         if (state_tracker.TouchStateEnable()) {
             UpdateDepthBoundsTestEnable(regs);
             UpdateDepthTestEnable(regs);
@@ -917,6 +913,9 @@ void RasterizerVulkan::UpdateDynamicStates() {
         if (device.IsExtExtendedDynamicState3Supported()) {
             UpdateBlending(regs);
         }
+    }
+    if (device.IsExtVertexInputDynamicStateSupported()) {
+        UpdateVertexInput(regs);
     }
 }
 


### PR DESCRIPTION
vkCmdSetVertexInputEXT does not work on every Qualcomm driver that supports it: the vertex input state is not persisted in the command buffer, so when you move to the next draw in the same command buffer and don't issue another command to update the state, it behaves as if there are no vertex bindings available. I'm pretty sure this behavior would not pass dEQP, and breaks basically everything except rendering demos.

Fixes #12215