### PR TITLE
path_util: copy output for GetParentPath

### DIFF
--- a/src/common/fs/path_util.cpp
+++ b/src/common/fs/path_util.cpp
@@ -418,9 +418,9 @@ std::string SanitizePath(std::string_view path_, DirectorySeparator directory_se
     return std::string(RemoveTrailingSlash(path));
 }
 
-std::string_view GetParentPath(std::string_view path) {
+std::string GetParentPath(std::string_view path) {
     if (path.empty()) {
-        return path;
+        return std::string(path);
     }
 
 #ifdef ANDROID
@@ -439,7 +439,7 @@ std::string_view GetParentPath(std::string_view path) {
         name_index = std::max(name_bck_index, name_fwd_index);
     }
 
-    return path.substr(0, name_index);
+    return std::string(path.substr(0, name_index));
 }
 
 std::string_view GetPathWithoutTop(std::string_view path) {

--- a/src/common/fs/path_util.h
+++ b/src/common/fs/path_util.h
@@ -302,7 +302,7 @@ enum class DirectorySeparator {
     DirectorySeparator directory_separator = DirectorySeparator::ForwardSlash);
 
 // Gets all of the text up to the last '/' or '\' in the path.
-[[nodiscard]] std::string_view GetParentPath(std::string_view path);
+[[nodiscard]] std::string GetParentPath(std::string_view path);
 
 // Gets all of the text after the first '/' or '\' in the path.
 [[nodiscard]] std::string_view GetPathWithoutTop(std::string_view path);


### PR DESCRIPTION
This resolves a lifetime issue where a reference to a temporary would be returned. After checking the Android ifdefs, this seems to be the only case where this happened.