### PR TITLE
renderer_vulkan: cap async presentation frame count

### DIFF
--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -102,8 +102,8 @@ PresentManager::PresentManager(const vk::Instance& instance_,
       memory_allocator{memory_allocator_}, scheduler{scheduler_}, swapchain{swapchain_},
       surface{surface_}, blit_supported{CanBlitToSwapchain(device.GetPhysical(),
                                                            swapchain.GetImageViewFormat())},
-      use_present_thread{Settings::values.async_presentation.GetValue()},
-      image_count{swapchain.GetImageCount()} {
+      use_present_thread{Settings::values.async_presentation.GetValue()} {
+    SetImageCount();
 
     auto& dld = device.GetLogical();
     cmdpool = dld.CreateCommandPool({
@@ -289,7 +289,14 @@ void PresentManager::PresentThread(std::stop_token token) {
 
 void PresentManager::RecreateSwapchain(Frame* frame) {
     swapchain.Create(*surface, frame->width, frame->height);
-    image_count = swapchain.GetImageCount();
+    SetImageCount();
+}
+
+void PresentManager::SetImageCount() {
+    // We cannot have more than 5 images in flight at any given time.
+    // FRAMES_IN_FLIGHT is 7, and the cache TICKS_TO_DESTROY is 6.
+    // Mali drivers will give us 6.
+    image_count = std::min<size_t>(swapchain.GetImageCount(), 5);
 }
 
 void PresentManager::CopyToSwapchain(Frame* frame) {

--- a/src/video_core/renderer_vulkan/vk_present_manager.h
+++ b/src/video_core/renderer_vulkan/vk_present_manager.h
@@ -62,6 +62,8 @@ private:
 
     void RecreateSwapchain(Frame* frame);
 
+    void SetImageCount();
+
 private:
     const vk::Instance& instance;
     Core::Frontend::EmuWindow& render_window;


### PR DESCRIPTION
For various reasons we can only allow up to 6 frames to be processed at any given time. However, with async presentation enabled (especially on Android), slow rendering can cause the present queue to grow up to the maximum number of presentation images, which might result in the descriptor queue data getting clobbered and subsequent driver crashes.

Some users have previously worked around this by changing the speed limit setting, which slows down the presentation rate and can prevent these crashes. This should remove the need to do that.

Here, we force presentation to wait before the maximum number of frames which can be enqueued is reached. This should also help with input lag a bit.