### PR TITLE
settings: Clearer NCE error messages

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -160,12 +160,16 @@ static bool is_nce_enabled = false;
 
 void SetNceEnabled(bool is_39bit) {
     const bool is_nce_selected = values.cpu_backend.GetValue() == CpuBackend::Nce;
-    is_nce_enabled = IsFastmemEnabled() && is_nce_selected && is_39bit;
-    if (is_nce_selected && !is_nce_enabled) {
+    if (is_nce_selected && !IsFastmemEnabled()) {
+        LOG_WARNING(Common, "Fastmem is required to natively execute code in a performant manner, "
+                            "falling back to Dynarmic");
+    }
+    if (is_nce_selected && !is_39bit) {
         LOG_WARNING(
             Common,
             "Program does not utilize 39-bit address space, unable to natively execute code");
     }
+    is_nce_enabled = IsFastmemEnabled() && is_nce_selected && is_39bit;
 }
 
 bool IsNceEnabled() {


### PR DESCRIPTION
Clarify when NCE is being auto-disabled due to disabled fastmem