### PR TITLE
vk_query_cache: Fix prefix sum max_accumulation_limit logic

### DIFF
--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -289,12 +289,15 @@ public:
         }
 
         if (has_multi_queries) {
-            size_t intermediary_buffer_index = ObtainBuffer<false>(num_slots_used);
+            const size_t min_accumulation_limit =
+                std::min(first_accumulation_checkpoint, num_slots_used);
+            const size_t max_accumulation_limit =
+                std::max(last_accumulation_checkpoint, num_slots_used);
+            const size_t intermediary_buffer_index = ObtainBuffer<false>(num_slots_used);
             resolve_buffers.push_back(intermediary_buffer_index);
             queries_prefix_scan_pass->Run(*accumulation_buffer, *buffers[intermediary_buffer_index],
                                           *buffers[resolve_buffer_index], num_slots_used,
-                                          std::min(first_accumulation_checkpoint, num_slots_used),
-                                          last_accumulation_checkpoint);
+                                          min_accumulation_limit, max_accumulation_limit);
 
         } else {
             scheduler.RequestOutsideRenderPassOperationContext();


### PR DESCRIPTION
There's an assumption that ResetCounter() would be called before reporting the counter value, but that's not always the case. 

When ResetCounter() is not called, `last_accumulation_checkpoint` would not be updated, passing in 0 as the `max_accumulation_base` to the prefix sum shader...
https://github.com/yuzu-emu/yuzu/blob/b8c50276869aa98bc3cf2622a18c08cf1fb66315/src/video_core/host_shaders/queries_prefix_scan_sum.comp#L107

This happens in Luigi's Mansion 3