### PR TITLE
externals: update Vulkan-Headers to v1.3.274

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ find_package(ZLIB 1.2 REQUIRED)
 find_package(zstd 1.5 REQUIRED)
 
 if (NOT YUZU_USE_EXTERNAL_VULKAN_HEADERS)
-    find_package(Vulkan 1.3.256 REQUIRED)
+    find_package(Vulkan 1.3.274 REQUIRED)
 endif()
 
 if (ENABLE_LIBUSB)

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -377,6 +377,8 @@ const char* ToString(VkResult result) noexcept {
         return "VK_OPERATION_DEFERRED_KHR";
     case VkResult::VK_OPERATION_NOT_DEFERRED_KHR:
         return "VK_OPERATION_NOT_DEFERRED_KHR";
+    case VkResult::VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR:
+        return "VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR";
     case VkResult::VK_PIPELINE_COMPILE_REQUIRED_EXT:
         return "VK_PIPELINE_COMPILE_REQUIRED_EXT";
     case VkResult::VK_RESULT_MAX_ENUM:


### PR DESCRIPTION
Similar #10017. Video encoding is [out of beta](https://www.khronos.org/blog/khronos-finalizes-vulkan-video-extensions-for-accelerated-h.264-and-h.265-encode).