### PR TITLE
service: hid: Fix crash on InitializeVibrationDevice

### DIFF
--- a/src/core/hle/service/hid/hid_server.cpp
+++ b/src/core/hle/service/hid/hid_server.cpp
@@ -51,7 +51,7 @@ private:
         IPC::RequestParser rp{ctx};
         const auto vibration_device_handle{rp.PopRaw<Core::HID::VibrationDeviceHandle>()};
 
-        if (resource_manager != nullptr) {
+        if (resource_manager != nullptr && resource_manager->GetNpad()) {
             resource_manager->GetNpad()->InitializeVibrationDevice(vibration_device_handle);
         }
 


### PR DESCRIPTION
Our object creation is a bit messed up while I'm rewriting hid. Npad is really big, it will take me a few weeks to get something together. Patch this function to avoid breaking games like rocket league.