### PR TITLE
shader_recompiler: patch small float image writes

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -74,9 +74,17 @@ spv::ImageFormat GetImageFormat(ImageFormat format) {
     throw InvalidArgument("Invalid image format {}", format);
 }
 
+Id GetImageSampledType(EmitContext& ctx, const ImageDescriptor& desc) {
+    if (desc.is_float) {
+        return ctx.F32[1];
+    } else {
+        return ctx.U32[1];
+    }
+}
+
 Id ImageType(EmitContext& ctx, const ImageDescriptor& desc) {
     const spv::ImageFormat format{GetImageFormat(desc.format)};
-    const Id type{ctx.U32[1]};
+    const Id type{GetImageSampledType(ctx, desc)};
     switch (desc.type) {
     case TextureType::Color1D:
         return ctx.TypeImage(type, spv::Dim::Dim1D, false, false, false, 2, format);

--- a/src/shader_recompiler/frontend/ir/opcodes.inc
+++ b/src/shader_recompiler/frontend/ir/opcodes.inc
@@ -512,7 +512,7 @@ OPCODE(ImageQueryDimensions,                                U32x4,          Opaq
 OPCODE(ImageQueryLod,                                       F32x4,          Opaque,         Opaque,                                                         )
 OPCODE(ImageGradient,                                       F32x4,          Opaque,         Opaque,         Opaque,         Opaque,         Opaque,         )
 OPCODE(ImageRead,                                           U32x4,          Opaque,         Opaque,                                                         )
-OPCODE(ImageWrite,                                          Void,           Opaque,         Opaque,         U32x4,                                          )
+OPCODE(ImageWrite,                                          Void,           Opaque,         Opaque,         Opaque,                                         )
 
 OPCODE(IsTextureScaled,                                     U1,             U32,                                                                            )
 OPCODE(IsImageScaled,                                       U1,             U32,                                                                            )

--- a/src/shader_recompiler/host_translate_info.h
+++ b/src/shader_recompiler/host_translate_info.h
@@ -19,8 +19,10 @@ struct HostTranslateInfo {
     u32 min_ssbo_alignment{};            ///< Minimum alignment supported by the device for SSBOs
     bool support_geometry_shader_passthrough{}; ///< True when the device supports geometry
                                                 ///< passthrough shaders
-    bool support_conditional_barrier{}; ///< True when the device supports barriers in conditional
-                                        ///< control flow
+    bool support_conditional_barrier{};  ///< True when the device supports barriers in conditional
+                                         ///< control flow
+    bool support_ufloat_write_as_uint{}; ///< True when the device supports writing float images
+                                         ///< as bitcasts to uint
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -42,6 +42,7 @@ enum class TexturePixelFormat : u32 {
     R16G16B16A16_SNORM,
     R16G16_SNORM,
     R16_SNORM,
+    B10G11R11_FLOAT,
     OTHER
 };
 
@@ -129,6 +130,7 @@ struct ImageDescriptor {
     ImageFormat format;
     bool is_written;
     bool is_read;
+    bool is_float;
     u32 cbuf_index;
     u32 cbuf_offset;
     u32 count;

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -245,6 +245,7 @@ ShaderCache::ShaderCache(RasterizerOpenGL& rasterizer_, Core::Frontend::EmuWindo
           .min_ssbo_alignment = static_cast<u32>(device.GetShaderStorageBufferAlignment()),
           .support_geometry_shader_passthrough = device.HasGeometryShaderPassthrough(),
           .support_conditional_barrier = device.SupportsConditionalBarriers(),
+          .support_ufloat_write_as_uint = true,
       } {
     if (use_asynchronous_shaders) {
         workers = CreateWorkers();

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -388,6 +388,8 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .min_ssbo_alignment = static_cast<u32>(device.GetStorageBufferAlignment()),
         .support_geometry_shader_passthrough = device.IsNvGeometryShaderPassthroughSupported(),
         .support_conditional_barrier = device.SupportsConditionalBarriers(),
+        .support_ufloat_write_as_uint =
+            driver_id != VK_DRIVER_ID_QUALCOMM_PROPRIETARY && driver_id != VK_DRIVER_ID_MESA_TURNIP,
     };
 
     if (device.GetMaxVertexInputAttributes() < Maxwell::NumVertexAttributes) {

--- a/src/video_core/shader_environment.cpp
+++ b/src/video_core/shader_environment.cpp
@@ -76,6 +76,8 @@ static Shader::TexturePixelFormat ConvertTexturePixelFormat(const Tegra::Texture
         return Shader::TexturePixelFormat::R16G16_SNORM;
     case VideoCore::Surface::PixelFormat::R16_SNORM:
         return Shader::TexturePixelFormat::R16_SNORM;
+    case VideoCore::Surface::PixelFormat::B10G11R11_FLOAT:
+        return Shader::TexturePixelFormat::B10G11R11_FLOAT;
     default:
         return Shader::TexturePixelFormat::OTHER;
     }


### PR DESCRIPTION
Both Qualcomm proprietary drivers and Turnip fail to handle the case of binding an R11G11B10_UFLOAT image as a uimage2D in a shader. Storing anything to the image does nothing. All other drivers handle this by bitcasting the uvec4 as a vec4 when processing the stored value. Edit: this is also broken on Mali. I am not sure if this behavior is spec-compliant or not, but we will work around this by ensuring we bind the image as a float.

Fixes rendering in Paper Mario: The Origami King
![screen](https://github.com/yuzu-emu/yuzu/assets/9658600/b0923b1e-0bed-4d49-8f51-6870e827d211)
