### PR TITLE
texture_pass: Fix wrong descriptor used with rectangle texture patching

### DIFF
--- a/src/shader_recompiler/ir_opt/texture_pass.cpp
+++ b/src/shader_recompiler/ir_opt/texture_pass.cpp
@@ -538,14 +538,6 @@ void TexturePass(Environment& env, IR::Program& program, const HostTranslateInfo
             flags.type.Assign(ReadTextureType(env, cbuf));
             inst->SetFlags(flags);
             break;
-        case IR::Opcode::ImageSampleImplicitLod:
-            if (flags.type != TextureType::Color2D) {
-                break;
-            }
-            if (ReadTextureType(env, cbuf) == TextureType::Color2DRect) {
-                PatchImageSampleImplicitLod(*texture_inst.block, *texture_inst.inst);
-            }
-            break;
         case IR::Opcode::ImageFetch:
             if (flags.type == TextureType::Color2D || flags.type == TextureType::Color2DRect ||
                 flags.type == TextureType::ColorArray2D) {
@@ -661,6 +653,19 @@ void TexturePass(Environment& env, IR::Program& program, const HostTranslateInfo
             if (pixel_format != TexturePixelFormat::OTHER) {
                 PatchTexelFetch(*texture_inst.block, *texture_inst.inst, pixel_format);
             }
+        }
+
+        switch (inst->GetOpcode()) {
+        case IR::Opcode::ImageSampleImplicitLod:
+            if (flags.type != TextureType::Color2D) {
+                break;
+            }
+            if (ReadTextureType(env, cbuf) == TextureType::Color2DRect) {
+                PatchImageSampleImplicitLod(*texture_inst.block, *texture_inst.inst);
+            }
+            break;
+        default:
+            break;
         }
     }
 }


### PR DESCRIPTION
PatchImageSampleImplicitLod will emit ImageQueryDimension which inherits the IR::TextureInstInfo from the instruction. However the descriptor_index is resolved in the second switch statement, which means that the query instruction wont query the correct texture in some cases.

| Before | After |
|---|---|
![bad](https://github.com/yuzu-emu/yuzu/assets/47210458/71a75d38-b7be-41be-b210-e326828eb5dc) | ![good](https://github.com/yuzu-emu/yuzu/assets/47210458/da416ea1-ea94-4efd-bd34-591516710276)
