### PR TITLE
 Port citra-emu/citra#7146: "assert/logging: Stop the logging thread and flush the backends before crashing"

### DIFF
--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -3,16 +3,19 @@
 
 #include "common/assert.h"
 #include "common/common_funcs.h"
+#include "common/logging/backend.h"
 
 #include "common/settings.h"
 
 void assert_fail_impl() {
     if (Settings::values.use_debug_asserts) {
+        Common::Log::Stop();
         Crash();
     }
 }
 
 [[noreturn]] void unreachable_impl() {
+    Common::Log::Stop();
     Crash();
     throw std::runtime_error("Unreachable code");
 }

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -208,6 +208,10 @@ public:
         instance->StartBackendThread();
     }
 
+    static void Stop() {
+        instance->StopBackendThread();
+    }
+
     Impl(const Impl&) = delete;
     Impl& operator=(const Impl&) = delete;
 
@@ -257,6 +261,15 @@ private:
                 write_logs();
             }
         });
+    }
+
+    void StopBackendThread() {
+        backend_thread.request_stop();
+        if (backend_thread.joinable()) {
+            backend_thread.join();
+        }
+
+        ForEachBackend([](Backend& backend) { backend.Flush(); });
     }
 
     Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
@@ -311,6 +324,10 @@ void Initialize() {
 
 void Start() {
     Impl::Start();
+}
+
+void Stop() {
+    Impl::Stop();
 }
 
 void DisableLoggingInTests() {

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -14,6 +14,9 @@ void Initialize();
 
 void Start();
 
+/// Explicitly stops the logger thread and flushes the buffers
+void Stop();
+
 void DisableLoggingInTests();
 
 /**


### PR DESCRIPTION
See citra-emu/citra#7146 for more details.

**Original description**:
Most of the time when an assert fails, Citra crashes without flushing the contents of the log file, leaving us with an incomplete log without the reason for assert.