### PR TITLE
service: hid: Introduce proper AppletResource emulation

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -541,6 +541,8 @@ add_library(core STATIC
     hle/service/hid/xcd.cpp
     hle/service/hid/xcd.h
     hle/service/hid/errors.h
+    hle/service/hid/controllers/applet_resource.cpp
+    hle/service/hid/controllers/applet_resource.h
     hle/service/hid/controllers/console_six_axis.cpp
     hle/service/hid/controllers/console_six_axis.h
     hle/service/hid/controllers/controller_base.cpp

--- a/src/core/hle/service/hid/controllers/applet_resource.cpp
+++ b/src/core/hle/service/hid/controllers/applet_resource.cpp
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "core/core.h"
+#include "core/hle/kernel/k_shared_memory.h"
+#include "core/hle/service/hid/controllers/applet_resource.h"
+#include "core/hle/service/hid/errors.h"
+
+namespace Service::HID {
+
+AppletResource::AppletResource(Core::System& system_) : system{system_} {}
+
+AppletResource::~AppletResource() = default;
+
+Result AppletResource::CreateAppletResource(u64 aruid) {
+    const u64 index = GetIndexFromAruid(aruid);
+
+    if (index >= AruidIndexMax) {
+        return ResultAruidNotRegistered;
+    }
+
+    if (data[index].flag.is_assigned) {
+        return ResultAruidAlreadyRegistered;
+    }
+
+    // TODO: Here shared memory is created for the process we don't quite emulate this part so
+    // obtain this pointer from system
+    auto& shared_memory = system.Kernel().GetHidSharedMem();
+
+    data[index].shared_memory_handle = &shared_memory;
+    data[index].flag.is_assigned.Assign(true);
+    // TODO: InitializeSixAxisControllerConfig(false);
+    active_aruid = aruid;
+    return ResultSuccess;
+}
+
+Result AppletResource::RegisterAppletResourceUserId(u64 aruid, bool enable_input) {
+    const u64 index = GetIndexFromAruid(aruid);
+
+    if (index < AruidIndexMax) {
+        return ResultAruidAlreadyRegistered;
+    }
+
+    std::size_t data_index = AruidIndexMax;
+    for (std::size_t i = 0; i < AruidIndexMax; i++) {
+        if (!data[i].flag.is_initialized) {
+            data_index = i;
+            break;
+        }
+    }
+
+    if (data_index == AruidIndexMax) {
+        return ResultAruidNoAvailableEntries;
+    }
+
+    AruidData& aruid_data = data[data_index];
+
+    aruid_data.aruid = aruid;
+    aruid_data.flag.is_initialized.Assign(true);
+    if (enable_input) {
+        aruid_data.flag.enable_pad_input.Assign(true);
+        aruid_data.flag.enable_six_axis_sensor.Assign(true);
+        aruid_data.flag.bit_18.Assign(true);
+        aruid_data.flag.enable_touchscreen.Assign(true);
+    }
+
+    data_index = AruidIndexMax;
+    for (std::size_t i = 0; i < AruidIndexMax; i++) {
+        if (registration_list.flag[i] == RegistrationStatus::Initialized) {
+            if (registration_list.aruid[i] != aruid) {
+                continue;
+            }
+            data_index = i;
+            break;
+        }
+        if (registration_list.flag[i] == RegistrationStatus::None) {
+            data_index = i;
+            break;
+        }
+    }
+
+    if (data_index == AruidIndexMax) {
+        return ResultSuccess;
+    }
+
+    registration_list.flag[data_index] = RegistrationStatus::Initialized;
+    registration_list.aruid[data_index] = aruid;
+
+    return ResultSuccess;
+}
+
+void AppletResource::UnregisterAppletResourceUserId(u64 aruid) {
+    u64 index = GetIndexFromAruid(aruid);
+
+    if (index < AruidIndexMax) {
+        if (data[index].flag.is_assigned) {
+            data[index].shared_memory_handle = nullptr;
+            data[index].flag.is_assigned.Assign(false);
+        }
+    }
+
+    index = GetIndexFromAruid(aruid);
+    if (index < AruidIndexMax) {
+        DestroySevenSixAxisTransferMemory();
+        data[index].flag.raw = 0;
+        data[index].aruid = 0;
+
+        index = GetIndexFromAruid(aruid);
+        if (index < AruidIndexMax) {
+            registration_list.flag[index] = RegistrationStatus::PendingDelete;
+        }
+    }
+}
+
+u64 AppletResource::GetActiveAruid() {
+    return active_aruid;
+}
+
+Result AppletResource::GetSharedMemoryHandle(Kernel::KSharedMemory** out_handle, u64 aruid) {
+    u64 index = GetIndexFromAruid(aruid);
+    if (index >= AruidIndexMax) {
+        return ResultAruidNotRegistered;
+    }
+
+    *out_handle = data[index].shared_memory_handle;
+    return ResultSuccess;
+}
+
+u64 AppletResource::GetIndexFromAruid(u64 aruid) {
+    for (std::size_t i = 0; i < AruidIndexMax; i++) {
+        if (registration_list.flag[i] == RegistrationStatus::Initialized &&
+            registration_list.aruid[i] == aruid) {
+            return i;
+        }
+    }
+    return AruidIndexMax;
+}
+
+Result AppletResource::DestroySevenSixAxisTransferMemory() {
+    // TODO
+    return ResultSuccess;
+}
+
+void AppletResource::EnableInput(u64 aruid, bool is_enabled) {
+    const u64 index = GetIndexFromAruid(aruid);
+    if (index >= AruidIndexMax) {
+        return;
+    }
+
+    data[index].flag.enable_pad_input.Assign(is_enabled);
+    data[index].flag.enable_touchscreen.Assign(is_enabled);
+}
+
+void AppletResource::EnableSixAxisSensor(u64 aruid, bool is_enabled) {
+    const u64 index = GetIndexFromAruid(aruid);
+    if (index >= AruidIndexMax) {
+        return;
+    }
+
+    data[index].flag.enable_six_axis_sensor.Assign(is_enabled);
+}
+
+void AppletResource::EnablePadInput(u64 aruid, bool is_enabled) {
+    const u64 index = GetIndexFromAruid(aruid);
+    if (index >= AruidIndexMax) {
+        return;
+    }
+
+    data[index].flag.enable_pad_input.Assign(is_enabled);
+}
+
+void AppletResource::EnableTouchScreen(u64 aruid, bool is_enabled) {
+    const u64 index = GetIndexFromAruid(aruid);
+    if (index >= AruidIndexMax) {
+        return;
+    }
+
+    data[index].flag.enable_touchscreen.Assign(is_enabled);
+}
+
+void AppletResource::SetIsPalmaConnectable(u64 aruid, bool is_connectable) {
+    const u64 index = GetIndexFromAruid(aruid);
+    if (index >= AruidIndexMax) {
+        return;
+    }
+
+    data[index].flag.is_palma_connectable.Assign(is_connectable);
+}
+
+void AppletResource::EnablePalmaBoostMode(u64 aruid, bool is_enabled) {
+    const u64 index = GetIndexFromAruid(aruid);
+    if (index >= AruidIndexMax) {
+        return;
+    }
+
+    data[index].flag.enable_palma_boost_mode.Assign(is_enabled);
+}
+
+} // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/applet_resource.h
+++ b/src/core/hle/service/hid/controllers/applet_resource.h
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <array>
+
+#include "common/bit_field.h"
+#include "common/common_types.h"
+#include "core/hle/result.h"
+
+namespace Core {
+class System;
+}
+
+namespace Kernel {
+class KSharedMemory;
+}
+
+namespace Service::HID {
+class AppletResource {
+public:
+    explicit AppletResource(Core::System& system_);
+    ~AppletResource();
+
+    Result CreateAppletResource(u64 aruid);
+
+    Result RegisterAppletResourceUserId(u64 aruid, bool enable_input);
+    void UnregisterAppletResourceUserId(u64 aruid);
+
+    u64 GetActiveAruid();
+    Result GetSharedMemoryHandle(Kernel::KSharedMemory** out_handle, u64 aruid);
+
+    u64 GetIndexFromAruid(u64 aruid);
+
+    Result DestroySevenSixAxisTransferMemory();
+
+    void EnableInput(u64 aruid, bool is_enabled);
+    void EnableSixAxisSensor(u64 aruid, bool is_enabled);
+    void EnablePadInput(u64 aruid, bool is_enabled);
+    void EnableTouchScreen(u64 aruid, bool is_enabled);
+    void SetIsPalmaConnectable(u64 aruid, bool is_connectable);
+    void EnablePalmaBoostMode(u64 aruid, bool is_enabled);
+
+private:
+    static constexpr std::size_t AruidIndexMax = 0x20;
+
+    enum RegistrationStatus : u32 {
+        None,
+        Initialized,
+        PendingDelete,
+    };
+
+    struct DataStatusFlag {
+        union {
+            u32 raw{};
+
+            BitField<0, 1, u32> is_initialized;
+            BitField<1, 1, u32> is_assigned;
+            BitField<16, 1, u32> enable_pad_input;
+            BitField<17, 1, u32> enable_six_axis_sensor;
+            BitField<18, 1, u32> bit_18;
+            BitField<19, 1, u32> is_palma_connectable;
+            BitField<20, 1, u32> enable_palma_boost_mode;
+            BitField<21, 1, u32> enable_touchscreen;
+        };
+    };
+
+    struct AruidRegisterList {
+        std::array<RegistrationStatus, AruidIndexMax> flag{};
+        std::array<u64, AruidIndexMax> aruid{};
+    };
+    static_assert(sizeof(AruidRegisterList) == 0x180, "AruidRegisterList is an invalid size");
+
+    struct AruidData {
+        DataStatusFlag flag{};
+        u64 aruid{};
+        Kernel::KSharedMemory* shared_memory_handle{nullptr};
+    };
+
+    u64 active_aruid{};
+    AruidRegisterList registration_list{};
+    std::array<AruidData, AruidIndexMax> data{};
+
+    Core::System& system;
+};
+} // namespace Service::HID

--- a/src/core/hle/service/hid/errors.h
+++ b/src/core/hle/service/hid/errors.h
@@ -19,6 +19,11 @@ constexpr Result NpadIsSameType{ErrorModule::HID, 602};
 constexpr Result InvalidNpadId{ErrorModule::HID, 709};
 constexpr Result NpadNotConnected{ErrorModule::HID, 710};
 constexpr Result InvalidArraySize{ErrorModule::HID, 715};
+
+constexpr Result ResultAruidNoAvailableEntries{ErrorModule::HID, 1044};
+constexpr Result ResultAruidAlreadyRegistered{ErrorModule::HID, 1046};
+constexpr Result ResultAruidNotRegistered{ErrorModule::HID, 1047};
+
 constexpr Result InvalidPalmaHandle{ErrorModule::HID, 3302};
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2018 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "core/hle/kernel/k_process.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/service/hid/hid.h"
 #include "core/hle/service/hid/hid_debug_server.h"
 #include "core/hle/service/hid/hid_firmware_settings.h"
@@ -19,6 +21,12 @@ void LoopProcess(Core::System& system) {
     std::shared_ptr<ResourceManager> resouce_manager = std::make_shared<ResourceManager>(system);
     std::shared_ptr<HidFirmwareSettings> firmware_settings =
         std::make_shared<HidFirmwareSettings>();
+
+    // TODO: Remove this hack until this service is emulated properly.
+    const auto process_list = system.Kernel().GetProcessList();
+    if (!process_list.empty()) {
+        resouce_manager->RegisterAppletResourceUserId(process_list[0]->GetId(), true);
+    }
 
     server_manager->RegisterNamedService(
         "hid", std::make_shared<IHidServer>(system, resouce_manager, firmware_settings));

--- a/src/core/hle/service/hid/hid_server.cpp
+++ b/src/core/hle/service/hid/hid_server.cpp
@@ -224,8 +224,13 @@ void IHidServer::CreateAppletResource(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
+    Result result = GetResourceManager()->CreateAppletResource(applet_resource_user_id);
+    if (result.IsSuccess()) {
+        result = GetResourceManager()->GetNpad()->Activate(applet_resource_user_id);
+    }
+
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
-    rb.Push(ResultSuccess);
+    rb.Push(result);
     rb.PushIpcInterface<IAppletResource>(system, resource_manager);
 }
 

--- a/src/core/hle/service/hid/hid_system_server.h
+++ b/src/core/hle/service/hid/hid_system_server.h
@@ -38,6 +38,12 @@ private:
     void HasLeftRightBattery(HLERequestContext& ctx);
     void GetUniquePadsFromNpad(HLERequestContext& ctx);
     void GetIrSensorState(HLERequestContext& ctx);
+    void RegisterAppletResourceUserId(HLERequestContext& ctx);
+    void UnregisterAppletResourceUserId(HLERequestContext& ctx);
+    void EnableAppletToGetInput(HLERequestContext& ctx);
+    void EnableAppletToGetSixAxisSensor(HLERequestContext& ctx);
+    void EnableAppletToGetPadInput(HLERequestContext& ctx);
+    void EnableAppletToGetTouchScreen(HLERequestContext& ctx);
     void AcquireConnectionTriggerTimeoutEvent(HLERequestContext& ctx);
     void AcquireDeviceRegisteredEventForControllerSupport(HLERequestContext& ctx);
     void GetRegisteredDevices(HLERequestContext& ctx);

--- a/src/core/hle/service/hid/resource_manager.h
+++ b/src/core/hle/service/hid/resource_manager.h
@@ -6,11 +6,20 @@
 #include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Core::Timing {
 struct EventType;
 }
 
+namespace Kernel {
+class KSharedMemory;
+}
+
 namespace Service::HID {
+class AppletResource;
 class Controller_Stubbed;
 class ConsoleSixAxis;
 class DebugPad;
@@ -38,6 +47,7 @@ public:
 
     void Initialize();
 
+    std::shared_ptr<AppletResource> GetAppletResource() const;
     std::shared_ptr<CaptureButton> GetCaptureButton() const;
     std::shared_ptr<ConsoleSixAxis> GetConsoleSixAxis() const;
     std::shared_ptr<DebugMouse> GetDebugMouse() const;
@@ -54,6 +64,18 @@ public:
     std::shared_ptr<TouchScreen> GetTouchScreen() const;
     std::shared_ptr<UniquePad> GetUniquePad() const;
 
+    Result CreateAppletResource(u64 aruid);
+
+    Result RegisterAppletResourceUserId(u64 aruid, bool bool_value);
+    void UnregisterAppletResourceUserId(u64 aruid);
+
+    Result GetSharedMemoryHandle(Kernel::KSharedMemory** out_handle, u64 aruid);
+
+    void EnableInput(u64 aruid, bool is_enabled);
+    void EnableSixAxisSensor(u64 aruid, bool is_enabled);
+    void EnablePadInput(u64 aruid, bool is_enabled);
+    void EnableTouchScreen(u64 aruid, bool is_enabled);
+
     void UpdateControllers(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
     void UpdateNpad(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
     void UpdateMouseKeyboard(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
@@ -61,6 +83,9 @@ public:
 
 private:
     bool is_initialized{false};
+
+    mutable std::mutex shared_mutex;
+    std::shared_ptr<AppletResource> applet_resource = nullptr;
 
     std::shared_ptr<CaptureButton> capture_button = nullptr;
     std::shared_ptr<ConsoleSixAxis> console_six_axis = nullptr;
@@ -106,6 +131,8 @@ private:
     std::shared_ptr<Core::Timing::EventType> default_update_event;
     std::shared_ptr<Core::Timing::EventType> mouse_keyboard_update_event;
     std::shared_ptr<Core::Timing::EventType> motion_update_event;
+
+    std::shared_ptr<ResourceManager> resource_manager;
 };
 
 } // namespace Service::HID


### PR DESCRIPTION
This is the first actual accuracy change of project leviathan. Here we start to actually emulate `AppletResource`. Now we should care about the actual `AppletResourceUserId`(aruid) sent by games. While this change is pretty barebones I will be completing this implementation as I start migrating controllers features to use aruid values.

These changes are necessary to handle multiprocess properly in the future.