### PR TITLE
fbshare: set external format correctly

### DIFF
--- a/src/core/hle/service/nvnflinger/fb_share_buffer_manager.cpp
+++ b/src/core/hle/service/nvnflinger/fb_share_buffer_manager.cpp
@@ -171,6 +171,7 @@ void MakeGraphicBuffer(android::BufferQueueProducer& producer, u32 slot, u32 han
     buffer->height = SharedBufferHeight;
     buffer->stride = SharedBufferBlockLinearStride;
     buffer->format = SharedBufferBlockLinearFormat;
+    buffer->external_format = SharedBufferBlockLinearFormat;
     buffer->buffer_id = handle;
     buffer->offset = slot * SharedBufferSlotSize;
     ASSERT(producer.SetPreallocatedBuffer(slot, buffer) == android::Status::NoError);


### PR DESCRIPTION
Fixes assertion failures in programs using shared layers