### PR TITLE
frontend_common: Use optional for language default

### DIFF
--- a/src/yuzu/configuration/qt_config.cpp
+++ b/src/yuzu/configuration/qt_config.cpp
@@ -225,7 +225,8 @@ void QtConfig::ReadPathValues() {
     UISettings::values.recent_files =
         QString::fromStdString(ReadStringSetting(std::string("recentFiles")))
             .split(QStringLiteral(", "), Qt::SkipEmptyParts, Qt::CaseSensitive);
-    UISettings::values.language = ReadStringSetting(std::string("language"), std::string(""));
+    UISettings::values.language =
+        ReadStringSetting(std::string("language"), std::make_optional(std::string("")));
 
     EndGroup();
 }


### PR DESCRIPTION
Fixes a bug where language selection wouldn't save properly