### PR TITLE
Report more SDL errors

### DIFF
--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -20,7 +20,7 @@ EmuWindow_SDL2::EmuWindow_SDL2(InputCommon::InputSubsystem* input_subsystem_, Co
     : input_subsystem{input_subsystem_}, system{system_} {
     input_subsystem->Initialize();
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) < 0) {
-        LOG_CRITICAL(Frontend, "Failed to initialize SDL2! Exiting...");
+        LOG_CRITICAL(Frontend, "Failed to initialize SDL2: {}, Exiting...", SDL_GetError());
         exit(1);
     }
     SDL_SetMainReady();

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
@@ -28,7 +28,8 @@ EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsyste
     SDL_SysWMinfo wm;
     SDL_VERSION(&wm.version);
     if (SDL_GetWindowWMInfo(render_window, &wm) == SDL_FALSE) {
-        LOG_CRITICAL(Frontend, "Failed to get information from the window manager");
+        LOG_CRITICAL(Frontend, "Failed to get information from the window manager: {}",
+                     SDL_GetError());
         std::exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
This PR prints the errors reported by SDL's `SDL_GetError` in yuzu-cmd in some places where it previously didn't.