### PR TITLE
nce: hide shadowing warnings from dynarmic headers

### DIFF
--- a/src/core/arm/nce/interpreter_visitor.cpp
+++ b/src/core/arm/nce/interpreter_visitor.cpp
@@ -5,8 +5,6 @@
 #include "common/bit_cast.h"
 #include "core/arm/nce/interpreter_visitor.h"
 
-#include <dynarmic/frontend/A64/decoder/a64.h>
-
 namespace Core {
 
 template <u32 BitSize>

--- a/src/core/arm/nce/visitor_base.h
+++ b/src/core/arm/nce/visitor_base.h
@@ -4,8 +4,14 @@
 
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 #include <dynarmic/frontend/A64/a64_types.h>
+#include <dynarmic/frontend/A64/decoder/a64.h>
 #include <dynarmic/frontend/imm.h>
+
+#pragma GCC diagnostic pop
 
 namespace Core {
 


### PR DESCRIPTION
Fixes #12413