### PR TITLE
Add option to log synchronously, add tooltip to log filter.

### DIFF
--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -170,7 +170,7 @@ const char* GetLogClassName(Class log_class) {
         return #x;
 #define SUB(x, y)                                                                                  \
     case Class::x##_##y:                                                                           \
-        return #x "." #y;
+        return #x "_" #y;
         ALL_LOG_CLASSES()
 #undef CLS
 #undef SUB

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -559,6 +559,7 @@ struct Values {
 
     // Miscellaneous
     Setting<std::string> log_filter{linkage, "*:Info", "log_filter", Category::Miscellaneous};
+    Setting<bool> log_async{linkage, true, "log_async", Category::Miscellaneous};
     Setting<bool> use_dev_keys{linkage, false, "use_dev_keys", Category::Miscellaneous};
 
     // Network

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -73,6 +73,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->disable_loop_safety_checks->setChecked(
         Settings::values.disable_shader_loop_safety_checks.GetValue());
     ui->extended_logging->setChecked(Settings::values.extended_logging.GetValue());
+    ui->log_async->setChecked(Settings::values.log_async.GetValue());
     ui->perform_vulkan_check->setChecked(Settings::values.perform_vulkan_check.GetValue());
 
 #ifdef YUZU_USE_QT_WEB_ENGINE
@@ -115,6 +116,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Common::Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter.GetValue());
     Common::Log::SetGlobalFilter(filter);
+    Settings::values.log_async = ui->log_async->isChecked();
 }
 
 void ConfigureDebug::changeEvent(QEvent* event) {

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -164,6 +164,20 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="log_async">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="toolTip">
+            <string>When checked, logging will run asynchronously. This may cut the log on crashes.
+When unchecked, logging will run synchronously. This will slow down the emulator, but allow all logs to be written. Useful for debugging.</string>
+           </property>
+           <property name="text">
+            <string>Log asynchronously</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="0" colspan="2">
           <widget class="QWidget" name="logging_widget" native="true">
            <property name="sizePolicy">
@@ -199,7 +213,14 @@
              </widget>
             </item>
             <item>
-             <widget class="QLineEdit" name="log_filter_edit"/>
+             <widget class="QLineEdit" name="log_filter_edit">
+              <property name="toolTip">
+               <string>Log filter in the form ＜class＞:＜level＞.
+Separate multiple filters with a space.
+Levels: Trace, Debug, Info, Warning, Error, Critical
+Classes: See Common/logging/types.h</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>


### PR DESCRIPTION
Adds an option under Debug to log messages synchronously, this is intended to be useful for cases where Yuzu crashes and cuts off the log. It has a performance penalty so it's disabled by default.

Changes the log filter to use `_` as the separator instead of `.` to match the code. Also add a hint on the log filter, as I always forget how to use it after a while.