### PR TITLE
VideoCore: A few fixes to DMA and swapchain

### DIFF
--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -683,7 +683,8 @@ public:
                 } else {
                     this->m_memory.WriteBlockUnsafe(this->m_addr, this->data(), this->size_bytes());
                 }
-            } else if constexpr ((FLAGS & GuestMemoryFlags::Safe) || (FLAGS & GuestMemoryFlags::Cached)) {
+            } else if constexpr ((FLAGS & GuestMemoryFlags::Safe) ||
+                                 (FLAGS & GuestMemoryFlags::Cached)) {
                 this->m_memory.InvalidateRegion(this->m_addr, this->size_bytes());
             }
         }

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -683,7 +683,7 @@ public:
                 } else {
                     this->m_memory.WriteBlockUnsafe(this->m_addr, this->data(), this->size_bytes());
                 }
-            } else if constexpr (FLAGS & GuestMemoryFlags::Safe) {
+            } else if constexpr ((FLAGS & GuestMemoryFlags::Safe) || (FLAGS & GuestMemoryFlags::Cached)) {
                 this->m_memory.InvalidateRegion(this->m_addr, this->size_bytes());
             }
         }

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -228,7 +228,7 @@ void MaxwellDMA::CopyBlockLinearToPitch() {
 
     Core::Memory::GpuGuestMemory<u8, Core::Memory::GuestMemoryFlags::SafeRead> tmp_read_buffer(
         memory_manager, src_operand.address, src_size, &read_buffer);
-    Core::Memory::GpuGuestMemoryScoped<u8, Core::Memory::GuestMemoryFlags::SafeReadCachedWrite>
+    Core::Memory::GpuGuestMemoryScoped<u8, Core::Memory::GuestMemoryFlags::UnsafeReadCachedWrite>
         tmp_write_buffer(memory_manager, dst_operand.address, dst_size, &write_buffer);
 
     UnswizzleSubrect(tmp_write_buffer, tmp_read_buffer, bytes_per_pixel, width, height, depth,
@@ -292,7 +292,7 @@ void MaxwellDMA::CopyPitchToBlockLinear() {
     GPUVAddr dst_addr = regs.offset_out;
     Core::Memory::GpuGuestMemory<u8, Core::Memory::GuestMemoryFlags::SafeRead> tmp_read_buffer(
         memory_manager, src_addr, src_size, &read_buffer);
-    Core::Memory::GpuGuestMemoryScoped<u8, Core::Memory::GuestMemoryFlags::SafeReadCachedWrite>
+    Core::Memory::GpuGuestMemoryScoped<u8, Core::Memory::GuestMemoryFlags::UnsafeReadCachedWrite>
         tmp_write_buffer(memory_manager, dst_addr, dst_size, &write_buffer);
 
     //  If the input is linear and the output is tiled, swizzle the input and copy it over.

--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -329,7 +329,7 @@ void PresentManager::CopyToSwapchainImpl(Frame* frame) {
     // to account for that.
     const bool is_suboptimal = swapchain.NeedsRecreation();
     const bool size_changed =
-        swapchain.GetWidth() != frame->width || swapchain.GetHeight() != frame->height;
+        swapchain.GetWidth() < frame->width || swapchain.GetHeight() < frame->height;
     if (is_suboptimal || size_changed) {
         RecreateSwapchain(frame);
     }


### PR DESCRIPTION
This set of fixes, fix the performance slowdowns in Super Mario Odessy in Android while videos are playing.

![image](https://github.com/yuzu-emu/yuzu/assets/1731197/011090d0-eacd-44c2-bf39-66943709c2f1)
