### PR TITLE
core: Use single instance of profile manager

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -291,9 +291,6 @@ Core::SystemResultStatus EmulationSession::InitializeEmulation(const std::string
     // Initialize filesystem.
     ConfigureFilesystemProvider(filepath);
 
-    // Initialize account manager
-    m_profile_manager = std::make_unique<Service::Account::ProfileManager>();
-
     // Load the ROM.
     m_load_result = m_system.Load(EmulationSession::GetInstance().Window(), filepath);
     if (m_load_result != Core::SystemResultStatus::Success) {
@@ -736,8 +733,8 @@ void Java_org_yuzu_yuzu_1emu_NativeLibrary_initializeEmptyUserDirectory(JNIEnv* 
     auto vfs_nand_dir = EmulationSession::GetInstance().System().GetFilesystem()->OpenDirectory(
         Common::FS::PathToUTF8String(nand_dir), FileSys::Mode::Read);
 
-    Service::Account::ProfileManager manager;
-    const auto user_id = manager.GetUser(static_cast<std::size_t>(0));
+    const auto user_id = EmulationSession::GetInstance().System().GetProfileManager().GetUser(
+        static_cast<std::size_t>(0));
     ASSERT(user_id);
 
     const auto user_save_data_path = FileSys::SaveDataFactory::GetFullPath(

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -73,7 +73,6 @@ private:
     std::atomic<bool> m_is_running = false;
     std::atomic<bool> m_is_paused = false;
     SoftwareKeyboard::AndroidKeyboard* m_software_keyboard{};
-    std::unique_ptr<Service::Account::ProfileManager> m_profile_manager;
     std::unique_ptr<FileSys::ManualContentProvider> m_manual_provider;
 
     // GPU driver parameters

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -36,6 +36,7 @@
 #include "core/hle/kernel/k_scheduler.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/physical_core.h"
+#include "core/hle/service/acc/profile_manager.h"
 #include "core/hle/service/am/applets/applets.h"
 #include "core/hle/service/apm/apm_controller.h"
 #include "core/hle/service/filesystem/filesystem.h"
@@ -130,8 +131,8 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
 struct System::Impl {
     explicit Impl(System& system)
         : kernel{system}, fs_controller{system}, memory{system}, hid_core{}, room_network{},
-          cpu_manager{system}, reporter{system}, applet_manager{system}, time_manager{system},
-          gpu_dirty_memory_write_manager{} {
+          cpu_manager{system}, reporter{system}, applet_manager{system}, profile_manager{},
+          time_manager{system}, gpu_dirty_memory_write_manager{} {
         memory.SetGPUDirtyManagers(gpu_dirty_memory_write_manager);
     }
 
@@ -532,6 +533,7 @@ struct System::Impl {
 
     /// Service State
     Service::Glue::ARPManager arp_manager;
+    Service::Account::ProfileManager profile_manager;
     Service::Time::TimeManager time_manager;
 
     /// Service manager
@@ -919,6 +921,14 @@ Service::APM::Controller& System::GetAPMController() {
 
 const Service::APM::Controller& System::GetAPMController() const {
     return impl->apm_controller;
+}
+
+Service::Account::ProfileManager& System::GetProfileManager() {
+    return impl->profile_manager;
+}
+
+const Service::Account::ProfileManager& System::GetProfileManager() const {
+    return impl->profile_manager;
 }
 
 Service::Time::TimeManager& System::GetTimeManager() {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -45,6 +45,10 @@ class Memory;
 
 namespace Service {
 
+namespace Account {
+class ProfileManager;
+} // namespace Account
+
 namespace AM::Applets {
 struct AppletFrontendSet;
 class AppletManager;
@@ -382,6 +386,9 @@ public:
 
     [[nodiscard]] Service::APM::Controller& GetAPMController();
     [[nodiscard]] const Service::APM::Controller& GetAPMController() const;
+
+    [[nodiscard]] Service::Account::ProfileManager& GetProfileManager();
+    [[nodiscard]] const Service::Account::ProfileManager& GetProfileManager() const;
 
     [[nodiscard]] Service::Time::TimeManager& GetTimeManager();
     [[nodiscard]] const Service::Time::TimeManager& GetTimeManager() const;

--- a/src/yuzu/applets/qt_profile_select.h
+++ b/src/yuzu/applets/qt_profile_select.h
@@ -7,7 +7,6 @@
 #include <QDialog>
 #include <QList>
 #include "core/frontend/applets/profile_select.h"
-#include "core/hle/service/acc/profile_manager.h"
 
 class ControllerNavigation;
 class GMainWindow;
@@ -20,15 +19,19 @@ class QStandardItemModel;
 class QTreeView;
 class QVBoxLayout;
 
-namespace Core::HID {
-class HIDCore;
-} // namespace Core::HID
+namespace Core {
+class System;
+}
+
+namespace Service::Account {
+class ProfileManager;
+}
 
 class QtProfileSelectionDialog final : public QDialog {
     Q_OBJECT
 
 public:
-    explicit QtProfileSelectionDialog(Core::HID::HIDCore& hid_core, QWidget* parent,
+    explicit QtProfileSelectionDialog(Core::System& system, QWidget* parent,
                                       const Core::Frontend::ProfileSelectParameters& parameters);
     ~QtProfileSelectionDialog() override;
 
@@ -58,7 +61,7 @@ private:
     QScrollArea* scroll_area;
     QDialogButtonBox* buttons;
 
-    std::unique_ptr<Service::Account::ProfileManager> profile_manager;
+    Service::Account::ProfileManager& profile_manager;
     ControllerNavigation* controller_navigation = nullptr;
 };
 

--- a/src/yuzu/configuration/configure_profile_manager.h
+++ b/src/yuzu/configuration/configure_profile_manager.h
@@ -52,7 +52,7 @@ class ConfigureProfileManager : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ConfigureProfileManager(const Core::System& system_, QWidget* parent = nullptr);
+    explicit ConfigureProfileManager(Core::System& system_, QWidget* parent = nullptr);
     ~ConfigureProfileManager() override;
 
     void ApplyConfiguration();
@@ -85,7 +85,6 @@ private:
     std::unique_ptr<Ui::ConfigureProfileManager> ui;
     bool enabled = false;
 
-    std::unique_ptr<Service::Account::ProfileManager> profile_manager;
-
+    Service::Account::ProfileManager& profile_manager;
     const Core::System& system;
 };

--- a/src/yuzu/multiplayer/lobby.cpp
+++ b/src/yuzu/multiplayer/lobby.cpp
@@ -27,9 +27,9 @@
 Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
              std::shared_ptr<Core::AnnounceMultiplayerSession> session, Core::System& system_)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint),
-      ui(std::make_unique<Ui::Lobby>()), announce_multiplayer_session(session),
-      profile_manager(std::make_unique<Service::Account::ProfileManager>()), system{system_},
-      room_network{system.GetRoomNetwork()} {
+      ui(std::make_unique<Ui::Lobby>()),
+      announce_multiplayer_session(session), system{system_}, room_network{
+                                                                  system.GetRoomNetwork()} {
     ui->setupUi(this);
 
     // setup the watcher for background connections
@@ -299,14 +299,15 @@ void Lobby::OnRefreshLobby() {
 }
 
 std::string Lobby::GetProfileUsername() {
-    const auto& current_user = profile_manager->GetUser(Settings::values.current_user.GetValue());
+    const auto& current_user =
+        system.GetProfileManager().GetUser(Settings::values.current_user.GetValue());
     Service::Account::ProfileBase profile{};
 
     if (!current_user.has_value()) {
         return "";
     }
 
-    if (!profile_manager->GetProfileBase(*current_user, profile)) {
+    if (!system.GetProfileManager().GetProfileBase(*current_user, profile)) {
         return "";
     }
 

--- a/src/yuzu/multiplayer/lobby.h
+++ b/src/yuzu/multiplayer/lobby.h
@@ -24,10 +24,6 @@ namespace Core {
 class System;
 }
 
-namespace Service::Account {
-class ProfileManager;
-}
-
 /**
  * Listing of all public games pulled from services. The lobby should be simple enough for users to
  * find the game they want to play, and join it.
@@ -103,7 +99,6 @@ private:
 
     QFutureWatcher<AnnounceMultiplayerRoom::RoomList> room_list_watcher;
     std::weak_ptr<Core::AnnounceMultiplayerSession> announce_multiplayer_session;
-    std::unique_ptr<Service::Account::ProfileManager> profile_manager;
     QFutureWatcher<void>* watcher;
     Validation validation;
     Core::System& system;

--- a/src/yuzu/play_time_manager.h
+++ b/src/yuzu/play_time_manager.h
@@ -11,6 +11,10 @@
 #include "common/common_types.h"
 #include "common/polyfill_thread.h"
 
+namespace Service::Account {
+class ProfileManager;
+}
+
 namespace PlayTime {
 
 using ProgramId = u64;
@@ -19,7 +23,7 @@ using PlayTimeDatabase = std::map<ProgramId, PlayTime>;
 
 class PlayTimeManager {
 public:
-    explicit PlayTimeManager();
+    explicit PlayTimeManager(Service::Account::ProfileManager& profile_manager);
     ~PlayTimeManager();
 
     YUZU_NON_COPYABLE(PlayTimeManager);
@@ -32,11 +36,13 @@ public:
     void Stop();
 
 private:
+    void AutoTimestamp(std::stop_token stop_token);
+    void Save();
+
     PlayTimeDatabase database;
     u64 running_program_id;
     std::jthread play_time_thread;
-    void AutoTimestamp(std::stop_token stop_token);
-    void Save();
+    Service::Account::ProfileManager& manager;
 };
 
 QString ReadablePlayTime(qulonglong time_seconds);


### PR DESCRIPTION
I counted around 13 different instances of the profile manager. This probably fixes all weirdness we have with this service specially randomly loosing your user file.