### PR TITLE
nvnflinger: mark buffer as acquired when acquired

### DIFF
--- a/src/core/hle/service/nvnflinger/buffer_queue_core.cpp
+++ b/src/core/hle/service/nvnflinger/buffer_queue_core.cpp
@@ -74,6 +74,10 @@ void BufferQueueCore::FreeBufferLocked(s32 slot) {
 
     slots[slot].graphic_buffer.reset();
 
+    if (slots[slot].buffer_state == BufferState::Acquired) {
+        slots[slot].needs_cleanup_on_release = true;
+    }
+
     slots[slot].buffer_state = BufferState::Free;
     slots[slot].frame_number = UINT32_MAX;
     slots[slot].acquire_called = false;

--- a/src/core/hle/service/nvnflinger/buffer_slot.h
+++ b/src/core/hle/service/nvnflinger/buffer_slot.h
@@ -31,6 +31,7 @@ struct BufferSlot final {
     u64 frame_number{};
     Fence fence;
     bool acquire_called{};
+    bool needs_cleanup_on_release{};
     bool attached_by_consumer{};
     bool is_preallocated{};
 };


### PR DESCRIPTION
Previously, buffers would instantly transition from queued to free after being flipped. Somehow, this didn't break anything.