### PR TITLE
video_core: Fix buffer_row_length for linear compressed textures

### DIFF
--- a/src/video_core/texture_cache/decode_bc.cpp
+++ b/src/video_core/texture_cache/decode_bc.cpp
@@ -60,66 +60,72 @@ u32 ConvertedBytesPerBlock(VideoCore::Surface::PixelFormat pixel_format) {
 }
 
 template <auto decompress, PixelFormat pixel_format>
-void DecompressBlocks(std::span<const u8> input, std::span<u8> output, Extent3D extent,
+void DecompressBlocks(std::span<const u8> input, std::span<u8> output, BufferImageCopy& copy,
                       bool is_signed = false) {
     const u32 out_bpp = ConvertedBytesPerBlock(pixel_format);
-    const u32 block_width = std::min(extent.width, BLOCK_SIZE);
-    const u32 block_height = std::min(extent.height, BLOCK_SIZE);
-    const u32 pitch = extent.width * out_bpp;
+    const u32 block_size = BlockSize(pixel_format);
+    const u32 width = copy.image_extent.width;
+    const u32 height = copy.image_extent.height * copy.image_subresource.num_layers;
+    const u32 depth = copy.image_extent.depth;
+    const u32 block_width = std::min(width, BLOCK_SIZE);
+    const u32 block_height = std::min(height, BLOCK_SIZE);
+    const u32 pitch = width * out_bpp;
     size_t input_offset = 0;
     size_t output_offset = 0;
-    for (u32 slice = 0; slice < extent.depth; ++slice) {
-        for (u32 y = 0; y < extent.height; y += block_height) {
-            size_t row_offset = 0;
-            for (u32 x = 0; x < extent.width;
-                 x += block_width, row_offset += block_width * out_bpp) {
-                const u8* src = input.data() + input_offset;
-                u8* const dst = output.data() + output_offset + row_offset;
+    for (u32 slice = 0; slice < depth; ++slice) {
+        for (u32 y = 0; y < height; y += block_height) {
+            size_t src_offset = input_offset;
+            size_t dst_offset = output_offset;
+            for (u32 x = 0; x < width; x += block_width) {
+                const u8* src = input.data() + src_offset;
+                u8* const dst = output.data() + dst_offset;
                 if constexpr (IsSigned(pixel_format)) {
-                    decompress(src, dst, x, y, extent.width, extent.height, is_signed);
+                    decompress(src, dst, x, y, width, height, is_signed);
                 } else {
-                    decompress(src, dst, x, y, extent.width, extent.height);
+                    decompress(src, dst, x, y, width, height);
                 }
-                input_offset += BlockSize(pixel_format);
+                src_offset += block_size;
+                dst_offset += block_width * out_bpp;
             }
+            input_offset += copy.buffer_row_length * block_size / block_width;
             output_offset += block_height * pitch;
         }
     }
 }
 
-void DecompressBCn(std::span<const u8> input, std::span<u8> output, Extent3D extent,
+void DecompressBCn(std::span<const u8> input, std::span<u8> output, BufferImageCopy& copy,
                    VideoCore::Surface::PixelFormat pixel_format) {
     switch (pixel_format) {
     case PixelFormat::BC1_RGBA_UNORM:
     case PixelFormat::BC1_RGBA_SRGB:
-        DecompressBlocks<bcn::DecodeBc1, PixelFormat::BC1_RGBA_UNORM>(input, output, extent);
+        DecompressBlocks<bcn::DecodeBc1, PixelFormat::BC1_RGBA_UNORM>(input, output, copy);
         break;
     case PixelFormat::BC2_UNORM:
     case PixelFormat::BC2_SRGB:
-        DecompressBlocks<bcn::DecodeBc2, PixelFormat::BC2_UNORM>(input, output, extent);
+        DecompressBlocks<bcn::DecodeBc2, PixelFormat::BC2_UNORM>(input, output, copy);
         break;
     case PixelFormat::BC3_UNORM:
     case PixelFormat::BC3_SRGB:
-        DecompressBlocks<bcn::DecodeBc3, PixelFormat::BC3_UNORM>(input, output, extent);
+        DecompressBlocks<bcn::DecodeBc3, PixelFormat::BC3_UNORM>(input, output, copy);
         break;
     case PixelFormat::BC4_SNORM:
     case PixelFormat::BC4_UNORM:
         DecompressBlocks<bcn::DecodeBc4, PixelFormat::BC4_UNORM>(
-            input, output, extent, pixel_format == PixelFormat::BC4_SNORM);
+            input, output, copy, pixel_format == PixelFormat::BC4_SNORM);
         break;
     case PixelFormat::BC5_SNORM:
     case PixelFormat::BC5_UNORM:
         DecompressBlocks<bcn::DecodeBc5, PixelFormat::BC5_UNORM>(
-            input, output, extent, pixel_format == PixelFormat::BC5_SNORM);
+            input, output, copy, pixel_format == PixelFormat::BC5_SNORM);
         break;
     case PixelFormat::BC6H_SFLOAT:
     case PixelFormat::BC6H_UFLOAT:
         DecompressBlocks<bcn::DecodeBc6, PixelFormat::BC6H_UFLOAT>(
-            input, output, extent, pixel_format == PixelFormat::BC6H_SFLOAT);
+            input, output, copy, pixel_format == PixelFormat::BC6H_SFLOAT);
         break;
     case PixelFormat::BC7_SRGB:
     case PixelFormat::BC7_UNORM:
-        DecompressBlocks<bcn::DecodeBc7, PixelFormat::BC7_UNORM>(input, output, extent);
+        DecompressBlocks<bcn::DecodeBc7, PixelFormat::BC7_UNORM>(input, output, copy);
         break;
     default:
         LOG_WARNING(HW_GPU, "Unimplemented BCn decompression {}", pixel_format);

--- a/src/video_core/texture_cache/decode_bc.h
+++ b/src/video_core/texture_cache/decode_bc.h
@@ -13,7 +13,7 @@ namespace VideoCommon {
 
 [[nodiscard]] u32 ConvertedBytesPerBlock(VideoCore::Surface::PixelFormat pixel_format);
 
-void DecompressBCn(std::span<const u8> input, std::span<u8> output, Extent3D extent,
+void DecompressBCn(std::span<const u8> input, std::span<u8> output, BufferImageCopy& copy,
                    VideoCore::Surface::PixelFormat pixel_format);
 
 } // namespace VideoCommon


### PR DESCRIPTION
For compressed textures info.pitch is the amount of bytes between one row of compressed blocks to another. Previously it was always divided by the block size, which results in the number of blocks per row, which works okay for uncompressed formats that have 1x1 blocks but breaks for compressed ones. To achieve the result Vulkan expects, which is the number of texels per row (with possible padding) we multiply with block_width first before dividing because:

buffer_row_length = pitch / (block_height * bpp) = pitch * block_width / (block_width * block_height * bpp) = pitch * block_width / block_size;

While at it, I've also adjusted the software BCn decoder to take the pitch into account so it can work with non tightly packed images.

| Before | After |
|---|---|
![0100dc701a388000_2023-12-26_16-31-38-152](https://github.com/yuzu-emu/yuzu/assets/47210458/bc8543d3-1075-44fa-9abf-0a73c2c4a6e2) | ![0100dc701a388000_2023-12-26_13-08-17-084](https://github.com/yuzu-emu/yuzu/assets/47210458/976645b3-663b-47b7-90c4-b562f0e9c198)

Fixes
https://github.com/yuzu-emu/yuzu/issues/12434