### PR TITLE
gl_rasterizer: Implement DrawTransformFeedback macro

### DIFF
--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -173,5 +173,13 @@ public:
     virtual void BindChannel(Tegra::Control::ChannelState& channel) {}
 
     virtual void ReleaseChannel(s32 channel_id) {}
+
+    /// Register the address as a Transform Feedback Object
+    virtual void RegisterTransformFeedback(GPUVAddr tfb_object_addr) {}
+
+    /// Returns true when the rasterizer has Draw Transform Feedback capabilities
+    virtual bool HasDrawTransformFeedback() {
+        return false;
+    }
 };
 } // namespace VideoCore

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -376,4 +376,15 @@ void BufferCacheRuntime::BindImageBuffer(Buffer& buffer, u32 offset, u32 size, P
     *image_handles++ = buffer.View(offset, size, format);
 }
 
+void BufferCacheRuntime::BindTransformFeedbackObject(GPUVAddr tfb_object_addr) {
+    OGLTransformFeedback& tfb_object = tfb_objects[tfb_object_addr];
+    tfb_object.Create();
+    glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, tfb_object.handle);
+}
+
+GLuint BufferCacheRuntime::GetTransformFeedbackObject(GPUVAddr tfb_object_addr) {
+    ASSERT(tfb_objects.contains(tfb_object_addr));
+    return tfb_objects[tfb_object_addr].handle;
+}
+
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <span>
+#include <unordered_map>
 
 #include "common/common_types.h"
 #include "video_core/buffer_cache/buffer_cache_base.h"
@@ -121,6 +122,9 @@ public:
     void BindImageBuffer(Buffer& buffer, u32 offset, u32 size,
                          VideoCore::Surface::PixelFormat format);
 
+    void BindTransformFeedbackObject(GPUVAddr tfb_object_addr);
+    GLuint GetTransformFeedbackObject(GPUVAddr tfb_object_addr);
+
     u64 GetDeviceMemoryUsage() const;
 
     void BindFastUniformBuffer(size_t stage, u32 binding_index, u32 size) {
@@ -233,6 +237,7 @@ private:
     u32 index_buffer_offset = 0;
 
     u64 device_access_memory;
+    std::unordered_map<GPUVAddr, OGLTransformFeedback> tfb_objects;
 };
 
 struct BufferCacheParams {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -139,6 +139,12 @@ public:
 
     void ReleaseChannel(s32 channel_id) override;
 
+    void RegisterTransformFeedback(GPUVAddr tfb_object_addr) override;
+
+    bool HasDrawTransformFeedback() override {
+        return true;
+    }
+
 private:
     static constexpr size_t MAX_TEXTURES = 192;
     static constexpr size_t MAX_IMAGES = 48;

--- a/src/video_core/renderer_opengl/gl_resource_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_resource_manager.cpp
@@ -207,4 +207,21 @@ void OGLQuery::Release() {
     handle = 0;
 }
 
+void OGLTransformFeedback::Create() {
+    if (handle != 0)
+        return;
+
+    MICROPROFILE_SCOPE(OpenGL_ResourceCreation);
+    glCreateTransformFeedbacks(1, &handle);
+}
+
+void OGLTransformFeedback::Release() {
+    if (handle == 0)
+        return;
+
+    MICROPROFILE_SCOPE(OpenGL_ResourceDeletion);
+    glDeleteTransformFeedbacks(1, &handle);
+    handle = 0;
+}
+
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -323,4 +323,31 @@ public:
     GLuint handle = 0;
 };
 
+class OGLTransformFeedback final {
+public:
+    YUZU_NON_COPYABLE(OGLTransformFeedback);
+
+    OGLTransformFeedback() = default;
+
+    OGLTransformFeedback(OGLTransformFeedback&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
+
+    ~OGLTransformFeedback() {
+        Release();
+    }
+
+    OGLTransformFeedback& operator=(OGLTransformFeedback&& o) noexcept {
+        Release();
+        handle = std::exchange(o.handle, 0);
+        return *this;
+    }
+
+    /// Creates a new internal OpenGL resource and stores the handle
+    void Create();
+
+    /// Deletes the internal OpenGL resource
+    void Release();
+
+    GLuint handle = 0;
+};
+
 } // namespace OpenGL


### PR DESCRIPTION
Should be functionally equivalent to Vulkan's `DrawIndirectByteCount`. 
The macro execution takes a slightly different path for OpenGL since the TFB byte count is not readily available.

Fixes particles in XC3

https://github.com/yuzu-emu/yuzu/assets/52414509/db4e96bc-221f-4947-bd38-f4954f7880ff

