### PR TITLE
Revert " shader_recompiler: use minimal clip distance array "

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -74,11 +74,6 @@ std::optional<OutAttr> OutputAttrPointer(EmitContext& ctx, IR::Attribute attr) {
     case IR::Attribute::ClipDistance7: {
         const u32 base{static_cast<u32>(IR::Attribute::ClipDistance0)};
         const u32 index{static_cast<u32>(attr) - base};
-        if (index >= ctx.profile.max_user_clip_distances) {
-            LOG_WARNING(Shader, "Ignoring clip distance store {} >= {} supported", index,
-                        ctx.profile.max_user_clip_distances);
-            return std::nullopt;
-        }
         const Id clip_num{ctx.Const(index)};
         return OutputAccessChain(ctx, ctx.output_f32, ctx.clip_distances, clip_num);
     }

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1532,8 +1532,7 @@ void EmitContext::DefineOutputs(const IR::Program& program) {
         if (stage == Stage::Fragment) {
             throw NotImplementedException("Storing ClipDistance in fragment stage");
         }
-        const Id type{TypeArray(
-            F32[1], Const(std::min(info.used_clip_distances, profile.max_user_clip_distances)))};
+        const Id type{TypeArray(F32[1], Const(8U))};
         clip_distances = DefineOutput(*this, type, invocations, spv::BuiltIn::ClipDistance);
     }
     if (info.stores[IR::Attribute::Layer] &&

--- a/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
+++ b/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
@@ -913,11 +913,7 @@ void GatherInfoFromHeader(Environment& env, Info& info) {
         }
         for (size_t index = 0; index < 8; ++index) {
             const u16 mask{header.vtg.omap_systemc.clip_distances};
-            const bool used{((mask >> index) & 1) != 0};
-            info.stores.Set(IR::Attribute::ClipDistance0 + index, used);
-            if (used) {
-                info.used_clip_distances = static_cast<u32>(index) + 1;
-            }
+            info.stores.Set(IR::Attribute::ClipDistance0 + index, ((mask >> index) & 1) != 0);
         }
         info.stores.Set(IR::Attribute::PrimitiveId,
                         header.vtg.omap_systemb.primitive_array_id != 0);

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -87,8 +87,6 @@ struct Profile {
     bool has_broken_robust{};
 
     u64 min_ssbo_alignment{};
-
-    u32 max_user_clip_distances{};
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -324,8 +324,6 @@ struct Info {
     bool requires_layer_emulation{};
     IR::Attribute emulated_layer{};
 
-    u32 used_clip_distances{};
-
     boost::container::static_vector<ConstantBufferDescriptor, MAX_CBUFS>
         constant_buffer_descriptors;
     boost::container::static_vector<StorageBufferDescriptor, MAX_SSBOS> storage_buffers_descriptors;

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -233,7 +233,6 @@ ShaderCache::ShaderCache(RasterizerOpenGL& rasterizer_, Core::Frontend::EmuWindo
           .ignore_nan_fp_comparisons = true,
           .gl_max_compute_smem_size = device.GetMaxComputeSharedMemorySize(),
           .min_ssbo_alignment = device.GetShaderStorageBufferAlignment(),
-          .max_user_clip_distances = 8,
       },
       host_info{
           .support_float64 = true,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -374,7 +374,6 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .has_broken_robust =
             device.IsNvidia() && device.GetNvidiaArch() <= NvidiaArchitecture::Arch_Pascal,
         .min_ssbo_alignment = device.GetStorageBufferAlignment(),
-        .max_user_clip_distances = device.GetMaxUserClipDistances(),
     };
 
     host_info = Shader::HostTranslateInfo{

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -665,10 +665,6 @@ public:
         return properties.properties.limits.maxViewports;
     }
 
-    u32 GetMaxUserClipDistances() const {
-        return properties.properties.limits.maxClipDistances;
-    }
-
     bool SupportsConditionalBarriers() const {
         return supports_conditional_barriers;
     }


### PR DESCRIPTION
Fixes #12462

I will look at this again later.