### PR TITLE
Fix UI internationalization translation issue.

### DIFF
--- a/src/yuzu/configuration/configure_cpu.h
+++ b/src/yuzu/configuration/configure_cpu.h
@@ -45,7 +45,7 @@ private:
 
     const Core::System& system;
 
-    const ConfigurationShared::ComboboxTranslationMap& combobox_translations;
+    const ConfigurationShared::TranslationShared::ComboboxTranslationMap& combobox_translations;
     std::vector<std::function<void(bool)>> apply_funcs{};
 
     QComboBox* accuracy_combobox;

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -97,7 +97,7 @@ private:
     const std::function<void(Settings::AspectRatio, Settings::ResolutionSetup)> update_aspect_ratio;
 
     const Core::System& system;
-    const ConfigurationShared::ComboboxTranslationMap& combobox_translations;
+    const ConfigurationShared::TranslationShared::ComboboxTranslationMap& combobox_translations;
     const std::vector<std::pair<u32, QString>>& shader_mapping;
 
     QPushButton* api_restore_global_button;

--- a/src/yuzu/configuration/shared_translation.cpp
+++ b/src/yuzu/configuration/shared_translation.cpp
@@ -16,10 +16,9 @@
 #include "yuzu/uisettings.h"
 
 namespace ConfigurationShared {
-
-std::unique_ptr<TranslationMap> InitializeTranslations(QWidget* parent) {
+std::unique_ptr<TranslationShared::TranslationMap> TranslationShared::InitializeTranslations(
+    QWidget* parent) {
     std::unique_ptr<TranslationMap> translations = std::make_unique<TranslationMap>();
-    const auto& tr = [parent](const char* text) -> QString { return parent->tr(text); };
 
 #define INSERT(SETTINGS, ID, NAME, TOOLTIP)                                                        \
     translations->insert(std::pair{SETTINGS::values.ID.Id(), std::pair{(NAME), (TOOLTIP)}})
@@ -190,13 +189,10 @@ std::unique_ptr<TranslationMap> InitializeTranslations(QWidget* parent) {
 
     return translations;
 }
-
-std::unique_ptr<ComboboxTranslationMap> ComboboxEnumeration(QWidget* parent) {
+std::unique_ptr<TranslationShared::ComboboxTranslationMap> TranslationShared::ComboboxEnumeration(
+    QWidget* parent) {
     std::unique_ptr<ComboboxTranslationMap> translations =
         std::make_unique<ComboboxTranslationMap>();
-    const auto& tr = [&](const char* text, const char* context = "") {
-        return parent->tr(text, context);
-    };
 
 #define PAIR(ENUM, VALUE, TRANSLATION) {static_cast<u32>(Settings::ENUM::VALUE), (TRANSLATION)}
 

--- a/src/yuzu/configuration/shared_translation.h
+++ b/src/yuzu/configuration/shared_translation.h
@@ -9,19 +9,13 @@
 #include <utility>
 #include <vector>
 #include <QString>
+#include <qobject.h>
 #include "common/common_types.h"
 #include "common/settings.h"
 
 class QWidget;
 
 namespace ConfigurationShared {
-using TranslationMap = std::map<u32, std::pair<QString, QString>>;
-using ComboboxTranslations = std::vector<std::pair<u32, QString>>;
-using ComboboxTranslationMap = std::map<u32, ComboboxTranslations>;
-
-std::unique_ptr<TranslationMap> InitializeTranslations(QWidget* parent);
-
-std::unique_ptr<ComboboxTranslationMap> ComboboxEnumeration(QWidget* parent);
 
 static const std::map<Settings::AntiAliasing, QString> anti_aliasing_texts_map = {
     {Settings::AntiAliasing::None, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "None"))},
@@ -65,4 +59,17 @@ static const std::map<Settings::ShaderBackend, QString> shader_backend_texts_map
     {Settings::ShaderBackend::SpirV, QStringLiteral(QT_TRANSLATE_NOOP("GMainWindow", "SPIRV"))},
 };
 
+} // namespace ConfigurationShared
+namespace ConfigurationShared {
+class TranslationShared : public QObject {
+    Q_OBJECT
+public:
+    using TranslationMap = std::map<u32, std::pair<QString, QString>>;
+    using ComboboxTranslations = std::vector<std::pair<u32, QString>>;
+    using ComboboxTranslationMap = std::map<u32, ComboboxTranslations>;
+    static std::unique_ptr<TranslationShared::TranslationMap> InitializeTranslations(
+        QWidget* parent);
+    static std::unique_ptr<TranslationShared::ComboboxTranslationMap> ComboboxEnumeration(
+        QWidget* parent);
+};
 } // namespace ConfigurationShared

--- a/src/yuzu/configuration/shared_widget.cpp
+++ b/src/yuzu/configuration/shared_widget.cpp
@@ -132,7 +132,7 @@ QWidget* Widget::CreateCombobox(std::function<std::string()>& serializer,
     combobox = new QComboBox(this);
     combobox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
-    const ComboboxTranslations* enumeration{nullptr};
+    const TranslationShared::ComboboxTranslations* enumeration{nullptr};
     if (combobox_enumerations.contains(type)) {
         enumeration = &combobox_enumerations.at(type);
         for (const auto& [id, name] : *enumeration) {
@@ -182,7 +182,7 @@ QWidget* Widget::CreateRadioGroup(std::function<std::string()>& serializer,
     layout->setContentsMargins(0, 0, 0, 0);
     group->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
-    const ComboboxTranslations* enumeration{nullptr};
+    const TranslationShared::ComboboxTranslations* enumeration{nullptr};
     if (combobox_enumerations.contains(type)) {
         enumeration = &combobox_enumerations.at(type);
         for (const auto& [id, name] : *enumeration) {
@@ -710,8 +710,10 @@ bool Widget::Valid() const {
 
 Widget::~Widget() = default;
 
-Widget::Widget(Settings::BasicSetting* setting_, const TranslationMap& translations_,
-               const ComboboxTranslationMap& combobox_translations_, QWidget* parent_,
+Widget::Widget(Settings::BasicSetting* setting_,
+               const TranslationShared::TranslationMap& translations_,
+               const TranslationShared::ComboboxTranslationMap& combobox_translations_,
+               QWidget* parent_,
                bool runtime_lock_, std::vector<std::function<void(bool)>>& apply_funcs_,
                RequestType request, bool managed, float multiplier,
                Settings::BasicSetting* other_setting, const QString& suffix)
@@ -765,8 +767,9 @@ Widget::Widget(Settings::BasicSetting* setting_, const TranslationMap& translati
 }
 
 Builder::Builder(QWidget* parent_, bool runtime_lock_)
-    : translations{InitializeTranslations(parent_)},
-      combobox_translations{ComboboxEnumeration(parent_)}, parent{parent_}, runtime_lock{
+    : translations{TranslationShared::InitializeTranslations(parent_)},
+      combobox_translations{TranslationShared::ComboboxEnumeration(parent_)}, parent{parent_},
+      runtime_lock{
                                                                                 runtime_lock_} {}
 
 Builder::~Builder() = default;
@@ -795,7 +798,7 @@ Widget* Builder::BuildWidget(Settings::BasicSetting* setting,
     return BuildWidget(setting, apply_funcs, request, true, 1.0f, other_setting, suffix);
 }
 
-const ComboboxTranslationMap& Builder::ComboboxTranslations() const {
+const TranslationShared::ComboboxTranslationMap& Builder::ComboboxTranslations() const {
     return *combobox_translations;
 }
 

--- a/src/yuzu/configuration/shared_widget.h
+++ b/src/yuzu/configuration/shared_widget.h
@@ -67,8 +67,10 @@ public:
      * @param other_setting Second setting to modify, to replace the label with a checkbox
      * @param suffix Set to specify formats for Slider feedback labels or SpinBox
      */
-    explicit Widget(Settings::BasicSetting* setting, const TranslationMap& translations,
-                    const ComboboxTranslationMap& combobox_translations, QWidget* parent,
+    explicit Widget(Settings::BasicSetting* setting,
+                    const TranslationShared::TranslationMap& translations,
+                    const TranslationShared::ComboboxTranslationMap& combobox_translations,
+                    QWidget* parent,
                     bool runtime_lock, std::vector<std::function<void(bool)>>& apply_funcs_,
                     RequestType request = RequestType::Default, bool managed = true,
                     float multiplier = default_multiplier,
@@ -138,8 +140,8 @@ private:
                                  const std::function<void()>& touch);
 
     QWidget* parent;
-    const TranslationMap& translations;
-    const ComboboxTranslationMap& combobox_enumerations;
+    const TranslationShared::TranslationMap& translations;
+    const TranslationShared::ComboboxTranslationMap& combobox_enumerations;
     Settings::BasicSetting& setting;
     std::vector<std::function<void(bool)>>& apply_funcs;
 
@@ -165,11 +167,11 @@ public:
                         RequestType request = RequestType::Default,
                         const QString& suffix = default_suffix) const;
 
-    const ComboboxTranslationMap& ComboboxTranslations() const;
+    const TranslationShared::ComboboxTranslationMap& ComboboxTranslations() const;
 
 private:
-    std::unique_ptr<TranslationMap> translations;
-    std::unique_ptr<ComboboxTranslationMap> combobox_translations;
+    std::unique_ptr<TranslationShared::TranslationMap> translations;
+    std::unique_ptr<TranslationShared::ComboboxTranslationMap> combobox_translations;
 
     QWidget* parent;
     const bool runtime_lock;


### PR DESCRIPTION
Fix the issue of UI interface internationalization translation, the original code did not add Q_ OBJET macro, resulting in some strings not being translated.