### PR TITLE
OpenGL: Fixes and workaround updates for AMD

### DIFF
--- a/src/shader_recompiler/backend/glsl/emit_glsl_instructions.h
+++ b/src/shader_recompiler/backend/glsl/emit_glsl_instructions.h
@@ -651,7 +651,7 @@ void EmitImageGatherDref(EmitContext& ctx, IR::Inst& inst, const IR::Value& inde
                          std::string_view coords, const IR::Value& offset, const IR::Value& offset2,
                          std::string_view dref);
 void EmitImageFetch(EmitContext& ctx, IR::Inst& inst, const IR::Value& index,
-                    std::string_view coords, std::string_view offset, std::string_view lod,
+                    std::string_view coords, const IR::Value& offset, std::string_view lod,
                     std::string_view ms);
 void EmitImageQueryDimensions(EmitContext& ctx, IR::Inst& inst, const IR::Value& index,
                               std::string_view lod, const IR::Value& skip_mips);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1427,7 +1427,7 @@ void EmitContext::DefineInputs(const IR::Program& program) {
         if (profile.support_vertex_instance_id) {
             instance_id = DefineInput(*this, U32[1], true, spv::BuiltIn::InstanceId);
             if (loads[IR::Attribute::BaseInstance]) {
-                base_instance = DefineInput(*this, U32[1], true, spv::BuiltIn::BaseVertex);
+                base_instance = DefineInput(*this, U32[1], true, spv::BuiltIn::BaseInstance);
             }
         } else {
             instance_index = DefineInput(*this, U32[1], true, spv::BuiltIn::InstanceIndex);

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -195,9 +195,9 @@ Device::Device(Core::Frontend::EmuWindow& emu_window) {
     has_texture_shadow_lod = HasExtension(extensions, "GL_EXT_texture_shadow_lod");
     has_astc = !has_slow_software_astc && IsASTCSupported();
     has_variable_aoffi = TestVariableAoffi();
-    has_component_indexing_bug = is_amd;
+    has_component_indexing_bug = false;
     has_precise_bug = TestPreciseBug();
-    has_broken_texture_view_formats = is_amd || (!is_linux && is_intel);
+    has_broken_texture_view_formats = (!is_linux && is_intel);
     has_nv_viewport_array2 = GLAD_GL_NV_viewport_array2;
     has_derivative_control = GLAD_GL_ARB_derivative_control;
     has_vertex_buffer_unified_memory = GLAD_GL_NV_vertex_buffer_unified_memory;
@@ -238,10 +238,11 @@ Device::Device(Core::Frontend::EmuWindow& emu_window) {
     has_lmem_perf_bug = is_nvidia;
 
     strict_context_required = emu_window.StrictContextRequired();
-    // Blocks AMD and Intel OpenGL drivers on Windows from using asynchronous shader compilation.
+    // Blocks Intel OpenGL drivers on Windows from using asynchronous shader compilation.
     // Blocks EGL on Wayland from using asynchronous shader compilation.
-    use_asynchronous_shaders = Settings::values.use_asynchronous_shaders.GetValue() &&
-                               !(is_amd || (is_intel && !is_linux)) && !strict_context_required;
+    const bool blacklist_async_shaders = (is_intel && !is_linux) || strict_context_required;
+    use_asynchronous_shaders =
+        Settings::values.use_asynchronous_shaders.GetValue() && !blacklist_async_shaders;
     use_driver_cache = is_nvidia;
     supports_conditional_barriers = !is_intel;
 

--- a/src/yuzu/configuration/shared_translation.cpp
+++ b/src/yuzu/configuration/shared_translation.cpp
@@ -228,7 +228,7 @@ std::unique_ptr<ComboboxTranslationMap> ComboboxEnumeration(QWidget* parent) {
          {
              PAIR(ShaderBackend, Glsl, tr("GLSL")),
              PAIR(ShaderBackend, Glasm, tr("GLASM (Assembly Shaders, NVIDIA Only)")),
-             PAIR(ShaderBackend, SpirV, tr("SPIR-V (Experimental, Mesa Only)")),
+             PAIR(ShaderBackend, SpirV, tr("SPIR-V (Experimental, AMD/Mesa Only)")),
          }});
     translations->insert({Settings::EnumMetadata<Settings::GpuAccuracy>::Index(),
                           {


### PR DESCRIPTION
AMD's new OGLP driver is no longer a complete insufferable joke, but still has its issues, so it's not always viable.

This removes some of the AMD specific OpenGL workarounds that are no longer applicable, and has a few fixes.