### PR TITLE
shader_recompiler: use float image operations on load/store when required

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -47,12 +47,14 @@ struct ImageBufferDefinition {
     Id id;
     Id image_type;
     u32 count;
+    bool is_integer;
 };
 
 struct ImageDefinition {
     Id id;
     Id image_type;
     u32 count;
+    bool is_integer;
 };
 
 struct UniformDefinitions {

--- a/src/shader_recompiler/environment.h
+++ b/src/shader_recompiler/environment.h
@@ -24,6 +24,8 @@ public:
 
     [[nodiscard]] virtual TexturePixelFormat ReadTexturePixelFormat(u32 raw_handle) = 0;
 
+    [[nodiscard]] virtual bool IsTexturePixelFormatInteger(u32 raw_handle) = 0;
+
     [[nodiscard]] virtual u32 ReadViewportTransformState() = 0;
 
     [[nodiscard]] virtual u32 TextureBoundBuffer() const = 0;

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -35,14 +35,109 @@ enum class TextureType : u32 {
 };
 constexpr u32 NUM_TEXTURE_TYPES = 9;
 
-enum class TexturePixelFormat : u32 {
+enum class TexturePixelFormat {
+    A8B8G8R8_UNORM,
     A8B8G8R8_SNORM,
+    A8B8G8R8_SINT,
+    A8B8G8R8_UINT,
+    R5G6B5_UNORM,
+    B5G6R5_UNORM,
+    A1R5G5B5_UNORM,
+    A2B10G10R10_UNORM,
+    A2B10G10R10_UINT,
+    A2R10G10B10_UNORM,
+    A1B5G5R5_UNORM,
+    A5B5G5R1_UNORM,
+    R8_UNORM,
     R8_SNORM,
-    R8G8_SNORM,
+    R8_SINT,
+    R8_UINT,
+    R16G16B16A16_FLOAT,
+    R16G16B16A16_UNORM,
     R16G16B16A16_SNORM,
-    R16G16_SNORM,
+    R16G16B16A16_SINT,
+    R16G16B16A16_UINT,
+    B10G11R11_FLOAT,
+    R32G32B32A32_UINT,
+    BC1_RGBA_UNORM,
+    BC2_UNORM,
+    BC3_UNORM,
+    BC4_UNORM,
+    BC4_SNORM,
+    BC5_UNORM,
+    BC5_SNORM,
+    BC7_UNORM,
+    BC6H_UFLOAT,
+    BC6H_SFLOAT,
+    ASTC_2D_4X4_UNORM,
+    B8G8R8A8_UNORM,
+    R32G32B32A32_FLOAT,
+    R32G32B32A32_SINT,
+    R32G32_FLOAT,
+    R32G32_SINT,
+    R32_FLOAT,
+    R16_FLOAT,
+    R16_UNORM,
     R16_SNORM,
-    OTHER
+    R16_UINT,
+    R16_SINT,
+    R16G16_UNORM,
+    R16G16_FLOAT,
+    R16G16_UINT,
+    R16G16_SINT,
+    R16G16_SNORM,
+    R32G32B32_FLOAT,
+    A8B8G8R8_SRGB,
+    R8G8_UNORM,
+    R8G8_SNORM,
+    R8G8_SINT,
+    R8G8_UINT,
+    R32G32_UINT,
+    R16G16B16X16_FLOAT,
+    R32_UINT,
+    R32_SINT,
+    ASTC_2D_8X8_UNORM,
+    ASTC_2D_8X5_UNORM,
+    ASTC_2D_5X4_UNORM,
+    B8G8R8A8_SRGB,
+    BC1_RGBA_SRGB,
+    BC2_SRGB,
+    BC3_SRGB,
+    BC7_SRGB,
+    A4B4G4R4_UNORM,
+    G4R4_UNORM,
+    ASTC_2D_4X4_SRGB,
+    ASTC_2D_8X8_SRGB,
+    ASTC_2D_8X5_SRGB,
+    ASTC_2D_5X4_SRGB,
+    ASTC_2D_5X5_UNORM,
+    ASTC_2D_5X5_SRGB,
+    ASTC_2D_10X8_UNORM,
+    ASTC_2D_10X8_SRGB,
+    ASTC_2D_6X6_UNORM,
+    ASTC_2D_6X6_SRGB,
+    ASTC_2D_10X6_UNORM,
+    ASTC_2D_10X6_SRGB,
+    ASTC_2D_10X5_UNORM,
+    ASTC_2D_10X5_SRGB,
+    ASTC_2D_10X10_UNORM,
+    ASTC_2D_10X10_SRGB,
+    ASTC_2D_12X10_UNORM,
+    ASTC_2D_12X10_SRGB,
+    ASTC_2D_12X12_UNORM,
+    ASTC_2D_12X12_SRGB,
+    ASTC_2D_8X6_UNORM,
+    ASTC_2D_8X6_SRGB,
+    ASTC_2D_6X5_UNORM,
+    ASTC_2D_6X5_SRGB,
+    E5B9G9R9_FLOAT,
+    D32_FLOAT,
+    D16_UNORM,
+    X8_D24_UNORM,
+    S8_UINT,
+    D24_UNORM_S8_UINT,
+    S8_UINT_D24_UNORM,
+    D32_FLOAT_S8_UINT,
 };
 
 enum class ImageFormat : u32 {
@@ -97,6 +192,7 @@ struct ImageBufferDescriptor {
     ImageFormat format;
     bool is_written;
     bool is_read;
+    bool is_integer;
     u32 cbuf_index;
     u32 cbuf_offset;
     u32 count;
@@ -129,6 +225,7 @@ struct ImageDescriptor {
     ImageFormat format;
     bool is_written;
     bool is_read;
+    bool is_integer;
     u32 cbuf_index;
     u32 cbuf_offset;
     u32 count;

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -51,7 +51,7 @@ using VideoCommon::LoadPipelines;
 using VideoCommon::SerializePipeline;
 using Context = ShaderContext::Context;
 
-constexpr u32 CACHE_VERSION = 9;
+constexpr u32 CACHE_VERSION = 10;
 
 template <typename Container>
 auto MakeSpan(Container& container) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -54,7 +54,7 @@ using VideoCommon::FileEnvironment;
 using VideoCommon::GenericEnvironment;
 using VideoCommon::GraphicsEnvironment;
 
-constexpr u32 CACHE_VERSION = 10;
+constexpr u32 CACHE_VERSION = 11;
 constexpr std::array<char, 8> VULKAN_CACHE_MAGIC_NUMBER{'y', 'u', 'z', 'u', 'v', 'k', 'c', 'h'};
 
 template <typename Container>

--- a/src/video_core/shader_environment.cpp
+++ b/src/video_core/shader_environment.cpp
@@ -62,23 +62,9 @@ static Shader::TextureType ConvertTextureType(const Tegra::Texture::TICEntry& en
 }
 
 static Shader::TexturePixelFormat ConvertTexturePixelFormat(const Tegra::Texture::TICEntry& entry) {
-    switch (PixelFormatFromTextureInfo(entry.format, entry.r_type, entry.g_type, entry.b_type,
-                                       entry.a_type, entry.srgb_conversion)) {
-    case VideoCore::Surface::PixelFormat::A8B8G8R8_SNORM:
-        return Shader::TexturePixelFormat::A8B8G8R8_SNORM;
-    case VideoCore::Surface::PixelFormat::R8_SNORM:
-        return Shader::TexturePixelFormat::R8_SNORM;
-    case VideoCore::Surface::PixelFormat::R8G8_SNORM:
-        return Shader::TexturePixelFormat::R8G8_SNORM;
-    case VideoCore::Surface::PixelFormat::R16G16B16A16_SNORM:
-        return Shader::TexturePixelFormat::R16G16B16A16_SNORM;
-    case VideoCore::Surface::PixelFormat::R16G16_SNORM:
-        return Shader::TexturePixelFormat::R16G16_SNORM;
-    case VideoCore::Surface::PixelFormat::R16_SNORM:
-        return Shader::TexturePixelFormat::R16_SNORM;
-    default:
-        return Shader::TexturePixelFormat::OTHER;
-    }
+    return static_cast<Shader::TexturePixelFormat>(
+        PixelFormatFromTextureInfo(entry.format, entry.r_type, entry.g_type, entry.b_type,
+                                   entry.a_type, entry.srgb_conversion));
 }
 
 static std::string_view StageToPrefix(Shader::Stage stage) {
@@ -398,6 +384,11 @@ Shader::TexturePixelFormat GraphicsEnvironment::ReadTexturePixelFormat(u32 handl
     return result;
 }
 
+bool GraphicsEnvironment::IsTexturePixelFormatInteger(u32 handle) {
+    return VideoCore::Surface::IsPixelFormatInteger(
+        static_cast<VideoCore::Surface::PixelFormat>(ReadTexturePixelFormat(handle)));
+}
+
 u32 GraphicsEnvironment::ReadViewportTransformState() {
     const auto& regs{maxwell3d->regs};
     viewport_transform_state = regs.viewport_scale_offset_enabled;
@@ -446,6 +437,11 @@ Shader::TexturePixelFormat ComputeEnvironment::ReadTexturePixelFormat(u32 handle
     const Shader::TexturePixelFormat result(ConvertTexturePixelFormat(entry));
     texture_pixel_formats.emplace(handle, result);
     return result;
+}
+
+bool ComputeEnvironment::IsTexturePixelFormatInteger(u32 handle) {
+    return VideoCore::Surface::IsPixelFormatInteger(
+        static_cast<VideoCore::Surface::PixelFormat>(ReadTexturePixelFormat(handle)));
 }
 
 u32 ComputeEnvironment::ReadViewportTransformState() {
@@ -549,6 +545,11 @@ Shader::TexturePixelFormat FileEnvironment::ReadTexturePixelFormat(u32 handle) {
         throw Shader::LogicError("Uncached read texture pixel format");
     }
     return it->second;
+}
+
+bool FileEnvironment::IsTexturePixelFormatInteger(u32 handle) {
+    return VideoCore::Surface::IsPixelFormatInteger(
+        static_cast<VideoCore::Surface::PixelFormat>(ReadTexturePixelFormat(handle)));
 }
 
 u32 FileEnvironment::ReadViewportTransformState() {

--- a/src/video_core/shader_environment.h
+++ b/src/video_core/shader_environment.h
@@ -115,6 +115,8 @@ public:
 
     Shader::TexturePixelFormat ReadTexturePixelFormat(u32 handle) override;
 
+    bool IsTexturePixelFormatInteger(u32 handle) override;
+
     u32 ReadViewportTransformState() override;
 
     std::optional<Shader::ReplaceConstant> GetReplaceConstBuffer(u32 bank, u32 offset) override;
@@ -138,6 +140,8 @@ public:
     Shader::TextureType ReadTextureType(u32 handle) override;
 
     Shader::TexturePixelFormat ReadTexturePixelFormat(u32 handle) override;
+
+    bool IsTexturePixelFormatInteger(u32 handle) override;
 
     u32 ReadViewportTransformState() override;
 
@@ -170,6 +174,8 @@ public:
     [[nodiscard]] Shader::TextureType ReadTextureType(u32 handle) override;
 
     [[nodiscard]] Shader::TexturePixelFormat ReadTexturePixelFormat(u32 handle) override;
+
+    [[nodiscard]] bool IsTexturePixelFormatInteger(u32 handle) override;
 
     [[nodiscard]] u32 ReadViewportTransformState() override;
 


### PR DESCRIPTION
This is a redo of #12407
It turns out that binding any float image type with a mismatched sampler type is actually not spec compliant (thanks to DadSchoorse🐸 on the mesa issue tracker for pointing this out:
> If a VkImageView is accessed as a result of this command, then the numeric type of the image view’s format and the Sampled Type operand of the OpTypeImage must match

This means we should make the sampled type be float for all pixel formats which are not explicitly integer. I now add the pixel format to the shader cache (and have increased the cache version, so this causes an invalidation) and test the pixel format when compiling image ops. I have also pushed required conversion into the backend to make the IR cleaner--we only want to get U32x4 on the output.

Fixes rendering on mobile drivers in Paper Mario: The Origami King
![291645471-b0923b1e-0bed-4d49-8f51-6870e827d211](https://github.com/yuzu-emu/yuzu/assets/9658600/6eb4b16a-a9c3-44c9-9e99-f8cbe2306fd2)
