### PR TITLE
actions: android: Build relWithDebInfo on main repo

### DIFF
--- a/.ci/scripts/android/build.sh
+++ b/.ci/scripts/android/build.sh
@@ -6,7 +6,12 @@
 export NDK_CCACHE="$(which ccache)"
 ccache -s
 
-BUILD_FLAVOR=mainline
+BUILD_FLAVOR="mainline"
+
+BUILD_TYPE="release"
+if [ "${GITHUB_REPOSITORY}" == "yuzu-emu/yuzu" ]; then
+    BUILD_TYPE="relWithDebInfo"
+fi
 
 if [ ! -z "${ANDROID_KEYSTORE_B64}" ]; then
     export ANDROID_KEYSTORE_FILE="${GITHUB_WORKSPACE}/ks.jks"
@@ -15,7 +20,7 @@ fi
 
 cd src/android
 chmod +x ./gradlew
-./gradlew "assemble${BUILD_FLAVOR}Release" "bundle${BUILD_FLAVOR}Release"
+./gradlew "assemble${BUILD_FLAVOR}${BUILD_TYPE}" "bundle${BUILD_FLAVOR}${BUILD_TYPE}"
 
 ccache -s
 

--- a/.ci/scripts/android/upload.sh
+++ b/.ci/scripts/android/upload.sh
@@ -7,9 +7,16 @@
 
 REV_NAME="yuzu-${GITDATE}-${GITREV}"
 
-BUILD_FLAVOR=mainline
+BUILD_FLAVOR="mainline"
 
-cp src/android/app/build/outputs/apk/"${BUILD_FLAVOR}/release/app-${BUILD_FLAVOR}-release.apk" \
+BUILD_TYPE_LOWER="release"
+BUILD_TYPE_UPPER="Release"
+if [ "${GITHUB_REPOSITORY}" == "yuzu-emu/yuzu" ]; then
+    BUILD_TYPE_LOWER="relWithDebInfo"
+    BUILD_TYPE_UPPER="RelWithDebInfo"
+fi
+
+cp src/android/app/build/outputs/apk/"${BUILD_FLAVOR}/${BUILD_TYPE_LOWER}/app-${BUILD_FLAVOR}-${BUILD_TYPE_LOWER}.apk" \
   "artifacts/${REV_NAME}.apk"
-cp src/android/app/build/outputs/bundle/"${BUILD_FLAVOR}Release"/"app-${BUILD_FLAVOR}-release.aab" \
+cp src/android/app/build/outputs/bundle/"${BUILD_FLAVOR}${BUILD_TYPE_UPPER}"/"app-${BUILD_FLAVOR}-${BUILD_TYPE_LOWER}.aab" \
   "artifacts/${REV_NAME}.aab"


### PR DESCRIPTION
Makes it so that the yuzu-emu/yuzu repo will generate RelWithDebInfo builds and yuzu-emu/yuzu-android will generate Release builds.

Allows you to install builds from PRs alongside release builds.