### PR TITLE
Texture Cache: Speedup texture views invalidation

### DIFF
--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -81,6 +81,7 @@ public:
     std::vector<ImageViewId> compute_image_view_ids;
 
     std::unordered_map<TICEntry, ImageViewId> image_views;
+    std::unordered_map<ImageViewId, TICEntry> image_views_inv;
     std::unordered_map<TSCEntry, SamplerId> samplers;
 
     TextureCacheGPUMap* gpu_page_table;


### PR DESCRIPTION
This should fix the slowdowns in Pikmin 4. I have not yet been able to verify it.

Just turned this from O(n*m) to O(m) at the expense of an additional unordered map per channel.