### PR TITLE
ci: fix homebrew installation issue in actions runner images

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -79,7 +79,8 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          brew install autoconf automake boost@1.83 ccache ffmpeg fmt glslang hidapi libtool libusb lz4 ninja nlohmann-json openssl pkg-config qt@5 sdl2 speexdsp zlib zlib zstd
+          # workaround for https://github.com/actions/setup-python/issues/577
+          brew install autoconf automake boost@1.83 ccache ffmpeg fmt glslang hidapi libtool libusb lz4 ninja nlohmann-json openssl pkg-config qt@5 sdl2 speexdsp zlib zlib zstd || brew link --overwrite python@3.12
       - name: Build
         run: |
           mkdir build


### PR DESCRIPTION
This got broken at some point today, so that when you run `brew install python` it now returns an error. Homebrew [explicitly rejected](https://github.com/Homebrew/brew/issues/1742) an option to force link during install so I guess this is the approach we'll be using.