### PR TITLE
 core_timing: minor refactors

### DIFF
--- a/src/audio_core/device/device_session.cpp
+++ b/src/audio_core/device/device_session.cpp
@@ -18,9 +18,7 @@ constexpr auto INCREMENT_TIME{5ms};
 DeviceSession::DeviceSession(Core::System& system_)
     : system{system_}, thread_event{Core::Timing::CreateEvent(
                            "AudioOutSampleTick",
-                           [this](std::uintptr_t, s64 time, std::chrono::nanoseconds) {
-                               return ThreadFunc();
-                           })} {}
+                           [this](s64 time, std::chrono::nanoseconds) { return ThreadFunc(); })} {}
 
 DeviceSession::~DeviceSession() {
     Finalize();

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -143,7 +143,8 @@ void CoreTiming::ScheduleLoopingEvent(std::chrono::nanoseconds start_time,
     event.Set();
 }
 
-void CoreTiming::UnscheduleEvent(const std::shared_ptr<EventType>& event_type, bool wait) {
+void CoreTiming::UnscheduleEvent(const std::shared_ptr<EventType>& event_type,
+                                 UnscheduleEventType type) {
     {
         std::scoped_lock lk{basic_lock};
 
@@ -161,7 +162,7 @@ void CoreTiming::UnscheduleEvent(const std::shared_ptr<EventType>& event_type, b
     }
 
     // Force any in-progress events to finish
-    if (wait) {
+    if (type == UnscheduleEventType::Wait) {
         std::scoped_lock lk{advance_lock};
     }
 }

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -72,8 +72,9 @@ void CoreTiming::Initialize(std::function<void()>&& on_thread_init_) {
 }
 
 void CoreTiming::ClearPendingEvents() {
-    std::scoped_lock lock{basic_lock};
+    std::scoped_lock lock{advance_lock, basic_lock};
     event_queue.clear();
+    event.Set();
 }
 
 void CoreTiming::Pause(bool is_paused) {

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -22,7 +22,7 @@ namespace Core::Timing {
 
 /// A callback that may be scheduled for a particular core timing event.
 using TimedCallback = std::function<std::optional<std::chrono::nanoseconds>(
-    std::uintptr_t user_data, s64 time, std::chrono::nanoseconds ns_late)>;
+    s64 time, std::chrono::nanoseconds ns_late)>;
 
 /// Contains the characteristics of a particular event.
 struct EventType {
@@ -89,22 +89,19 @@ public:
 
     /// Schedules an event in core timing
     void ScheduleEvent(std::chrono::nanoseconds ns_into_future,
-                       const std::shared_ptr<EventType>& event_type, std::uintptr_t user_data = 0,
-                       bool absolute_time = false);
+                       const std::shared_ptr<EventType>& event_type, bool absolute_time = false);
 
     /// Schedules an event which will automatically re-schedule itself with the given time, until
     /// unscheduled
     void ScheduleLoopingEvent(std::chrono::nanoseconds start_time,
                               std::chrono::nanoseconds resched_time,
                               const std::shared_ptr<EventType>& event_type,
-                              std::uintptr_t user_data = 0, bool absolute_time = false);
+                              bool absolute_time = false);
 
-    void UnscheduleEvent(const std::shared_ptr<EventType>& event_type, std::uintptr_t user_data,
-                         bool wait = true);
+    void UnscheduleEvent(const std::shared_ptr<EventType>& event_type, bool wait = true);
 
-    void UnscheduleEventWithoutWait(const std::shared_ptr<EventType>& event_type,
-                                    std::uintptr_t user_data) {
-        UnscheduleEvent(event_type, user_data, false);
+    void UnscheduleEventWithoutWait(const std::shared_ptr<EventType>& event_type) {
+        UnscheduleEvent(event_type, false);
     }
 
     void AddTicks(u64 ticks_to_add);
@@ -158,7 +155,6 @@ private:
     heap_t event_queue;
     u64 event_fifo_id = 0;
 
-    std::shared_ptr<EventType> ev_lost;
     Common::Event event{};
     Common::Event pause_event{};
     mutable std::mutex basic_lock;

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -27,12 +27,15 @@ using TimedCallback = std::function<std::optional<std::chrono::nanoseconds>(
 /// Contains the characteristics of a particular event.
 struct EventType {
     explicit EventType(TimedCallback&& callback_, std::string&& name_)
-        : callback{std::move(callback_)}, name{std::move(name_)} {}
+        : callback{std::move(callback_)}, name{std::move(name_)}, sequence_number{0} {}
 
     /// The event's callback function.
     TimedCallback callback;
     /// A pointer to the name of the event.
     const std::string name;
+    /// A monotonic sequence number, incremented when this event is
+    /// changed externally.
+    size_t sequence_number;
 };
 
 enum class UnscheduleEventType {

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -35,6 +35,11 @@ struct EventType {
     const std::string name;
 };
 
+enum class UnscheduleEventType {
+    Wait,
+    NoWait,
+};
+
 /**
  * This is a system to schedule events into the emulated machine's future. Time is measured
  * in main CPU clock cycles.
@@ -98,11 +103,8 @@ public:
                               const std::shared_ptr<EventType>& event_type,
                               bool absolute_time = false);
 
-    void UnscheduleEvent(const std::shared_ptr<EventType>& event_type, bool wait = true);
-
-    void UnscheduleEventWithoutWait(const std::shared_ptr<EventType>& event_type) {
-        UnscheduleEvent(event_type, false);
-    }
+    void UnscheduleEvent(const std::shared_ptr<EventType>& event_type,
+                         UnscheduleEventType type = UnscheduleEventType::Wait);
 
     void AddTicks(u64 ticks_to_add);
 

--- a/src/core/hle/kernel/k_hardware_timer.cpp
+++ b/src/core/hle/kernel/k_hardware_timer.cpp
@@ -10,15 +10,15 @@ namespace Kernel {
 
 void KHardwareTimer::Initialize() {
     // Create the timing callback to register with CoreTiming.
-    m_event_type = Core::Timing::CreateEvent(
-        "KHardwareTimer::Callback", [](std::uintptr_t timer_handle, s64, std::chrono::nanoseconds) {
-            reinterpret_cast<KHardwareTimer*>(timer_handle)->DoTask();
-            return std::nullopt;
-        });
+    m_event_type = Core::Timing::CreateEvent("KHardwareTimer::Callback",
+                                             [this](s64, std::chrono::nanoseconds) {
+                                                 this->DoTask();
+                                                 return std::nullopt;
+                                             });
 }
 
 void KHardwareTimer::Finalize() {
-    m_kernel.System().CoreTiming().UnscheduleEvent(m_event_type, reinterpret_cast<uintptr_t>(this));
+    m_kernel.System().CoreTiming().UnscheduleEvent(m_event_type);
     m_wakeup_time = std::numeric_limits<s64>::max();
     m_event_type.reset();
 }
@@ -57,13 +57,11 @@ void KHardwareTimer::EnableInterrupt(s64 wakeup_time) {
 
     m_wakeup_time = wakeup_time;
     m_kernel.System().CoreTiming().ScheduleEvent(std::chrono::nanoseconds{m_wakeup_time},
-                                                 m_event_type, reinterpret_cast<uintptr_t>(this),
-                                                 true);
+                                                 m_event_type, true);
 }
 
 void KHardwareTimer::DisableInterrupt() {
-    m_kernel.System().CoreTiming().UnscheduleEventWithoutWait(m_event_type,
-                                                              reinterpret_cast<uintptr_t>(this));
+    m_kernel.System().CoreTiming().UnscheduleEventWithoutWait(m_event_type);
     m_wakeup_time = std::numeric_limits<s64>::max();
 }
 

--- a/src/core/hle/kernel/k_hardware_timer.cpp
+++ b/src/core/hle/kernel/k_hardware_timer.cpp
@@ -61,7 +61,8 @@ void KHardwareTimer::EnableInterrupt(s64 wakeup_time) {
 }
 
 void KHardwareTimer::DisableInterrupt() {
-    m_kernel.System().CoreTiming().UnscheduleEventWithoutWait(m_event_type);
+    m_kernel.System().CoreTiming().UnscheduleEvent(m_event_type,
+                                                   Core::Timing::UnscheduleEventType::NoWait);
     m_wakeup_time = std::numeric_limits<s64>::max();
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -247,7 +247,7 @@ struct KernelCore::Impl {
     void InitializePreemption(KernelCore& kernel) {
         preemption_event = Core::Timing::CreateEvent(
             "PreemptionCallback",
-            [this, &kernel](std::uintptr_t, s64 time,
+            [this, &kernel](s64 time,
                             std::chrono::nanoseconds) -> std::optional<std::chrono::nanoseconds> {
                 {
                     KScopedSchedulerLock lock(kernel);

--- a/src/core/hle/service/hid/hidbus.cpp
+++ b/src/core/hle/service/hid/hidbus.cpp
@@ -49,10 +49,10 @@ HidBus::HidBus(Core::System& system_)
     // Register update callbacks
     hidbus_update_event = Core::Timing::CreateEvent(
         "Hidbus::UpdateCallback",
-        [this](std::uintptr_t user_data, s64 time,
+        [this](s64 time,
                std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
-            UpdateHidbus(user_data, ns_late);
+            UpdateHidbus(ns_late);
             return std::nullopt;
         });
 
@@ -61,10 +61,10 @@ HidBus::HidBus(Core::System& system_)
 }
 
 HidBus::~HidBus() {
-    system.CoreTiming().UnscheduleEvent(hidbus_update_event, 0);
+    system.CoreTiming().UnscheduleEvent(hidbus_update_event);
 }
 
-void HidBus::UpdateHidbus(std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+void HidBus::UpdateHidbus(std::chrono::nanoseconds ns_late) {
     if (is_hidbus_enabled) {
         for (std::size_t i = 0; i < devices.size(); ++i) {
             if (!devices[i].is_device_initializated) {

--- a/src/core/hle/service/hid/hidbus.h
+++ b/src/core/hle/service/hid/hidbus.h
@@ -108,7 +108,7 @@ private:
     void DisableJoyPollingReceiveMode(HLERequestContext& ctx);
     void SetStatusManagerType(HLERequestContext& ctx);
 
-    void UpdateHidbus(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
+    void UpdateHidbus(std::chrono::nanoseconds ns_late);
     std::optional<std::size_t> GetDeviceIndexFromHandle(BusHandle handle) const;
 
     template <typename T>

--- a/src/core/hle/service/hid/resource_manager.cpp
+++ b/src/core/hle/service/hid/resource_manager.cpp
@@ -227,8 +227,7 @@ void ResourceManager::EnableTouchScreen(u64 aruid, bool is_enabled) {
     applet_resource->EnableTouchScreen(aruid, is_enabled);
 }
 
-void ResourceManager::UpdateControllers(std::uintptr_t user_data,
-                                        std::chrono::nanoseconds ns_late) {
+void ResourceManager::UpdateControllers(std::chrono::nanoseconds ns_late) {
     auto& core_timing = system.CoreTiming();
     debug_pad->OnUpdate(core_timing);
     digitizer->OnUpdate(core_timing);
@@ -241,20 +240,19 @@ void ResourceManager::UpdateControllers(std::uintptr_t user_data,
     capture_button->OnUpdate(core_timing);
 }
 
-void ResourceManager::UpdateNpad(std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+void ResourceManager::UpdateNpad(std::chrono::nanoseconds ns_late) {
     auto& core_timing = system.CoreTiming();
     npad->OnUpdate(core_timing);
 }
 
-void ResourceManager::UpdateMouseKeyboard(std::uintptr_t user_data,
-                                          std::chrono::nanoseconds ns_late) {
+void ResourceManager::UpdateMouseKeyboard(std::chrono::nanoseconds ns_late) {
     auto& core_timing = system.CoreTiming();
     mouse->OnUpdate(core_timing);
     debug_mouse->OnUpdate(core_timing);
     keyboard->OnUpdate(core_timing);
 }
 
-void ResourceManager::UpdateMotion(std::uintptr_t user_data, std::chrono::nanoseconds ns_late) {
+void ResourceManager::UpdateMotion(std::chrono::nanoseconds ns_late) {
     auto& core_timing = system.CoreTiming();
     six_axis->OnUpdate(core_timing);
     seven_six_axis->OnUpdate(core_timing);
@@ -273,34 +271,34 @@ IAppletResource::IAppletResource(Core::System& system_, std::shared_ptr<Resource
     // Register update callbacks
     npad_update_event = Core::Timing::CreateEvent(
         "HID::UpdatePadCallback",
-        [this, resource](std::uintptr_t user_data, s64 time, std::chrono::nanoseconds ns_late)
-            -> std::optional<std::chrono::nanoseconds> {
+        [this, resource](
+            s64 time, std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
-            resource->UpdateNpad(user_data, ns_late);
+            resource->UpdateNpad(ns_late);
             return std::nullopt;
         });
     default_update_event = Core::Timing::CreateEvent(
         "HID::UpdateDefaultCallback",
-        [this, resource](std::uintptr_t user_data, s64 time, std::chrono::nanoseconds ns_late)
-            -> std::optional<std::chrono::nanoseconds> {
+        [this, resource](
+            s64 time, std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
-            resource->UpdateControllers(user_data, ns_late);
+            resource->UpdateControllers(ns_late);
             return std::nullopt;
         });
     mouse_keyboard_update_event = Core::Timing::CreateEvent(
         "HID::UpdateMouseKeyboardCallback",
-        [this, resource](std::uintptr_t user_data, s64 time, std::chrono::nanoseconds ns_late)
-            -> std::optional<std::chrono::nanoseconds> {
+        [this, resource](
+            s64 time, std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
-            resource->UpdateMouseKeyboard(user_data, ns_late);
+            resource->UpdateMouseKeyboard(ns_late);
             return std::nullopt;
         });
     motion_update_event = Core::Timing::CreateEvent(
         "HID::UpdateMotionCallback",
-        [this, resource](std::uintptr_t user_data, s64 time, std::chrono::nanoseconds ns_late)
-            -> std::optional<std::chrono::nanoseconds> {
+        [this, resource](
+            s64 time, std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto guard = LockService();
-            resource->UpdateMotion(user_data, ns_late);
+            resource->UpdateMotion(ns_late);
             return std::nullopt;
         });
 
@@ -314,10 +312,10 @@ IAppletResource::IAppletResource(Core::System& system_, std::shared_ptr<Resource
 }
 
 IAppletResource::~IAppletResource() {
-    system.CoreTiming().UnscheduleEvent(npad_update_event, 0);
-    system.CoreTiming().UnscheduleEvent(default_update_event, 0);
-    system.CoreTiming().UnscheduleEvent(mouse_keyboard_update_event, 0);
-    system.CoreTiming().UnscheduleEvent(motion_update_event, 0);
+    system.CoreTiming().UnscheduleEvent(npad_update_event);
+    system.CoreTiming().UnscheduleEvent(default_update_event);
+    system.CoreTiming().UnscheduleEvent(mouse_keyboard_update_event);
+    system.CoreTiming().UnscheduleEvent(motion_update_event);
     resource_manager->FreeAppletResourceId(aruid);
 }
 

--- a/src/core/hle/service/hid/resource_manager.h
+++ b/src/core/hle/service/hid/resource_manager.h
@@ -81,10 +81,10 @@ public:
     void EnablePadInput(u64 aruid, bool is_enabled);
     void EnableTouchScreen(u64 aruid, bool is_enabled);
 
-    void UpdateControllers(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
-    void UpdateNpad(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
-    void UpdateMouseKeyboard(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
-    void UpdateMotion(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
+    void UpdateControllers(std::chrono::nanoseconds ns_late);
+    void UpdateNpad(std::chrono::nanoseconds ns_late);
+    void UpdateMouseKeyboard(std::chrono::nanoseconds ns_late);
+    void UpdateMotion(std::chrono::nanoseconds ns_late);
 
 private:
     Result CreateAppletResourceImpl(u64 aruid);

--- a/src/core/hle/service/nvnflinger/nvnflinger.cpp
+++ b/src/core/hle/service/nvnflinger/nvnflinger.cpp
@@ -67,7 +67,7 @@ Nvnflinger::Nvnflinger(Core::System& system_, HosBinderDriverServer& hos_binder_
     // Schedule the screen composition events
     multi_composition_event = Core::Timing::CreateEvent(
         "ScreenComposition",
-        [this](std::uintptr_t, s64 time,
+        [this](s64 time,
                std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             vsync_signal.Set();
             return std::chrono::nanoseconds(GetNextTicks());
@@ -75,7 +75,7 @@ Nvnflinger::Nvnflinger(Core::System& system_, HosBinderDriverServer& hos_binder_
 
     single_composition_event = Core::Timing::CreateEvent(
         "ScreenComposition",
-        [this](std::uintptr_t, s64 time,
+        [this](s64 time,
                std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
             const auto lock_guard = Lock();
             Compose();
@@ -93,11 +93,11 @@ Nvnflinger::Nvnflinger(Core::System& system_, HosBinderDriverServer& hos_binder_
 
 Nvnflinger::~Nvnflinger() {
     if (system.IsMulticore()) {
-        system.CoreTiming().UnscheduleEvent(multi_composition_event, {});
+        system.CoreTiming().UnscheduleEvent(multi_composition_event);
         vsync_thread.request_stop();
         vsync_signal.Set();
     } else {
-        system.CoreTiming().UnscheduleEvent(single_composition_event, {});
+        system.CoreTiming().UnscheduleEvent(single_composition_event);
     }
 
     ShutdownLayers();

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -190,15 +190,15 @@ CheatEngine::CheatEngine(System& system_, std::vector<CheatEntry> cheats_,
 }
 
 CheatEngine::~CheatEngine() {
-    core_timing.UnscheduleEvent(event, 0);
+    core_timing.UnscheduleEvent(event);
 }
 
 void CheatEngine::Initialize() {
     event = Core::Timing::CreateEvent(
         "CheatEngine::FrameCallback::" + Common::HexToString(metadata.main_nso_build_id),
-        [this](std::uintptr_t user_data, s64 time,
+        [this](s64 time,
                std::chrono::nanoseconds ns_late) -> std::optional<std::chrono::nanoseconds> {
-            FrameCallback(user_data, ns_late);
+            FrameCallback(ns_late);
             return std::nullopt;
         });
     core_timing.ScheduleLoopingEvent(CHEAT_ENGINE_NS, CHEAT_ENGINE_NS, event);
@@ -239,7 +239,7 @@ void CheatEngine::Reload(std::vector<CheatEntry> reload_cheats) {
 
 MICROPROFILE_DEFINE(Cheat_Engine, "Add-Ons", "Cheat Engine", MP_RGB(70, 200, 70));
 
-void CheatEngine::FrameCallback(std::uintptr_t, std::chrono::nanoseconds ns_late) {
+void CheatEngine::FrameCallback(std::chrono::nanoseconds ns_late) {
     if (is_pending_reload.exchange(false)) {
         vm.LoadProgram(cheats);
     }

--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -70,7 +70,7 @@ public:
     void Reload(std::vector<CheatEntry> reload_cheats);
 
 private:
-    void FrameCallback(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
+    void FrameCallback(std::chrono::nanoseconds ns_late);
 
     DmntCheatVm vm;
     CheatProcessMetadata metadata;

--- a/src/core/tools/freezer.h
+++ b/src/core/tools/freezer.h
@@ -77,7 +77,7 @@ private:
     Entries::iterator FindEntry(VAddr address);
     Entries::const_iterator FindEntry(VAddr address) const;
 
-    void FrameCallback(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
+    void FrameCallback(std::chrono::nanoseconds ns_late);
     void FillEntryReads();
 
     std::atomic_bool active{false};


### PR DESCRIPTION
This simplifies and increases the robustness of client code, and solves another shutdown crash related to timing.