### PR TITLE
nce: fix pre-text patch for single modules

### DIFF
--- a/src/core/arm/nce/patcher.cpp
+++ b/src/core/arm/nce/patcher.cpp
@@ -28,6 +28,8 @@ Patcher::~Patcher() = default;
 
 void Patcher::PatchText(const Kernel::PhysicalMemory& program_image,
                         const Kernel::CodeSet::Segment& code) {
+    // Branch to the first instruction of the module.
+    this->BranchToModule(0);
 
     // Write save context helper function.
     c.l(m_save_context);


### PR DESCRIPTION
When a single module has a pre-text patch, the kernel will assign the pc to be the first instruction of the patch section. Make this instruction be a jump to the module body.