### PR TITLE
vcpkg: Update fmt to 10.1.1

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "yuzu",
-    "builtin-baseline": "cbf56573a987527b39272e88cbdd11389b78c6e4",
+    "builtin-baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6",
     "version": "1.0",
     "dependencies": [
         "boost-algorithm",
@@ -50,7 +50,7 @@
         },
         {
             "name": "fmt",
-            "version": "10.0.0"
+            "version": "10.1.1"
         }
     ]
 }


### PR DESCRIPTION
Should fix compiling on the latest version of MSVC.

Fixes https://github.com/yuzu-emu/yuzu/issues/12270.