### PR TITLE
renderer_vulkan: don't pass null view when nullDescriptor is not supported

### DIFF
--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -63,6 +63,7 @@ private:
     vk::Buffer buffer;
     std::vector<BufferView> views;
     VideoCommon::UsageTracker tracker;
+    bool is_null{};
 };
 
 class QuadArrayIndexBuffer;
@@ -151,6 +152,7 @@ private:
     }
 
     void ReserveNullBuffer();
+    vk::Buffer CreateNullBuffer();
 
     const Device& device;
     MemoryAllocator& memory_allocator;


### PR DESCRIPTION
Works around yet another crash due to the lack of support for nullDescriptor.