### PR TITLE
android: Small settings tweaks

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
@@ -18,7 +18,8 @@ enum class IntSetting(override val key: String) : AbstractIntSetting {
     RENDERER_ANTI_ALIASING("anti_aliasing"),
     RENDERER_SCREEN_LAYOUT("screen_layout"),
     RENDERER_ASPECT_RATIO("aspect_ratio"),
-    AUDIO_OUTPUT_ENGINE("output_engine");
+    AUDIO_OUTPUT_ENGINE("output_engine"),
+    MAX_ANISOTROPY("max_anisotropy");
 
     override fun getInt(needsGlobal: Boolean): Int = NativeConfig.getInt(key, needsGlobal)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
@@ -298,6 +298,7 @@ abstract class SettingsItem(
 
                 override val key: String = FASTMEM_COMBINED
                 override val isRuntimeModifiable: Boolean = false
+                override val pairedSettingKey = BooleanSetting.CPU_DEBUG_MODE.key
                 override val defaultValue: Boolean = true
                 override val isSwitchable: Boolean = true
                 override var global: Boolean

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
@@ -245,6 +245,15 @@ abstract class SettingsItem(
             )
             put(
                 SingleChoiceSetting(
+                    IntSetting.MAX_ANISOTROPY,
+                    R.string.anisotropic_filtering,
+                    R.string.anisotropic_filtering_description,
+                    R.array.anisoEntries,
+                    R.array.anisoValues
+                )
+            )
+            put(
+                SingleChoiceSetting(
                     IntSetting.AUDIO_OUTPUT_ENGINE,
                     R.string.audio_output_engine,
                     0,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -149,6 +149,7 @@ class SettingsFragmentPresenter(
             add(IntSetting.RENDERER_VSYNC.key)
             add(IntSetting.RENDERER_SCALING_FILTER.key)
             add(IntSetting.RENDERER_ANTI_ALIASING.key)
+            add(IntSetting.MAX_ANISOTROPY.key)
             add(IntSetting.RENDERER_SCREEN_LAYOUT.key)
             add(IntSetting.RENDERER_ASPECT_RATIO.key)
             add(BooleanSetting.PICTURE_IN_PICTURE.key)

--- a/src/android/app/src/main/res/layout/list_item_setting_switch.xml
+++ b/src/android/app/src/main/res/layout/list_item_setting_switch.xml
@@ -24,7 +24,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="24dp"
-                android:gravity="center_vertical"
+                android:layout_gravity="center_vertical"
                 android:orientation="vertical"
                 android:layout_weight="1">
 

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -267,4 +267,21 @@
         <item>3</item>
     </integer-array>
 
+    <string-array name="anisoEntries">
+        <item>@string/auto</item>
+        <item>@string/slider_default</item>
+        <item>@string/multiplier_two</item>
+        <item>@string/multiplier_four</item>
+        <item>@string/multiplier_eight</item>
+        <item>@string/multiplier_sixteen</item>
+    </string-array>
+    <integer-array name="anisoValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+    </integer-array>
+
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -225,6 +225,8 @@
     <string name="renderer_reactive_flushing_description">Improves rendering accuracy in some games at the cost of performance.</string>
     <string name="use_disk_shader_cache">Disk shader cache</string>
     <string name="use_disk_shader_cache_description">Reduces stuttering by locally storing and loading generated shaders.</string>
+    <string name="anisotropic_filtering">Anisotropic filtering</string>
+    <string name="anisotropic_filtering_description">Improves the quality of textures when viewed at oblique angles</string>
 
     <!-- Debug settings strings -->
     <string name="cpu">CPU</string>
@@ -505,6 +507,12 @@
     <!-- Audio output engines -->
     <string name="oboe">oboe</string>
     <string name="cubeb">cubeb</string>
+
+    <!-- Anisotropic filtering options -->
+    <string name="multiplier_two">2x</string>
+    <string name="multiplier_four">4x</string>
+    <string name="multiplier_eight">8x</string>
+    <string name="multiplier_sixteen">16x</string>
 
     <!-- Black backgrounds theme -->
     <string name="use_black_backgrounds">Black backgrounds</string>


### PR DESCRIPTION
Had a couple requests for these tweaks
- Hide fastmem toggle when CPU Debugging is disabled
- Expose anisotropic filtering setting
- Center switch setting title when no description is present