### PR TITLE
yuzu: Make language persistent and remove symbols_path

### DIFF
--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -193,8 +193,8 @@ void ConfigureUi::RequestGameListUpdate() {
 void ConfigureUi::SetConfiguration() {
     ui->theme_combobox->setCurrentIndex(
         ui->theme_combobox->findData(QString::fromStdString(UISettings::values.theme)));
-    ui->language_combobox->setCurrentIndex(
-        ui->language_combobox->findData(QString::fromStdString(UISettings::values.language)));
+    ui->language_combobox->setCurrentIndex(ui->language_combobox->findData(
+        QString::fromStdString(UISettings::values.language.GetValue())));
     ui->show_add_ons->setChecked(UISettings::values.show_add_ons.GetValue());
     ui->show_compat->setChecked(UISettings::values.show_compat.GetValue());
     ui->show_size->setChecked(UISettings::values.show_size.GetValue());

--- a/src/yuzu/configuration/qt_config.cpp
+++ b/src/yuzu/configuration/qt_config.cpp
@@ -187,7 +187,6 @@ void QtConfig::ReadPathValues() {
     BeginGroup(Settings::TranslateCategory(Settings::Category::Paths));
 
     UISettings::values.roms_path = ReadStringSetting(std::string("romsPath"));
-    UISettings::values.symbols_path = ReadStringSetting(std::string("symbolsPath"));
     UISettings::values.game_dir_deprecated =
         ReadStringSetting(std::string("gameListRootDir"), std::string("."));
     UISettings::values.game_dir_deprecated_deepscan =
@@ -225,8 +224,6 @@ void QtConfig::ReadPathValues() {
     UISettings::values.recent_files =
         QString::fromStdString(ReadStringSetting(std::string("recentFiles")))
             .split(QStringLiteral(", "), Qt::SkipEmptyParts, Qt::CaseSensitive);
-    UISettings::values.language =
-        ReadStringSetting(std::string("language"), std::make_optional(std::string("")));
 
     EndGroup();
 }
@@ -409,7 +406,6 @@ void QtConfig::SavePathValues() {
     BeginGroup(Settings::TranslateCategory(Settings::Category::Paths));
 
     WriteSetting(std::string("romsPath"), UISettings::values.roms_path);
-    WriteSetting(std::string("symbolsPath"), UISettings::values.symbols_path);
     BeginArray(std::string("gamedirs"));
     for (int i = 0; i < UISettings::values.game_dirs.size(); ++i) {
         SetArrayIndex(i);
@@ -422,7 +418,6 @@ void QtConfig::SavePathValues() {
 
     WriteSetting(std::string("recentFiles"),
                  UISettings::values.recent_files.join(QStringLiteral(", ")).toStdString());
-    WriteSetting(std::string("language"), UISettings::values.language);
 
     EndGroup();
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -5147,12 +5147,12 @@ void GMainWindow::UpdateUITheme() {
 void GMainWindow::LoadTranslation() {
     bool loaded;
 
-    if (UISettings::values.language.empty()) {
+    if (UISettings::values.language.GetValue().empty()) {
         // If the selected language is empty, use system locale
         loaded = translator.load(QLocale(), {}, {}, QStringLiteral(":/languages/"));
     } else {
         // Otherwise load from the specified file
-        loaded = translator.load(QString::fromStdString(UISettings::values.language),
+        loaded = translator.load(QString::fromStdString(UISettings::values.language.GetValue()),
                                  QStringLiteral(":/languages/"));
     }
 
@@ -5164,7 +5164,7 @@ void GMainWindow::LoadTranslation() {
 }
 
 void GMainWindow::OnLanguageChanged(const QString& locale) {
-    if (UISettings::values.language != std::string("en")) {
+    if (UISettings::values.language.GetValue() != std::string("en")) {
         qApp->removeTranslator(&translator);
     }
 

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -154,12 +154,11 @@ struct Values {
     Setting<u32> screenshot_height{linkage, 0, "screenshot_height", Category::Screenshots};
 
     std::string roms_path;
-    std::string symbols_path;
     std::string game_dir_deprecated;
     bool game_dir_deprecated_deepscan;
     QVector<GameDir> game_dirs;
     QStringList recent_files;
-    std::string language;
+    Setting<std::string> language{linkage, {}, "language", Category::Paths};
 
     std::string theme;
 


### PR DESCRIPTION
Symbols path seems unused. Language wasn't saved with default value but it was read with one. This made yuzu to load the default value every time. This change ensures it will be saved/read properly.