### PR TITLE
Fix Wayland appId

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -5342,6 +5342,10 @@ int main(int argc, char* argv[]) {
     if (QString::fromLocal8Bit(qgetenv("DISPLAY")).isEmpty()) {
         qputenv("DISPLAY", ":0");
     }
+
+    // Fix the Wayland appId. This needs to match the name of the .desktop file without the .desktop
+    // suffix.
+    QGuiApplication::setDesktopFileName(QStringLiteral("org.yuzu_emu.yuzu"));
 #endif
 
     SetHighDPIAttributes();


### PR DESCRIPTION
On compliant Wayland compositors windows are matched to their .desktop files by comparing the appId window property to the name of the .desktop file without the .deskop extension.

Qt5/6 by default set this property to the basename of the binary (IE `yuzu`) which does not match the expected value `org.yuzu_emu.yuzu`. We can fix this and fix window associations on compliant compositors (like Plasma) by using the `setDesktopFileName()` function which will set the appId window property. This is a no-op on X11 so is safe to be ran without guards.