### PR TITLE
yuzu: Use displayed port on direct connect

### DIFF
--- a/src/yuzu/multiplayer/direct_connect.cpp
+++ b/src/yuzu/multiplayer/direct_connect.cpp
@@ -94,7 +94,7 @@ void DirectConnectWindow::Connect() {
     // Store settings
     UISettings::values.multiplayer_nickname = ui->nickname->text().toStdString();
     UISettings::values.multiplayer_ip = ui->ip->text().toStdString();
-    if (ui->port->isModified() && !ui->port->text().isEmpty()) {
+    if (!ui->port->text().isEmpty()) {
         UISettings::values.multiplayer_port = ui->port->text().toInt();
     } else {
         UISettings::values.multiplayer_port = UISettings::values.multiplayer_port.GetDefault();


### PR DESCRIPTION
We load the port from settings. But when connecting to the room we used the default port if it wasn't modified. This resulted in a mismatch on what is displayed on the UI and what is actually doing.

closes #12550 