### PR TITLE
common: use memory holepunching when clearing memory

### DIFF
--- a/src/common/host_memory.h
+++ b/src/common/host_memory.h
@@ -48,6 +48,8 @@ public:
 
     void EnableDirectMappedAddress();
 
+    void ClearBackingRegion(size_t physical_offset, size_t length, u32 fill_value);
+
     [[nodiscard]] u8* BackingBasePointer() noexcept {
         return backing_base;
     }

--- a/src/core/hle/kernel/k_memory_manager.cpp
+++ b/src/core/hle/kernel/k_memory_manager.cpp
@@ -421,8 +421,9 @@ Result KMemoryManager::AllocateForProcess(KPageGroup* out, size_t num_pages, u32
     } else {
         // Set all the allocated memory.
         for (const auto& block : *out) {
-            std::memset(m_system.DeviceMemory().GetPointer<void>(block.GetAddress()), fill_pattern,
-                        block.GetSize());
+            m_system.DeviceMemory().buffer.ClearBackingRegion(GetInteger(block.GetAddress()) -
+                                                                  Core::DramMemoryMap::Base,
+                                                              block.GetSize(), fill_pattern);
         }
     }
 

--- a/src/core/hle/kernel/k_page_table_base.cpp
+++ b/src/core/hle/kernel/k_page_table_base.cpp
@@ -81,6 +81,11 @@ void InvalidateInstructionCache(KernelCore& kernel, AddressType addr, u64 size) 
     }
 }
 
+void ClearBackingRegion(Core::System& system, KPhysicalAddress addr, u64 size, u32 fill_value) {
+    system.DeviceMemory().buffer.ClearBackingRegion(GetInteger(addr) - Core::DramMemoryMap::Base,
+                                                    size, fill_value);
+}
+
 template <typename AddressType>
 Result InvalidateDataCache(AddressType addr, u64 size) {
     R_SUCCEED();
@@ -1363,8 +1368,7 @@ Result KPageTableBase::MapInsecureMemory(KProcessAddress address, size_t size) {
 
     // Clear all the newly allocated pages.
     for (const auto& it : pg) {
-        std::memset(GetHeapVirtualPointer(m_kernel, it.GetAddress()),
-                    static_cast<u32>(m_heap_fill_value), it.GetSize());
+        ClearBackingRegion(m_system, it.GetAddress(), it.GetSize(), m_heap_fill_value);
     }
 
     // Lock the table.
@@ -1570,8 +1574,7 @@ Result KPageTableBase::AllocateAndMapPagesImpl(PageLinkedList* page_list, KProce
 
     // Clear all pages.
     for (const auto& it : pg) {
-        std::memset(GetHeapVirtualPointer(m_kernel, it.GetAddress()),
-                    static_cast<u32>(m_heap_fill_value), it.GetSize());
+        ClearBackingRegion(m_system, it.GetAddress(), it.GetSize(), m_heap_fill_value);
     }
 
     // Map the pages.
@@ -2159,8 +2162,7 @@ Result KPageTableBase::SetHeapSize(KProcessAddress* out, size_t size) {
 
     // Clear all the newly allocated pages.
     for (const auto& it : pg) {
-        std::memset(GetHeapVirtualPointer(m_kernel, it.GetAddress()), m_heap_fill_value,
-                    it.GetSize());
+        ClearBackingRegion(m_system, it.GetAddress(), it.GetSize(), m_heap_fill_value);
     }
 
     // Map the pages.


### PR DESCRIPTION
On Linux (and by extension Android) we can take advantage of the MADV_REMOVE extension to madvise, which deletes the backing memory and makes future reads return zero. This decreases boot time by more than a full second on all Linux-based platforms and also prevents us from needing to have 3GB available immediately on boot - the needed memory can be allocated on demand.

I could not find a way to implement this on Windows. There is simply no way to decommit a portion of a page-file backed mapping, which we use in order to support memory aliasing. This is documented in the API:
> After a page from the reserved range is committed, it cannot be freed or decommitted by calling VirtualFree.

