### PR TITLE
Have GetActiveChannelCount return the system channels instead of host device channels

### DIFF
--- a/src/audio_core/sink/cubeb_sink.cpp
+++ b/src/audio_core/sink/cubeb_sink.cpp
@@ -253,8 +253,9 @@ CubebSink::~CubebSink() {
 #endif
 }
 
-SinkStream* CubebSink::AcquireSinkStream(Core::System& system, u32 system_channels,
+SinkStream* CubebSink::AcquireSinkStream(Core::System& system, u32 system_channels_,
                                          const std::string& name, StreamType type) {
+    system_channels = system_channels_;
     SinkStreamPtr& stream = sink_streams.emplace_back(std::make_unique<CubebSinkStream>(
         ctx, device_channels, system_channels, output_device, input_device, name, type, system));
 

--- a/src/audio_core/sink/sdl2_sink.cpp
+++ b/src/audio_core/sink/sdl2_sink.cpp
@@ -168,8 +168,9 @@ SDLSink::SDLSink(std::string_view target_device_name) {
 
 SDLSink::~SDLSink() = default;
 
-SinkStream* SDLSink::AcquireSinkStream(Core::System& system, u32 system_channels,
+SinkStream* SDLSink::AcquireSinkStream(Core::System& system, u32 system_channels_,
                                        const std::string&, StreamType type) {
+    system_channels = system_channels_;
     SinkStreamPtr& stream = sink_streams.emplace_back(std::make_unique<SDLSinkStream>(
         device_channels, system_channels, output_device, input_device, type, system));
     return stream.get();

--- a/src/audio_core/sink/sink.h
+++ b/src/audio_core/sink/sink.h
@@ -85,9 +85,21 @@ public:
      */
     virtual void SetSystemVolume(f32 volume) = 0;
 
+    /**
+     * Get the number of channels the game has set, can be different to the host hardware's support.
+     * Either 2 or 6.
+     *
+     * @return Number of device channels.
+     */
+    u32 GetSystemChannels() const {
+        return system_channels;
+    }
+
 protected:
     /// Number of device channels supported by the hardware
     u32 device_channels{2};
+    /// Number of channels the game is sending
+    u32 system_channels{2};
 };
 
 using SinkPtr = std::unique_ptr<Sink>;

--- a/src/audio_core/sink/sink_stream.cpp
+++ b/src/audio_core/sink/sink_stream.cpp
@@ -42,11 +42,9 @@ void SinkStream::AppendBuffer(SinkBuffer& buffer, std::span<s16> samples) {
         // We're given 6 channels, but our device only outputs 2, so downmix.
         // Front = 1.0
         // Center = 0.596
-        // Back = 0.707
         // LFE = 0.354
-        // 1.0 + 0.596 + 0.707 + 0.354 = 2.657, 1/2.657 = 0.37636f downscale coefficient
-        static constexpr std::array<f32, 4> down_mix_coeff{0.37636f, 0.22431056f, 0.13323144f,
-                                                           0.26608652f};
+        // Back = 0.707
+        static constexpr std::array<f32, 4> down_mix_coeff{1.0, 0.596f, 0.354f, 0.707f};
 
         for (u32 read_index = 0, write_index = 0; read_index < samples.size();
              read_index += system_channels, write_index += device_channels) {

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -359,7 +359,7 @@ private:
 
     void GetActiveChannelCount(HLERequestContext& ctx) {
         const auto& sink{system.AudioCore().GetOutputSink()};
-        u32 channel_count{sink.GetDeviceChannels()};
+        u32 channel_count{sink.GetSystemChannels()};
 
         LOG_DEBUG(Service_Audio, "(STUBBED) called. Channels={}", channel_count);
 


### PR DESCRIPTION
Games usually create their audio output using the max number of channels (6), and then afterwards query the active output device for how many channels it's actually outputting, and then they send data to match that. So a game may open audio out with 6 channels, query the device and find it only supports 2 channels, and then send 6 channels of data, but with only 2 of the channels filled, and leaving the other 4 as 0, silence.

In the case that your host output only supports 2 channels, GetActiveChannelCount will return 2, and Tales of Vesperia seems to struggle with this. It opens 6 channel output which we can't control as far as I know, but then we return 2 channels from GetActiveChannelCount back to it, and Tales of Vesperia seems to mis-calculate its audio data rate due to the 6-2 difference and we get semi-garbled audio. It's as if the game is reading its 2-channel audio as 6 channels, and speed-playing its audio 3 times faster than intended and in the wrong channels. I'm not sure if that's really the issue, but either way, this PR just has GetActiveChannelCount return the number of channels audio was opened with, hiding the host channels from games, and we just handle it in the backend instead.

This should fix the weird audio in Tales of Vesperia. Also hopefully improves the downmixing in that path as well, as all of the coefficients together should equal 1 to avoid overflow, and I hadn't normalised them previously. Thanks byte for pointing that out.