### PR TITLE
Save configuration profile name used by players

### DIFF
--- a/src/android/app/src/main/jni/android_config.cpp
+++ b/src/android/app/src/main/jni/android_config.cpp
@@ -21,7 +21,7 @@ void AndroidConfig::ReloadAllValues() {
 }
 
 void AndroidConfig::SaveAllValues() {
-    Save();
+    SaveValues();
     SaveAndroidValues();
 }
 

--- a/src/frontend_common/config.h
+++ b/src/frontend_common/config.h
@@ -51,7 +51,6 @@ protected:
     [[nodiscard]] bool IsCustomConfig() const;
 
     void Reload();
-    void Save();
 
     /**
      * Derived config classes must implement this so they can reload all platform-specific

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -1650,9 +1650,21 @@ void ConfigureInputPlayer::SaveProfile() {
 void ConfigureInputPlayer::UpdateInputProfiles() {
     ui->comboProfiles->clear();
 
-    for (const auto& profile_name : profiles->GetInputProfileNames()) {
+    // Set current profile as empty by default
+    int profile_index = -1;
+
+    // Add every available profile and search the player profile to set it as current one
+    auto& current_profile = Settings::values.players.GetValue()[player_index].profile_name;
+    std::vector<std::string> profile_names = profiles->GetInputProfileNames();
+    std::string profile_name;
+    for (size_t i = 0; i < profile_names.size(); i++) {
+        profile_name = profile_names[i];
         ui->comboProfiles->addItem(QString::fromStdString(profile_name));
+        if (current_profile == profile_name) {
+            profile_index = (int)i;
+        }
     }
 
-    ui->comboProfiles->setCurrentIndex(-1);
+    LOG_DEBUG(Frontend, "Setting the current input profile to index {}", profile_index);
+    ui->comboProfiles->setCurrentIndex(profile_index);
 }

--- a/src/yuzu/configuration/input_profiles.cpp
+++ b/src/yuzu/configuration/input_profiles.cpp
@@ -5,6 +5,7 @@
 
 #include "common/fs/fs.h"
 #include "common/fs/path_util.h"
+#include "common/logging/log.h"
 #include "frontend_common/config.h"
 #include "yuzu/configuration/input_profiles.h"
 
@@ -112,6 +113,8 @@ bool InputProfiles::LoadProfile(const std::string& profile_name, std::size_t pla
         map_profiles.erase(profile_name);
         return false;
     }
+
+    LOG_INFO(Config, "Loading input profile `{}`", profile_name);
 
     map_profiles[profile_name]->ReadQtControlPlayerValues(player_index);
     return true;

--- a/src/yuzu/configuration/qt_config.cpp
+++ b/src/yuzu/configuration/qt_config.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/logging/log.h"
 #include "input_common/main.h"
 #include "qt_config.h"
 #include "uisettings.h"
@@ -65,7 +66,7 @@ void QtConfig::ReloadAllValues() {
 }
 
 void QtConfig::SaveAllValues() {
-    Save();
+    SaveValues();
     SaveQtValues();
 }
 
@@ -327,7 +328,10 @@ void QtConfig::ReadMultiplayerValues() {
 
 void QtConfig::SaveQtValues() {
     if (global) {
+        LOG_DEBUG(Config, "Saving global Qt configuration values");
         SaveUIValues();
+    } else {
+        LOG_DEBUG(Config, "Saving Qt configuration values");
     }
     SaveQtControlValues();
 
@@ -545,6 +549,7 @@ void QtConfig::ReadQtControlPlayerValues(std::size_t player_index) {
 void QtConfig::SaveQtControlPlayerValues(std::size_t player_index) {
     BeginGroup(Settings::TranslateCategory(Settings::Category::Controls));
 
+    LOG_DEBUG(Config, "Saving players control configuration values");
     SavePlayerValues(player_index);
     SaveQtPlayerValues(player_index);
 

--- a/src/yuzu_cmd/sdl_config.cpp
+++ b/src/yuzu_cmd/sdl_config.cpp
@@ -5,6 +5,7 @@
 #define SDL_MAIN_HANDLED
 #include <SDL.h>
 
+#include "common/logging/log.h"
 #include "input_common/main.h"
 #include "sdl_config.h"
 
@@ -64,7 +65,7 @@ void SdlConfig::ReloadAllValues() {
 }
 
 void SdlConfig::SaveAllValues() {
-    Save();
+    SaveValues();
     SaveSdlValues();
 }
 
@@ -177,6 +178,7 @@ void SdlConfig::ReadHidbusValues() {
 }
 
 void SdlConfig::SaveSdlValues() {
+    LOG_DEBUG(Config, "Saving SDL configuration values");
     SaveSdlControlValues();
 
     WriteToIni();


### PR DESCRIPTION
For each player, the controller configuration profile name is saved in the qt-config.ini file. The one selected is restored when opening the configuration window, even after closing yuzu