### PR TITLE
service: nfc: Don't tag amiibos as corrupted if they are loaded as read only

### DIFF
--- a/src/core/hle/service/nfc/common/device.cpp
+++ b/src/core/hle/service/nfc/common/device.cpp
@@ -438,16 +438,16 @@ Result NfcDevice::Mount(NFP::ModelType model_type, NFP::MountTarget mount_target
         is_corrupted = true;
     }
 
-    if (!is_corrupted) {
+    device_state = DeviceState::TagMounted;
+    mount_target = mount_target_;
+
+    if (!is_corrupted && mount_target != NFP::MountTarget::Rom) {
         std::vector<u8> data(sizeof(NFP::EncryptedNTAG215File));
         memcpy(data.data(), &encrypted_tag_data, sizeof(encrypted_tag_data));
         WriteBackupData(encrypted_tag_data.uuid, data);
     }
 
-    device_state = DeviceState::TagMounted;
-    mount_target = mount_target_;
-
-    if (is_corrupted) {
+    if (is_corrupted && mount_target != NFP::MountTarget::Rom) {
         bool has_backup = HasBackup(encrypted_tag_data.uuid).IsSuccess();
         return has_backup ? ResultCorruptedDataWithBackup : ResultCorruptedData;
     }


### PR DESCRIPTION
If you mount amiibos with read only permissions you can't access any of the encrypted data. We shouldn't be returning corrupted data because read only memory can't be corrupted as this data is set by factory. 

Closes: #12254 