### PR TITLE
renderer_vulkan: work around turnip binding bug in a610

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -695,6 +695,11 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
             std::min(properties.properties.limits.maxVertexInputBindings, 16U);
     }
 
+    if (is_turnip) {
+        LOG_WARNING(Render_Vulkan, "Turnip requires higher-than-reported binding limits");
+        properties.properties.limits.maxVertexInputBindings = 32;
+    }
+
     if (!extensions.extended_dynamic_state && extensions.extended_dynamic_state2) {
         LOG_INFO(Render_Vulkan,
                  "Removing extendedDynamicState2 due to missing extendedDynamicState");


### PR DESCRIPTION
PR #11471 changed yuzu to be able to respect the maximum vertex binding count of the driver. There was a minor issue in how this was implemented, which is now fixed.

Bizarrely, respecting the maximum binding count and binding all 16 buffers causes Turnip on a610 to device loss on any guest program, when using either vkCmdBindVertexBuffers2EXT or vkCmdBindVertexBuffers - it seems that you _have_ to use the API incorrectly and bind too many buffers to avoid this. I didn't try binding the inputs one at a time, but suspect it might also work.

This needs to be reported to mesa.