### PR TITLE
renderer_vulkan: skip SetObjectNameEXT on unsupported driver

### DIFF
--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -246,7 +246,9 @@ void SetObjectName(const DeviceDispatch* dld, VkDevice device, T handle, VkObjec
         .objectHandle = reinterpret_cast<u64>(handle),
         .pObjectName = name,
     };
-    Check(dld->vkSetDebugUtilsObjectNameEXT(device, &name_info));
+    if (dld->vkSetDebugUtilsObjectNameEXT) {
+        Check(dld->vkSetDebugUtilsObjectNameEXT(device, &name_info));
+    }
 }
 
 } // Anonymous namespace


### PR DESCRIPTION
This isn't supported on the a6xx proprietary driver natively and is emulated by the validation layer. When not using the validation layer, this causes a crash with a debugging tool attached. (Not relevant for normal use)