### PR TITLE
vk_blit_screen: Use correct format for fxaa renderpass

### DIFF
--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -1211,7 +1211,7 @@ void BlitScreen::CreateRawImages(const Tegra::FramebufferConfig& framebuffer) {
         aa_framebuffer = CreateFramebuffer(*aa_image_view, size, aa_renderpass);
         return;
     }
-    aa_renderpass = CreateRenderPassImpl(GetFormat(framebuffer));
+    aa_renderpass = CreateRenderPassImpl(VK_FORMAT_R16G16B16A16_SFLOAT);
     aa_framebuffer = CreateFramebuffer(*aa_image_view, size, aa_renderpass);
 
     const std::array<VkPipelineShaderStageCreateInfo, 2> fxaa_shader_stages{{


### PR DESCRIPTION
PR https://github.com/yuzu-emu/yuzu/pull/10670 changed the format of the AA image_views but the renderpass format wasn't updated accordingly. This caused qcom proprietary drivers to break.

| Before | After |
|---|---|
![Screenshot_20231201_230129_yuzu](https://github.com/yuzu-emu/yuzu/assets/47210458/e6a82f79-739b-430c-8f5b-7e33a1ca197b) | ![Screenshot_20231201_204703_yuzu Debug Release](https://github.com/yuzu-emu/yuzu/assets/47210458/49ca8cff-2b18-4482-bf5a-c22c13d3da69)



Fixes https://github.com/yuzu-emu/yuzu/issues/10730
Fixes #12247