### PR TITLE
Save gamemode configuration and add per-game config

### DIFF
--- a/src/frontend_common/config.cpp
+++ b/src/frontend_common/config.cpp
@@ -280,6 +280,16 @@ void Config::ReadDebuggingValues() {
     EndGroup();
 }
 
+#ifdef __unix__
+void Config::ReadLinuxValues() {
+    BeginGroup(Settings::TranslateCategory(Settings::Category::Linux));
+
+    ReadCategory(Settings::Category::Linux);
+
+    EndGroup();
+}
+#endif
+
 void Config::ReadServiceValues() {
     BeginGroup(Settings::TranslateCategory(Settings::Category::Services));
 
@@ -386,6 +396,9 @@ void Config::ReadValues() {
     ReadControlValues();
     ReadCoreValues();
     ReadCpuValues();
+#ifdef __unix__
+    ReadLinuxValues();
+#endif
     ReadRendererValues();
     ReadAudioValues();
     ReadSystemValues();
@@ -478,6 +491,9 @@ void Config::SaveValues() {
     SaveControlValues();
     SaveCoreValues();
     SaveCpuValues();
+#ifdef __unix__
+    SaveLinuxValues();
+#endif
     SaveRendererValues();
     SaveAudioValues();
     SaveSystemValues();
@@ -551,6 +567,16 @@ void Config::SaveDebuggingValues() {
 
     EndGroup();
 }
+
+#ifdef __unix__
+void Config::SaveLinuxValues() {
+    BeginGroup(Settings::TranslateCategory(Settings::Category::Linux));
+
+    WriteCategory(Settings::Category::Linux);
+
+    EndGroup();
+}
+#endif
 
 void Config::SaveNetworkValues() {
     BeginGroup(Settings::TranslateCategory(Settings::Category::Services));

--- a/src/frontend_common/config.h
+++ b/src/frontend_common/config.h
@@ -77,6 +77,9 @@ protected:
     void ReadCoreValues();
     void ReadDataStorageValues();
     void ReadDebuggingValues();
+#ifdef __unix__
+    void ReadLinuxValues();
+#endif
     void ReadServiceValues();
     void ReadDisabledAddOnValues();
     void ReadMiscellaneousValues();
@@ -108,6 +111,9 @@ protected:
     void SaveCoreValues();
     void SaveDataStorageValues();
     void SaveDebuggingValues();
+#ifdef __unix__
+    void SaveLinuxValues();
+#endif
     void SaveNetworkValues();
     void SaveDisabledAddOnValues();
     void SaveMiscellaneousValues();

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -96,6 +96,9 @@ add_executable(yuzu
     configuration/configure_input_profile_dialog.cpp
     configuration/configure_input_profile_dialog.h
     configuration/configure_input_profile_dialog.ui
+    configuration/configure_linux_tab.cpp
+    configuration/configure_linux_tab.h
+    configuration/configure_linux_tab.ui
     configuration/configure_mouse_panning.cpp
     configuration/configure_mouse_panning.h
     configuration/configure_mouse_panning.ui

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -24,6 +24,8 @@ class Builder;
 }
 
 class ConfigureAudio : public ConfigurationShared::Tab {
+    Q_OBJECT
+
 public:
     explicit ConfigureAudio(const Core::System& system_,
                             std::shared_ptr<std::vector<ConfigurationShared::Tab*>> group,

--- a/src/yuzu/configuration/configure_cpu.h
+++ b/src/yuzu/configuration/configure_cpu.h
@@ -24,6 +24,8 @@ class Builder;
 }
 
 class ConfigureCpu : public ConfigurationShared::Tab {
+    Q_OBJECT
+
 public:
     explicit ConfigureCpu(const Core::System& system_,
                           std::shared_ptr<std::vector<ConfigurationShared::Tab*>> group,

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -25,6 +25,8 @@ class Builder;
 }
 
 class ConfigureGeneral : public ConfigurationShared::Tab {
+    Q_OBJECT
+
 public:
     explicit ConfigureGeneral(const Core::System& system_,
                               std::shared_ptr<std::vector<ConfigurationShared::Tab*>> group,

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -43,6 +43,8 @@ class Builder;
 }
 
 class ConfigureGraphics : public ConfigurationShared::Tab {
+    Q_OBJECT
+
 public:
     explicit ConfigureGraphics(
         const Core::System& system_, std::vector<VkDeviceInfo::Record>& records,

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -21,6 +21,8 @@ class Builder;
 }
 
 class ConfigureGraphicsAdvanced : public ConfigurationShared::Tab {
+    Q_OBJECT
+
 public:
     explicit ConfigureGraphicsAdvanced(
         const Core::System& system_, std::shared_ptr<std::vector<ConfigurationShared::Tab*>> group,

--- a/src/yuzu/configuration/configure_linux_tab.cpp
+++ b/src/yuzu/configuration/configure_linux_tab.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright 2019 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/settings.h"
+#include "core/core.h"
+#include "ui_configure_linux_tab.h"
+#include "yuzu/configuration/configuration_shared.h"
+#include "yuzu/configuration/configure_linux_tab.h"
+#include "yuzu/configuration/shared_widget.h"
+
+ConfigureLinuxTab::ConfigureLinuxTab(const Core::System& system_,
+                                     std::shared_ptr<std::vector<ConfigurationShared::Tab*>> group_,
+                                     const ConfigurationShared::Builder& builder, QWidget* parent)
+    : Tab(group_, parent), ui(std::make_unique<Ui::ConfigureLinuxTab>()), system{system_} {
+    ui->setupUi(this);
+
+    Setup(builder);
+
+    SetConfiguration();
+}
+
+ConfigureLinuxTab::~ConfigureLinuxTab() = default;
+
+void ConfigureLinuxTab::SetConfiguration() {}
+void ConfigureLinuxTab::Setup(const ConfigurationShared::Builder& builder) {
+    QLayout& linux_layout = *ui->linux_widget->layout();
+
+    std::map<u32, QWidget*> linux_hold{};
+
+    std::vector<Settings::BasicSetting*> settings;
+    const auto push = [&](Settings::Category category) {
+        for (const auto setting : Settings::values.linkage.by_category[category]) {
+            settings.push_back(setting);
+        }
+    };
+
+    push(Settings::Category::Linux);
+
+    for (auto* setting : settings) {
+        auto* widget = builder.BuildWidget(setting, apply_funcs);
+
+        if (widget == nullptr) {
+            continue;
+        }
+        if (!widget->Valid()) {
+            widget->deleteLater();
+            continue;
+        }
+
+        linux_hold.insert({setting->Id(), widget});
+    }
+
+    for (const auto& [id, widget] : linux_hold) {
+        linux_layout.addWidget(widget);
+    }
+}
+
+void ConfigureLinuxTab::ApplyConfiguration() {
+    const bool is_powered_on = system.IsPoweredOn();
+    for (const auto& apply_func : apply_funcs) {
+        apply_func(is_powered_on);
+    }
+}
+
+void ConfigureLinuxTab::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureLinuxTab::RetranslateUI() {
+    ui->retranslateUi(this);
+}

--- a/src/yuzu/configuration/configure_linux_tab.h
+++ b/src/yuzu/configuration/configure_linux_tab.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QWidget>
+
+namespace Core {
+class System;
+}
+
+namespace Ui {
+class ConfigureLinuxTab;
+}
+
+namespace ConfigurationShared {
+class Builder;
+}
+
+class ConfigureLinuxTab : public ConfigurationShared::Tab {
+    Q_OBJECT
+
+public:
+    explicit ConfigureLinuxTab(const Core::System& system_,
+                               std::shared_ptr<std::vector<ConfigurationShared::Tab*>> group,
+                               const ConfigurationShared::Builder& builder,
+                               QWidget* parent = nullptr);
+    ~ConfigureLinuxTab() override;
+
+    void ApplyConfiguration() override;
+    void SetConfiguration() override;
+
+private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
+    void Setup(const ConfigurationShared::Builder& builder);
+
+    std::unique_ptr<Ui::ConfigureLinuxTab> ui;
+
+    const Core::System& system;
+
+    std::vector<std::function<void(bool)>> apply_funcs{};
+};

--- a/src/yuzu/configuration/configure_linux_tab.ui
+++ b/src/yuzu/configuration/configure_linux_tab.ui
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureLinuxTab</class>
+ <widget class="QWidget" name="ConfigureLinuxTab">
+  <property name="accessibleName">
+   <string>Linux</string>
+  </property>
+  <layout class="QVBoxLayout">
+   <item>
+    <widget class="QGroupBox" name="LinuxGroupBox">
+     <property name="title">
+      <string>Linux</string>
+     </property>
+     <layout class="QVBoxLayout" name="LinuxVerticalLayout_1">
+      <item>
+       <widget class="QWidget" name="linux_widget" native="true">
+        <layout class="QVBoxLayout" name="LinuxVerticalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yuzu/configuration/configure_motion_touch.h
+++ b/src/yuzu/configuration/configure_motion_touch.h
@@ -26,6 +26,7 @@ class ConfigureMotionTouch;
 /// A dialog for touchpad calibration configuration.
 class CalibrationConfigurationDialog : public QDialog {
     Q_OBJECT
+
 public:
     explicit CalibrationConfigurationDialog(QWidget* parent, const std::string& host, u16 port);
     ~CalibrationConfigurationDialog() override;

--- a/src/yuzu/configuration/configure_mouse_panning.h
+++ b/src/yuzu/configuration/configure_mouse_panning.h
@@ -16,6 +16,7 @@ class ConfigureMousePanning;
 
 class ConfigureMousePanning : public QDialog {
     Q_OBJECT
+
 public:
     explicit ConfigureMousePanning(QWidget* parent, InputCommon::InputSubsystem* input_subsystem_,
                                    float right_stick_deadzone, float right_stick_range);

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -33,6 +33,7 @@
 #include "yuzu/configuration/configure_graphics.h"
 #include "yuzu/configuration/configure_graphics_advanced.h"
 #include "yuzu/configuration/configure_input_per_game.h"
+#include "yuzu/configuration/configure_linux_tab.h"
 #include "yuzu/configuration/configure_per_game.h"
 #include "yuzu/configuration/configure_per_game_addons.h"
 #include "yuzu/configuration/configure_system.h"
@@ -60,6 +61,7 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::st
         system_, vk_device_records, [&]() { graphics_advanced_tab->ExposeComputeOption(); },
         [](Settings::AspectRatio, Settings::ResolutionSetup) {}, tab_group, *builder, this);
     input_tab = std::make_unique<ConfigureInputPerGame>(system_, game_config.get(), this);
+    linux_tab = std::make_unique<ConfigureLinuxTab>(system_, tab_group, *builder, this);
     system_tab = std::make_unique<ConfigureSystem>(system_, tab_group, *builder, this);
 
     ui->setupUi(this);
@@ -71,6 +73,10 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::st
     ui->tabWidget->addTab(graphics_advanced_tab.get(), tr("Adv. Graphics"));
     ui->tabWidget->addTab(audio_tab.get(), tr("Audio"));
     ui->tabWidget->addTab(input_tab.get(), tr("Input Profiles"));
+    // Only show Linux tab on Unix
+#ifdef __unix__
+    ui->tabWidget->addTab(linux_tab.get(), tr("Linux"));
+#endif
 
     setFocusPolicy(Qt::ClickFocus);
     setWindowTitle(tr("Properties"));

--- a/src/yuzu/configuration/configure_per_game.h
+++ b/src/yuzu/configuration/configure_per_game.h
@@ -32,6 +32,7 @@ class ConfigureCpu;
 class ConfigureGraphics;
 class ConfigureGraphicsAdvanced;
 class ConfigureInputPerGame;
+class ConfigureLinuxTab;
 class ConfigureSystem;
 
 class QGraphicsScene;
@@ -85,5 +86,6 @@ private:
     std::unique_ptr<ConfigureGraphicsAdvanced> graphics_advanced_tab;
     std::unique_ptr<ConfigureGraphics> graphics_tab;
     std::unique_ptr<ConfigureInputPerGame> input_tab;
+    std::unique_ptr<ConfigureLinuxTab> linux_tab;
     std::unique_ptr<ConfigureSystem> system_tab;
 };

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -27,6 +27,8 @@ class Builder;
 }
 
 class ConfigureSystem : public ConfigurationShared::Tab {
+    Q_OBJECT
+
 public:
     explicit ConfigureSystem(Core::System& system_,
                              std::shared_ptr<std::vector<ConfigurationShared::Tab*>> group,


### PR DESCRIPTION
- Linux settings were not saved or loaded in config file. Fix for https://github.com/yuzu-emu/yuzu/issues/12444
- Add per-game gamemode option :
  - Create a new Linux configuration tab, because General tab is not present per-game
  - Add settings of Linux category in the tab
  - Show the tab in per-game configuration, on Linux only

I added Q_OBJECT macro on other tab classes, for consistency, even if it is mostly needed only when declaring signal and slots. Some already had it, others not, with no reason.
