### PR TITLE
jit: use code memory handles correctly

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -987,6 +987,8 @@ if (ARCHITECTURE_x86_64 OR ARCHITECTURE_arm64)
         arm/dynarmic/dynarmic_cp15.h
         arm/dynarmic/dynarmic_exclusive_monitor.cpp
         arm/dynarmic/dynarmic_exclusive_monitor.h
+        hle/service/jit/jit_code_memory.cpp
+        hle/service/jit/jit_code_memory.h
         hle/service/jit/jit_context.cpp
         hle/service/jit/jit_context.h
         hle/service/jit/jit.cpp

--- a/src/core/hle/service/jit/jit_code_memory.cpp
+++ b/src/core/hle/service/jit/jit_code_memory.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "core/hle/service/jit/jit_code_memory.h"
+
+namespace Service::JIT {
+
+Result CodeMemory::Initialize(Kernel::KProcess& process, Kernel::KCodeMemory& code_memory,
+                              size_t size, Kernel::Svc::MemoryPermission perm,
+                              std::mt19937_64& generate_random) {
+    auto& page_table = process.GetPageTable();
+    const u64 alias_code_start =
+        GetInteger(page_table.GetAliasCodeRegionStart()) / Kernel::PageSize;
+    const u64 alias_code_size = page_table.GetAliasCodeRegionSize() / Kernel::PageSize;
+
+    // NOTE: This will retry indefinitely until mapping the code memory succeeds.
+    while (true) {
+        // Generate a new trial address.
+        const u64 mapped_address =
+            (alias_code_start + (generate_random() % alias_code_size)) * Kernel::PageSize;
+
+        // Try to map the address
+        R_TRY_CATCH(code_memory.MapToOwner(mapped_address, size, perm)) {
+            R_CATCH(Kernel::ResultInvalidMemoryRegion) {
+                // If we could not map here, retry.
+                continue;
+            }
+        }
+        R_END_TRY_CATCH;
+
+        // Set members.
+        m_code_memory = std::addressof(code_memory);
+        m_size = size;
+        m_address = mapped_address;
+        m_perm = perm;
+
+        // Open a new reference to the code memory.
+        m_code_memory->Open();
+
+        // We succeeded.
+        R_SUCCEED();
+    }
+}
+
+void CodeMemory::Finalize() {
+    if (m_code_memory) {
+        R_ASSERT(m_code_memory->UnmapFromOwner(m_address, m_size));
+        m_code_memory->Close();
+    }
+
+    m_code_memory = nullptr;
+}
+
+} // namespace Service::JIT

--- a/src/core/hle/service/jit/jit_code_memory.h
+++ b/src/core/hle/service/jit/jit_code_memory.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <random>
+
+#include "core/hle/kernel/k_code_memory.h"
+
+namespace Service::JIT {
+
+class CodeMemory {
+public:
+    YUZU_NON_COPYABLE(CodeMemory);
+
+    explicit CodeMemory() = default;
+
+    CodeMemory(CodeMemory&& rhs) {
+        std::swap(m_code_memory, rhs.m_code_memory);
+        std::swap(m_size, rhs.m_size);
+        std::swap(m_address, rhs.m_address);
+        std::swap(m_perm, rhs.m_perm);
+    }
+
+    ~CodeMemory() {
+        this->Finalize();
+    }
+
+public:
+    Result Initialize(Kernel::KProcess& process, Kernel::KCodeMemory& code_memory, size_t size,
+                      Kernel::Svc::MemoryPermission perm, std::mt19937_64& generate_random);
+    void Finalize();
+
+    size_t GetSize() const {
+        return m_size;
+    }
+
+    u64 GetAddress() const {
+        return m_address;
+    }
+
+private:
+    Kernel::KCodeMemory* m_code_memory{};
+    size_t m_size{};
+    u64 m_address{};
+    Kernel::Svc::MemoryPermission m_perm{};
+};
+
+} // namespace Service::JIT


### PR DESCRIPTION
This allows the N64 games to work with NCE
![sm64](https://github.com/yuzu-emu/yuzu/assets/9658600/b7ba3ac8-c43b-4375-bf84-0abfc128d7bd)
