### PR TITLE
kernel: use simple mutex for object list container

### DIFF
--- a/src/core/hle/kernel/k_auto_object_container.cpp
+++ b/src/core/hle/kernel/k_auto_object_container.cpp
@@ -8,19 +8,22 @@
 namespace Kernel {
 
 void KAutoObjectWithListContainer::Register(KAutoObjectWithList* obj) {
-    KScopedLightLock lk(m_lock);
+    // KScopedInterruptDisable di;
+    KScopedSpinLock lk(m_lock);
 
     m_object_list.insert_unique(*obj);
 }
 
 void KAutoObjectWithListContainer::Unregister(KAutoObjectWithList* obj) {
-    KScopedLightLock lk(m_lock);
+    // KScopedInterruptDisable di;
+    KScopedSpinLock lk(m_lock);
 
     m_object_list.erase(*obj);
 }
 
 size_t KAutoObjectWithListContainer::GetOwnedCount(KProcess* owner) {
-    KScopedLightLock lk(m_lock);
+    // KScopedInterruptDisable di;
+    KScopedSpinLock lk(m_lock);
 
     return std::count_if(m_object_list.begin(), m_object_list.end(),
                          [&](const auto& obj) { return obj.GetOwner() == owner; });

--- a/src/core/hle/kernel/k_auto_object_container.h
+++ b/src/core/hle/kernel/k_auto_object_container.h
@@ -7,7 +7,7 @@
 
 #include "common/common_funcs.h"
 #include "core/hle/kernel/k_auto_object.h"
-#include "core/hle/kernel/k_light_lock.h"
+#include "core/hle/kernel/k_spin_lock.h"
 
 namespace Kernel {
 
@@ -21,32 +21,7 @@ public:
 
     using ListType = boost::intrusive::rbtree<KAutoObjectWithList>;
 
-    class ListAccessor : public KScopedLightLock {
-    public:
-        explicit ListAccessor(KAutoObjectWithListContainer* container)
-            : KScopedLightLock(container->m_lock), m_list(container->m_object_list) {}
-        explicit ListAccessor(KAutoObjectWithListContainer& container)
-            : KScopedLightLock(container.m_lock), m_list(container.m_object_list) {}
-
-        typename ListType::iterator begin() const {
-            return m_list.begin();
-        }
-
-        typename ListType::iterator end() const {
-            return m_list.end();
-        }
-
-        typename ListType::iterator find(typename ListType::const_reference ref) const {
-            return m_list.find(ref);
-        }
-
-    private:
-        ListType& m_list;
-    };
-
-    friend class ListAccessor;
-
-    KAutoObjectWithListContainer(KernelCore& kernel) : m_lock(kernel), m_object_list() {}
+    KAutoObjectWithListContainer(KernelCore& kernel) : m_lock(), m_object_list() {}
 
     void Initialize() {}
     void Finalize() {}
@@ -56,7 +31,7 @@ public:
     size_t GetOwnedCount(KProcess* owner);
 
 private:
-    KLightLock m_lock;
+    KSpinLock m_lock;
     ListType m_object_list;
 };
 

--- a/src/core/hle/kernel/k_transfer_memory.h
+++ b/src/core/hle/kernel/k_transfer_memory.h
@@ -5,6 +5,7 @@
 
 #include <optional>
 
+#include "core/hle/kernel/k_light_lock.h"
 #include "core/hle/kernel/k_page_group.h"
 #include "core/hle/kernel/slab_helpers.h"
 #include "core/hle/kernel/svc_types.h"


### PR DESCRIPTION
Until we have the framework in place to have deferred object destruction, this needs to use an OS mutex instead. Should fix an extremely rare shutdown crash in EndWait.