### PR TITLE
renderer_vulkan: demote format assert to error log

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -755,10 +755,10 @@ VkFormat Device::GetSupportedFormat(VkFormat wanted_format, VkFormatFeatureFlags
     // The wanted format is not supported by hardware, search for alternatives
     const VkFormat* alternatives = GetFormatAlternatives(wanted_format);
     if (alternatives == nullptr) {
-        ASSERT_MSG(false,
-                   "Format={} with usage={} and type={} has no defined alternatives and host "
-                   "hardware does not support it",
-                   wanted_format, wanted_usage, format_type);
+        LOG_ERROR(Render_Vulkan,
+                  "Format={} with usage={} and type={} has no defined alternatives and host "
+                  "hardware does not support it",
+                  wanted_format, wanted_usage, format_type);
         return wanted_format;
     }
 
@@ -774,10 +774,10 @@ VkFormat Device::GetSupportedFormat(VkFormat wanted_format, VkFormatFeatureFlags
     }
 
     // No alternatives found, panic
-    ASSERT_MSG(false,
-               "Format={} with usage={} and type={} is not supported by the host hardware and "
-               "doesn't support any of the alternatives",
-               wanted_format, wanted_usage, format_type);
+    LOG_ERROR(Render_Vulkan,
+              "Format={} with usage={} and type={} is not supported by the host hardware and "
+              "doesn't support any of the alternatives",
+              wanted_format, wanted_usage, format_type);
     return wanted_format;
 }
 


### PR DESCRIPTION
This loop https://github.com/yuzu-emu/yuzu/blob/91290b9be4e99a9890c6545e327f600484e39914/src/video_core/renderer_vulkan/vk_texture_cache.cpp#L858-L871 enumerates all of the Maxwell-supported formats on the device to see which ones are view-compatible. Doing this will generally cause assertion failures on non-Nvidia devices because they don't support all the same formats. This should just be logged as an error instead.