### PR TITLE
vi: fix confusion between closing and destroying layers

### DIFF
--- a/src/core/hle/service/nvnflinger/fb_share_buffer_manager.cpp
+++ b/src/core/hle/service/nvnflinger/fb_share_buffer_manager.cpp
@@ -204,8 +204,9 @@ Result FbShareBufferManager::Initialize(u64* out_buffer_id, u64* out_layer_id, u
     // Record the display id.
     m_display_id = display_id;
 
-    // Create a layer for the display.
+    // Create and open a layer for the display.
     m_layer_id = m_flinger.CreateLayer(m_display_id).value();
+    m_flinger.OpenLayer(m_layer_id);
 
     // Set up the buffer.
     m_buffer_id = m_next_buffer_id++;

--- a/src/core/hle/service/nvnflinger/nvnflinger.h
+++ b/src/core/hle/service/nvnflinger/nvnflinger.h
@@ -73,8 +73,14 @@ public:
     /// If an invalid display ID is specified, then an empty optional is returned.
     [[nodiscard]] std::optional<u64> CreateLayer(u64 display_id);
 
+    /// Opens a layer on all displays for the given layer ID.
+    void OpenLayer(u64 layer_id);
+
     /// Closes a layer on all displays for the given layer ID.
     void CloseLayer(u64 layer_id);
+
+    /// Destroys the given layer ID.
+    void DestroyLayer(u64 layer_id);
 
     /// Finds the buffer queue ID of the specified layer in the specified display.
     ///
@@ -116,11 +122,6 @@ private:
 
     /// Finds the layer identified by the specified ID in the desired display.
     [[nodiscard]] VI::Layer* FindLayer(u64 display_id, u64 layer_id);
-
-    /// Finds the layer identified by the specified ID in the desired display,
-    /// or creates the layer if it is not found.
-    /// To be used when the system expects the specified ID to already exist.
-    [[nodiscard]] VI::Layer* FindOrCreateLayer(u64 display_id, u64 layer_id);
 
     /// Creates a layer with the specified layer ID in the desired display.
     void CreateLayerAtId(VI::Display& display, u64 layer_id);

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -66,18 +66,13 @@ public:
 
     /// Whether or not this display has any layers added to it.
     bool HasLayers() const {
-        return !layers.empty();
+        return GetNumLayers() > 0;
     }
 
     /// Gets a layer for this display based off an index.
     Layer& GetLayer(std::size_t index);
 
-    /// Gets a layer for this display based off an index.
-    const Layer& GetLayer(std::size_t index) const;
-
-    std::size_t GetNumLayers() const {
-        return layers.size();
-    }
+    std::size_t GetNumLayers() const;
 
     /**
      * Gets the internal vsync event.
@@ -100,11 +95,11 @@ public:
     ///
     void CreateLayer(u64 layer_id, u32 binder_id, Service::Nvidia::NvCore::Container& core);
 
-    /// Closes and removes a layer from this display with the given ID.
+    /// Removes a layer from this display with the given ID.
     ///
-    /// @param layer_id The ID assigned to the layer to close.
+    /// @param layer_id The ID assigned to the layer to destroy.
     ///
-    void CloseLayer(u64 layer_id);
+    void DestroyLayer(u64 layer_id);
 
     /// Resets the display for a new connection.
     void Reset() {

--- a/src/core/hle/service/vi/layer/vi_layer.cpp
+++ b/src/core/hle/service/vi/layer/vi_layer.cpp
@@ -8,8 +8,8 @@ namespace Service::VI {
 Layer::Layer(u64 layer_id_, u32 binder_id_, android::BufferQueueCore& core_,
              android::BufferQueueProducer& binder_,
              std::shared_ptr<android::BufferItemConsumer>&& consumer_)
-    : layer_id{layer_id_}, binder_id{binder_id_}, core{core_}, binder{binder_}, consumer{std::move(
-                                                                                    consumer_)} {}
+    : layer_id{layer_id_}, binder_id{binder_id_}, core{core_}, binder{binder_},
+      consumer{std::move(consumer_)}, open{false} {}
 
 Layer::~Layer() = default;
 

--- a/src/core/hle/service/vi/layer/vi_layer.h
+++ b/src/core/hle/service/vi/layer/vi_layer.h
@@ -71,12 +71,25 @@ public:
         return core;
     }
 
+    bool IsOpen() const {
+        return open;
+    }
+
+    void Close() {
+        open = false;
+    }
+
+    void Open() {
+        open = true;
+    }
+
 private:
     const u64 layer_id;
     const u32 binder_id;
     android::BufferQueueCore& core;
     android::BufferQueueProducer& binder;
     std::shared_ptr<android::BufferItemConsumer> consumer;
+    bool open;
 };
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -719,6 +719,8 @@ private:
             return;
         }
 
+        nv_flinger.OpenLayer(layer_id);
+
         android::OutputParcel parcel;
         parcel.WriteInterface(NativeWindow{*buffer_queue_id});
 
@@ -783,6 +785,7 @@ private:
         const u64 layer_id = rp.Pop<u64>();
 
         LOG_WARNING(Service_VI, "(STUBBED) called. layer_id=0x{:016X}", layer_id);
+        nv_flinger.DestroyLayer(layer_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultSuccess);


### PR DESCRIPTION
When combined with the previous two fixes, Portal 2 can now go in game. The vi service implementation could use an overhaul.