### PR TITLE
Automatically deduce the size of IPC responses

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -111,7 +111,7 @@ public:
 private:
     void CheckAvailability(HLERequestContext& ctx) {
         LOG_WARNING(Service_ACC, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };
@@ -331,13 +331,13 @@ protected:
         UserData data{};
         if (profile_manager.GetProfileBaseAndData(user_id, profile_base, data)) {
             ctx.WriteBuffer(data);
-            IPC::ResponseBuilder rb{ctx, 16};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultSuccess);
             rb.PushRaw(profile_base);
         } else {
             LOG_ERROR(Service_ACC, "Failed to get profile base and data for user=0x{}",
                       user_id.RawString());
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown); // TODO(ogniK): Get actual error code
         }
     }
@@ -346,12 +346,12 @@ protected:
         LOG_DEBUG(Service_ACC, "called user_id=0x{}", user_id.RawString());
         ProfileBase profile_base{};
         if (profile_manager.GetProfileBase(user_id, profile_base)) {
-            IPC::ResponseBuilder rb{ctx, 16};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultSuccess);
             rb.PushRaw(profile_base);
         } else {
             LOG_ERROR(Service_ACC, "Failed to get profile base for user=0x{}", user_id.RawString());
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown); // TODO(ogniK): Get actual error code
         }
     }
@@ -359,7 +359,7 @@ protected:
     void LoadImage(HLERequestContext& ctx) {
         LOG_DEBUG(Service_ACC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         const Common::FS::IOFile image(GetImagePath(user_id), Common::FS::FileAccessMode::Read,
@@ -386,7 +386,7 @@ protected:
 
     void GetImageSize(HLERequestContext& ctx) {
         LOG_DEBUG(Service_ACC, "called");
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         const Common::FS::IOFile image(GetImagePath(user_id), Common::FS::FileAccessMode::Read,
@@ -422,7 +422,7 @@ protected:
 
         if (user_data.size() < sizeof(UserData)) {
             LOG_ERROR(Service_ACC, "UserData buffer too small!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Account::ResultInvalidArrayLength);
             return;
         }
@@ -432,12 +432,12 @@ protected:
 
         if (!profile_manager.SetProfileBaseAndData(user_id, base, data)) {
             LOG_ERROR(Service_ACC, "Failed to update user data and base!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Account::ResultAccountUpdateFailed);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -455,7 +455,7 @@ protected:
 
         if (user_data.size() < sizeof(UserData)) {
             LOG_ERROR(Service_ACC, "UserData buffer too small!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Account::ResultInvalidArrayLength);
             return;
         }
@@ -470,12 +470,12 @@ protected:
             image.Write(image_data) != image_data.size() ||
             !profile_manager.SetProfileBaseAndData(user_id, base, data)) {
             LOG_ERROR(Service_ACC, "Failed to update profile data, base, and image!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Account::ResultAccountUpdateFailed);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -541,7 +541,7 @@ public:
     void LoadIdTokenCache(HLERequestContext& ctx) {
         LOG_WARNING(Service_ACC, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(0);
     }
@@ -584,7 +584,7 @@ public:
 private:
     void CheckAvailability(HLERequestContext& ctx) {
         LOG_DEBUG(Service_ACC, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(false); // TODO: Check when this is supposed to return true and when not
     }
@@ -592,7 +592,7 @@ private:
     void GetAccountId(HLERequestContext& ctx) {
         LOG_DEBUG(Service_ACC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw<u64>(profile_manager->GetLastOpenedUser().Hash());
     }
@@ -600,7 +600,7 @@ private:
     void EnsureIdTokenCacheAsync(HLERequestContext& ctx) {
         LOG_WARNING(Service_ACC, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface(ensure_token_id);
     }
@@ -622,7 +622,7 @@ private:
             ctx.WriteBuffer(unknown_out_buffer, 1);
         }
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw<u64>(profile_manager->GetLastOpenedUser().Hash());
     }
@@ -632,7 +632,7 @@ private:
 
         profile_manager->StoreOpenedUsers();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -731,7 +731,7 @@ public:
 
 void Module::Interface::GetUserCount(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(static_cast<u32>(profile_manager->GetUserCount()));
 }
@@ -741,7 +741,7 @@ void Module::Interface::GetUserExistence(HLERequestContext& ctx) {
     Common::UUID user_id = rp.PopRaw<Common::UUID>();
     LOG_DEBUG(Service_ACC, "called user_id=0x{}", user_id.RawString());
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(profile_manager->UserExists(user_id));
 }
@@ -749,20 +749,20 @@ void Module::Interface::GetUserExistence(HLERequestContext& ctx) {
 void Module::Interface::ListAllUsers(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
     ctx.WriteBuffer(profile_manager->GetAllUsers());
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void Module::Interface::ListOpenUsers(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
     ctx.WriteBuffer(profile_manager->GetOpenUsers());
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void Module::Interface::GetLastOpenedUser(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw<Common::UUID>(profile_manager->GetLastOpenedUser());
 }
@@ -772,21 +772,21 @@ void Module::Interface::GetProfile(HLERequestContext& ctx) {
     Common::UUID user_id = rp.PopRaw<Common::UUID>();
     LOG_DEBUG(Service_ACC, "called user_id=0x{}", user_id.RawString());
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IProfile>(system, user_id, *profile_manager);
 }
 
 void Module::Interface::IsUserRegistrationRequestPermitted(HLERequestContext& ctx) {
     LOG_WARNING(Service_ACC, "(STUBBED) called");
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(profile_manager->CanSystemRegisterUser());
 }
 
 void Module::Interface::InitializeApplicationInfo(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(InitializeApplicationInfoBase());
 }
 
@@ -797,7 +797,7 @@ void Module::Interface::InitializeApplicationInfoRestricted(HLERequestContext& c
     // currently, we assume the user owns the title. InitializeApplicationInfoBase SHOULD be called
     // first then we do extra checks if the game is a digital copy.
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(InitializeApplicationInfoBase());
 }
 
@@ -843,7 +843,7 @@ Result Module::Interface::InitializeApplicationInfoBase() {
 
 void Module::Interface::GetBaasAccountManagerForApplication(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IManagerForApplication>(system, profile_manager);
 }
@@ -870,7 +870,7 @@ void Module::Interface::IsUserAccountSwitchLocked(HLERequestContext& ctx) {
         is_locked = nacp.GetUserAccountSwitchLock();
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_locked);
 }
@@ -878,7 +878,7 @@ void Module::Interface::IsUserAccountSwitchLocked(HLERequestContext& ctx) {
 void Module::Interface::InitializeApplicationInfoV2(HLERequestContext& ctx) {
     LOG_WARNING(Service_ACC, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -888,7 +888,7 @@ void Module::Interface::BeginUserRegistration(HLERequestContext& ctx) {
 
     LOG_INFO(Service_ACC, "called, uuid={}", user_id.FormattedString());
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(user_id);
 }
@@ -901,7 +901,7 @@ void Module::Interface::CompleteUserRegistration(HLERequestContext& ctx) {
 
     profile_manager->WriteUserSaveFile();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -911,7 +911,7 @@ void Module::Interface::GetProfileEditor(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_ACC, "called, user_id=0x{}", user_id.RawString());
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IProfileEditor>(system, user_id, *profile_manager);
 }
@@ -923,7 +923,7 @@ void Module::Interface::ListQualifiedUsers(HLERequestContext& ctx) {
     // nintendo online currently. We're just going to assume the user running the game has access to
     // the game regardless of parental control settings.
     ctx.WriteBuffer(profile_manager->GetAllUsers());
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -931,7 +931,7 @@ void Module::Interface::ListOpenContextStoredUsers(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
 
     ctx.WriteBuffer(profile_manager->GetStoredOpenedUsers());
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -954,7 +954,7 @@ void Module::Interface::GetBaasAccountManagerForSystemService(HLERequestContext&
 
     LOG_INFO(Service_ACC, "called, uuid=0x{}", uuid.RawString());
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IManagerForSystemService>(system, uuid);
 }
@@ -970,7 +970,7 @@ void Module::Interface::StoreSaveDataThumbnailSystem(HLERequestContext& ctx) {
 
 void Module::Interface::StoreSaveDataThumbnail(HLERequestContext& ctx, const Common::UUID& uuid,
                                                const u64 tid) {
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
 
     if (tid == 0) {
         LOG_ERROR(Service_ACC, "TitleID is not valid!");
@@ -999,7 +999,7 @@ void Module::Interface::TrySelectUserWithoutInteraction(HLERequestContext& ctx) 
     LOG_DEBUG(Service_ACC, "called");
     // A u8 is passed into this function which we can safely ignore. It's to determine if we have
     // access to use the network or not by the looks of it
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     if (profile_manager->GetUserCount() != 1) {
         rb.Push(ResultSuccess);
         rb.PushRaw(Common::InvalidUUID);

--- a/src/core/hle/service/acc/async_context.cpp
+++ b/src/core/hle/service/acc/async_context.cpp
@@ -30,7 +30,7 @@ IAsyncContext::~IAsyncContext() {
 void IAsyncContext::GetSystemEvent(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(completion_event->GetReadableEvent());
 }
@@ -41,7 +41,7 @@ void IAsyncContext::Cancel(HLERequestContext& ctx) {
     Cancel();
     MarkComplete();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -50,7 +50,7 @@ void IAsyncContext::HasDone(HLERequestContext& ctx) {
 
     is_complete.store(IsComplete());
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_complete.load());
 }
@@ -58,7 +58,7 @@ void IAsyncContext::HasDone(HLERequestContext& ctx) {
 void IAsyncContext::GetResult(HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(GetResult());
 }
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -95,7 +95,7 @@ void IWindowController::GetAppletResourceUserId(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_AM, "called. Process ID=0x{:016X}", process_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u64>(process_id);
 }
@@ -105,14 +105,14 @@ void IWindowController::GetAppletResourceUserIdOfCallerApplet(HLERequestContext&
 
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u64>(process_id);
 }
 
 void IWindowController::AcquireForegroundRights(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -146,20 +146,20 @@ void IAudioController::SetExpectedMasterVolume(HLERequestContext& ctx) {
     library_applet_volume =
         std::clamp(library_applet_volume_tmp, min_allowed_volume, max_allowed_volume);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IAudioController::GetMainAppletExpectedMasterVolume(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called. main_applet_volume={}", main_applet_volume);
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(main_applet_volume);
 }
 
 void IAudioController::GetLibraryAppletExpectedMasterVolume(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called. library_applet_volume={}", library_applet_volume);
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(library_applet_volume);
 }
@@ -180,7 +180,7 @@ void IAudioController::ChangeMainAppletMasterVolume(HLERequestContext& ctx) {
     main_applet_volume = std::clamp(parameters.volume, min_allowed_volume, max_allowed_volume);
     fade_time_ns = std::chrono::nanoseconds{parameters.fade_time_ns};
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -194,7 +194,7 @@ void IAudioController::SetTransparentAudioRate(HLERequestContext& ctx) {
     transparent_volume_rate =
         std::clamp(transparent_volume_rate_tmp, min_allowed_volume, max_allowed_volume);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -241,7 +241,7 @@ IDisplayController::~IDisplayController() = default;
 void IDisplayController::GetCallerAppletCaptureImageEx(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(1u);
     rb.Push(0);
@@ -250,14 +250,14 @@ void IDisplayController::GetCallerAppletCaptureImageEx(HLERequestContext& ctx) {
 void IDisplayController::TakeScreenShotOfOwnLayer(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IDisplayController::AcquireLastForegroundCaptureSharedBuffer(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(1U);
     rb.Push(0);
@@ -266,14 +266,14 @@ void IDisplayController::AcquireLastForegroundCaptureSharedBuffer(HLERequestCont
 void IDisplayController::ReleaseLastForegroundCaptureSharedBuffer(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IDisplayController::AcquireCallerAppletCaptureSharedBuffer(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(1U);
     rb.Push(0);
@@ -282,7 +282,7 @@ void IDisplayController::AcquireCallerAppletCaptureSharedBuffer(HLERequestContex
 void IDisplayController::ReleaseCallerAppletCaptureSharedBuffer(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -400,7 +400,7 @@ ISelfController::~ISelfController() {
 void ISelfController::Exit(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     system.Exit();
@@ -411,7 +411,7 @@ void ISelfController::LockExit(HLERequestContext& ctx) {
 
     system.SetExitLocked(true);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -420,7 +420,7 @@ void ISelfController::UnlockExit(HLERequestContext& ctx) {
 
     system.SetExitLocked(false);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     if (system.GetExitRequested()) {
@@ -432,7 +432,7 @@ void ISelfController::EnterFatalSection(HLERequestContext& ctx) {
     ++num_fatal_sections_entered;
     LOG_DEBUG(Service_AM, "called. Num fatal sections entered: {}", num_fatal_sections_entered);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -441,14 +441,14 @@ void ISelfController::LeaveFatalSection(HLERequestContext& ctx) {
 
     // Entry and exit of fatal sections must be balanced.
     if (num_fatal_sections_entered == 0) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Result{ErrorModule::AM, 512});
         return;
     }
 
     --num_fatal_sections_entered;
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -457,7 +457,7 @@ void ISelfController::GetLibraryAppletLaunchableEvent(HLERequestContext& ctx) {
 
     launchable_event->Signal();
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(launchable_event->GetReadableEvent());
 }
@@ -469,7 +469,7 @@ void ISelfController::SetScreenShotPermission(HLERequestContext& ctx) {
 
     screenshot_permission = permission;
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -479,7 +479,7 @@ void ISelfController::SetOperationModeChangedNotification(HLERequestContext& ctx
     bool flag = rp.Pop<bool>();
     LOG_WARNING(Service_AM, "(STUBBED) called flag={}", flag);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -489,7 +489,7 @@ void ISelfController::SetPerformanceModeChangedNotification(HLERequestContext& c
     bool flag = rp.Pop<bool>();
     LOG_WARNING(Service_AM, "(STUBBED) called flag={}", flag);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -508,14 +508,14 @@ void ISelfController::SetFocusHandlingMode(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called. unknown0={}, unknown1={}, unknown2={}",
                 flags.unknown0, flags.unknown1, flags.unknown2);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ISelfController::SetRestartMessageEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -527,14 +527,14 @@ void ISelfController::SetOutOfFocusSuspendingEnabled(HLERequestContext& ctx) {
     bool enabled = rp.Pop<bool>();
     LOG_WARNING(Service_AM, "(STUBBED) called enabled={}", enabled);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ISelfController::SetAlbumImageOrientation(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -546,7 +546,7 @@ void ISelfController::CreateManagedDisplayLayer(HLERequestContext& ctx) {
     const auto display_id = nvnflinger.OpenDisplay("Default");
     const auto layer_id = nvnflinger.CreateLayer(*display_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(*layer_id);
 }
@@ -554,14 +554,14 @@ void ISelfController::CreateManagedDisplayLayer(HLERequestContext& ctx) {
 void ISelfController::IsSystemBufferSharingEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(this->EnsureBufferSharingEnabled());
 }
 
 void ISelfController::GetSystemSharedLayerHandle(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(this->EnsureBufferSharingEnabled());
     rb.Push<s64>(system_shared_buffer_id);
     rb.Push<s64>(system_shared_layer_id);
@@ -570,7 +570,7 @@ void ISelfController::GetSystemSharedLayerHandle(HLERequestContext& ctx) {
 void ISelfController::GetSystemSharedBufferHandle(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(this->EnsureBufferSharingEnabled());
     rb.Push<s64>(system_shared_buffer_id);
 }
@@ -608,7 +608,7 @@ void ISelfController::CreateManagedDisplaySeparableLayer(HLERequestContext& ctx)
     const auto display_id = nvnflinger.OpenDisplay("Default");
     const auto layer_id = nvnflinger.CreateLayer(*display_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(*layer_id);
 }
@@ -616,14 +616,14 @@ void ISelfController::CreateManagedDisplaySeparableLayer(HLERequestContext& ctx)
 void ISelfController::SetHandlesRequestToDisplay(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ISelfController::ApproveToDisplay(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -633,14 +633,14 @@ void ISelfController::SetIdleTimeDetectionExtension(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "(STUBBED) called idle_time_detection_extension={}",
               idle_time_detection_extension);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ISelfController::GetIdleTimeDetectionExtension(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(idle_time_detection_extension);
 }
@@ -648,7 +648,7 @@ void ISelfController::GetIdleTimeDetectionExtension(HLERequestContext& ctx) {
 void ISelfController::ReportUserIsActive(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -668,14 +668,14 @@ void ISelfController::SetAutoSleepDisabled(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_AM, "called. is_auto_sleep_disabled={}", is_auto_sleep_disabled);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ISelfController::IsAutoSleepDisabled(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called.");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_auto_sleep_disabled);
 }
@@ -686,7 +686,7 @@ void ISelfController::GetAccumulatedSuspendedTickValue(HLERequestContext& ctx) {
     // This command returns the total number of system ticks since ISelfController creation
     // where the game was suspended. Since Yuzu doesn't implement game suspension, this command
     // can just always return 0 ticks.
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u64>(0);
 }
@@ -694,7 +694,7 @@ void ISelfController::GetAccumulatedSuspendedTickValue(HLERequestContext& ctx) {
 void ISelfController::GetAccumulatedSuspendedTickChangedEvent(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called.");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(accumulated_suspended_tick_changed_event->GetReadableEvent());
 }
@@ -710,7 +710,7 @@ void ISelfController::SetAlbumImageTakenNotificationEnabled(HLERequestContext& c
     LOG_WARNING(Service_AM, "(STUBBED) called. album_image_taken_notification_enabled={}",
                 album_image_taken_notification_enabled);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -729,7 +729,7 @@ void ISelfController::SaveCurrentScreenshot(HLERequestContext& ctx) {
         screenshot_service->CaptureAndSaveScreenshot(report_option);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -740,7 +740,7 @@ void ISelfController::SetRecordVolumeMuted(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_AM, "(STUBBED) called. is_record_volume_muted={}", is_record_volume_muted);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -833,7 +833,7 @@ void ILockAccessor::TryLock(HLERequestContext& ctx) {
 
     is_locked = true;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(is_locked);
 }
@@ -843,7 +843,7 @@ void ILockAccessor::Unlock(HLERequestContext& ctx) {
 
     is_locked = false;
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -852,7 +852,7 @@ void ILockAccessor::GetEvent(HLERequestContext& ctx) {
 
     lock_event->Signal();
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(lock_event->GetReadableEvent());
 }
@@ -860,7 +860,7 @@ void ILockAccessor::GetEvent(HLERequestContext& ctx) {
 void ILockAccessor::IsLocked(HLERequestContext& ctx) {
     LOG_INFO(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(is_locked);
 }
@@ -941,7 +941,7 @@ ICommonStateGetter::~ICommonStateGetter() {
 void ICommonStateGetter::GetBootMode(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(static_cast<u8>(Service::PM::SystemBootMode::Normal)); // Normal boot mode
 }
@@ -949,7 +949,7 @@ void ICommonStateGetter::GetBootMode(HLERequestContext& ctx) {
 void ICommonStateGetter::GetEventHandle(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(msg_queue->GetMessageReceiveEvent());
 }
@@ -958,7 +958,7 @@ void ICommonStateGetter::ReceiveMessage(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
     const auto message = msg_queue->PopMessage();
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
 
     if (message == AppletMessageQueue::AppletMessage::None) {
         LOG_ERROR(Service_AM, "Message queue is empty");
@@ -974,7 +974,7 @@ void ICommonStateGetter::ReceiveMessage(HLERequestContext& ctx) {
 void ICommonStateGetter::GetCurrentFocusState(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u8>(FocusState::InFocus));
 }
@@ -985,7 +985,7 @@ void ICommonStateGetter::RequestToAcquireSleepLock(HLERequestContext& ctx) {
     // Sleep lock is acquired immediately.
     sleep_lock_event->Signal();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -995,7 +995,7 @@ void ICommonStateGetter::GetReaderLockAccessorEx(HLERequestContext& ctx) {
 
     LOG_INFO(Service_AM, "called, unknown={}", unknown);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ILockAccessor>(system);
@@ -1004,7 +1004,7 @@ void ICommonStateGetter::GetReaderLockAccessorEx(HLERequestContext& ctx) {
 void ICommonStateGetter::GetAcquiredSleepLockEvent(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(sleep_lock_event->GetReadableEvent());
 }
@@ -1012,7 +1012,7 @@ void ICommonStateGetter::GetAcquiredSleepLockEvent(HLERequestContext& ctx) {
 void ICommonStateGetter::IsVrModeEnabled(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(vr_mode_state);
 }
@@ -1023,7 +1023,7 @@ void ICommonStateGetter::SetVrModeEnabled(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_AM, "VR Mode is {}", vr_mode_state ? "on" : "off");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1034,28 +1034,28 @@ void ICommonStateGetter::SetLcdBacklighOffEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called. is_lcd_backlight_off_enabled={}",
                 is_lcd_backlight_off_enabled);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ICommonStateGetter::BeginVrModeEx(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ICommonStateGetter::EndVrModeEx(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ICommonStateGetter::GetDefaultDisplayResolutionChangeEvent(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(msg_queue->GetOperationModeChangedEvent());
 }
@@ -1063,7 +1063,7 @@ void ICommonStateGetter::GetDefaultDisplayResolutionChangeEvent(HLERequestContex
 void ICommonStateGetter::GetDefaultDisplayResolution(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     if (Settings::IsDockedMode()) {
@@ -1088,7 +1088,7 @@ void ICommonStateGetter::SetCpuBoostMode(HLERequestContext& ctx) {
 void ICommonStateGetter::GetBuiltInDisplayType(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(0);
 }
@@ -1099,14 +1099,14 @@ void ICommonStateGetter::PerformSystemButtonPressingIfInFocus(HLERequestContext&
 
     LOG_WARNING(Service_AM, "(STUBBED) called, system_button={}", system_button);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void ICommonStateGetter::GetSettingsPlatformRegion(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(SysPlatformRegion::Global);
 }
@@ -1115,7 +1115,7 @@ void ICommonStateGetter::SetRequestExitToLibraryAppletAtExecuteNextProgramEnable
     HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1163,7 +1163,7 @@ IStorage::~IStorage() = default;
 void IStorage::Open(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IStorageAccessor>(system, *this);
@@ -1173,7 +1173,7 @@ void ICommonStateGetter::GetOperationMode(HLERequestContext& ctx) {
     const bool use_docked_mode{Settings::IsDockedMode()};
     LOG_DEBUG(Service_AM, "called, use_docked_mode={}", use_docked_mode);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u8>(use_docked_mode ? OperationMode::Docked : OperationMode::Handheld));
 }
@@ -1181,7 +1181,7 @@ void ICommonStateGetter::GetOperationMode(HLERequestContext& ctx) {
 void ICommonStateGetter::GetPerformanceMode(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(system.GetAPMController().GetCurrentPerformanceMode());
 }
@@ -1221,7 +1221,7 @@ private:
     void GetAppletStateChangedEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(applet->GetBroker().GetStateChangedEvent());
     }
@@ -1229,7 +1229,7 @@ private:
     void IsCompleted(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(applet->TransactionComplete());
     }
@@ -1237,14 +1237,14 @@ private:
     void GetResult(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(applet->GetStatus());
     }
 
     void PresetLibraryAppletGpuTimeSliceZero(HLERequestContext& ctx) {
         LOG_WARNING(Service_AM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -1256,7 +1256,7 @@ private:
         applet->Initialize();
         applet->Execute();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -1265,7 +1265,7 @@ private:
 
         ASSERT(applet != nullptr);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(applet->RequestExit());
     }
 
@@ -1275,7 +1275,7 @@ private:
         IPC::RequestParser rp{ctx};
         applet->GetBroker().PushNormalDataFromGame(rp.PopIpcInterface<IStorage>().lock());
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -1286,12 +1286,12 @@ private:
         if (storage == nullptr) {
             LOG_DEBUG(Service_AM,
                       "storage is a nullptr. There is no data in the current normal channel");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(AM::ResultNoDataInChannel);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IStorage>(std::move(storage));
     }
@@ -1306,7 +1306,7 @@ private:
         applet->ExecuteInteractive();
         applet->Execute();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -1317,12 +1317,12 @@ private:
         if (storage == nullptr) {
             LOG_DEBUG(Service_AM,
                       "storage is a nullptr. There is no data in the current interactive channel");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(AM::ResultNoDataInChannel);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IStorage>(std::move(storage));
     }
@@ -1330,7 +1330,7 @@ private:
     void GetPopOutDataEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(applet->GetBroker().GetNormalDataEvent());
     }
@@ -1338,7 +1338,7 @@ private:
     void GetPopInteractiveOutDataEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(applet->GetBroker().GetInteractiveDataEvent());
     }
@@ -1350,7 +1350,7 @@ private:
         // actually used anywhere
         constexpr u64 handle = 0xdeadbeef;
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(handle);
     }
@@ -1376,7 +1376,7 @@ IStorageAccessor::~IStorageAccessor() = default;
 void IStorageAccessor::GetSize(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u64>(backing.GetSize()));
@@ -1396,14 +1396,14 @@ void IStorageAccessor::Write(HLERequestContext& ctx) {
                   "offset is out of bounds, backing_buffer_sz={}, data_size={}, offset={}",
                   backing.GetSize(), size, offset);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(AM::ResultInvalidOffset);
         return;
     }
 
     std::memcpy(backing.GetData().data() + offset, data.data(), size);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1419,14 +1419,14 @@ void IStorageAccessor::Read(HLERequestContext& ctx) {
         LOG_ERROR(Service_AM, "offset is out of bounds, backing_buffer_sz={}, size={}, offset={}",
                   backing.GetSize(), size, offset);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(AM::ResultInvalidOffset);
         return;
     }
 
     ctx.WriteBuffer(backing.GetData().data() + offset, size);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1460,12 +1460,12 @@ void ILibraryAppletCreator::CreateLibraryApplet(HLERequestContext& ctx) {
     if (applet == nullptr) {
         LOG_ERROR(Service_AM, "Applet doesn't exist! applet_id={}", applet_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ILibraryAppletAccessor>(system, applet);
@@ -1480,14 +1480,14 @@ void ILibraryAppletCreator::CreateStorage(HLERequestContext& ctx) {
 
     if (size <= 0) {
         LOG_ERROR(Service_AM, "size is less than or equal to 0");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
 
     std::vector<u8> buffer(size);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IStorage>(system, std::move(buffer));
 }
@@ -1508,7 +1508,7 @@ void ILibraryAppletCreator::CreateTransferMemoryStorage(HLERequestContext& ctx) 
 
     if (parameters.size <= 0) {
         LOG_ERROR(Service_AM, "size is less than or equal to 0");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -1517,7 +1517,7 @@ void ILibraryAppletCreator::CreateTransferMemoryStorage(HLERequestContext& ctx) 
 
     if (transfer_mem.IsNull()) {
         LOG_ERROR(Service_AM, "transfer_mem is a nullptr for handle={:08X}", handle);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -1525,7 +1525,7 @@ void ILibraryAppletCreator::CreateTransferMemoryStorage(HLERequestContext& ctx) 
     std::vector<u8> memory(transfer_mem->GetSize());
     ctx.GetMemory().ReadBlock(transfer_mem->GetSourceAddress(), memory.data(), memory.size());
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IStorage>(system, std::move(memory));
 }
@@ -1540,7 +1540,7 @@ void ILibraryAppletCreator::CreateHandleStorage(HLERequestContext& ctx) {
 
     if (size <= 0) {
         LOG_ERROR(Service_AM, "size is less than or equal to 0");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -1549,7 +1549,7 @@ void ILibraryAppletCreator::CreateHandleStorage(HLERequestContext& ctx) {
 
     if (transfer_mem.IsNull()) {
         LOG_ERROR(Service_AM, "transfer_mem is a nullptr for handle={:08X}", handle);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -1557,7 +1557,7 @@ void ILibraryAppletCreator::CreateHandleStorage(HLERequestContext& ctx) {
     std::vector<u8> memory(transfer_mem->GetSize());
     ctx.GetMemory().ReadBlock(transfer_mem->GetSourceAddress(), memory.data(), memory.size());
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IStorage>(system, std::move(memory));
 }
@@ -1631,7 +1631,7 @@ void ILibraryAppletSelfAccessor::PopInData(HLERequestContext& ctx) {
     LOG_INFO(Service_AM, "called");
 
     if (queue_data.empty()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultNoDataInChannel);
         return;
     }
@@ -1639,7 +1639,7 @@ void ILibraryAppletSelfAccessor::PopInData(HLERequestContext& ctx) {
     auto data = queue_data.front();
     queue_data.pop_front();
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IStorage>(system, std::move(data));
 }
@@ -1647,7 +1647,7 @@ void ILibraryAppletSelfAccessor::PopInData(HLERequestContext& ctx) {
 void ILibraryAppletSelfAccessor::PushOutData(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1656,7 +1656,7 @@ void ILibraryAppletSelfAccessor::ExitProcessAndReturn(HLERequestContext& ctx) {
 
     system.Exit();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1673,7 +1673,7 @@ void ILibraryAppletSelfAccessor::GetLibraryAppletInfo(HLERequestContext& ctx) {
         .library_applet_mode = Applets::LibraryAppletMode::AllForeground,
     };
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(applet_info);
 }
@@ -1693,7 +1693,7 @@ void ILibraryAppletSelfAccessor::GetMainAppletIdentityInfo(HLERequestContext& ct
         .application_id = 0x0100000000001000ull,
     };
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(applet_info);
 }
@@ -1712,7 +1712,7 @@ void ILibraryAppletSelfAccessor::GetCallerAppletIdentityInfo(HLERequestContext& 
         .application_id = 0x0100000000001000ull,
     };
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(applet_info);
 }
@@ -1720,7 +1720,7 @@ void ILibraryAppletSelfAccessor::GetCallerAppletIdentityInfo(HLERequestContext& 
 void ILibraryAppletSelfAccessor::GetDesirableKeyboardLayout(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(0);
 }
@@ -1738,7 +1738,7 @@ void ILibraryAppletSelfAccessor::GetMainAppletAvailableUsers(HLERequestContext& 
         ctx.WriteBuffer(manager.GetAllUsers());
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(is_empty);
     rb.Push(user_count);
@@ -1747,7 +1747,7 @@ void ILibraryAppletSelfAccessor::GetMainAppletAvailableUsers(HLERequestContext& 
 void ILibraryAppletSelfAccessor::ShouldSetGpuTimeSliceManually(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(0);
 }
@@ -1958,7 +1958,7 @@ IAppletCommonFunctions::~IAppletCommonFunctions() = default;
 void IAppletCommonFunctions::SetCpuBoostRequestPriority(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2054,21 +2054,21 @@ IApplicationFunctions::~IApplicationFunctions() {
 void IApplicationFunctions::EnableApplicationCrashReport(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::InitializeApplicationCopyrightFrameBuffer(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::SetApplicationCopyrightImage(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2078,35 +2078,35 @@ void IApplicationFunctions::SetApplicationCopyrightVisibility(HLERequestContext&
 
     LOG_WARNING(Service_AM, "(STUBBED) called, is_visible={}", is_visible);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::BeginBlockingHomeButtonShortAndLongPressed(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::EndBlockingHomeButtonShortAndLongPressed(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::BeginBlockingHomeButton(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::EndBlockingHomeButton(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2120,7 +2120,7 @@ void IApplicationFunctions::PopLaunchParameter(HLERequestContext& ctx) {
         auto channel = system.GetUserChannel();
         if (channel.empty()) {
             LOG_ERROR(Service_AM, "Attempted to load launch parameter but none was found!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(AM::ResultNoDataInChannel);
             return;
         }
@@ -2128,7 +2128,7 @@ void IApplicationFunctions::PopLaunchParameter(HLERequestContext& ctx) {
         auto data = channel.back();
         channel.pop_back();
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IStorage>(system, std::move(data));
     } else if (kind == LaunchParameterKind::AccountPreselectedUser &&
@@ -2144,7 +2144,7 @@ void IApplicationFunctions::PopLaunchParameter(HLERequestContext& ctx) {
         ASSERT(uuid.has_value() && uuid->IsValid());
         params.current_user = *uuid;
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         std::vector<u8> buffer(sizeof(LaunchParameterAccountPreselectedUser));
@@ -2154,7 +2154,7 @@ void IApplicationFunctions::PopLaunchParameter(HLERequestContext& ctx) {
         launch_popped_account_preselect = true;
     } else {
         LOG_ERROR(Service_AM, "Unknown launch parameter kind.");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(AM::ResultNoDataInChannel);
     }
 }
@@ -2162,7 +2162,7 @@ void IApplicationFunctions::PopLaunchParameter(HLERequestContext& ctx) {
 void IApplicationFunctions::CreateApplicationAndRequestToStartForQuest(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2181,7 +2181,7 @@ void IApplicationFunctions::EnsureSaveData(HLERequestContext& ctx) {
     const auto res = system.GetFileSystemController().CreateSaveData(
         &save_data, FileSys::SaveDataSpaceId::NandUser, attribute);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.Push<u64>(0);
 }
@@ -2195,7 +2195,7 @@ void IApplicationFunctions::SetTerminateResult(HLERequestContext& ctx) {
     u32 result = rp.Pop<u32>();
     LOG_WARNING(Service_AM, "(STUBBED) called, result=0x{:08X}", result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2228,7 +2228,7 @@ void IApplicationFunctions::GetDisplayVersion(HLERequestContext& ctx) {
         std::memcpy(version_string.data(), default_version, sizeof(default_version));
     }
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(version_string);
 }
@@ -2271,7 +2271,7 @@ void IApplicationFunctions::GetDesiredLanguage(HLERequestContext& ctx) {
     const auto res_lang =
         app_man->GetApplicationDesiredLanguage(&desired_language, supported_languages);
     if (res_lang != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res_lang);
         return;
     }
@@ -2281,14 +2281,14 @@ void IApplicationFunctions::GetDesiredLanguage(HLERequestContext& ctx) {
     const auto res_code =
         app_man->ConvertApplicationLanguageToLanguageCode(&language_code, desired_language);
     if (res_code != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res_code);
         return;
     }
 
     LOG_DEBUG(Service_AM, "got desired_language={:016X}", language_code);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(language_code);
 }
@@ -2298,7 +2298,7 @@ void IApplicationFunctions::IsGamePlayRecordingSupported(HLERequestContext& ctx)
 
     constexpr bool gameplay_recording_supported = false;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(gameplay_recording_supported);
 }
@@ -2306,21 +2306,21 @@ void IApplicationFunctions::IsGamePlayRecordingSupported(HLERequestContext& ctx)
 void IApplicationFunctions::InitializeGamePlayRecording(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::SetGamePlayRecordingState(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::NotifyRunning(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(0); // Unknown, seems to be ignored by official processes
 }
@@ -2328,7 +2328,7 @@ void IApplicationFunctions::NotifyRunning(HLERequestContext& ctx) {
 void IApplicationFunctions::GetPseudoDeviceId(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     // Returns a 128-bit UUID
@@ -2357,7 +2357,7 @@ void IApplicationFunctions::ExtendSaveData(HLERequestContext& ctx) {
         type, system.GetApplicationProcessProgramID(), user_id,
         {new_normal_size, new_journal_size});
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     // The following value is used upon failure to help the system recover.
@@ -2381,7 +2381,7 @@ void IApplicationFunctions::GetSaveDataSize(HLERequestContext& ctx) {
     const auto size = system.GetFileSystemController().ReadSaveDataSize(
         type, system.GetApplicationProcessProgramID(), user_id);
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(size.normal);
     rb.Push(size.journal);
@@ -2412,7 +2412,7 @@ void IApplicationFunctions::CreateCacheStorage(HLERequestContext& ctx) {
         .required_size = 0,
     };
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(resp);
 }
@@ -2423,7 +2423,7 @@ void IApplicationFunctions::GetSaveDataSizeMax(HLERequestContext& ctx) {
     constexpr u64 size_max_normal = 0xFFFFFFF;
     constexpr u64 size_max_journal = 0xFFFFFFF;
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(size_max_normal);
     rb.Push(size_max_journal);
@@ -2432,7 +2432,7 @@ void IApplicationFunctions::GetSaveDataSizeMax(HLERequestContext& ctx) {
 void IApplicationFunctions::QueryApplicationPlayStatistics(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(0);
 }
@@ -2440,7 +2440,7 @@ void IApplicationFunctions::QueryApplicationPlayStatistics(HLERequestContext& ct
 void IApplicationFunctions::QueryApplicationPlayStatisticsByUid(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(0);
 }
@@ -2453,7 +2453,7 @@ void IApplicationFunctions::ExecuteProgram(HLERequestContext& ctx) {
     [[maybe_unused]] const auto unk_2 = rp.Pop<u32>();
     const auto program_index = rp.Pop<u64>();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     system.ExecuteProgram(program_index);
@@ -2464,7 +2464,7 @@ void IApplicationFunctions::ClearUserChannel(HLERequestContext& ctx) {
 
     system.GetUserChannel().clear();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2477,14 +2477,14 @@ void IApplicationFunctions::UnpopToUserChannel(HLERequestContext& ctx) {
         system.GetUserChannel().push_back(storage->GetData());
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IApplicationFunctions::GetPreviousProgramIndex(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(previous_program_index);
 }
@@ -2492,7 +2492,7 @@ void IApplicationFunctions::GetPreviousProgramIndex(HLERequestContext& ctx) {
 void IApplicationFunctions::GetGpuErrorDetectedSystemEvent(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(gpu_error_detected_event->GetReadableEvent());
 }
@@ -2500,7 +2500,7 @@ void IApplicationFunctions::GetGpuErrorDetectedSystemEvent(HLERequestContext& ct
 void IApplicationFunctions::GetFriendInvitationStorageChannelEvent(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(friend_invitation_storage_channel_event->GetReadableEvent());
 }
@@ -2508,14 +2508,14 @@ void IApplicationFunctions::GetFriendInvitationStorageChannelEvent(HLERequestCon
 void IApplicationFunctions::TryPopFromFriendInvitationStorageChannel(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(AM::ResultNoDataInChannel);
 }
 
 void IApplicationFunctions::GetNotificationStorageChannelEvent(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(notification_storage_channel_event->GetReadableEvent());
 }
@@ -2523,7 +2523,7 @@ void IApplicationFunctions::GetNotificationStorageChannelEvent(HLERequestContext
 void IApplicationFunctions::GetHealthWarningDisappearedSystemEvent(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(health_warning_disappeared_system_event->GetReadableEvent());
 }
@@ -2531,7 +2531,7 @@ void IApplicationFunctions::GetHealthWarningDisappearedSystemEvent(HLERequestCon
 void IApplicationFunctions::PrepareForJit(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2585,14 +2585,14 @@ IHomeMenuFunctions::~IHomeMenuFunctions() {
 void IHomeMenuFunctions::RequestToGetForeground(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHomeMenuFunctions::GetPopFromGeneralChannelEvent(HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(pop_from_general_channel_event->GetReadableEvent());
 }
@@ -2672,7 +2672,7 @@ void IProcessWindingController::GetLaunchReason(HLERequestContext& ctx) {
         .flag = 0,
     };
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(reason);
 }
@@ -2690,12 +2690,12 @@ void IProcessWindingController::OpenCallingLibraryApplet(HLERequestContext& ctx)
     if (applet == nullptr) {
         LOG_ERROR(Service_AM, "Applet doesn't exist! applet_id={}", applet_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ILibraryAppletAccessor>(system, applet);
 }

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -41,7 +41,7 @@ private:
     void GetCommonStateGetter(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ICommonStateGetter>(system, msg_queue);
     }
@@ -49,7 +49,7 @@ private:
     void GetSelfController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISelfController>(system, nvnflinger);
     }
@@ -57,7 +57,7 @@ private:
     void GetWindowController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IWindowController>(system);
     }
@@ -65,7 +65,7 @@ private:
     void GetAudioController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IAudioController>(system);
     }
@@ -73,7 +73,7 @@ private:
     void GetDisplayController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDisplayController>(system);
     }
@@ -81,7 +81,7 @@ private:
     void GetProcessWindingController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IProcessWindingController>(system);
     }
@@ -89,7 +89,7 @@ private:
     void GetLibraryAppletCreator(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ILibraryAppletCreator>(system);
     }
@@ -97,7 +97,7 @@ private:
     void OpenLibraryAppletSelfAccessor(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ILibraryAppletSelfAccessor>(system);
     }
@@ -105,7 +105,7 @@ private:
     void GetAppletCommonFunctions(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IAppletCommonFunctions>(system);
     }
@@ -113,7 +113,7 @@ private:
     void GetHomeMenuFunctions(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IHomeMenuFunctions>(system);
     }
@@ -121,7 +121,7 @@ private:
     void GetGlobalStateController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IGlobalStateController>(system);
     }
@@ -129,7 +129,7 @@ private:
     void GetDebugFunctions(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDebugFunctions>(system);
     }
@@ -169,7 +169,7 @@ private:
     void GetCommonStateGetter(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ICommonStateGetter>(system, msg_queue);
     }
@@ -177,7 +177,7 @@ private:
     void GetSelfController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISelfController>(system, nvnflinger);
     }
@@ -185,7 +185,7 @@ private:
     void GetWindowController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IWindowController>(system);
     }
@@ -193,7 +193,7 @@ private:
     void GetAudioController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IAudioController>(system);
     }
@@ -201,7 +201,7 @@ private:
     void GetDisplayController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDisplayController>(system);
     }
@@ -209,7 +209,7 @@ private:
     void GetLibraryAppletCreator(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ILibraryAppletCreator>(system);
     }
@@ -217,7 +217,7 @@ private:
     void GetHomeMenuFunctions(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IHomeMenuFunctions>(system);
     }
@@ -225,7 +225,7 @@ private:
     void GetGlobalStateController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IGlobalStateController>(system);
     }
@@ -233,7 +233,7 @@ private:
     void GetApplicationCreator(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IApplicationCreator>(system);
     }
@@ -241,7 +241,7 @@ private:
     void GetAppletCommonFunctions(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IAppletCommonFunctions>(system);
     }
@@ -249,7 +249,7 @@ private:
     void GetDebugFunctions(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDebugFunctions>(system);
     }
@@ -261,7 +261,7 @@ private:
 void AppletAE::OpenSystemAppletProxy(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISystemAppletProxy>(nvnflinger, msg_queue, system);
 }
@@ -269,7 +269,7 @@ void AppletAE::OpenSystemAppletProxy(HLERequestContext& ctx) {
 void AppletAE::OpenLibraryAppletProxy(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ILibraryAppletProxy>(nvnflinger, msg_queue, system);
 }
@@ -277,7 +277,7 @@ void AppletAE::OpenLibraryAppletProxy(HLERequestContext& ctx) {
 void AppletAE::OpenLibraryAppletProxyOld(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ILibraryAppletProxy>(nvnflinger, msg_queue, system);
 }

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -37,7 +37,7 @@ private:
     void GetAudioController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IAudioController>(system);
     }
@@ -45,7 +45,7 @@ private:
     void GetDisplayController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDisplayController>(system);
     }
@@ -53,7 +53,7 @@ private:
     void GetDebugFunctions(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDebugFunctions>(system);
     }
@@ -61,7 +61,7 @@ private:
     void GetWindowController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IWindowController>(system);
     }
@@ -69,7 +69,7 @@ private:
     void GetSelfController(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISelfController>(system, nvnflinger);
     }
@@ -77,7 +77,7 @@ private:
     void GetCommonStateGetter(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ICommonStateGetter>(system, msg_queue);
     }
@@ -85,7 +85,7 @@ private:
     void GetLibraryAppletCreator(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ILibraryAppletCreator>(system);
     }
@@ -93,7 +93,7 @@ private:
     void GetApplicationFunctions(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IApplicationFunctions>(system);
     }
@@ -105,7 +105,7 @@ private:
 void AppletOE::OpenApplicationProxy(HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IApplicationProxy>(nvnflinger, msg_queue, system);
 }

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -79,7 +79,7 @@ private:
 
         LOG_WARNING(Service_AOC, "(STUBBED) called, unknown_1={}", unknown_1);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -91,14 +91,14 @@ private:
 
         LOG_WARNING(Service_AOC, "(STUBBED) called, unknown_1={}", unknown_1);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetPurchasedEventReadableHandle(HLERequestContext& ctx) {
         LOG_WARNING(Service_AOC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(purchased_event->GetReadableEvent());
     }
@@ -106,14 +106,14 @@ private:
     void PopPurchasedProductInfo(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AOC, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultNoPurchasedProductInfoAvailable);
     }
 
     void PopPurchasedProductInfoWithUid(HLERequestContext& ctx) {
         LOG_DEBUG(Service_AOC, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultNoPurchasedProductInfoAvailable);
     }
 
@@ -172,7 +172,7 @@ void AOC_U::CountAddOnContent(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_AOC, "called. process_id={}", params.process_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     const auto current = system.GetApplicationProcessProgramID();
@@ -217,7 +217,7 @@ void AOC_U::ListAddOnContent(HLERequestContext& ctx) {
     }
 
     if (out.size() < offset) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         // TODO(DarkLordZach): Find the correct error code.
         rb.Push(ResultUnknown);
         return;
@@ -229,7 +229,7 @@ void AOC_U::ListAddOnContent(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(out);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(out_count);
 }
@@ -245,7 +245,7 @@ void AOC_U::GetAddOnContentBaseId(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_AOC, "called. process_id={}", params.process_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     const auto title_id = system.GetApplicationProcessProgramID();
@@ -274,14 +274,14 @@ void AOC_U::PrepareAddOnContent(HLERequestContext& ctx) {
     LOG_WARNING(Service_AOC, "(STUBBED) called with addon_index={}, process_id={}", addon_index,
                 process_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void AOC_U::GetAddOnContentListChangedEvent(HLERequestContext& ctx) {
     LOG_WARNING(Service_AOC, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(aoc_change_event->GetReadableEvent());
 }
@@ -289,7 +289,7 @@ void AOC_U::GetAddOnContentListChangedEvent(HLERequestContext& ctx) {
 void AOC_U::GetAddOnContentListChangedEventWithProcessId(HLERequestContext& ctx) {
     LOG_WARNING(Service_AOC, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(aoc_change_event->GetReadableEvent());
 }
@@ -297,28 +297,28 @@ void AOC_U::GetAddOnContentListChangedEventWithProcessId(HLERequestContext& ctx)
 void AOC_U::NotifyMountAddOnContent(HLERequestContext& ctx) {
     LOG_WARNING(Service_AOC, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void AOC_U::NotifyUnmountAddOnContent(HLERequestContext& ctx) {
     LOG_WARNING(Service_AOC, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void AOC_U::CheckAddOnContentMountStatus(HLERequestContext& ctx) {
     LOG_WARNING(Service_AOC, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void AOC_U::CreateEcPurchasedEventManager(HLERequestContext& ctx) {
     LOG_WARNING(Service_AOC, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IPurchaseEventManager>(system);
 }
@@ -326,7 +326,7 @@ void AOC_U::CreateEcPurchasedEventManager(HLERequestContext& ctx) {
 void AOC_U::CreatePermanentEcPurchasedEventManager(HLERequestContext& ctx) {
     LOG_WARNING(Service_AOC, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IPurchaseEventManager>(system);
 }

--- a/src/core/hle/service/apm/apm_interface.cpp
+++ b/src/core/hle/service/apm/apm_interface.cpp
@@ -31,7 +31,7 @@ private:
 
         controller.SetPerformanceConfiguration(mode, config);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -41,7 +41,7 @@ private:
         const auto mode = rp.PopEnum<PerformanceMode>();
         LOG_DEBUG(Service_APM, "called mode={}", mode);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushEnum(controller.GetCurrentPerformanceConfiguration(mode));
     }
@@ -54,7 +54,7 @@ private:
         LOG_WARNING(Service_APM, "(STUBBED) called, cpu_overclock_enabled={}",
                     cpu_overclock_enabled);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -77,7 +77,7 @@ APM::~APM() = default;
 void APM::OpenSession(HLERequestContext& ctx) {
     LOG_DEBUG(Service_APM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISession>(system, controller);
 }
@@ -85,14 +85,14 @@ void APM::OpenSession(HLERequestContext& ctx) {
 void APM::GetPerformanceMode(HLERequestContext& ctx) {
     LOG_DEBUG(Service_APM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.PushEnum(controller.GetCurrentPerformanceMode());
 }
 
 void APM::IsCpuOverclockEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Service_APM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(false);
 }
@@ -120,7 +120,7 @@ APM_Sys::~APM_Sys() = default;
 void APM_Sys::GetPerformanceEvent(HLERequestContext& ctx) {
     LOG_DEBUG(Service_APM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISession>(system, controller);
 }
@@ -133,14 +133,14 @@ void APM_Sys::SetCpuBoostMode(HLERequestContext& ctx) {
 
     controller.SetFromCpuBoostMode(mode);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void APM_Sys::GetCurrentPerformanceConfiguration(HLERequestContext& ctx) {
     LOG_DEBUG(Service_APM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(
         controller.GetCurrentPerformanceConfiguration(controller.GetCurrentPerformanceMode()));

--- a/src/core/hle/service/audio/audctl.cpp
+++ b/src/core/hle/service/audio/audctl.cpp
@@ -79,7 +79,7 @@ void AudCtl::GetTargetVolumeMin(HLERequestContext& ctx) {
     // actual console to this value (as of 8.0.0).
     constexpr s32 target_min_volume = 0;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(target_min_volume);
 }
@@ -91,7 +91,7 @@ void AudCtl::GetTargetVolumeMax(HLERequestContext& ctx) {
     // actual console to this value (as of 8.0.0).
     constexpr s32 target_max_volume = 15;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(target_max_volume);
 }
@@ -99,7 +99,7 @@ void AudCtl::GetTargetVolumeMax(HLERequestContext& ctx) {
 void AudCtl::GetForceMutePolicy(HLERequestContext& ctx) {
     LOG_WARNING(Audio, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(ForceMutePolicy::Disable);
 }
@@ -110,7 +110,7 @@ void AudCtl::GetOutputModeSetting(HLERequestContext& ctx) {
 
     LOG_WARNING(Audio, "(STUBBED) called, value={}", value);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(AudioOutputMode::PcmAuto);
 }
@@ -118,7 +118,7 @@ void AudCtl::GetOutputModeSetting(HLERequestContext& ctx) {
 void AudCtl::GetHeadphoneOutputLevelMode(HLERequestContext& ctx) {
     LOG_WARNING(Audio, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(HeadphoneOutputLevelMode::Normal);
 }
@@ -129,7 +129,7 @@ void AudCtl::IsSpeakerAutoMuteEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Audio, "(STUBBED) called, is_speaker_auto_mute_enabled={}",
                 is_speaker_auto_mute_enabled);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(is_speaker_auto_mute_enabled);
 }

--- a/src/core/hle/service/audio/audin_u.cpp
+++ b/src/core/hle/service/audio/audin_u.cpp
@@ -67,7 +67,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. State={}", state);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(state);
     }
@@ -77,7 +77,7 @@ private:
 
         auto result = impl->StartSystem();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -86,7 +86,7 @@ private:
 
         auto result = impl->StopSystem();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -108,7 +108,7 @@ private:
 
         auto result = impl->AppendBuffer(buffer, tag);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -117,7 +117,7 @@ private:
 
         auto& buffer_event = impl->GetBufferEvent();
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(buffer_event);
     }
@@ -134,7 +134,7 @@ private:
 
         ctx.WriteBuffer(released_buffer);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(count);
     }
@@ -147,7 +147,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Is buffer {:08X} registered? {}", tag, buffer_queued);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(buffer_queued);
     }
@@ -157,7 +157,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Buffer count={}", buffer_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(buffer_count);
     }
@@ -170,7 +170,7 @@ private:
 
         impl->SetVolume(volume);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -179,7 +179,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Gain {}", volume);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(volume);
     }
@@ -189,7 +189,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Were any buffers flushed? {}", flushed);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(flushed);
     }
@@ -234,7 +234,7 @@ void AudInU::ListAudioIns(HLERequestContext& ctx) {
         ctx.WriteBuffer(device_names);
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(out_count);
 }
@@ -254,7 +254,7 @@ void AudInU::ListAudioInsAutoFiltered(HLERequestContext& ctx) {
         ctx.WriteBuffer(device_names);
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(out_count);
 }
@@ -271,7 +271,7 @@ void AudInU::OpenAudioIn(HLERequestContext& ctx) {
     auto link{impl->LinkToManager()};
     if (link.IsError()) {
         LOG_ERROR(Service_Audio, "Failed to link Audio In to Audio Manager");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(link);
         return;
     }
@@ -279,7 +279,7 @@ void AudInU::OpenAudioIn(HLERequestContext& ctx) {
     size_t new_session_id{};
     auto result{impl->AcquireSessionId(new_session_id)};
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
@@ -299,7 +299,7 @@ void AudInU::OpenAudioIn(HLERequestContext& ctx) {
                                             static_cast<u32>(out_system.GetSampleFormat()),
                                         .state = static_cast<u32>(out_system.GetState())};
 
-    IPC::ResponseBuilder rb{ctx, 6, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     std::string out_name{out_system.GetName()};
     ctx.WriteBuffer(out_name);
@@ -322,7 +322,7 @@ void AudInU::OpenAudioInProtocolSpecified(HLERequestContext& ctx) {
     auto link{impl->LinkToManager()};
     if (link.IsError()) {
         LOG_ERROR(Service_Audio, "Failed to link Audio In to Audio Manager");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(link);
         return;
     }
@@ -330,7 +330,7 @@ void AudInU::OpenAudioInProtocolSpecified(HLERequestContext& ctx) {
     size_t new_session_id{};
     auto result{impl->AcquireSessionId(new_session_id)};
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
@@ -350,7 +350,7 @@ void AudInU::OpenAudioInProtocolSpecified(HLERequestContext& ctx) {
                                             static_cast<u32>(out_system.GetSampleFormat()),
                                         .state = static_cast<u32>(out_system.GetState())};
 
-    IPC::ResponseBuilder rb{ctx, 6, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     std::string out_name{out_system.GetName()};
     if (protocol_specified == 0) {

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -67,7 +67,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. State={}", state);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(state);
     }
@@ -77,7 +77,7 @@ private:
 
         auto result = impl->StartSystem();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -86,7 +86,7 @@ private:
 
         auto result = impl->StopSystem();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -108,7 +108,7 @@ private:
 
         auto result = impl->AppendBuffer(buffer, tag);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -117,7 +117,7 @@ private:
 
         auto& buffer_event = impl->GetBufferEvent();
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(buffer_event);
     }
@@ -134,7 +134,7 @@ private:
         LOG_TRACE(Service_Audio, "called. Session {} released {} buffers",
                   impl->GetSystem().GetSessionId(), count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(count);
     }
@@ -147,7 +147,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Is buffer {:08X} registered? {}", tag, buffer_queued);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(buffer_queued);
     }
@@ -157,7 +157,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Buffer count={}", buffer_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(buffer_count);
     }
@@ -167,7 +167,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Played samples={}", samples_played);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(samples_played);
     }
@@ -177,7 +177,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Were any buffers flushed? {}", flushed);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(flushed);
     }
@@ -190,7 +190,7 @@ private:
 
         impl->SetVolume(volume);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -199,7 +199,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Volume={}", volume);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(volume);
     }
@@ -244,7 +244,7 @@ void AudOutU::ListAudioOuts(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(device_names);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(static_cast<u32>(device_names.size()));
 }
@@ -260,7 +260,7 @@ void AudOutU::OpenAudioOut(HLERequestContext& ctx) {
     auto link{impl->LinkToManager()};
     if (link.IsError()) {
         LOG_ERROR(Service_Audio, "Failed to link Audio Out to Audio Manager");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(link);
         return;
     }
@@ -268,7 +268,7 @@ void AudOutU::OpenAudioOut(HLERequestContext& ctx) {
     size_t new_session_id{};
     auto result{impl->AcquireSessionId(new_session_id)};
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
@@ -282,7 +282,7 @@ void AudOutU::OpenAudioOut(HLERequestContext& ctx) {
                                                           applet_resource_user_id);
     if (result.IsError()) {
         LOG_ERROR(Service_Audio, "Failed to initialize the AudioOut System!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
@@ -297,7 +297,7 @@ void AudOutU::OpenAudioOut(HLERequestContext& ctx) {
                                              static_cast<u32>(out_system.GetSampleFormat()),
                                          .state = static_cast<u32>(out_system.GetState())};
 
-    IPC::ResponseBuilder rb{ctx, 6, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     ctx.WriteBuffer(out_system.GetName());
 

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -74,7 +74,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Sample rate {}", sample_rate);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(sample_rate);
     }
@@ -84,7 +84,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called. Sample count {}", sample_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(sample_count);
     }
@@ -94,7 +94,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called, state {}", state);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(state);
     }
@@ -104,7 +104,7 @@ private:
 
         const auto buffer_count{impl->GetSystem().GetMixBufferCount()};
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(buffer_count);
     }
@@ -142,7 +142,7 @@ private:
             LOG_ERROR(Service_Audio, "RequestUpdate failed error 0x{:02X}!", result.description);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -151,7 +151,7 @@ private:
 
         impl->Start();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -160,7 +160,7 @@ private:
 
         impl->Stop();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -168,12 +168,12 @@ private:
         LOG_DEBUG(Service_Audio, "called");
 
         if (impl->GetSystem().GetExecutionMode() == AudioCore::ExecutionMode::Manual) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Audio::ResultNotSupported);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(rendered_event->GetReadableEvent());
     }
@@ -187,7 +187,7 @@ private:
         auto& system_ = impl->GetSystem();
         system_.SetRenderingTimeLimit(limit);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -197,7 +197,7 @@ private:
         auto& system_ = impl->GetSystem();
         auto time = system_.GetRenderingTimeLimit();
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(time);
     }
@@ -215,7 +215,7 @@ private:
         auto& system_ = impl->GetSystem();
         system_.SetVoiceDropParameter(voice_drop_param);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -225,7 +225,7 @@ private:
         auto& system_ = impl->GetSystem();
         auto voice_drop_param{system_.GetVoiceDropParameter()};
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(voice_drop_param);
     }
@@ -292,7 +292,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called.\nNames={}", out);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
 
         ctx.WriteBuffer(out_names);
 
@@ -313,7 +313,7 @@ private:
             impl->SetDeviceVolumes(volume);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -328,7 +328,7 @@ private:
             volume = impl->GetDeviceVolume(name);
         }
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(volume);
     }
@@ -343,7 +343,7 @@ private:
 
         ctx.WriteBuffer(out_name);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -352,7 +352,7 @@ private:
 
         event->Signal();
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(event->GetReadableEvent());
     }
@@ -363,7 +363,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "(STUBBED) called. Channels={}", channel_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
 
         rb.Push(ResultSuccess);
         rb.Push<u32>(channel_count);
@@ -372,7 +372,7 @@ private:
     void QueryAudioDeviceInputEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_Audio, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(event->GetReadableEvent());
     }
@@ -380,7 +380,7 @@ private:
     void QueryAudioDeviceOutputEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_Audio, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(event->GetReadableEvent());
     }
@@ -405,7 +405,7 @@ private:
 
         LOG_DEBUG(Service_Audio, "called.\nNames={}", out);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
 
         ctx.WriteBuffer(out_names);
 
@@ -449,7 +449,7 @@ void AudRenU::OpenAudioRenderer(HLERequestContext& ctx) {
 
     if (impl->GetSessionCount() + 1 > AudioCore::MaxRendererSessions) {
         LOG_ERROR(Service_Audio, "Too many AudioRenderer sessions open!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Audio::ResultOutOfSessions);
         return;
     }
@@ -460,7 +460,7 @@ void AudRenU::OpenAudioRenderer(HLERequestContext& ctx) {
     const auto session_id{impl->GetSessionId()};
     if (session_id == -1) {
         LOG_ERROR(Service_Audio, "Tried to open a session that's already in use!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Audio::ResultOutOfSessions);
         return;
     }
@@ -468,7 +468,7 @@ void AudRenU::OpenAudioRenderer(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Audio, "Opened new AudioRenderer session {} sessions open {}", session_id,
               impl->GetSessionCount());
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IAudioRenderer>(system, *impl, params, transfer_memory.GetPointerUnsafe(),
                                         transfer_memory_size, process_handle,
@@ -501,7 +501,7 @@ void AudRenU::GetWorkBufferSize(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Audio, "called.\nInput params:\n{}\nOutput params:\n\tWorkbuffer size {:08X}",
               output_info, size);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push<u64>(size);
 }
@@ -513,7 +513,7 @@ void AudRenU::GetAudioDeviceService(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_Audio, "called. Applet resource id {}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IAudioDevice>(system, applet_resource_user_id,
@@ -537,7 +537,7 @@ void AudRenU::GetAudioDeviceServiceWithRevisionInfo(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Audio, "called. Revision {} Applet resource id {}",
               AudioCore::GetRevisionNum(revision), applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IAudioDevice>(system, applet_resource_user_id, revision,

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -65,7 +65,7 @@ private:
 
         ctx.WriteBuffer(output_data);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(size);
         rb.Push(sample_count);
@@ -79,7 +79,7 @@ private:
         auto input_data{ctx.ReadBuffer(0)};
         auto result = impl->SetContext(input_data);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -98,7 +98,7 @@ private:
 
         ctx.WriteBuffer(output_data);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(size);
         rb.Push(sample_count);
@@ -112,7 +112,7 @@ private:
         auto input_data{ctx.ReadBuffer(0)};
         auto result = impl->SetContext(input_data);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -133,7 +133,7 @@ private:
 
         ctx.WriteBuffer(output_data);
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(size);
         rb.Push(sample_count);
@@ -157,7 +157,7 @@ private:
 
         ctx.WriteBuffer(output_data);
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(size);
         rb.Push(sample_count);
@@ -183,7 +183,7 @@ private:
 
         ctx.WriteBuffer(output_data);
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(size);
         rb.Push(sample_count);
@@ -209,7 +209,7 @@ private:
 
         ctx.WriteBuffer(output_data);
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(size);
         rb.Push(sample_count);
@@ -235,7 +235,7 @@ private:
 
         ctx.WriteBuffer(output_data);
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(size);
         rb.Push(sample_count);
@@ -261,7 +261,7 @@ private:
 
         ctx.WriteBuffer(output_data);
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(size);
         rb.Push(sample_count);
@@ -292,7 +292,7 @@ void HwOpus::OpenHardwareOpusDecoder(HLERequestContext& ctx) {
     };
     auto result = decoder->Initialize(ex, transfer_memory.GetPointerUnsafe(), transfer_memory_size);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushIpcInterface(decoder);
 }
@@ -307,7 +307,7 @@ void HwOpus::GetWorkBufferSize(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Audio, "sample_rate {} channel_count {} -- returned size 0x{:X}",
               params.sample_rate, params.channel_count, size);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(size);
 }
@@ -342,7 +342,7 @@ void HwOpus::OpenHardwareOpusDecoderForMultiStream(HLERequestContext& ctx) {
     std::memcpy(ex.mappings.data(), params.mappings.data(), sizeof(params.mappings));
     auto result = decoder->Initialize(ex, transfer_memory.GetPointerUnsafe(), transfer_memory_size);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushIpcInterface(decoder);
 }
@@ -359,7 +359,7 @@ void HwOpus::GetWorkBufferSizeForMultiStream(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_Audio, "size 0x{:X}", size);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(size);
 }
@@ -380,7 +380,7 @@ void HwOpus::OpenHardwareOpusDecoderEx(HLERequestContext& ctx) {
     auto result =
         decoder->Initialize(params, transfer_memory.GetPointerUnsafe(), transfer_memory_size);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushIpcInterface(decoder);
 }
@@ -394,7 +394,7 @@ void HwOpus::GetWorkBufferSizeEx(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_Audio, "size 0x{:X}", size);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(size);
 }
@@ -422,7 +422,7 @@ void HwOpus::OpenHardwareOpusDecoderForMultiStreamEx(HLERequestContext& ctx) {
     auto result =
         decoder->Initialize(params, transfer_memory.GetPointerUnsafe(), transfer_memory_size);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushIpcInterface(decoder);
 }
@@ -443,7 +443,7 @@ void HwOpus::GetWorkBufferSizeForMultiStreamEx(HLERequestContext& ctx) {
               params.sample_rate, params.channel_count, params.total_stream_count,
               params.stereo_stream_count, params.use_large_frame_size, size);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(size);
 }
@@ -457,7 +457,7 @@ void HwOpus::GetWorkBufferSizeExEx(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_Audio, "size 0x{:X}", size);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(size);
 }
@@ -474,7 +474,7 @@ void HwOpus::GetWorkBufferSizeForMultiStreamExEx(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_Audio, "size 0x{:X}", size);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(size);
 }

--- a/src/core/hle/service/bcat/bcat_module.cpp
+++ b/src/core/hle/service/bcat/bcat_module.cpp
@@ -58,7 +58,7 @@ bool VerifyNameValidInternal(HLERequestContext& ctx, std::array<char, 0x20> name
     });
     if (null_chars == 0x20 || null_chars == 0 || bad_chars != 0 || name[0x1F] != '\0') {
         LOG_ERROR(Service_BCAT, "Name passed was invalid!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ERROR_INVALID_ARGUMENT);
         return false;
     }
@@ -101,7 +101,7 @@ private:
     void GetEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_BCAT, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(event);
     }
@@ -111,7 +111,7 @@ private:
 
         ctx.WriteBuffer(impl);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -180,7 +180,7 @@ private:
                              GetCurrentBuildID(system.GetApplicationProcessBuildID())},
                             GetProgressBackend(SyncType::Normal));
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface(CreateProgressService(SyncType::Normal));
     }
@@ -197,7 +197,7 @@ private:
                                       GetCurrentBuildID(system.GetApplicationProcessBuildID())},
                                      name, GetProgressBackend(SyncType::Directory));
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface(CreateProgressService(SyncType::Directory));
     }
@@ -213,13 +213,13 @@ private:
 
         if (title_id == 0) {
             LOG_ERROR(Service_BCAT, "Invalid title ID!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_INVALID_ARGUMENT);
         }
 
         if (passphrase_raw.size() > 0x40) {
             LOG_ERROR(Service_BCAT, "Passphrase too large!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_INVALID_ARGUMENT);
             return;
         }
@@ -230,7 +230,7 @@ private:
 
         backend.SetPassphrase(title_id, passphrase);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -242,19 +242,19 @@ private:
 
         if (title_id == 0) {
             LOG_ERROR(Service_BCAT, "Invalid title ID!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_INVALID_ARGUMENT);
             return;
         }
 
         if (!backend.Clear(title_id)) {
             LOG_ERROR(Service_BCAT, "Could not clear the directory successfully!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_FAILED_CLEAR_CACHE);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -273,7 +273,7 @@ private:
 void Module::Interface::CreateBcatService(HLERequestContext& ctx) {
     LOG_DEBUG(Service_BCAT, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IBcatService>(system, *backend);
 }
@@ -312,7 +312,7 @@ private:
 
         if (current_file != nullptr) {
             LOG_ERROR(Service_BCAT, "A file has already been opened on this interface!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_ENTITY_ALREADY_OPEN);
             return;
         }
@@ -321,7 +321,7 @@ private:
 
         if (dir == nullptr) {
             LOG_ERROR(Service_BCAT, "The directory of name={} couldn't be opened!", dir_name);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_FAILED_OPEN_ENTITY);
             return;
         }
@@ -330,12 +330,12 @@ private:
 
         if (current_file == nullptr) {
             LOG_ERROR(Service_BCAT, "The file of name={} couldn't be opened!", file_name);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_FAILED_OPEN_ENTITY);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -349,7 +349,7 @@ private:
 
         if (current_file == nullptr) {
             LOG_ERROR(Service_BCAT, "There is no file currently open!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_NO_OPEN_ENTITY);
         }
 
@@ -357,7 +357,7 @@ private:
         const auto buffer = current_file->ReadBytes(size, offset);
         ctx.WriteBuffer(buffer);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(buffer.size());
     }
@@ -367,11 +367,11 @@ private:
 
         if (current_file == nullptr) {
             LOG_ERROR(Service_BCAT, "There is no file currently open!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_NO_OPEN_ENTITY);
         }
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(current_file->GetSize());
     }
@@ -381,11 +381,11 @@ private:
 
         if (current_file == nullptr) {
             LOG_ERROR(Service_BCAT, "There is no file currently open!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_NO_OPEN_ENTITY);
         }
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(DigestFile(current_file));
     }
@@ -424,7 +424,7 @@ private:
 
         if (current_dir != nullptr) {
             LOG_ERROR(Service_BCAT, "A file has already been opened on this interface!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_ENTITY_ALREADY_OPEN);
             return;
         }
@@ -433,12 +433,12 @@ private:
 
         if (current_dir == nullptr) {
             LOG_ERROR(Service_BCAT, "Failed to open the directory name={}!", name);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_FAILED_OPEN_ENTITY);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -449,7 +449,7 @@ private:
 
         if (current_dir == nullptr) {
             LOG_ERROR(Service_BCAT, "There is no open directory!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_NO_OPEN_ENTITY);
             return;
         }
@@ -467,7 +467,7 @@ private:
 
         ctx.WriteBuffer(entries);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(static_cast<u32>(write_size * sizeof(DeliveryCacheDirectoryEntry)));
     }
@@ -477,14 +477,14 @@ private:
 
         if (current_dir == nullptr) {
             LOG_ERROR(Service_BCAT, "There is no open directory!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_NO_OPEN_ENTITY);
             return;
         }
 
         const auto files = current_dir->GetFiles();
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(static_cast<u32>(files.size()));
     }
@@ -519,7 +519,7 @@ private:
     void CreateFileService(HLERequestContext& ctx) {
         LOG_DEBUG(Service_BCAT, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDeliveryCacheFileService>(system, root);
     }
@@ -527,7 +527,7 @@ private:
     void CreateDirectoryService(HLERequestContext& ctx) {
         LOG_DEBUG(Service_BCAT, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDeliveryCacheDirectoryService>(system, root);
     }
@@ -541,7 +541,7 @@ private:
         ctx.WriteBuffer(entries.data() + next_read_index, size * sizeof(DirectoryName));
         next_read_index += size;
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(static_cast<u32>(size));
     }
@@ -555,7 +555,7 @@ void Module::Interface::CreateDeliveryCacheStorageService(HLERequestContext& ctx
     LOG_DEBUG(Service_BCAT, "called");
 
     const auto title_id = system.GetApplicationProcessProgramID();
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IDeliveryCacheStorageService>(system, fsc.GetBCATDirectory(title_id));
 }
@@ -566,7 +566,7 @@ void Module::Interface::CreateDeliveryCacheStorageServiceWithApplicationId(HLERe
 
     LOG_DEBUG(Service_BCAT, "called, title_id={:016X}", title_id);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IDeliveryCacheStorageService>(system, fsc.GetBCATDirectory(title_id));
 }

--- a/src/core/hle/service/btdrv/btdrv.cpp
+++ b/src/core/hle/service/btdrv/btdrv.cpp
@@ -44,7 +44,7 @@ private:
     void RegisterBleEvent(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(register_event->GetReadableEvent());
     }

--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -73,7 +73,7 @@ private:
     void AcquireBleScanEvent(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(true);
         rb.PushCopyObjects(scan_event->GetReadableEvent());
@@ -82,7 +82,7 @@ private:
     void AcquireBleConnectionEvent(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(true);
         rb.PushCopyObjects(connection_event->GetReadableEvent());
@@ -91,7 +91,7 @@ private:
     void AcquireBleServiceDiscoveryEvent(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(true);
         rb.PushCopyObjects(service_discovery_event->GetReadableEvent());
@@ -100,7 +100,7 @@ private:
     void AcquireBleMtuConfigEvent(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(true);
         rb.PushCopyObjects(config_event->GetReadableEvent());
@@ -129,7 +129,7 @@ private:
     void GetCore(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IBtmUserCore>(system);
     }
@@ -297,39 +297,39 @@ private:
     void IsRadioEnabled(HLERequestContext& ctx) {
         LOG_DEBUG(Service_BTM, "(STUBBED) called"); // Spams a lot when controller applet is running
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(true);
     }
 
     void StartGamepadPairing(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void CancelGamepadPairing(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void CancelAudioDeviceConnectionRejection(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetConnectedAudioDevices(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(0);
     }
 
     void RequestAudioDeviceConnectionRejection(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };
@@ -350,7 +350,7 @@ private:
     void GetCore(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IBtmSystemCore>(system);
     }

--- a/src/core/hle/service/caps/caps_a.cpp
+++ b/src/core/hle/service/caps/caps_a.cpp
@@ -72,7 +72,7 @@ void IAlbumAccessorService::DeleteAlbumFile(HLERequestContext& ctx) {
     Result result = manager->DeleteAlbumFile(file_id);
     result = TranslateResult(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -86,7 +86,7 @@ void IAlbumAccessorService::IsAlbumMounted(HLERequestContext& ctx) {
     const bool is_mounted = result.IsSuccess();
     result = TranslateResult(result);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push<u8>(is_mounted);
 }
@@ -105,7 +105,7 @@ void IAlbumAccessorService::Unknown18(HLERequestContext& ctx) {
         ctx.WriteBuffer(buffer);
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(buffer.size()));
 }
@@ -128,7 +128,7 @@ void IAlbumAccessorService::GetAlbumFileListEx0(HLERequestContext& ctx) {
         ctx.WriteBuffer(entries);
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push<u64>(entries.size());
 }
@@ -140,7 +140,7 @@ void IAlbumAccessorService::GetAutoSavingStorage(HLERequestContext& ctx) {
     Result result = manager->GetAutoSavingStorage(is_autosaving);
     result = TranslateResult(result);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push<u8>(is_autosaving);
 }
@@ -169,7 +169,7 @@ void IAlbumAccessorService::LoadAlbumScreenShotImageEx1(HLERequestContext& ctx) 
         ctx.WriteBuffer(image, 1);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -192,7 +192,7 @@ void IAlbumAccessorService::LoadAlbumScreenShotThumbnailImageEx1(HLERequestConte
         ctx.WriteBuffer(image, 1);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 

--- a/src/core/hle/service/caps/caps_c.cpp
+++ b/src/core/hle/service/caps/caps_c.cpp
@@ -50,7 +50,7 @@ void IAlbumControlService::SetShimLibraryVersion(HLERequestContext& ctx) {
     LOG_WARNING(Service_Capture, "(STUBBED) called. library_version={}, applet_resource_user_id={}",
                 library_version, applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 

--- a/src/core/hle/service/caps/caps_ss.cpp
+++ b/src/core/hle/service/caps/caps_ss.cpp
@@ -54,7 +54,7 @@ void IScreenShotService::SaveScreenShotEx0(HLERequestContext& ctx) {
         manager->SaveScreenShot(entry, parameters.attribute, parameters.report_option,
                                 image_data_buffer, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 10};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushRaw(entry);
 }
@@ -90,7 +90,7 @@ void IScreenShotService::SaveEditedScreenShotEx1(HLERequestContext& ctx) {
     const auto result = manager->SaveEditedScreenShot(entry, parameters.attribute,
                                                       parameters.file_id, image_data_buffer);
 
-    IPC::ResponseBuilder rb{ctx, 10};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushRaw(entry);
 }

--- a/src/core/hle/service/caps/caps_su.cpp
+++ b/src/core/hle/service/caps/caps_su.cpp
@@ -37,7 +37,7 @@ void IScreenShotApplicationService::SetShimLibraryVersion(HLERequestContext& ctx
     LOG_WARNING(Service_Capture, "(STUBBED) called. library_version={}, applet_resource_user_id={}",
                 library_version, applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -65,7 +65,7 @@ void IScreenShotApplicationService::SaveScreenShotEx0(HLERequestContext& ctx) {
         manager->SaveScreenShot(entry, parameters.attribute, parameters.report_option,
                                 image_data_buffer, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 10};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushRaw(entry);
 }
@@ -97,7 +97,7 @@ void IScreenShotApplicationService::SaveScreenShotEx1(HLERequestContext& ctx) {
         manager->SaveScreenShot(entry, parameters.attribute, parameters.report_option, app_data,
                                 image_data_buffer, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 10};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushRaw(entry);
 }

--- a/src/core/hle/service/caps/caps_u.cpp
+++ b/src/core/hle/service/caps/caps_u.cpp
@@ -44,7 +44,7 @@ void IAlbumApplicationService::SetShimLibraryVersion(HLERequestContext& ctx) {
     LOG_WARNING(Service_Capture, "(STUBBED) called. library_version={}, applet_resource_user_id={}",
                 library_version, applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -84,7 +84,7 @@ void IAlbumApplicationService::GetAlbumFileList0AafeAruidDeprecated(HLERequestCo
         ctx.WriteBuffer(entries);
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push<u64>(entries.size());
 }
@@ -128,7 +128,7 @@ void IAlbumApplicationService::GetAlbumFileList3AaeAruid(HLERequestContext& ctx)
         ctx.WriteBuffer(entries);
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push<u64>(entries.size());
 }

--- a/src/core/hle/service/es/es.cpp
+++ b/src/core/hle/service/es/es.cpp
@@ -113,7 +113,7 @@ private:
     bool CheckRightsId(HLERequestContext& ctx, const u128& rights_id) {
         if (rights_id == u128{}) {
             LOG_ERROR(Service_ETicket, "The rights ID was invalid!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_INVALID_RIGHTS_ID);
             return false;
         }
@@ -127,7 +127,7 @@ private:
 
         if (raw_ticket.size() < sizeof(Core::Crypto::Ticket)) {
             LOG_ERROR(Service_ETicket, "The input buffer is not large enough!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_INVALID_ARGUMENT);
             return;
         }
@@ -135,12 +135,12 @@ private:
         Core::Crypto::Ticket ticket = Core::Crypto::Ticket::Read(raw_ticket);
         if (!keys.AddTicket(ticket)) {
             LOG_ERROR(Service_ETicket, "The ticket could not be imported!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_INVALID_ARGUMENT);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -159,14 +159,14 @@ private:
         if (key == Core::Crypto::Key128{}) {
             LOG_ERROR(Service_ETicket,
                       "The titlekey doesn't exist in the KeyManager or the rights ID was invalid!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_INVALID_RIGHTS_ID);
             return;
         }
 
         ctx.WriteBuffer(key);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -175,7 +175,7 @@ private:
 
         const u32 count = static_cast<u32>(keys.GetCommonTickets().size());
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(count);
     }
@@ -185,7 +185,7 @@ private:
 
         const u32 count = static_cast<u32>(keys.GetPersonalizedTickets().size());
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(count);
     }
@@ -206,7 +206,7 @@ private:
         out_entries = std::min(ids.size(), out_entries);
         ctx.WriteBuffer(ids.data(), out_entries * sizeof(u128));
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(static_cast<u32>(out_entries));
     }
@@ -228,7 +228,7 @@ private:
         out_entries = std::min(ids.size(), out_entries);
         ctx.WriteBuffer(ids.data(), out_entries * sizeof(u128));
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(static_cast<u32>(out_entries));
     }
@@ -244,7 +244,7 @@ private:
 
         const auto ticket = keys.GetCommonTickets().at(rights_id);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(ticket.GetSize());
     }
@@ -260,7 +260,7 @@ private:
 
         const auto ticket = keys.GetPersonalizedTickets().at(rights_id);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(ticket.GetSize());
     }
@@ -279,7 +279,7 @@ private:
         const auto write_size = std::min<u64>(ticket.GetSize(), ctx.GetWriteBufferSize());
         ctx.WriteBuffer(&ticket, write_size);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(write_size);
     }
@@ -298,7 +298,7 @@ private:
         const auto write_size = std::min<u64>(ticket.GetSize(), ctx.GetWriteBufferSize());
         ctx.WriteBuffer(&ticket, write_size);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(write_size);
     }

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -132,7 +132,7 @@ void Module::Interface::ThrowFatal(HLERequestContext& ctx) {
     const auto error_code = rp.Pop<Result>();
 
     ThrowFatalError(system, error_code, FatalType::ErrorScreen, {});
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -144,7 +144,7 @@ void Module::Interface::ThrowFatalWithPolicy(HLERequestContext& ctx) {
 
     ThrowFatalError(system, error_code, fatal_type,
                     {}); // No info is passed with ThrowFatalWithPolicy
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -160,7 +160,7 @@ void Module::Interface::ThrowFatalWithCpuContext(HLERequestContext& ctx) {
     std::memcpy(&info, fatal_info.data(), sizeof(FatalInfo));
 
     ThrowFatalError(system, error_code, fatal_type, info);
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 

--- a/src/core/hle/service/fgm/fgm.cpp
+++ b/src/core/hle/service/fgm/fgm.cpp
@@ -43,7 +43,7 @@ private:
     void Initialize(HLERequestContext& ctx) {
         LOG_DEBUG(Service_FGM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IRequest>(system);
     }

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -84,13 +84,13 @@ private:
         // Error checking
         if (length < 0) {
             LOG_ERROR(Service_FS, "Length is less than 0, length={}", length);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(FileSys::ERROR_INVALID_SIZE);
             return;
         }
         if (offset < 0) {
             LOG_ERROR(Service_FS, "Offset is less than 0, offset={}", offset);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(FileSys::ERROR_INVALID_OFFSET);
             return;
         }
@@ -100,7 +100,7 @@ private:
         // Write the data to memory
         ctx.WriteBuffer(output);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -108,7 +108,7 @@ private:
         const u64 size = backend->GetSize();
         LOG_DEBUG(Service_FS, "called, size={}", size);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(size);
     }
@@ -145,13 +145,13 @@ private:
         // Error checking
         if (length < 0) {
             LOG_ERROR(Service_FS, "Length is less than 0, length={}", length);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(FileSys::ERROR_INVALID_SIZE);
             return;
         }
         if (offset < 0) {
             LOG_ERROR(Service_FS, "Offset is less than 0, offset={}", offset);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(FileSys::ERROR_INVALID_OFFSET);
             return;
         }
@@ -162,7 +162,7 @@ private:
         // Write the data to memory
         ctx.WriteBuffer(output);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(static_cast<u64>(output.size()));
     }
@@ -179,13 +179,13 @@ private:
         // Error checking
         if (length < 0) {
             LOG_ERROR(Service_FS, "Length is less than 0, length={}", length);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(FileSys::ERROR_INVALID_SIZE);
             return;
         }
         if (offset < 0) {
             LOG_ERROR(Service_FS, "Offset is less than 0, offset={}", offset);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(FileSys::ERROR_INVALID_OFFSET);
             return;
         }
@@ -206,7 +206,7 @@ private:
                    "Could not write all bytes to file (requested={:016X}, actual={:016X}).", length,
                    written);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -215,7 +215,7 @@ private:
 
         // Exists for SDK compatibiltity -- No need to flush file.
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -226,7 +226,7 @@ private:
 
         backend->Resize(size);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -234,7 +234,7 @@ private:
         const u64 size = backend->GetSize();
         LOG_DEBUG(Service_FS, "called, size={}", size);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(size);
     }
@@ -301,7 +301,7 @@ private:
         // Write the data to memory
         ctx.WriteBuffer(begin, range_size);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(actual_entries);
     }
@@ -311,7 +311,7 @@ private:
 
         u64 count = entries.size() - next_entry_index;
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(count);
     }
@@ -356,7 +356,7 @@ public:
         LOG_DEBUG(Service_FS, "called. file={}, mode=0x{:X}, size=0x{:08X}", name, file_mode,
                   file_size);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(backend.CreateFile(name, file_size));
     }
 
@@ -366,7 +366,7 @@ public:
 
         LOG_DEBUG(Service_FS, "called. file={}", name);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(backend.DeleteFile(name));
     }
 
@@ -376,7 +376,7 @@ public:
 
         LOG_DEBUG(Service_FS, "called. directory={}", name);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(backend.CreateDirectory(name));
     }
 
@@ -386,7 +386,7 @@ public:
 
         LOG_DEBUG(Service_FS, "called. directory={}", name);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(backend.DeleteDirectory(name));
     }
 
@@ -396,7 +396,7 @@ public:
 
         LOG_DEBUG(Service_FS, "called. directory={}", name);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(backend.DeleteDirectoryRecursively(name));
     }
 
@@ -406,7 +406,7 @@ public:
 
         LOG_DEBUG(Service_FS, "called. Directory: {}", name);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(backend.CleanDirectoryRecursively(name));
     }
 
@@ -416,7 +416,7 @@ public:
 
         LOG_DEBUG(Service_FS, "called. file '{}' to file '{}'", src_name, dst_name);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(backend.RenameFile(src_name, dst_name));
     }
 
@@ -433,14 +433,14 @@ public:
         FileSys::VirtualFile vfs_file{};
         auto result = backend.OpenFile(&vfs_file, name, mode);
         if (result != ResultSuccess) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
         auto file = std::make_shared<IFile>(system, vfs_file);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IFile>(std::move(file));
     }
@@ -457,14 +457,14 @@ public:
         FileSys::VirtualDir vfs_dir{};
         auto result = backend.OpenDirectory(&vfs_dir, name);
         if (result != ResultSuccess) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
         auto directory = std::make_shared<IDirectory>(system, vfs_dir, mode);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDirectory>(std::move(directory));
     }
@@ -478,12 +478,12 @@ public:
         FileSys::EntryType vfs_entry_type{};
         auto result = backend.GetEntryType(&vfs_entry_type, name);
         if (result != ResultSuccess) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(static_cast<u32>(vfs_entry_type));
     }
@@ -491,14 +491,14 @@ public:
     void Commit(HLERequestContext& ctx) {
         LOG_WARNING(Service_FS, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetFreeSpaceSize(HLERequestContext& ctx) {
         LOG_DEBUG(Service_FS, "called");
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(size.get_free_size());
     }
@@ -506,7 +506,7 @@ public:
     void GetTotalSpaceSize(HLERequestContext& ctx) {
         LOG_DEBUG(Service_FS, "called");
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(size.get_total_size());
     }
@@ -520,12 +520,12 @@ public:
         FileSys::FileTimeStampRaw vfs_timestamp{};
         auto result = backend.GetFileTimeStampRaw(&vfs_timestamp, name);
         if (result != ResultSuccess) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 10};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(vfs_timestamp);
     }
@@ -565,7 +565,7 @@ public:
         savedata_attribute.dir_entry_name_length_max = 0x40;
         savedata_attribute.file_entry_name_length_max = 0x40;
 
-        IPC::ResponseBuilder rb{ctx, 50};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(savedata_attribute);
     }
@@ -607,7 +607,7 @@ public:
         // Write the data to memory
         ctx.WriteBuffer(begin, range_size);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(actual_entries);
     }
@@ -876,7 +876,7 @@ void FSP_SRV::SetCurrentProcess(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS, "called. current_process_id=0x{:016X}", current_process_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -887,7 +887,7 @@ void FSP_SRV::OpenFileSystemWithPatch(HLERequestContext& ctx) {
     const auto title_id = rp.PopRaw<u64>();
     LOG_WARNING(Service_FS, "(STUBBED) called with type={}, title_id={:016X}", type, title_id);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 0};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
 }
 
@@ -900,7 +900,7 @@ void FSP_SRV::OpenSdCardFileSystem(HLERequestContext& ctx) {
     auto filesystem = std::make_shared<IFileSystem>(
         system, sdmc_dir, SizeGetter::FromStorageId(fsc, FileSys::StorageId::SdCard));
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IFileSystem>(std::move(filesystem));
 }
@@ -918,7 +918,7 @@ void FSP_SRV::CreateSaveDataFileSystem(HLERequestContext& ctx) {
     FileSys::VirtualDir save_data_dir{};
     fsc.CreateSaveData(&save_data_dir, FileSys::SaveDataSpaceId::NandUser, save_struct);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -933,7 +933,7 @@ void FSP_SRV::CreateSaveDataFileSystemBySystemSaveDataId(HLERequestContext& ctx)
     FileSys::VirtualDir save_data_dir{};
     fsc.CreateSaveData(&save_data_dir, FileSys::SaveDataSpaceId::NandSystem, save_struct);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -952,7 +952,7 @@ void FSP_SRV::OpenSaveDataFileSystem(HLERequestContext& ctx) {
     FileSys::VirtualDir dir{};
     auto result = fsc.OpenSaveData(&dir, parameters.space_id, parameters.attribute);
     if (result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2, 0, 0};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(FileSys::ERROR_ENTITY_NOT_FOUND);
         return;
     }
@@ -978,7 +978,7 @@ void FSP_SRV::OpenSaveDataFileSystem(HLERequestContext& ctx) {
     auto filesystem =
         std::make_shared<IFileSystem>(system, std::move(dir), SizeGetter::FromStorageId(fsc, id));
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IFileSystem>(std::move(filesystem));
 }
@@ -998,7 +998,7 @@ void FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(HLERequestContext& ctx) {
     const auto space = rp.PopRaw<FileSys::SaveDataSpaceId>();
     LOG_INFO(Service_FS, "called, space={}", space);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISaveDataInfoReader>(
         std::make_shared<ISaveDataInfoReader>(system, space, fsc));
@@ -1007,7 +1007,7 @@ void FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(HLERequestContext& ctx) {
 void FSP_SRV::OpenSaveDataInfoReaderOnlyCacheStorage(HLERequestContext& ctx) {
     LOG_WARNING(Service_FS, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISaveDataInfoReader>(system, FileSys::SaveDataSpaceId::TemporaryStorage,
                                              fsc);
@@ -1016,7 +1016,7 @@ void FSP_SRV::OpenSaveDataInfoReaderOnlyCacheStorage(HLERequestContext& ctx) {
 void FSP_SRV::WriteSaveDataFileSystemExtraDataBySaveDataAttribute(HLERequestContext& ctx) {
     LOG_WARNING(Service_FS, "(STUBBED) called.");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1041,7 +1041,7 @@ void FSP_SRV::ReadSaveDataFileSystemExtraDataWithMaskBySaveDataAttribute(HLERequ
                 parameters.attribute.save_id, parameters.attribute.type, parameters.attribute.rank,
                 parameters.attribute.index);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(flags);
 }
@@ -1054,7 +1054,7 @@ void FSP_SRV::OpenDataStorageByCurrentProcess(HLERequestContext& ctx) {
         if (!current_romfs) {
             // TODO (bunnei): Find the right error code to use here
             LOG_CRITICAL(Service_FS, "no file system interface available!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -1064,7 +1064,7 @@ void FSP_SRV::OpenDataStorageByCurrentProcess(HLERequestContext& ctx) {
 
     auto storage = std::make_shared<IStorage>(system, romfs);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IStorage>(std::move(storage));
 }
@@ -1084,7 +1084,7 @@ void FSP_SRV::OpenDataStorageByDataId(HLERequestContext& ctx) {
         const auto archive = FileSys::SystemArchive::SynthesizeSystemArchive(title_id);
 
         if (archive != nullptr) {
-            IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultSuccess);
             rb.PushIpcInterface(std::make_shared<IStorage>(system, archive));
             return;
@@ -1094,7 +1094,7 @@ void FSP_SRV::OpenDataStorageByDataId(HLERequestContext& ctx) {
         LOG_ERROR(Service_FS,
                   "could not open data storage with title_id={:016X}, storage_id={:02X}", title_id,
                   storage_id);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -1105,7 +1105,7 @@ void FSP_SRV::OpenDataStorageByDataId(HLERequestContext& ctx) {
     auto storage = std::make_shared<IStorage>(
         system, pm.PatchRomFS(base.get(), std::move(data), FileSys::ContentRecordType::Data));
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IStorage>(std::move(storage));
 }
@@ -1118,7 +1118,7 @@ void FSP_SRV::OpenPatchDataStorageByCurrentProcess(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS, "called with storage_id={:02X}, title_id={:016X}", storage_id, title_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(FileSys::ERROR_ENTITY_NOT_FOUND);
 }
 
@@ -1137,14 +1137,14 @@ void FSP_SRV::OpenDataStorageWithProgramIndex(HLERequestContext& ctx) {
         // TODO: Find the right error code to use here
         LOG_ERROR(Service_FS, "could not open storage with program_index={}", program_index);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
 
     auto storage = std::make_shared<IStorage>(system, std::move(patched_romfs));
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IStorage>(std::move(storage));
 }
@@ -1154,7 +1154,7 @@ void FSP_SRV::DisableAutoSaveDataCreation(HLERequestContext& ctx) {
 
     fsc.SetAutoSaveDataCreation(false);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1164,14 +1164,14 @@ void FSP_SRV::SetGlobalAccessLogMode(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS, "called, access_log_mode={}", access_log_mode);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void FSP_SRV::GetGlobalAccessLogMode(HLERequestContext& ctx) {
     LOG_DEBUG(Service_FS, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(access_log_mode);
 }
@@ -1185,14 +1185,14 @@ void FSP_SRV::OutputAccessLogToSdCard(HLERequestContext& ctx) {
 
     reporter.SaveFSAccessLog(log);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void FSP_SRV::GetProgramIndexForAccessLog(HLERequestContext& ctx) {
     LOG_DEBUG(Service_FS, "called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(AccessLogVersion::Latest);
     rb.Push(access_log_program_index);
@@ -1204,7 +1204,7 @@ void FSP_SRV::GetCacheStorageSize(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_FS, "(STUBBED) called with index={}", index);
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(s64{0});
     rb.Push(s64{0});
@@ -1227,14 +1227,14 @@ private:
     void Add(HLERequestContext& ctx) {
         LOG_WARNING(Service_FS, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void Commit(HLERequestContext& ctx) {
         LOG_WARNING(Service_FS, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };
@@ -1242,7 +1242,7 @@ private:
 void FSP_SRV::OpenMultiCommitManager(HLERequestContext& ctx) {
     LOG_DEBUG(Service_FS, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IMultiCommitManager>(std::make_shared<IMultiCommitManager>(system));
 }

--- a/src/core/hle/service/friend/friend.cpp
+++ b/src/core/hle/service/friend/friend.cpp
@@ -139,7 +139,7 @@ private:
     void GetCompletionEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_Friend, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(completion_event->GetReadableEvent());
     }
@@ -148,7 +148,7 @@ private:
         // This is safe to stub, as there should be no adverse consequences from reporting no
         // blocked users.
         LOG_WARNING(Service_Friend, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(0); // Indicates there are no blocked users
     }
@@ -156,14 +156,14 @@ private:
     void DeclareCloseOnlinePlaySession(HLERequestContext& ctx) {
         // Stub used by Splatoon 2
         LOG_WARNING(Service_Friend, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void UpdateUserPresence(HLERequestContext& ctx) {
         // Stub used by Retro City Rampage
         LOG_WARNING(Service_Friend, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -175,7 +175,7 @@ private:
         LOG_WARNING(Service_Friend, "(STUBBED) called, local_play={}, uuid=0x{}", local_play,
                     uuid.RawString());
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -188,7 +188,7 @@ private:
         LOG_WARNING(Service_Friend, "(STUBBED) called, offset={}, uuid=0x{}, pid={}", friend_offset,
                     uuid.RawString(), pid);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         rb.Push<u32>(0); // Friend count
@@ -201,7 +201,7 @@ private:
 
         LOG_WARNING(Service_Friend, "(STUBBED) called, uuid=0x{}", uuid.RawString());
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(true);
     }
@@ -212,7 +212,7 @@ private:
 
         LOG_WARNING(Service_Friend, "(STUBBED) called, uuid=0x{}", uuid.RawString());
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(true);
     }
@@ -248,7 +248,7 @@ private:
     void GetEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_Friend, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(notification_event->GetReadableEvent());
     }
@@ -260,7 +260,7 @@ private:
         }
         std::memset(&states, 0, sizeof(States));
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -269,7 +269,7 @@ private:
 
         if (notifications.empty()) {
             LOG_ERROR(Service_Friend, "No notifications in queue!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Account::ResultNoNotifications);
             return;
         }
@@ -291,7 +291,7 @@ private:
             break;
         }
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw<SizedNotificationInfo>(notification);
     }
@@ -324,7 +324,7 @@ private:
 };
 
 void Module::Interface::CreateFriendService(HLERequestContext& ctx) {
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IFriendService>(system);
     LOG_DEBUG(Service_Friend, "called");
@@ -336,7 +336,7 @@ void Module::Interface::CreateNotificationService(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_Friend, "called, uuid=0x{}", uuid.RawString());
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<INotificationService>(system, uuid);
 }

--- a/src/core/hle/service/glue/arp.cpp
+++ b/src/core/hle/service/glue/arp.cpp
@@ -60,7 +60,7 @@ void ARP_R::GetApplicationLaunchProperty(HLERequestContext& ctx) {
     const auto title_id = GetTitleIDForProcessID(system, process_id);
     if (!title_id.has_value()) {
         LOG_ERROR(Service_ARP, "Failed to get title ID for process ID!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Glue::ResultProcessIdNotRegistered);
         return;
     }
@@ -70,12 +70,12 @@ void ARP_R::GetApplicationLaunchProperty(HLERequestContext& ctx) {
 
     if (res != ResultSuccess) {
         LOG_ERROR(Service_ARP, "Failed to get launch property!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(launch_property);
 }
@@ -91,12 +91,12 @@ void ARP_R::GetApplicationLaunchPropertyWithApplicationId(HLERequestContext& ctx
 
     if (res != ResultSuccess) {
         LOG_ERROR(Service_ARP, "Failed to get launch property!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(launch_property);
 }
@@ -110,7 +110,7 @@ void ARP_R::GetApplicationControlProperty(HLERequestContext& ctx) {
     const auto title_id = GetTitleIDForProcessID(system, process_id);
     if (!title_id.has_value()) {
         LOG_ERROR(Service_ARP, "Failed to get title ID for process ID!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Glue::ResultProcessIdNotRegistered);
         return;
     }
@@ -120,14 +120,14 @@ void ARP_R::GetApplicationControlProperty(HLERequestContext& ctx) {
 
     if (res != ResultSuccess) {
         LOG_ERROR(Service_ARP, "Failed to get control property!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         return;
     }
 
     ctx.WriteBuffer(nacp_data);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -142,14 +142,14 @@ void ARP_R::GetApplicationControlPropertyWithApplicationId(HLERequestContext& ct
 
     if (res != ResultSuccess) {
         LOG_ERROR(Service_ARP, "Failed to get control property!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         return;
     }
 
     ctx.WriteBuffer(nacp_data);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -181,7 +181,7 @@ private:
 
         if (process_id == 0) {
             LOG_ERROR(Service_ARP, "Must have non-zero process ID!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Glue::ResultInvalidProcessId);
             return;
         }
@@ -189,7 +189,7 @@ private:
         if (issued) {
             LOG_ERROR(Service_ARP,
                       "Attempted to issue registrar, but registrar is already issued!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Glue::ResultAlreadyBound);
             return;
         }
@@ -197,7 +197,7 @@ private:
         issue_process_id(process_id, launch, std::move(control));
         issued = true;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -208,7 +208,7 @@ private:
             LOG_ERROR(
                 Service_ARP,
                 "Attempted to set application launch property, but registrar is already issued!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Glue::ResultAlreadyBound);
             return;
         }
@@ -216,7 +216,7 @@ private:
         IPC::RequestParser rp{ctx};
         launch = rp.PopRaw<ApplicationLaunchProperty>();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -227,7 +227,7 @@ private:
             LOG_ERROR(
                 Service_ARP,
                 "Attempted to set application control property, but registrar is already issued!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(Glue::ResultAlreadyBound);
             return;
         }
@@ -235,7 +235,7 @@ private:
         // TODO: Can this be a span?
         control = ctx.ReadBufferCopy();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -273,7 +273,7 @@ void ARP_W::AcquireRegistrar(HLERequestContext& ctx) {
             return manager.Register(*res, launch, std::move(control));
         });
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface(registrar);
 }
@@ -286,7 +286,7 @@ void ARP_W::UnregisterApplicationInstance(HLERequestContext& ctx) {
 
     if (process_id == 0) {
         LOG_ERROR(Service_ARP, "Must have non-zero process ID!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Glue::ResultInvalidProcessId);
         return;
     }
@@ -295,12 +295,12 @@ void ARP_W::UnregisterApplicationInstance(HLERequestContext& ctx) {
 
     if (!title_id.has_value()) {
         LOG_ERROR(Service_ARP, "No title ID for process ID!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Glue::ResultProcessIdNotRegistered);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(manager.Unregister(*title_id));
 }
 

--- a/src/core/hle/service/glue/bgtc.cpp
+++ b/src/core/hle/service/glue/bgtc.cpp
@@ -23,7 +23,7 @@ BGTC_T::~BGTC_T() = default;
 void BGTC_T::OpenTaskService(HLERequestContext& ctx) {
     LOG_DEBUG(Service_BGTC, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ITaskService>(system);
 }

--- a/src/core/hle/service/glue/ectx.cpp
+++ b/src/core/hle/service/glue/ectx.cpp
@@ -34,7 +34,7 @@ private:
         [[maybe_unused]] auto input = rp.PopRaw<InputParameters>();
         [[maybe_unused]] auto value = ctx.ReadBuffer();
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(0);
     }
@@ -54,7 +54,7 @@ ECTX_AW::ECTX_AW(Core::System& system_) : ServiceFramework{system_, "ectx:aw"} {
 ECTX_AW::~ECTX_AW() = default;
 
 void ECTX_AW::CreateContextRegistrar(HLERequestContext& ctx) {
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IContextRegistrar>(std::make_shared<IContextRegistrar>(system));
 }

--- a/src/core/hle/service/glue/notif.cpp
+++ b/src/core/hle/service/glue/notif.cpp
@@ -43,7 +43,7 @@ void NOTIF_A::RegisterAlarmSetting(HLERequestContext& ctx) {
     // TODO: Count alarms per game id
     if (alarms.size() >= max_alarms) {
         LOG_ERROR(Service_NOTIF, "Alarm limit reached");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -58,7 +58,7 @@ void NOTIF_A::RegisterAlarmSetting(HLERequestContext& ctx) {
                 application_parameter_size, new_alarm.alarm_setting_id, new_alarm.kind,
                 new_alarm.muted);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(new_alarm.alarm_setting_id);
 }
@@ -87,7 +87,7 @@ void NOTIF_A::UpdateAlarmSetting(HLERequestContext& ctx) {
                 application_parameter_size, alarm_setting.alarm_setting_id, alarm_setting.kind,
                 alarm_setting.muted);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -97,7 +97,7 @@ void NOTIF_A::ListAlarmSettings(HLERequestContext& ctx) {
     // TODO: Only return alarms of this game id
     ctx.WriteBuffer(alarms);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(alarms.size()));
 }
@@ -109,7 +109,7 @@ void NOTIF_A::LoadApplicationParameter(HLERequestContext& ctx) {
     const auto alarm_it = GetAlarmFromId(alarm_setting_id);
     if (alarm_it == alarms.end()) {
         LOG_ERROR(Service_NOTIF, "Invalid alarm setting id={}", alarm_setting_id);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -121,7 +121,7 @@ void NOTIF_A::LoadApplicationParameter(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(application_parameter);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(application_parameter.size()));
 }
@@ -136,7 +136,7 @@ void NOTIF_A::DeleteAlarmSetting(HLERequestContext& ctx) {
 
     LOG_INFO(Service_NOTIF, "called, alarm_setting_id={}", alarm_setting_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -144,7 +144,7 @@ void NOTIF_A::Initialize(HLERequestContext& ctx) {
     // TODO: Load previous alarms from config
 
     LOG_WARNING(Service_NOTIF, "(STUBBED) called");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 

--- a/src/core/hle/service/hid/hid_server.cpp
+++ b/src/core/hle/service/hid/hid_server.cpp
@@ -59,7 +59,7 @@ private:
                   vibration_device_handle.npad_type, vibration_device_handle.npad_id,
                   vibration_device_handle.device_index);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -228,7 +228,7 @@ void IHidServer::CreateAppletResource(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}, result=0x{:X}",
               applet_resource_user_id, result.raw);
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushIpcInterface<IAppletResource>(system, resource_manager, applet_resource_user_id);
 }
@@ -250,7 +250,7 @@ void IHidServer::ActivateDebugPad(HLERequestContext& ctx) {
         result = debug_pad->Activate(applet_resource_user_id);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -271,7 +271,7 @@ void IHidServer::ActivateTouchScreen(HLERequestContext& ctx) {
         result = touch_screen->Activate(applet_resource_user_id);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -292,7 +292,7 @@ void IHidServer::ActivateMouse(HLERequestContext& ctx) {
         result = mouse->Activate(applet_resource_user_id);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -313,7 +313,7 @@ void IHidServer::ActivateKeyboard(HLERequestContext& ctx) {
         result = keyboard->Activate(applet_resource_user_id);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -323,7 +323,7 @@ void IHidServer::SendKeyboardLockKeyEvent(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_HID, "(STUBBED) called. flags={}", flags);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -335,7 +335,7 @@ void IHidServer::AcquireXpadIdEventHandle(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     // Handle returned is null here
 }
@@ -348,7 +348,7 @@ void IHidServer::ReleaseXpadIdEventHandle(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -368,7 +368,7 @@ void IHidServer::ActivateXpad(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -379,7 +379,7 @@ void IHidServer::GetXpadIds(HLERequestContext& ctx) {
     const std::array<u32, 4> basic_xpad_id{0, 1, 2, 3};
     ctx.WriteBuffer(basic_xpad_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s64>(basic_xpad_id.size());
 }
@@ -392,7 +392,7 @@ void IHidServer::ActivateJoyXpad(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -404,7 +404,7 @@ void IHidServer::GetJoyXpadLifoHandle(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     // Handle returned is null here
 }
@@ -415,7 +415,7 @@ void IHidServer::GetJoyXpadIds(HLERequestContext& ctx) {
     // This function has been hardcoded since 10.0.0+
     const s64 basic_xpad_id_count{};
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(basic_xpad_id_count);
 }
@@ -428,7 +428,7 @@ void IHidServer::ActivateSixAxisSensor(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -440,7 +440,7 @@ void IHidServer::DeactivateSixAxisSensor(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -452,7 +452,7 @@ void IHidServer::GetSixAxisSensorLifoHandle(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -464,7 +464,7 @@ void IHidServer::ActivateJoySixAxisSensor(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -476,7 +476,7 @@ void IHidServer::DeactivateJoySixAxisSensor(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -488,7 +488,7 @@ void IHidServer::GetJoySixAxisSensorLifoHandle(HLERequestContext& ctx) {
 
     // This function has been stubbed since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     // Handle returned is null here
 }
@@ -512,7 +512,7 @@ void IHidServer::StartSixAxisSensor(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
               parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -535,7 +535,7 @@ void IHidServer::StopSixAxisSensor(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
               parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -560,7 +560,7 @@ void IHidServer::IsSixAxisSensorFusionEnabled(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
               parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(is_enabled);
 }
@@ -588,7 +588,7 @@ void IHidServer::EnableSixAxisSensorFusion(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_id, parameters.sixaxis_handle.device_index,
               parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -615,7 +615,7 @@ void IHidServer::SetSixAxisSensorFusionParameters(HLERequestContext& ctx) {
               parameters.sixaxis_handle.device_index, parameters.sixaxis_fusion.parameter1,
               parameters.sixaxis_fusion.parameter2, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -640,7 +640,7 @@ void IHidServer::GetSixAxisSensorFusionParameters(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
               parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushRaw(fusion_parameters);
 }
@@ -671,7 +671,7 @@ void IHidServer::ResetSixAxisSensorFusionParameters(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
               parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     if (result1.IsError()) {
         rb.Push(result1);
         return;
@@ -694,7 +694,7 @@ void IHidServer::SetGyroscopeZeroDriftMode(HLERequestContext& ctx) {
               sixaxis_handle.npad_type, sixaxis_handle.npad_id, sixaxis_handle.device_index,
               drift_mode, applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -718,7 +718,7 @@ void IHidServer::GetGyroscopeZeroDriftMode(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
               parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushEnum(drift_mode);
 }
@@ -743,7 +743,7 @@ void IHidServer::ResetGyroscopeZeroDriftMode(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
               parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -767,7 +767,7 @@ void IHidServer::IsSixAxisSensorAtRest(HLERequestContext& ctx) {
               parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
               parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_at_rest);
 }
@@ -794,7 +794,7 @@ void IHidServer::IsFirmwareUpdateAvailableForSixAxisSensor(HLERequestContext& ct
         parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
         parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_firmware_available);
 }
@@ -821,7 +821,7 @@ void IHidServer::EnableSixAxisSensorUnalteredPassthrough(HLERequestContext& ctx)
               parameters.sixaxis_handle.npad_id, parameters.sixaxis_handle.device_index,
               parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -847,7 +847,7 @@ void IHidServer::IsSixAxisSensorUnalteredPassthroughEnabled(HLERequestContext& c
         parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
         parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(is_unaltered_sisxaxis_enabled);
 }
@@ -878,7 +878,7 @@ void IHidServer::LoadSixAxisSensorCalibrationParameter(HLERequestContext& ctx) {
         ctx.WriteBuffer(calibration);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -908,7 +908,7 @@ void IHidServer::GetSixAxisSensorIcInformation(HLERequestContext& ctx) {
         ctx.WriteBuffer(ic_information);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -933,7 +933,7 @@ void IHidServer::ResetIsSixAxisSensorDeviceNewlyAssigned(HLERequestContext& ctx)
         parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
         parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -963,7 +963,7 @@ void IHidServer::ActivateGesture(HLERequestContext& ctx) {
         result = gesture->Activate(parameters.applet_resource_user_id);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -983,7 +983,7 @@ void IHidServer::SetSupportedNpadStyleSet(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called, supported_styleset={}, applet_resource_user_id={}",
               parameters.supported_styleset, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -993,7 +993,7 @@ void IHidServer::GetSupportedNpadStyleSet(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(GetResourceManager()->GetNpad()->GetSupportedStyleSet().raw);
 }
@@ -1006,7 +1006,7 @@ void IHidServer::SetSupportedNpadIdType(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -1021,7 +1021,7 @@ void IHidServer::ActivateNpad(HLERequestContext& ctx) {
     // TODO: npad->SetRevision(applet_resource_user_id, NpadRevision::Revision0);
     const Result result = npad->Activate(applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -1033,7 +1033,7 @@ void IHidServer::DeactivateNpad(HLERequestContext& ctx) {
 
     // This function does nothing since 10.0.0+
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1055,7 +1055,7 @@ void IHidServer::AcquireNpadStyleSetUpdateEventHandle(HLERequestContext& ctx) {
     // Games expect this event to be signaled after calling this function
     GetResourceManager()->GetNpad()->SignalStyleSetChangedEvent(parameters.npad_id);
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(
         GetResourceManager()->GetNpad()->GetStyleSetChangedEvent(parameters.npad_id));
@@ -1078,7 +1078,7 @@ void IHidServer::DisconnectNpad(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called, npad_id={}, applet_resource_user_id={}", parameters.npad_id,
               parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1092,7 +1092,7 @@ void IHidServer::GetPlayerLedPattern(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, npad_id={}", npad_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(pattern.raw);
 }
@@ -1116,7 +1116,7 @@ void IHidServer::ActivateNpadWithRevision(HLERequestContext& ctx) {
     // TODO: npad->SetRevision(applet_resource_user_id, revision);
     const auto result = npad->Activate(parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -1130,7 +1130,7 @@ void IHidServer::SetNpadJoyHoldType(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}, hold_type={}",
               applet_resource_user_id, hold_type);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1140,7 +1140,7 @@ void IHidServer::GetNpadJoyHoldType(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(GetResourceManager()->GetNpad()->GetHoldType());
 }
@@ -1164,7 +1164,7 @@ void IHidServer::SetNpadJoyAssignmentModeSingleByDefault(HLERequestContext& ctx)
     LOG_INFO(Service_HID, "called, npad_id={}, applet_resource_user_id={}", parameters.npad_id,
              parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1189,7 +1189,7 @@ void IHidServer::SetNpadJoyAssignmentModeSingle(HLERequestContext& ctx) {
              parameters.npad_id, parameters.applet_resource_user_id,
              parameters.npad_joy_device_type);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1211,7 +1211,7 @@ void IHidServer::SetNpadJoyAssignmentModeDual(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called, npad_id={}, applet_resource_user_id={}", parameters.npad_id,
               parameters.applet_resource_user_id); // Spams a lot when controller applet is open
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1227,7 +1227,7 @@ void IHidServer::MergeSingleJoyAsDualJoy(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called, npad_id_1={}, npad_id_2={}, applet_resource_user_id={}",
               npad_id_1, npad_id_2, applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -1239,7 +1239,7 @@ void IHidServer::StartLrAssignmentMode(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1251,7 +1251,7 @@ void IHidServer::StopLrAssignmentMode(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1265,7 +1265,7 @@ void IHidServer::SetNpadHandheldActivationMode(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}, activation_mode={}",
               applet_resource_user_id, activation_mode);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1275,7 +1275,7 @@ void IHidServer::GetNpadHandheldActivationMode(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(GetResourceManager()->GetNpad()->GetNpadHandheldActivationMode());
 }
@@ -1292,7 +1292,7 @@ void IHidServer::SwapNpadAssignment(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called, npad_id_1={}, npad_id_2={}, applet_resource_user_id={}",
               npad_id_1, npad_id_2, applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -1315,7 +1315,7 @@ void IHidServer::IsUnintendedHomeButtonInputProtectionEnabled(HLERequestContext&
     LOG_WARNING(Service_HID, "(STUBBED) called, npad_id={}, applet_resource_user_id={}",
                 parameters.npad_id, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(is_enabled);
 }
@@ -1340,7 +1340,7 @@ void IHidServer::EnableUnintendedHomeButtonInputProtection(HLERequestContext& ct
               "(STUBBED) called, is_enabled={}, npad_id={}, applet_resource_user_id={}",
               parameters.is_enabled, parameters.npad_id, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -1366,7 +1366,7 @@ void IHidServer::SetNpadJoyAssignmentModeSingleWithDestination(HLERequestContext
              parameters.npad_id, parameters.applet_resource_user_id,
              parameters.npad_joy_device_type);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_reassigned);
     rb.PushEnum(new_npad_id);
@@ -1390,7 +1390,7 @@ void IHidServer::SetNpadAnalogStickUseCenterClamp(HLERequestContext& ctx) {
                 "(STUBBED) called, analog_stick_use_center_clamp={}, applet_resource_user_id={}",
                 parameters.analog_stick_use_center_clamp, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1410,7 +1410,7 @@ void IHidServer::SetNpadCaptureButtonAssignment(HLERequestContext& ctx) {
                 "(STUBBED) called, npad_styleset={}, applet_resource_user_id={}, button={}",
                 parameters.npad_styleset, parameters.applet_resource_user_id, parameters.button);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1421,7 +1421,7 @@ void IHidServer::ClearNpadCaptureButtonAssignment(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
                 applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1474,12 +1474,12 @@ void IHidServer::GetVibrationDeviceInfo(HLERequestContext& ctx) {
 
     const auto result = IsVibrationHandleValid(vibration_device_handle);
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(vibration_device_info);
 }
@@ -1505,7 +1505,7 @@ void IHidServer::SendVibrationValue(HLERequestContext& ctx) {
               parameters.vibration_device_handle.npad_id,
               parameters.vibration_device_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1526,7 +1526,7 @@ void IHidServer::GetActualVibrationValue(HLERequestContext& ctx) {
               parameters.vibration_device_handle.npad_id,
               parameters.vibration_device_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(
         GetResourceManager()->GetNpad()->GetLastVibration(parameters.vibration_device_handle));
@@ -1535,7 +1535,7 @@ void IHidServer::GetActualVibrationValue(HLERequestContext& ctx) {
 void IHidServer::CreateActiveVibrationDeviceList(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IActiveVibrationDeviceList>(system, GetResourceManager());
 }
@@ -1550,7 +1550,7 @@ void IHidServer::PermitVibration(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, can_vibrate={}", can_vibrate);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1560,7 +1560,7 @@ void IHidServer::IsVibrationPermitted(HLERequestContext& ctx) {
     // nnSDK checks if a float is greater than zero. We return the bool we stored earlier
     const auto is_enabled = Settings::values.vibration_enabled.GetValue();
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_enabled);
 }
@@ -1584,7 +1584,7 @@ void IHidServer::SendVibrationValues(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1645,7 +1645,7 @@ void IHidServer::SendVibrationGcErmCommand(HLERequestContext& ctx) {
               parameters.vibration_device_handle.device_index, parameters.applet_resource_user_id,
               parameters.gc_erm_command);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1686,7 +1686,7 @@ void IHidServer::GetActualVibrationGcErmCommand(HLERequestContext& ctx) {
               parameters.vibration_device_handle.npad_id,
               parameters.vibration_device_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(gc_erm_command);
 }
@@ -1699,7 +1699,7 @@ void IHidServer::BeginPermitVibrationSession(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1708,7 +1708,7 @@ void IHidServer::EndPermitVibrationSession(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1729,7 +1729,7 @@ void IHidServer::IsVibrationDeviceMounted(HLERequestContext& ctx) {
               parameters.vibration_device_handle.npad_id,
               parameters.vibration_device_handle.device_index, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(GetResourceManager()->GetNpad()->IsVibrationDeviceMounted(
         parameters.vibration_device_handle));
@@ -1752,7 +1752,7 @@ void IHidServer::ActivateConsoleSixAxisSensor(HLERequestContext& ctx) {
         result = console_sixaxis->Activate(applet_resource_user_id);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -1772,7 +1772,7 @@ void IHidServer::StartConsoleSixAxisSensor(HLERequestContext& ctx) {
                 parameters.console_sixaxis_handle.unknown_1,
                 parameters.console_sixaxis_handle.unknown_2, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1792,7 +1792,7 @@ void IHidServer::StopConsoleSixAxisSensor(HLERequestContext& ctx) {
                 parameters.console_sixaxis_handle.unknown_1,
                 parameters.console_sixaxis_handle.unknown_2, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1813,7 +1813,7 @@ void IHidServer::ActivateSevenSixAxisSensor(HLERequestContext& ctx) {
         seven_sixaxis->Activate(applet_resource_user_id);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1824,7 +1824,7 @@ void IHidServer::StartSevenSixAxisSensor(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
                 applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1835,7 +1835,7 @@ void IHidServer::StopSevenSixAxisSensor(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
                 applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1854,7 +1854,7 @@ void IHidServer::InitializeSevenSixAxisSensor(HLERequestContext& ctx) {
 
     if (t_mem_1.IsNull()) {
         LOG_ERROR(Service_HID, "t_mem_1 is a nullptr for handle=0x{:08X}", t_mem_1_handle);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -1863,7 +1863,7 @@ void IHidServer::InitializeSevenSixAxisSensor(HLERequestContext& ctx) {
 
     if (t_mem_2.IsNull()) {
         LOG_ERROR(Service_HID, "t_mem_2 is a nullptr for handle=0x{:08X}", t_mem_2_handle);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -1882,7 +1882,7 @@ void IHidServer::InitializeSevenSixAxisSensor(HLERequestContext& ctx) {
                 "applet_resource_user_id={}",
                 t_mem_1_handle, t_mem_2_handle, applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1893,7 +1893,7 @@ void IHidServer::FinalizeSevenSixAxisSensor(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
                 applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1905,7 +1905,7 @@ void IHidServer::ResetSevenSixAxisSensorTimestamp(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_HID, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -1914,7 +1914,7 @@ void IHidServer::IsUsbFullKeyControllerEnabled(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(false);
 }
@@ -1937,7 +1937,7 @@ void IHidServer::GetPalmaConnectionHandle(HLERequestContext& ctx) {
     auto controller = GetResourceManager()->GetPalma();
     const auto result = controller->GetPalmaConnectionHandle(parameters.npad_id, handle);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushRaw(handle);
 }
@@ -1951,7 +1951,7 @@ void IHidServer::InitializePalma(HLERequestContext& ctx) {
     auto controller = GetResourceManager()->GetPalma();
     const auto result = controller->InitializePalma(connection_handle);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -1963,7 +1963,7 @@ void IHidServer::AcquirePalmaOperationCompleteEvent(HLERequestContext& ctx) {
 
     auto controller = GetResourceManager()->GetPalma();
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(controller->AcquirePalmaOperationCompleteEvent(connection_handle));
 }
@@ -1980,12 +1980,12 @@ void IHidServer::GetPalmaOperationInfo(HLERequestContext& ctx) {
     const auto result = controller->GetPalmaOperationInfo(connection_handle, operation_type, data);
 
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
     ctx.WriteBuffer(data);
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(static_cast<u64>(operation_type));
 }
@@ -2001,7 +2001,7 @@ void IHidServer::PlayPalmaActivity(HLERequestContext& ctx) {
     auto controller = GetResourceManager()->GetPalma();
     const auto result = controller->PlayPalmaActivity(connection_handle, palma_activity);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -2016,7 +2016,7 @@ void IHidServer::SetPalmaFrModeType(HLERequestContext& ctx) {
     auto controller = GetResourceManager()->GetPalma();
     const auto result = controller->SetPalmaFrModeType(connection_handle, fr_mode);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -2029,7 +2029,7 @@ void IHidServer::ReadPalmaStep(HLERequestContext& ctx) {
     auto controller = GetResourceManager()->GetPalma();
     const auto result = controller->ReadPalmaStep(connection_handle);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -2051,7 +2051,7 @@ void IHidServer::EnablePalmaStep(HLERequestContext& ctx) {
     const auto result =
         controller->EnablePalmaStep(parameters.connection_handle, parameters.is_enabled);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -2064,21 +2064,21 @@ void IHidServer::ResetPalmaStep(HLERequestContext& ctx) {
     auto controller = GetResourceManager()->GetPalma();
     const auto result = controller->ResetPalmaStep(connection_handle);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
 void IHidServer::ReadPalmaApplicationSection(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::WritePalmaApplicationSection(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2090,7 +2090,7 @@ void IHidServer::ReadPalmaUniqueCode(HLERequestContext& ctx) {
 
     GetResourceManager()->GetPalma()->ReadPalmaUniqueCode(connection_handle);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2102,14 +2102,14 @@ void IHidServer::SetPalmaUniqueCodeInvalid(HLERequestContext& ctx) {
 
     GetResourceManager()->GetPalma()->SetPalmaUniqueCodeInvalid(connection_handle);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::WritePalmaActivityEntry(HLERequestContext& ctx) {
     LOG_CRITICAL(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2125,7 +2125,7 @@ void IHidServer::WritePalmaRgbLedPatternEntry(HLERequestContext& ctx) {
 
     GetResourceManager()->GetPalma()->WritePalmaRgbLedPatternEntry(connection_handle, unknown);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2144,7 +2144,7 @@ void IHidServer::WritePalmaWaveEntry(HLERequestContext& ctx) {
 
     if (t_mem.IsNull()) {
         LOG_ERROR(Service_HID, "t_mem is a nullptr for handle=0x{:08X}", t_mem_handle);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -2159,7 +2159,7 @@ void IHidServer::WritePalmaWaveEntry(HLERequestContext& ctx) {
     GetResourceManager()->GetPalma()->WritePalmaWaveEntry(connection_handle, wave_set,
                                                           t_mem->GetSourceAddress(), t_mem_size);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2180,7 +2180,7 @@ void IHidServer::SetPalmaDataBaseIdentificationVersion(HLERequestContext& ctx) {
     GetResourceManager()->GetPalma()->SetPalmaDataBaseIdentificationVersion(
         parameters.connection_handle, parameters.database_id_version);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2192,14 +2192,14 @@ void IHidServer::GetPalmaDataBaseIdentificationVersion(HLERequestContext& ctx) {
 
     GetResourceManager()->GetPalma()->GetPalmaDataBaseIdentificationVersion(connection_handle);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::SuspendPalmaFeature(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2212,21 +2212,21 @@ void IHidServer::GetPalmaOperationResult(HLERequestContext& ctx) {
     const auto result =
         GetResourceManager()->GetPalma()->GetPalmaOperationResult(connection_handle);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
 void IHidServer::ReadPalmaPlayLog(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::ResetPalmaPlayLog(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2247,14 +2247,14 @@ void IHidServer::SetIsPalmaAllConnectable(HLERequestContext& ctx) {
 
     GetResourceManager()->GetPalma()->SetIsPalmaAllConnectable(parameters.is_palma_all_connectable);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::SetIsPalmaPairedConnectable(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2266,7 +2266,7 @@ void IHidServer::PairPalma(HLERequestContext& ctx) {
 
     GetResourceManager()->GetPalma()->PairPalma(connection_handle);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2278,35 +2278,35 @@ void IHidServer::SetPalmaBoostMode(HLERequestContext& ctx) {
 
     GetResourceManager()->GetPalma()->SetPalmaBoostMode(palma_boost_mode);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::CancelWritePalmaWaveEntry(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::EnablePalmaBoostMode(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::GetPalmaBluetoothAddress(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidServer::SetDisallowedPalmaConnection(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2320,7 +2320,7 @@ void IHidServer::SetNpadCommunicationMode(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}, communication_mode={}",
                 applet_resource_user_id, communication_mode);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2329,7 +2329,7 @@ void IHidServer::GetNpadCommunicationMode(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(GetResourceManager()->GetNpad()->GetNpadCommunicationMode());
 }
@@ -2342,7 +2342,7 @@ void IHidServer::SetTouchScreenConfiguration(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called, touchscreen_mode={}, applet_resource_user_id={}",
                 touchscreen_mode.mode, applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -2360,7 +2360,7 @@ void IHidServer::IsFirmwareUpdateNeededForNotification(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called, unknown={}, applet_resource_user_id={}",
                 parameters.unknown, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(false);
 }
@@ -2376,7 +2376,7 @@ void IHidServer::SetTouchScreenResolution(HLERequestContext& ctx) {
     LOG_INFO(Service_HID, "called, width={}, height={}, applet_resource_user_id={}", width, height,
              applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 

--- a/src/core/hle/service/hid/hid_system_server.cpp
+++ b/src/core/hle/service/hid/hid_system_server.cpp
@@ -244,28 +244,28 @@ void IHidSystemServer::ApplyNpadSystemCommonPolicy(HLERequestContext& ctx) {
 
     GetResourceManager()->GetNpad()->ApplyNpadSystemCommonPolicy();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidSystemServer::EnableAssigningSingleOnSlSrPress(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidSystemServer::DisableAssigningSingleOnSlSrPress(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidSystemServer::GetLastActiveNpad(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "(STUBBED) called"); // Spams a lot when controller applet is running
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(system.HIDCore().GetLastActiveController());
 }
@@ -275,7 +275,7 @@ void IHidSystemServer::ApplyNpadSystemCommonPolicyFull(HLERequestContext& ctx) {
 
     GetResourceManager()->GetNpad()->ApplyNpadSystemCommonPolicy();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -290,7 +290,7 @@ void IHidSystemServer::GetNpadFullKeyGripColor(HLERequestContext& ctx) {
     Core::HID::NpadColor right_color{};
     // TODO: Get colors from Npad
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(left_color);
     rb.PushRaw(right_color);
@@ -304,7 +304,7 @@ void IHidSystemServer::GetMaskedSupportedNpadStyleSet(HLERequestContext& ctx) {
     Core::HID::NpadStyleSet supported_styleset =
         GetResourceManager()->GetNpad()->GetSupportedStyleSet().raw;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(supported_styleset);
 }
@@ -317,7 +317,7 @@ void IHidSystemServer::SetSupportedNpadStyleSetAll(HLERequestContext& ctx) {
     Core::HID::NpadStyleSet supported_styleset =
         GetResourceManager()->GetNpad()->GetSupportedStyleSet().raw;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(supported_styleset);
 }
@@ -332,7 +332,7 @@ void IHidSystemServer::GetAppletDetailedUiType(HLERequestContext& ctx) {
     const AppletDetailedUiType detailed_ui_type =
         GetResourceManager()->GetNpad()->GetAppletDetailedUiType(npad_id_type);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(detailed_ui_type);
 }
@@ -344,7 +344,7 @@ void IHidSystemServer::GetNpadInterfaceType(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "(STUBBED) called, npad_id_type={}",
               npad_id_type); // Spams a lot when controller applet is running
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(Core::HID::NpadInterfaceType::Bluetooth);
 }
@@ -356,7 +356,7 @@ void IHidSystemServer::GetNpadLeftRightInterfaceType(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "(STUBBED) called, npad_id_type={}",
               npad_id_type); // Spams a lot when controller applet is running
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(Core::HID::NpadInterfaceType::Bluetooth);
     rb.PushEnum(Core::HID::NpadInterfaceType::Bluetooth);
@@ -369,7 +369,7 @@ void IHidSystemServer::HasBattery(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "(STUBBED) called, npad_id_type={}",
               npad_id_type); // Spams a lot when controller applet is running
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(false);
 }
@@ -391,7 +391,7 @@ void IHidSystemServer::HasLeftRightBattery(HLERequestContext& ctx) {
         .right = false,
     };
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(left_right_battery);
 }
@@ -409,7 +409,7 @@ void IHidSystemServer::GetUniquePadsFromNpad(HLERequestContext& ctx) {
         ctx.WriteBuffer(unique_pads);
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(unique_pads.size()));
 }
@@ -419,7 +419,7 @@ void IHidSystemServer::GetIrSensorState(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 void IHidSystemServer::RegisterAppletResourceUserId(HLERequestContext& ctx) {
@@ -444,7 +444,7 @@ void IHidSystemServer::RegisterAppletResourceUserId(HLERequestContext& ctx) {
         //     parameters.applet_resource_user_id);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -458,7 +458,7 @@ void IHidSystemServer::UnregisterAppletResourceUserId(HLERequestContext& ctx) {
     // GetResourceManager()->GetNpad()->UnregisterAppletResourceUserId(applet_resource_user_id);
     // GetResourceManager()->GetPalma()->UnregisterAppletResourceUserId(applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -479,7 +479,7 @@ void IHidSystemServer::EnableAppletToGetInput(HLERequestContext& ctx) {
     GetResourceManager()->EnableInput(parameters.applet_resource_user_id, parameters.is_enabled);
     // GetResourceManager()->GetNpad()->EnableInput(parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -500,7 +500,7 @@ void IHidSystemServer::EnableAppletToGetSixAxisSensor(HLERequestContext& ctx) {
     GetResourceManager()->EnableTouchScreen(parameters.applet_resource_user_id,
                                             parameters.is_enabled);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -521,7 +521,7 @@ void IHidSystemServer::EnableAppletToGetPadInput(HLERequestContext& ctx) {
     GetResourceManager()->EnablePadInput(parameters.applet_resource_user_id, parameters.is_enabled);
     // GetResourceManager()->GetNpad()->EnableInput(parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -542,14 +542,14 @@ void IHidSystemServer::EnableAppletToGetTouchScreen(HLERequestContext& ctx) {
     GetResourceManager()->EnableTouchScreen(parameters.applet_resource_user_id,
                                             parameters.is_enabled);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidSystemServer::AcquireConnectionTriggerTimeoutEvent(HLERequestContext& ctx) {
     LOG_INFO(Service_AM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(acquire_device_registered_event->GetReadableEvent());
 }
@@ -557,7 +557,7 @@ void IHidSystemServer::AcquireConnectionTriggerTimeoutEvent(HLERequestContext& c
 void IHidSystemServer::AcquireDeviceRegisteredEventForControllerSupport(HLERequestContext& ctx) {
     LOG_INFO(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(acquire_device_registered_event->GetReadableEvent());
 }
@@ -575,7 +575,7 @@ void IHidSystemServer::GetRegisteredDevices(HLERequestContext& ctx) {
         ctx.WriteBuffer(registered_devices);
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u64>(registered_devices.size());
 }
@@ -583,7 +583,7 @@ void IHidSystemServer::GetRegisteredDevices(HLERequestContext& ctx) {
 void IHidSystemServer::AcquireUniquePadConnectionEventHandle(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.PushCopyObjects(unique_pad_connection_event->GetReadableEvent());
     rb.Push(ResultSuccess);
 }
@@ -591,7 +591,7 @@ void IHidSystemServer::AcquireUniquePadConnectionEventHandle(HLERequestContext& 
 void IHidSystemServer::GetUniquePadIds(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u64>(0);
 }
@@ -599,7 +599,7 @@ void IHidSystemServer::GetUniquePadIds(HLERequestContext& ctx) {
 void IHidSystemServer::AcquireJoyDetachOnBluetoothOffEventHandle(HLERequestContext& ctx) {
     LOG_INFO(Service_AM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(joy_detach_event->GetReadableEvent());
 }
@@ -609,7 +609,7 @@ void IHidSystemServer::IsUsbFullKeyControllerEnabled(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_HID, "(STUBBED) called, is_enabled={}", is_enabled);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_enabled);
 }
@@ -620,7 +620,7 @@ void IHidSystemServer::IsHandheldButtonPressedOnConsoleMode(HLERequestContext& c
     LOG_DEBUG(Service_HID, "(STUBBED) called, is_enabled={}",
               button_pressed); // Spams a lot when controller applet is open
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(button_pressed);
 }
@@ -628,14 +628,14 @@ void IHidSystemServer::IsHandheldButtonPressedOnConsoleMode(HLERequestContext& c
 void IHidSystemServer::InitializeFirmwareUpdate(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IHidSystemServer::InitializeUsbFirmwareUpdateWithoutMemory(HLERequestContext& ctx) {
     LOG_WARNING(Service_HID, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -651,7 +651,7 @@ void IHidSystemServer::GetTouchScreenDefaultConfiguration(HLERequestContext& ctx
         touchscreen_config.mode = Core::HID::TouchScreenModeForNx::UseSystemSetting;
     }
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(touchscreen_config);
 }

--- a/src/core/hle/service/hid/hidbus.cpp
+++ b/src/core/hle/service/hid/hidbus.cpp
@@ -159,7 +159,7 @@ void HidBus::GetBusHandle(HLERequestContext& ctx) {
         .handle = devices[handle_index].handle,
     };
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(out_data);
 }
@@ -180,14 +180,14 @@ void HidBus::IsExternalDeviceConnected(HLERequestContext& ctx) {
         const auto& device = devices[device_index.value()].device;
         const bool is_attached = device->IsDeviceActivated();
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(is_attached);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 }
@@ -233,13 +233,13 @@ void HidBus::Initialize(HLERequestContext& ctx) {
         std::memcpy(system.Kernel().GetHidBusSharedMem().GetPointer(), &hidbus_status,
                     sizeof(hidbus_status));
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 }
@@ -272,13 +272,13 @@ void HidBus::Finalize(HLERequestContext& ctx) {
         std::memcpy(system.Kernel().GetHidBusSharedMem().GetPointer(), &hidbus_status,
                     sizeof(hidbus_status));
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 }
@@ -310,13 +310,13 @@ void HidBus::EnableExternalDevice(HLERequestContext& ctx) {
         auto& device = devices[device_index.value()].device;
         device->Enable(parameters.enable);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 }
@@ -336,14 +336,14 @@ void HidBus::GetExternalDeviceId(HLERequestContext& ctx) {
     if (device_index) {
         const auto& device = devices[device_index.value()].device;
         u32 device_id = device->GetDeviceId();
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(device_id);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 }
@@ -365,13 +365,13 @@ void HidBus::SendCommandAsync(HLERequestContext& ctx) {
         auto& device = devices[device_index.value()].device;
         device->SetCommand(data);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 };
@@ -393,14 +393,14 @@ void HidBus::GetSendCommandAsynceResult(HLERequestContext& ctx) {
         const std::vector<u8> data = device->GetReply();
         const u64 data_size = ctx.WriteBuffer(data);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(data_size);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 };
@@ -419,14 +419,14 @@ void HidBus::SetEventForSendCommandAsycResult(HLERequestContext& ctx) {
 
     if (device_index) {
         const auto& device = devices[device_index.value()].device;
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(device->GetSendCommandAsycEvent());
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 };
@@ -434,7 +434,7 @@ void HidBus::SetEventForSendCommandAsycResult(HLERequestContext& ctx) {
 void HidBus::GetSharedMemoryHandle(HLERequestContext& ctx) {
     LOG_DEBUG(Service_HID, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(&system.Kernel().GetHidBusSharedMem());
 }
@@ -452,7 +452,7 @@ void HidBus::EnableJoyPollingReceiveMode(HLERequestContext& ctx) {
 
     if (t_mem.IsNull()) {
         LOG_ERROR(Service_HID, "t_mem is a nullptr for handle=0x{:08X}", t_mem_handle);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -472,13 +472,13 @@ void HidBus::EnableJoyPollingReceiveMode(HLERequestContext& ctx) {
         device->SetPollingMode(polling_mode_);
         device->SetTransferMemoryAddress(t_mem->GetSourceAddress());
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 }
@@ -499,13 +499,13 @@ void HidBus::DisableJoyPollingReceiveMode(HLERequestContext& ctx) {
         auto& device = devices[device_index.value()].device;
         device->DisablePollingMode();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         return;
     }
 
     LOG_ERROR(Service_HID, "Invalid handle");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultUnknown);
     return;
 }
@@ -516,7 +516,7 @@ void HidBus::SetStatusManagerType(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_HID, "(STUBBED) called, manager_type={}", manager_type);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -64,7 +64,7 @@ void IRS::ActivateIrsensor(HLERequestContext& ctx) {
     LOG_WARNING(Service_IRS, "(STUBBED) called, applet_resource_user_id={}",
                 applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -75,7 +75,7 @@ void IRS::DeactivateIrsensor(HLERequestContext& ctx) {
     LOG_WARNING(Service_IRS, "(STUBBED) called, applet_resource_user_id={}",
                 applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -85,7 +85,7 @@ void IRS::GetIrsensorSharedMemoryHandle(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_IRS, "called, applet_resource_user_id={}", applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(&system.Kernel().GetIrsSharedMem());
 }
@@ -114,7 +114,7 @@ void IRS::StopImageProcessor(HLERequestContext& ctx) {
         result = ResultSuccess;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -146,7 +146,7 @@ void IRS::RunMomentProcessor(HLERequestContext& ctx) {
                                     Common::Input::PollingMode::IR);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -179,7 +179,7 @@ void IRS::RunClusteringProcessor(HLERequestContext& ctx) {
                                     Common::Input::PollingMode::IR);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -201,7 +201,7 @@ void IRS::RunImageTransferProcessor(HLERequestContext& ctx) {
 
     if (t_mem.IsNull()) {
         LOG_ERROR(Service_IRS, "t_mem is a nullptr for handle=0x{:08X}", t_mem_handle);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultUnknown);
         return;
     }
@@ -227,7 +227,7 @@ void IRS::RunImageTransferProcessor(HLERequestContext& ctx) {
                                     Common::Input::PollingMode::IR);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -248,7 +248,7 @@ void IRS::GetImageTransferProcessorState(HLERequestContext& ctx) {
 
     const auto result = IsIrCameraHandleValid(parameters.camera_handle);
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
@@ -256,7 +256,7 @@ void IRS::GetImageTransferProcessorState(HLERequestContext& ctx) {
     const auto& device = GetIrCameraSharedMemoryDeviceEntry(parameters.camera_handle);
 
     if (device.mode != Core::IrSensor::IrSensorMode::ImageTransferProcessor) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(InvalidProcessorState);
         return;
     }
@@ -267,7 +267,7 @@ void IRS::GetImageTransferProcessorState(HLERequestContext& ctx) {
     const auto& state = image_transfer_processor.GetState(data);
 
     ctx.WriteBuffer(data);
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(state);
 }
@@ -304,7 +304,7 @@ void IRS::RunTeraPluginProcessor(HLERequestContext& ctx) {
                                     Common::Input::PollingMode::IR);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -314,7 +314,7 @@ void IRS::GetNpadIrCameraHandle(HLERequestContext& ctx) {
 
     if (npad_id > Core::HID::NpadIdType::Player8 && npad_id != Core::HID::NpadIdType::Invalid &&
         npad_id != Core::HID::NpadIdType::Handheld) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Service::HID::InvalidNpadId);
         return;
     }
@@ -327,7 +327,7 @@ void IRS::GetNpadIrCameraHandle(HLERequestContext& ctx) {
     LOG_INFO(Service_IRS, "called, npad_id={}, camera_npad_id={}, camera_npad_type={}", npad_id,
              camera_handle.npad_id, camera_handle.npad_type);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(camera_handle);
 }
@@ -355,7 +355,7 @@ void IRS::RunPointingProcessor(HLERequestContext& ctx) {
                                     Common::Input::PollingMode::IR);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -381,7 +381,7 @@ void IRS::SuspendImageProcessor(HLERequestContext& ctx) {
         result = ResultSuccess;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -403,7 +403,7 @@ void IRS::CheckFirmwareVersion(HLERequestContext& ctx) {
         result = ResultSuccess;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -425,7 +425,7 @@ void IRS::SetFunctionLevel(HLERequestContext& ctx) {
         result = ResultSuccess;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -464,7 +464,7 @@ void IRS::RunImageTransferExProcessor(HLERequestContext& ctx) {
                                     Common::Input::PollingMode::IR);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -492,7 +492,7 @@ void IRS::RunIrLedProcessor(HLERequestContext& ctx) {
                                     Common::Input::PollingMode::IR);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -520,7 +520,7 @@ void IRS::StopImageProcessorAsync(HLERequestContext& ctx) {
         result = ResultSuccess;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -538,7 +538,7 @@ void IRS::ActivateIrsensorWithFunctionLevel(HLERequestContext& ctx) {
     LOG_WARNING(Service_IRS, "(STUBBED) called, function_level={}, applet_resource_user_id={}",
                 parameters.function_level.function_level, parameters.applet_resource_user_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 

--- a/src/core/hle/service/hid/resource_manager.cpp
+++ b/src/core/hle/service/hid/resource_manager.cpp
@@ -350,7 +350,7 @@ void IAppletResource::GetSharedMemoryHandle(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_HID, "called, applet_resource_user_id={}, result=0x{:X}", aruid, result.raw);
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushCopyObjects(handle);
 }

--- a/src/core/hle/service/hle_ipc.cpp
+++ b/src/core/hle/service/hle_ipc.cpp
@@ -79,7 +79,7 @@ Result SessionRequestManager::CompleteSyncRequest(Kernel::KServerSession* server
         }
     } else {
         ASSERT_MSG(false, "Session handler is invalid, stubbing response!");
-        IPC::ResponseBuilder rb(context, 2);
+        IPC::ResponseBuilder rb{context};
         rb.Push(ResultSuccess);
     }
 
@@ -126,7 +126,7 @@ Result SessionRequestManager::HandleDomainSyncRequest(Kernel::KServerSession* se
 
         this->CloseDomainHandler(object_id - 1);
 
-        IPC::ResponseBuilder rb{context, 2};
+        IPC::ResponseBuilder rb{context};
         rb.Push(ResultSuccess);
         return ResultSuccess;
     }
@@ -309,7 +309,7 @@ Result HLERequestContext::WriteToOutgoingCommandBuffer() {
     // TODO(Subv): This completely ignores C buffers.
 
     if (GetManager()->IsDomain()) {
-        current_offset = domain_offset - static_cast<u32>(outgoing_domain_objects.size());
+        current_offset = domain_offset;
         for (auto& object : outgoing_domain_objects) {
             GetManager()->AppendDomainHandler(std::move(object));
             cmd_buf[current_offset++] = static_cast<u32_le>(GetManager()->DomainHandlerCount());

--- a/src/core/hle/service/jit/jit.cpp
+++ b/src/core/hle/service/jit/jit.cpp
@@ -123,12 +123,12 @@ public:
                     },
             };
 
-            IPC::ResponseBuilder rb{ctx, 8};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultSuccess);
             rb.PushRaw(out);
         } else {
             LOG_WARNING(Service_JIT, "plugin GenerateCode callback failed");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
         }
     };
@@ -168,12 +168,12 @@ public:
                 ctx.WriteBuffer(output_buffer.data(), output_buffer.size());
             }
 
-            IPC::ResponseBuilder rb{ctx, 3};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultSuccess);
             rb.Push(return_value);
         } else {
             LOG_WARNING(Service_JIT, "plugin Control callback failed");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
         }
     }
@@ -188,7 +188,7 @@ public:
 
         if (tmem_size == 0) {
             LOG_ERROR(Service_JIT, "attempted to load plugin with empty transfer memory");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -196,7 +196,7 @@ public:
         auto tmem{ctx.GetObjectFromHandle<Kernel::KTransferMemory>(tmem_handle)};
         if (tmem.IsNull()) {
             LOG_ERROR(Service_JIT, "attempted to load plugin with invalid transfer memory handle");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -223,14 +223,14 @@ public:
         if (callbacks.GetVersion == 0 || callbacks.Configure == 0 || callbacks.GenerateCode == 0 ||
             callbacks.OnPrepared == 0) {
             LOG_ERROR(Service_JIT, "plugin does not implement all necessary functionality");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
 
         if (!context.LoadNRO(nro_plugin)) {
             LOG_ERROR(Service_JIT, "failed to load plugin");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -252,7 +252,7 @@ public:
         const auto version{context.CallFunction(callbacks.GetVersion)};
         if (version != 1) {
             LOG_ERROR(Service_JIT, "unknown plugin version {}", version);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -280,14 +280,14 @@ public:
         const auto configuration_ptr{context.AddHeap(configuration)};
         context.CallFunction(callbacks.OnPrepared, configuration_ptr);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetCodeAddress(HLERequestContext& ctx) {
         LOG_DEBUG(Service_JIT, "called");
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(configuration.user_rx_memory.offset);
         rb.Push(configuration.user_ro_memory.offset);
@@ -359,7 +359,7 @@ private:
 
         if (parameters.rx_size == 0 || parameters.ro_size == 0) {
             LOG_ERROR(Service_JIT, "attempted to init with empty code regions");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -367,7 +367,7 @@ private:
         auto process{ctx.GetObjectFromHandle<Kernel::KProcess>(process_handle)};
         if (process.IsNull()) {
             LOG_ERROR(Service_JIT, "process is null for handle=0x{:08X}", process_handle);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -375,7 +375,7 @@ private:
         auto rx_mem{ctx.GetObjectFromHandle<Kernel::KCodeMemory>(rx_mem_handle)};
         if (rx_mem.IsNull()) {
             LOG_ERROR(Service_JIT, "rx_mem is null for handle=0x{:08X}", rx_mem_handle);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -383,7 +383,7 @@ private:
         auto ro_mem{ctx.GetObjectFromHandle<Kernel::KCodeMemory>(ro_mem_handle)};
         if (ro_mem.IsNull()) {
             LOG_ERROR(Service_JIT, "ro_mem is null for handle=0x{:08X}", ro_mem_handle);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultUnknown);
             return;
         }
@@ -395,7 +395,7 @@ private:
                             Kernel::Svc::MemoryPermission::ReadExecute, generate_random);
         if (R_FAILED(res)) {
             LOG_ERROR(Service_JIT, "rx_mem could not be mapped for handle=0x{:08X}", rx_mem_handle);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(res);
             return;
         }
@@ -404,12 +404,12 @@ private:
                             Kernel::Svc::MemoryPermission::Read, generate_random);
         if (R_FAILED(res)) {
             LOG_ERROR(Service_JIT, "ro_mem could not be mapped for handle=0x{:08X}", ro_mem_handle);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(res);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IJitEnvironment>(system, std::move(process), std::move(rx),
                                              std::move(ro));

--- a/src/core/hle/service/lbl/lbl.cpp
+++ b/src/core/hle/service/lbl/lbl.cpp
@@ -74,7 +74,7 @@ private:
         current_brightness = brightness;
         update_instantly = true;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -87,7 +87,7 @@ private:
 
         LOG_DEBUG(Service_LBL, "called brightness={}", brightness);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(brightness);
     }
@@ -99,7 +99,7 @@ private:
 
         backlight_enabled = true;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -110,14 +110,14 @@ private:
 
         backlight_enabled = false;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetBacklightSwitchStatus(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushEnum<BacklightSwitchStatus>(backlight_enabled ? BacklightSwitchStatus::On
                                                              : BacklightSwitchStatus::Off);
@@ -128,7 +128,7 @@ private:
 
         dimming = true;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -137,14 +137,14 @@ private:
 
         dimming = false;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void IsDimmingEnabled(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(dimming);
     }
@@ -154,7 +154,7 @@ private:
         auto_brightness = true;
         update_instantly = true;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -162,14 +162,14 @@ private:
         LOG_DEBUG(Service_LBL, "called");
         auto_brightness = false;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void IsAutoBrightnessControlEnabled(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(auto_brightness);
     }
@@ -182,14 +182,14 @@ private:
 
         ambient_light_value = light_value;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetAmbientLightSensorValue(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(ambient_light_value);
     }
@@ -198,7 +198,7 @@ private:
         // This is Intentional, this function does absolutely nothing
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -206,7 +206,7 @@ private:
         // This is intentional, the function is hard coded to return 0.0f on hardware
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(0.0f);
     }
@@ -215,7 +215,7 @@ private:
         // This is Intentional, this function does absolutely nothing
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -223,7 +223,7 @@ private:
         // This is Intentional, this function does absolutely nothing
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         // This function is suppose to return something but it seems like it doesn't
     }
@@ -232,7 +232,7 @@ private:
         // This is Intentional, this function does absolutely nothing
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -240,14 +240,14 @@ private:
         // This is Intentional, this function does absolutely nothing
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         // This function is suppose to return something but it seems like it doesn't
     }
 
     void IsAmbientLightSensorAvailable(HLERequestContext& ctx) {
         LOG_WARNING(Service_LBL, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         // TODO(ogniK): Only return true if there's no device error
         rb.Push(true);
@@ -266,7 +266,7 @@ private:
 
         current_vr_brightness = brightness;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -279,7 +279,7 @@ private:
 
         LOG_DEBUG(Service_LBL, "called brightness={}", brightness);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(brightness);
     }
@@ -287,7 +287,7 @@ private:
     void EnableVrMode(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         vr_mode_enabled = true;
@@ -296,7 +296,7 @@ private:
     void DisableVrMode(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         vr_mode_enabled = false;
@@ -305,7 +305,7 @@ private:
     void IsVrModeEnabled(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LBL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(vr_mode_enabled);
     }

--- a/src/core/hle/service/ldn/ldn.cpp
+++ b/src/core/hle/service/ldn/ldn.cpp
@@ -41,7 +41,7 @@ private:
     void GetStateForMonitor(HLERequestContext& ctx) {
         LOG_INFO(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushEnum(state);
     }
@@ -51,7 +51,7 @@ private:
 
         state = State::Initialized;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -73,7 +73,7 @@ public:
     void CreateMonitorService(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IMonitorService>(system);
     }
@@ -126,7 +126,7 @@ private:
     void InitializeSystem2(HLERequestContext& ctx) {
         LOG_WARNING(Service_LDN, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };
@@ -204,7 +204,7 @@ public:
             state = lan_discovery.GetState();
         }
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushEnum(state);
     }
@@ -214,7 +214,7 @@ public:
 
         if (write_buffer_size != sizeof(NetworkInfo)) {
             LOG_ERROR(Service_LDN, "Invalid buffer size {}", write_buffer_size);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultBadInput);
             return;
         }
@@ -223,13 +223,13 @@ public:
         const auto rc = lan_discovery.GetNetworkInfo(network_info);
         if (rc.IsError()) {
             LOG_ERROR(Service_LDN, "NetworkInfo is not valid {}", rc.raw);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(rc);
             return;
         }
 
         ctx.WriteBuffer<NetworkInfo>(network_info);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -238,7 +238,7 @@ public:
 
         if (!network_interface) {
             LOG_ERROR(Service_LDN, "No network interface available");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultNoIpAddress);
             return;
         }
@@ -256,14 +256,14 @@ public:
         std::reverse(std::begin(current_address), std::end(current_address)); // ntohl
         std::reverse(std::begin(subnet_mask), std::end(subnet_mask));         // ntohl
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(current_address);
         rb.PushRaw(subnet_mask);
     }
 
     void GetDisconnectReason(HLERequestContext& ctx) {
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushEnum(lan_discovery.GetDisconnectReason());
     }
@@ -275,7 +275,7 @@ public:
 
         if (rc.IsError()) {
             LOG_ERROR(Service_LDN, "NetworkInfo is not valid {}", rc.raw);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(rc);
             return;
         }
@@ -284,7 +284,7 @@ public:
         std::memcpy(security_parameter.data.data(), info.ldn.security_parameter.data(),
                     sizeof(SecurityParameter::data));
 
-        IPC::ResponseBuilder rb{ctx, 10};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(rc);
         rb.PushRaw<SecurityParameter>(security_parameter);
     }
@@ -296,7 +296,7 @@ public:
 
         if (rc.IsError()) {
             LOG_ERROR(Service_LDN, "NetworkConfig is not valid {}", rc.raw);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(rc);
             return;
         }
@@ -306,7 +306,7 @@ public:
         config.node_count_max = info.ldn.node_count_max;
         config.local_communication_version = info.ldn.nodes[0].local_communication_version;
 
-        IPC::ResponseBuilder rb{ctx, 10};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(rc);
         rb.PushRaw<NetworkConfig>(config);
     }
@@ -314,7 +314,7 @@ public:
     void AttachStateChangeEvent(HLERequestContext& ctx) {
         LOG_INFO(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(state_change_event->GetReadableEvent());
     }
@@ -326,7 +326,7 @@ public:
         if (node_buffer_count == 0 || network_buffer_size != sizeof(NetworkInfo)) {
             LOG_ERROR(Service_LDN, "Invalid buffer, size = {}, count = {}", network_buffer_size,
                       node_buffer_count);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultBadInput);
             return;
         }
@@ -337,7 +337,7 @@ public:
         const auto rc = lan_discovery.GetNetworkInfo(info, latest_update, latest_update.size());
         if (rc.IsError()) {
             LOG_ERROR(Service_LDN, "NetworkInfo is not valid {}", rc.raw);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(rc);
             return;
         }
@@ -345,7 +345,7 @@ public:
         ctx.WriteBuffer(info, 0);
         ctx.WriteBuffer(latest_update, 1);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -366,7 +366,7 @@ public:
 
         if (network_info_size == 0) {
             LOG_ERROR(Service_LDN, "Invalid buffer size {}", network_info_size);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultBadInput);
             return;
         }
@@ -381,7 +381,7 @@ public:
 
         ctx.WriteBuffer(network_infos);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(rc);
         rb.Push<u32>(count);
     }
@@ -389,21 +389,21 @@ public:
     void SetWirelessControllerRestriction(HLERequestContext& ctx) {
         LOG_WARNING(Service_LDN, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void OpenAccessPoint(HLERequestContext& ctx) {
         LOG_INFO(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.OpenAccessPoint());
     }
 
     void CloseAccessPoint(HLERequestContext& ctx) {
         LOG_INFO(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.CloseAccessPoint());
     }
 
@@ -429,49 +429,49 @@ public:
         rp.Pop<u32>(); // Padding
         const auto network_Config{rp.PopRaw<NetworkConfig>()};
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.CreateNetwork(security_config, user_config, network_Config));
     }
 
     void DestroyNetwork(HLERequestContext& ctx) {
         LOG_INFO(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.DestroyNetwork());
     }
 
     void SetAdvertiseData(HLERequestContext& ctx) {
         const auto read_buffer = ctx.ReadBuffer();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.SetAdvertiseData(read_buffer));
     }
 
     void SetStationAcceptPolicy(HLERequestContext& ctx) {
         LOG_WARNING(Service_LDN, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void AddAcceptFilterEntry(HLERequestContext& ctx) {
         LOG_WARNING(Service_LDN, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void OpenStation(HLERequestContext& ctx) {
         LOG_INFO(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.OpenStation());
     }
 
     void CloseStation(HLERequestContext& ctx) {
         LOG_INFO(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.CloseStation());
     }
 
@@ -496,7 +496,7 @@ public:
         const auto read_buffer = ctx.ReadBuffer();
         if (read_buffer.size() != sizeof(NetworkInfo)) {
             LOG_ERROR(Frontend, "NetworkInfo doesn't match read_buffer size!");
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultBadInput);
             return;
         }
@@ -504,7 +504,7 @@ public:
         NetworkInfo network_info{};
         std::memcpy(&network_info, read_buffer.data(), read_buffer.size());
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.Connect(network_info, parameters.user_config,
                                       static_cast<u16>(parameters.local_communication_version)));
     }
@@ -512,7 +512,7 @@ public:
     void Disconnect(HLERequestContext& ctx) {
         LOG_INFO(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.Disconnect());
     }
 
@@ -522,7 +522,7 @@ public:
             LOG_ERROR(Service_LDN, "Network isn't initialized, rc={}", rc.raw);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(rc);
     }
 
@@ -533,7 +533,7 @@ public:
 
         is_initialized = false;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(lan_discovery.Finalize());
     }
 
@@ -543,7 +543,7 @@ public:
             LOG_ERROR(Service_LDN, "Network isn't initialized, rc={}", rc.raw);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(rc);
     }
 
@@ -593,7 +593,7 @@ public:
     void CreateSystemLocalCommunicationService(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISystemLocalCommunicationService>(system);
     }
@@ -614,7 +614,7 @@ public:
     void CreateUserLocalCommunicationService(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LDN, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IUserLocalCommunicationService>(system);
     }
@@ -678,7 +678,7 @@ public:
     void Initialize(HLERequestContext& ctx) {
         LOG_WARNING(Service_LDN, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultDisabled);
     }
 };
@@ -704,7 +704,7 @@ public:
         LOG_WARNING(Service_LDN, "(STUBBED) called reserved_input={} input={}", reserved_input,
                     input);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<INetworkService>(system);
     }
@@ -715,7 +715,7 @@ public:
 
         LOG_WARNING(Service_LDN, "(STUBBED) called reserved_input={}", reserved_input);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<INetworkServiceMonitor>(system);
     }
@@ -742,7 +742,7 @@ public:
         LOG_WARNING(Service_LDN, "(STUBBED) called reserved_input={} input={}", reserved_input,
                     input);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<INetworkService>(system);
     }
@@ -753,7 +753,7 @@ public:
 
         LOG_WARNING(Service_LDN, "(STUBBED) called reserved_input={}", reserved_input);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<INetworkServiceMonitor>(system);
     }
@@ -778,7 +778,7 @@ private:
     void Initialize(HLERequestContext& ctx) {
         LOG_WARNING(Service_LDN, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(0);
     }
@@ -793,7 +793,7 @@ private:
         GroupInfo group_info{};
 
         ctx.WriteBuffer(group_info);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };
@@ -817,7 +817,7 @@ private:
 
         LOG_INFO(Service_LDN, "called, reserved_input={}", reserved_input);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISfMonitorService>(system);
     }

--- a/src/core/hle/service/lm/lm.cpp
+++ b/src/core/hle/service/lm/lm.cpp
@@ -98,7 +98,7 @@ private:
         const auto data = ctx.ReadBuffer();
 
         // This function only succeeds - Get that out of the way
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         if (data.size() < sizeof(LogPacketHeader)) {
@@ -155,7 +155,7 @@ private:
         LOG_DEBUG(Service_LM, "called, destination={}", DestinationToString(log_destination));
         destination = log_destination;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -346,7 +346,7 @@ private:
     void OpenLogger(HLERequestContext& ctx) {
         LOG_DEBUG(Service_LM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ILogger>(system);
     }

--- a/src/core/hle/service/mii/mii.cpp
+++ b/src/core/hle/service/mii/mii.cpp
@@ -68,7 +68,7 @@ private:
 
         const bool is_updated = manager->IsUpdated(metadata, source_flag);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u8>(is_updated);
     }
@@ -78,7 +78,7 @@ private:
 
         const bool is_full_database = manager->IsFullDatabase();
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u8>(is_full_database);
     }
@@ -91,7 +91,7 @@ private:
 
         LOG_DEBUG(Service_Mii, "called with source_flag={}, mii_count={}", source_flag, mii_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(mii_count);
     }
@@ -112,7 +112,7 @@ private:
         LOG_INFO(Service_Mii, "called with source_flag={}, out_size={}, mii_count={}", source_flag,
                  output_size, mii_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(mii_count);
     }
@@ -133,7 +133,7 @@ private:
         LOG_INFO(Service_Mii, "called with source_flag={}, out_size={}, mii_count={}", source_flag,
                  output_size, mii_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(mii_count);
     }
@@ -148,12 +148,12 @@ private:
         CharInfo new_char_info{};
         const auto result = manager->UpdateLatest(metadata, new_char_info, char_info, source_flag);
         if (result.IsFailure()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(new_char_info);
     }
@@ -167,19 +167,19 @@ private:
         LOG_DEBUG(Service_Mii, "called with age={}, gender={}, race={}", age, gender, race);
 
         if (age > Age::All) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultInvalidArgument);
             return;
         }
 
         if (gender > Gender::All) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultInvalidArgument);
             return;
         }
 
         if (race > Race::All) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultInvalidArgument);
             return;
         }
@@ -187,7 +187,7 @@ private:
         CharInfo char_info{};
         manager->BuildRandom(char_info, age, gender, race);
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(char_info);
     }
@@ -199,7 +199,7 @@ private:
         LOG_DEBUG(Service_Mii, "called with index={}", index);
 
         if (index > 5) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultInvalidArgument);
             return;
         }
@@ -207,7 +207,7 @@ private:
         CharInfo char_info{};
         manager->BuildDefault(char_info, index);
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(char_info);
     }
@@ -228,7 +228,7 @@ private:
         LOG_INFO(Service_Mii, "called with source_flag={}, out_size={}, mii_count={}", source_flag,
                  output_size, mii_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(mii_count);
     }
@@ -249,7 +249,7 @@ private:
         LOG_INFO(Service_Mii, "called with source_flag={}, out_size={}, mii_count={}", source_flag,
                  output_size, mii_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(mii_count);
     }
@@ -272,12 +272,12 @@ private:
         }
 
         if (result.IsFailure()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(StoreData) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw<StoreData>(new_store_data);
     }
@@ -292,7 +292,7 @@ private:
 
         const s32 index = manager->FindIndex(create_id, is_special);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(index);
     }
@@ -321,7 +321,7 @@ private:
             result = manager->Move(metadata, new_index, create_id);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -341,7 +341,7 @@ private:
             result = manager->AddOrReplace(metadata, store_data);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -361,7 +361,7 @@ private:
             result = manager->Delete(metadata, create_id);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -381,7 +381,7 @@ private:
             result = manager->DestroyFile(metadata);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -401,7 +401,7 @@ private:
             result = manager->DeleteFile();
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -421,7 +421,7 @@ private:
             result = manager->Format(metadata);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -439,7 +439,7 @@ private:
             is_broken_with_clear_flag = manager->IsBrokenWithClearFlag(metadata);
         }
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push<u8>(is_broken_with_clear_flag);
     }
@@ -453,7 +453,7 @@ private:
         s32 index{};
         const auto result = manager->GetIndex(metadata, info, index);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(index);
     }
@@ -466,7 +466,7 @@ private:
 
         manager->SetInterfaceVersion(metadata, interface_version);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -479,7 +479,7 @@ private:
         CharInfo char_info{};
         const auto result = manager->ConvertV3ToCharInfo(char_info, mii_v3);
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.PushRaw<CharInfo>(char_info);
     }
@@ -493,7 +493,7 @@ private:
         CharInfo char_info{};
         const auto result = manager->ConvertCoreDataToCharInfo(char_info, core_data);
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CharInfo) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.PushRaw<CharInfo>(char_info);
     }
@@ -507,7 +507,7 @@ private:
         CoreData core_data{};
         const auto result = manager->ConvertCharInfoToCoreData(core_data, char_info);
 
-        IPC::ResponseBuilder rb{ctx, 2 + sizeof(CoreData) / sizeof(u32)};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.PushRaw<CoreData>(core_data);
     }
@@ -520,7 +520,7 @@ private:
 
         const auto result = manager->Append(metadata, char_info);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -548,7 +548,7 @@ MiiDBModule::MiiDBModule(Core::System& system_, const char* name_,
 MiiDBModule::~MiiDBModule() = default;
 
 void MiiDBModule::GetDatabaseService(HLERequestContext& ctx) {
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IDatabaseService>(system, manager, is_system);
 
@@ -588,14 +588,14 @@ private:
     void Initialize(HLERequestContext& ctx) {
         LOG_INFO(Service_Mii, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetCount(HLERequestContext& ctx) {
         LOG_DEBUG(Service_Mii, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(0);
     }

--- a/src/core/hle/service/mm/mm_u.cpp
+++ b/src/core/hle/service/mm/mm_u.cpp
@@ -32,14 +32,14 @@ private:
     void InitializeOld(HLERequestContext& ctx) {
         LOG_WARNING(Service_MM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void FinalizeOld(HLERequestContext& ctx) {
         LOG_WARNING(Service_MM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -50,14 +50,14 @@ private:
         LOG_DEBUG(Service_MM, "(STUBBED) called, min=0x{:X}, max=0x{:X}", min, max);
 
         current = min;
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetOld(HLERequestContext& ctx) {
         LOG_DEBUG(Service_MM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(current);
     }
@@ -65,7 +65,7 @@ private:
     void Initialize(HLERequestContext& ctx) {
         LOG_WARNING(Service_MM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(id); // Any non zero value
     }
@@ -73,7 +73,7 @@ private:
     void Finalize(HLERequestContext& ctx) {
         LOG_WARNING(Service_MM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -86,14 +86,14 @@ private:
                   min, max);
 
         current = min;
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void Get(HLERequestContext& ctx) {
         LOG_DEBUG(Service_MM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(current);
     }

--- a/src/core/hle/service/mnpp/mnpp_app.cpp
+++ b/src/core/hle/service/mnpp/mnpp_app.cpp
@@ -26,14 +26,14 @@ private:
     void Unknown0(HLERequestContext& ctx) {
         LOG_WARNING(Service_MNPP, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void Unknown1(HLERequestContext& ctx) {
         LOG_WARNING(Service_MNPP, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -146,7 +146,7 @@ private:
     void CreateAmNfcInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NFC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IAm>(system);
     }
@@ -168,7 +168,7 @@ private:
     void CreateUserNfcInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NFC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<MFIUser>(system);
     }
@@ -190,7 +190,7 @@ private:
     void CreateUserNfcInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NFC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IUser>(system);
     }
@@ -212,7 +212,7 @@ private:
     void CreateSystemNfcInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NFC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISystem>(system);
     }

--- a/src/core/hle/service/nfc/nfc_interface.cpp
+++ b/src/core/hle/service/nfc/nfc_interface.cpp
@@ -36,7 +36,7 @@ void NfcInterface::Initialize(HLERequestContext& ctx) {
         manager->Finalize();
     }
 
-    IPC::ResponseBuilder rb{ctx, 2, 0};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -51,14 +51,14 @@ void NfcInterface::Finalize(HLERequestContext& ctx) {
         state = State::NonInitialized;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void NfcInterface::GetState(HLERequestContext& ctx) {
     LOG_DEBUG(Service_NFC, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(state);
 }
@@ -69,7 +69,7 @@ void NfcInterface::IsNfcEnabled(HLERequestContext& ctx) {
     // TODO: This calls nn::settings::detail::GetNfcEnableFlag
     const bool is_enabled = true;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(is_enabled);
 }
@@ -83,14 +83,14 @@ void NfcInterface::ListDevices(HLERequestContext& ctx) {
     result = TranslateResultToServiceError(result);
 
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
     ctx.WriteBuffer(nfp_devices);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<s32>(nfp_devices.size()));
 }
@@ -106,7 +106,7 @@ void NfcInterface::GetDeviceState(HLERequestContext& ctx) {
         ASSERT_MSG(false, "Invalid device state");
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(device_state);
 }
@@ -121,12 +121,12 @@ void NfcInterface::GetNpadId(HLERequestContext& ctx) {
     result = TranslateResultToServiceError(result);
 
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(npad_id);
 }
@@ -134,7 +134,7 @@ void NfcInterface::GetNpadId(HLERequestContext& ctx) {
 void NfcInterface::AttachAvailabilityChangeEvent(HLERequestContext& ctx) {
     LOG_INFO(Service_NFC, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(GetManager()->AttachAvailabilityChangeEvent());
 }
@@ -152,7 +152,7 @@ void NfcInterface::StartDetection(HLERequestContext& ctx) {
     auto result = GetManager()->StartDetection(device_handle, tag_protocol);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -164,7 +164,7 @@ void NfcInterface::StopDetection(HLERequestContext& ctx) {
     auto result = GetManager()->StopDetection(device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -181,7 +181,7 @@ void NfcInterface::GetTagInfo(HLERequestContext& ctx) {
         ctx.WriteBuffer(tag_info);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -194,7 +194,7 @@ void NfcInterface::AttachActivateEvent(HLERequestContext& ctx) {
     auto result = GetManager()->AttachActivateEvent(&out_event, device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushCopyObjects(out_event);
 }
@@ -208,7 +208,7 @@ void NfcInterface::AttachDeactivateEvent(HLERequestContext& ctx) {
     auto result = GetManager()->AttachDeactivateEvent(&out_event, device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.PushCopyObjects(out_event);
 }
@@ -234,7 +234,7 @@ void NfcInterface::ReadMifare(HLERequestContext& ctx) {
         ctx.WriteBuffer(out_data);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -254,7 +254,7 @@ void NfcInterface::WriteMifare(HLERequestContext& ctx) {
     auto result = GetManager()->WriteMifare(device_handle, write_commands);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -272,14 +272,14 @@ void NfcInterface::SendCommandByPassThrough(HLERequestContext& ctx) {
     result = TranslateResultToServiceError(result);
 
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
     ctx.WriteBuffer(out_data);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(out_data.size()));
 }

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -152,7 +152,7 @@ private:
     void CreateUserInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NFP, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IUser>(system);
     }
@@ -174,7 +174,7 @@ private:
     void CreateSystemInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NFP, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISystem>(system);
     }
@@ -196,7 +196,7 @@ private:
     void CreateDebugInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NFP, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IDebug>(system);
     }

--- a/src/core/hle/service/nfp/nfp_interface.cpp
+++ b/src/core/hle/service/nfp/nfp_interface.cpp
@@ -47,7 +47,7 @@ void Interface::Mount(HLERequestContext& ctx) {
     auto result = GetManager()->Mount(device_handle, model_type, mount_target);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -59,7 +59,7 @@ void Interface::Unmount(HLERequestContext& ctx) {
     auto result = GetManager()->Unmount(device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -72,7 +72,7 @@ void Interface::OpenApplicationArea(HLERequestContext& ctx) {
     auto result = GetManager()->OpenApplicationArea(device_handle, access_id);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -87,13 +87,13 @@ void Interface::GetApplicationArea(HLERequestContext& ctx) {
     result = TranslateResultToServiceError(result);
 
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
     ctx.WriteBuffer(data);
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(static_cast<u32>(data_size));
 }
@@ -107,7 +107,7 @@ void Interface::SetApplicationArea(HLERequestContext& ctx) {
     auto result = GetManager()->SetApplicationArea(device_handle, data);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -119,7 +119,7 @@ void Interface::Flush(HLERequestContext& ctx) {
     auto result = GetManager()->Flush(device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -131,7 +131,7 @@ void Interface::Restore(HLERequestContext& ctx) {
     auto result = GetManager()->Restore(device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -146,7 +146,7 @@ void Interface::CreateApplicationArea(HLERequestContext& ctx) {
     auto result = GetManager()->CreateApplicationArea(device_handle, access_id, data);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -163,7 +163,7 @@ void Interface::GetRegisterInfo(HLERequestContext& ctx) {
         ctx.WriteBuffer(register_info);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -180,7 +180,7 @@ void Interface::GetCommonInfo(HLERequestContext& ctx) {
         ctx.WriteBuffer(common_info);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -197,7 +197,7 @@ void Interface::GetModelInfo(HLERequestContext& ctx) {
         ctx.WriteBuffer(model_info);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -206,7 +206,7 @@ void Interface::GetApplicationAreaSize(HLERequestContext& ctx) {
     const auto device_handle{rp.Pop<u64>()};
     LOG_DEBUG(Service_NFP, "called, device_handle={}", device_handle);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(GetManager()->GetApplicationAreaSize());
 }
@@ -222,7 +222,7 @@ void Interface::RecreateApplicationArea(HLERequestContext& ctx) {
     auto result = GetManager()->RecreateApplicationArea(device_handle, access_id, data);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -234,7 +234,7 @@ void Interface::Format(HLERequestContext& ctx) {
     auto result = GetManager()->Format(device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -251,7 +251,7 @@ void Interface::GetAdminInfo(HLERequestContext& ctx) {
         ctx.WriteBuffer(admin_info);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -268,7 +268,7 @@ void Interface::GetRegisterInfoPrivate(HLERequestContext& ctx) {
         ctx.WriteBuffer(register_info);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -284,7 +284,7 @@ void Interface::SetRegisterInfoPrivate(HLERequestContext& ctx) {
     auto result = GetManager()->SetRegisterInfoPrivate(device_handle, register_info);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -296,7 +296,7 @@ void Interface::DeleteRegisterInfo(HLERequestContext& ctx) {
     auto result = GetManager()->DeleteRegisterInfo(device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -308,7 +308,7 @@ void Interface::DeleteApplicationArea(HLERequestContext& ctx) {
     auto result = GetManager()->DeleteApplicationArea(device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -322,12 +322,12 @@ void Interface::ExistsApplicationArea(HLERequestContext& ctx) {
     result = TranslateResultToServiceError(result);
 
     if (result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
     rb.Push(has_application_area);
 }
@@ -345,7 +345,7 @@ void Interface::GetAll(HLERequestContext& ctx) {
         ctx.WriteBuffer(nfp_data);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -361,7 +361,7 @@ void Interface::SetAll(HLERequestContext& ctx) {
     auto result = GetManager()->SetAll(device_handle, nfp_data);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -373,7 +373,7 @@ void Interface::FlushDebug(HLERequestContext& ctx) {
     auto result = GetManager()->FlushDebug(device_handle);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -387,7 +387,7 @@ void Interface::BreakTag(HLERequestContext& ctx) {
     auto result = GetManager()->BreakTag(device_handle, break_type);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -404,7 +404,7 @@ void Interface::ReadBackupData(HLERequestContext& ctx) {
         ctx.WriteBuffer(backup_data);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -417,7 +417,7 @@ void Interface::WriteBackupData(HLERequestContext& ctx) {
     auto result = GetManager()->WriteBackupData(device_handle, backup_data_buffer);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -431,7 +431,7 @@ void Interface::WriteNtf(HLERequestContext& ctx) {
     auto result = GetManager()->WriteNtf(device_handle, write_type, ntf_data_buffer);
     result = TranslateResultToServiceError(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 

--- a/src/core/hle/service/ngc/ngc.cpp
+++ b/src/core/hle/service/ngc/ngc.cpp
@@ -31,7 +31,7 @@ private:
 
         LOG_WARNING(Service_NGC, "(STUBBED) called, text={}", text);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         // Return false since we don't censor anything
         rb.Push(false);
@@ -47,7 +47,7 @@ private:
         // Return the same string since we don't censor anything
         ctx.WriteBuffer(buffer);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };
@@ -83,7 +83,7 @@ private:
         // This calls nn::ngc::ProfanityFilter::GetContentVersion
         const u32 version = NgcContentVersion;
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(version);
     }
@@ -103,7 +103,7 @@ private:
         // This calls nn::ngc::ProfanityFilter::CheckProfanityWords
         const u32 out_flags = 0;
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(out_flags);
     }
@@ -124,7 +124,7 @@ private:
         const u32 out_flags = 0;
         ctx.WriteBuffer(input);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(out_flags);
     }
@@ -134,7 +134,7 @@ private:
 
         // This reloads the database.
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -225,14 +225,14 @@ private:
             UpdateState(RequestState::OnHold);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetRequestState(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NIFM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushEnum(state);
     }
@@ -258,14 +258,14 @@ private:
             }
         }();
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
     void GetSystemEventReadableHandles(HLERequestContext& ctx) {
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(event1->GetReadableEvent(), event2->GetReadableEvent());
     }
@@ -273,14 +273,14 @@ private:
     void Cancel(HLERequestContext& ctx) {
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void SetConnectionConfirmationOption(HLERequestContext& ctx) {
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -291,7 +291,7 @@ private:
 
         ctx.WriteBuffer(out_buffer);
 
-        IPC::ResponseBuilder rb{ctx, 5};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(0);
         rb.Push<u32>(0);
@@ -327,7 +327,7 @@ void IGeneralService::GetClientId(HLERequestContext& ctx) {
     static constexpr u32 client_id = 1;
     LOG_WARNING(Service_NIFM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u64>(client_id); // Client ID needs to be non zero otherwise it's considered invalid
 }
@@ -335,7 +335,7 @@ void IGeneralService::GetClientId(HLERequestContext& ctx) {
 void IGeneralService::CreateScanRequest(HLERequestContext& ctx) {
     LOG_DEBUG(Service_NIFM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IScanRequest>(system);
@@ -344,7 +344,7 @@ void IGeneralService::CreateScanRequest(HLERequestContext& ctx) {
 void IGeneralService::CreateRequest(HLERequestContext& ctx) {
     LOG_DEBUG(Service_NIFM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IRequest>(system);
@@ -405,14 +405,14 @@ void IGeneralService::GetCurrentNetworkProfile(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(network_profile_data);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void IGeneralService::RemoveNetworkProfile(HLERequestContext& ctx) {
     LOG_WARNING(Service_NIFM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -432,7 +432,7 @@ void IGeneralService::GetCurrentIpAddress(HLERequestContext& ctx) {
         }
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(*ipv4);
 }
@@ -445,7 +445,7 @@ void IGeneralService::CreateTemporaryNetworkProfile(HLERequestContext& ctx) {
     auto buffer = ctx.ReadBuffer();
     std::memcpy(&uuid, buffer.data() + 8, sizeof(u128));
 
-    IPC::ResponseBuilder rb{ctx, 6, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<INetworkProfile>(system);
@@ -491,7 +491,7 @@ void IGeneralService::GetCurrentIpConfigInfo(HLERequestContext& ctx) {
         }
     }
 
-    IPC::ResponseBuilder rb{ctx, 2 + (sizeof(IpConfigInfo) + 3) / sizeof(u32)};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw<IpConfigInfo>(ip_config_info);
 }
@@ -499,7 +499,7 @@ void IGeneralService::GetCurrentIpConfigInfo(HLERequestContext& ctx) {
 void IGeneralService::IsWirelessCommunicationEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Service_NIFM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(1);
 }
@@ -516,7 +516,7 @@ void IGeneralService::GetInternetConnectionStatus(HLERequestContext& ctx) {
 
     constexpr Output out{};
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(out);
 }
@@ -524,7 +524,7 @@ void IGeneralService::GetInternetConnectionStatus(HLERequestContext& ctx) {
 void IGeneralService::IsEthernetCommunicationEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Service_NIFM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     if (Network::GetHostIPv4Address().has_value()) {
         rb.Push<u8>(1);
@@ -536,7 +536,7 @@ void IGeneralService::IsEthernetCommunicationEnabled(HLERequestContext& ctx) {
 void IGeneralService::IsAnyInternetRequestAccepted(HLERequestContext& ctx) {
     LOG_ERROR(Service_NIFM, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     if (Network::GetHostIPv4Address().has_value()) {
         rb.Push<u8>(1);
@@ -550,7 +550,7 @@ void IGeneralService::IsAnyForegroundRequestAccepted(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_NIFM, "(STUBBED) called, is_accepted={}", is_accepted);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(is_accepted);
 }
@@ -624,7 +624,7 @@ private:
     void CreateGeneralServiceOld(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NIFM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IGeneralService>(system);
     }
@@ -632,7 +632,7 @@ private:
     void CreateGeneralService(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NIFM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IGeneralService>(system);
     }

--- a/src/core/hle/service/nim/nim.cpp
+++ b/src/core/hle/service/nim/nim.cpp
@@ -48,7 +48,7 @@ public:
 private:
     void CreateAsyncInterface(HLERequestContext& ctx) {
         LOG_WARNING(Service_NIM, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IShopServiceAsync>(system);
     }
@@ -70,7 +70,7 @@ public:
 private:
     void CreateAccessorInterface(HLERequestContext& ctx) {
         LOG_WARNING(Service_NIM, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IShopServiceAccessor>(system);
     }
@@ -241,7 +241,7 @@ public:
 private:
     void CreateServerInterface(HLERequestContext& ctx) {
         LOG_WARNING(Service_NIM, "(STUBBED) called");
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IShopServiceAccessServer>(system);
     }
@@ -253,7 +253,7 @@ private:
 
         LOG_INFO(Service_NIM, "(STUBBED) called, unknown={}", unknown);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(false);
     }
@@ -329,14 +329,14 @@ private:
         // No need to connect to the internet, just finish the task straight away.
         LOG_DEBUG(Service_NIM, "called");
         finished_event->Signal();
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetFinishNotificationEvent(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NIM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(finished_event->GetReadableEvent());
     }
@@ -344,21 +344,21 @@ private:
     void GetResult(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NIM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void Cancel(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NIM, "called");
         finished_event->Clear();
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void IsProcessing(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NIM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw<u32>(0); // We instantly process the request
     }
@@ -369,7 +369,7 @@ private:
         const s64 server_time{std::chrono::duration_cast<std::chrono::seconds>(
                                   std::chrono::system_clock::now().time_since_epoch())
                                   .count()};
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw<s64>(server_time);
     }
@@ -397,7 +397,7 @@ private:
     void OpenEnsureNetworkClockAvailabilityService(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NIM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IEnsureNetworkClockAvailabilityService>(system);
     }
@@ -406,14 +406,14 @@ private:
     void SuspendAutonomicTimeCorrection(HLERequestContext& ctx) {
         LOG_WARNING(Service_NIM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void ResumeAutonomicTimeCorrection(HLERequestContext& ctx) {
         LOG_WARNING(Service_NIM, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };

--- a/src/core/hle/service/ns/iplatform_service_manager.cpp
+++ b/src/core/hle/service/ns/iplatform_service_manager.cpp
@@ -214,7 +214,7 @@ void IPlatformServiceManager::RequestLoad(HLERequestContext& ctx) {
     // Games don't call this so all fonts should be loaded
     LOG_DEBUG(Service_NS, "called, shared_font_type={}", shared_font_type);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -223,7 +223,7 @@ void IPlatformServiceManager::GetLoadState(HLERequestContext& ctx) {
     const u32 font_id{rp.Pop<u32>()};
     LOG_DEBUG(Service_NS, "called, font_id={}", font_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(static_cast<u32>(LoadState::Done));
 }
@@ -233,7 +233,7 @@ void IPlatformServiceManager::GetSize(HLERequestContext& ctx) {
     const u32 font_id{rp.Pop<u32>()};
     LOG_DEBUG(Service_NS, "called, font_id={}", font_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(impl->GetSharedFontRegion(font_id).size);
 }
@@ -243,7 +243,7 @@ void IPlatformServiceManager::GetSharedMemoryAddressOffset(HLERequestContext& ct
     const u32 font_id{rp.Pop<u32>()};
     LOG_DEBUG(Service_NS, "called, font_id={}", font_id);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(impl->GetSharedFontRegion(font_id).offset);
 }
@@ -256,7 +256,7 @@ void IPlatformServiceManager::GetSharedMemoryNativeHandle(HLERequestContext& ctx
     std::memcpy(kernel.GetFontSharedMem().GetPointer(), impl->shared_font->data(),
                 impl->shared_font->size());
 
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(&kernel.GetFontSharedMem());
 }
@@ -275,7 +275,7 @@ void IPlatformServiceManager::GetSharedFontInOrderOfPriority(HLERequestContext& 
         std::min(MaxElementCount, ctx.GetWriteBufferNumElements<u32>(2));
     LOG_DEBUG(Service_NS, "called, language_code={:X}", language_code);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     std::vector<u32> font_codes;
     std::vector<u32> font_offsets;
     std::vector<u32> font_sizes;

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -349,7 +349,7 @@ void IApplicationManagerInterface::GetApplicationControlData(HLERequestContext& 
         if (size < 0x4000) {
             LOG_ERROR(Service_NS,
                       "output buffer is too small! (actual={:016X}, expected_min=0x4000)", size);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             // TODO(DarkLordZach): Find a better error code for this.
             rb.Push(ResultUnknown);
             return;
@@ -369,7 +369,7 @@ void IApplicationManagerInterface::GetApplicationControlData(HLERequestContext& 
             LOG_ERROR(Service_NS,
                       "output buffer is too small! (actual={:016X}, expected_min={:016X})", size,
                       0x4000 + control.second->GetSize());
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             // TODO(DarkLordZach): Find a better error code for this.
             rb.Push(ResultUnknown);
             return;
@@ -384,7 +384,7 @@ void IApplicationManagerInterface::GetApplicationControlData(HLERequestContext& 
 
     ctx.WriteBuffer(out);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(static_cast<u32>(out.size()));
 }
@@ -396,11 +396,11 @@ void IApplicationManagerInterface::GetApplicationDesiredLanguage(HLERequestConte
     u8 desired_language{};
     const auto res = GetApplicationDesiredLanguage(&desired_language, supported_languages);
     if (res == ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(desired_language);
     } else {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
     }
 }
@@ -450,11 +450,11 @@ void IApplicationManagerInterface::ConvertApplicationLanguageToLanguageCode(
     u64 language_code{};
     const auto res = ConvertApplicationLanguageToLanguageCode(&language_code, application_language);
     if (res == ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(language_code);
     } else {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
     }
 }
@@ -523,7 +523,7 @@ void IContentManagementInterface::GetTotalSpaceSize(HLERequestContext& ctx) {
 
     LOG_INFO(Service_Capture, "called, storage={}", storage);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u64>(system.GetFileSystemController().GetTotalSpaceSize(storage));
 }
@@ -534,7 +534,7 @@ void IContentManagementInterface::GetFreeSpaceSize(HLERequestContext& ctx) {
 
     LOG_INFO(Service_Capture, "called, storage={}", storage);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u64>(system.GetFileSystemController().GetFreeSpaceSize(storage));
 }
@@ -654,7 +654,7 @@ void IReadOnlyApplicationControlDataInterface::GetApplicationControlData(HLERequ
         ctx.WriteBuffer(nacp_data.data(), nacp_data.size());
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -783,7 +783,7 @@ private:
     void OpenSystemUpdateControl(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NS, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISystemUpdateControl>(system);
     }
@@ -807,7 +807,7 @@ private:
     void NeedsUpdateVulnerability(HLERequestContext& ctx) {
         LOG_WARNING(Service_NS, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(false);
     }

--- a/src/core/hle/service/ns/ns.h
+++ b/src/core/hle/service/ns/ns.h
@@ -100,7 +100,7 @@ private:
     void PushInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NS, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<T>(system);
     }
@@ -108,7 +108,7 @@ private:
     void PushIApplicationManagerInterface(HLERequestContext& ctx) {
         LOG_DEBUG(Service_NS, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IApplicationManagerInterface>(system);
     }

--- a/src/core/hle/service/ns/pdm_qry.cpp
+++ b/src/core/hle/service/ns/pdm_qry.cpp
@@ -59,7 +59,7 @@ void PDM_QRY::QueryPlayStatisticsByApplicationIdAndUserAccountId(HLERequestConte
                 "(STUBBED) called. unknown={}. application_id=0x{:016X}, user_account_uid=0x{}",
                 unknown, application_id, user_account_uid.RawString());
 
-    IPC::ResponseBuilder rb{ctx, 12};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(statistics);
 }

--- a/src/core/hle/service/nvdrv/nvdrv_interface.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv_interface.cpp
@@ -15,7 +15,7 @@ namespace Service::Nvidia {
 
 void NVDRV::Open(HLERequestContext& ctx) {
     LOG_DEBUG(Service_NVDRV, "called");
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 
     if (!is_initialized) {
@@ -44,7 +44,7 @@ void NVDRV::Open(HLERequestContext& ctx) {
 }
 
 void NVDRV::ServiceError(HLERequestContext& ctx, NvResult result) {
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(result);
 }
@@ -70,7 +70,7 @@ void NVDRV::Ioctl1(HLERequestContext& ctx) {
         ctx.WriteBuffer(output_buffer);
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(nv_result);
 }
@@ -97,7 +97,7 @@ void NVDRV::Ioctl2(HLERequestContext& ctx) {
         ctx.WriteBuffer(output_buffer);
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(nv_result);
 }
@@ -125,7 +125,7 @@ void NVDRV::Ioctl3(HLERequestContext& ctx) {
         ctx.WriteBuffer(inline_output_buffer, 1);
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(nv_result);
 }
@@ -143,7 +143,7 @@ void NVDRV::Close(HLERequestContext& ctx) {
     const auto fd = rp.Pop<DeviceFD>();
     const auto result = nvdrv->Close(fd);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(result);
 }
@@ -153,7 +153,7 @@ void NVDRV::Initialize(HLERequestContext& ctx) {
 
     is_initialized = true;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(NvResult::Success);
 }
@@ -173,14 +173,14 @@ void NVDRV::QueryEvent(HLERequestContext& ctx) {
     NvResult result = nvdrv->QueryEvent(fd, event_id, event);
 
     if (result == NvResult::Success) {
-        IPC::ResponseBuilder rb{ctx, 3, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         auto& readable_event = event->GetReadableEvent();
         rb.PushCopyObjects(readable_event);
         rb.PushEnum(NvResult::Success);
     } else {
         LOG_ERROR(Service_NVDRV, "Invalid event request!");
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushEnum(result);
     }
@@ -191,7 +191,7 @@ void NVDRV::SetAruid(HLERequestContext& ctx) {
     pid = rp.Pop<u64>();
     LOG_WARNING(Service_NVDRV, "(STUBBED) called, pid=0x{:X}", pid);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(NvResult::Success);
 }
@@ -199,14 +199,14 @@ void NVDRV::SetAruid(HLERequestContext& ctx) {
 void NVDRV::SetGraphicsFirmwareMemoryMarginEnabled(HLERequestContext& ctx) {
     LOG_WARNING(Service_NVDRV, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void NVDRV::GetStatus(HLERequestContext& ctx) {
     LOG_WARNING(Service_NVDRV, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(NvResult::Success);
 }
@@ -216,7 +216,7 @@ void NVDRV::DumpGraphicsMemoryInfo(HLERequestContext& ctx) {
     // retail hardware.
     LOG_DEBUG(Service_NVDRV, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 

--- a/src/core/hle/service/olsc/olsc.cpp
+++ b/src/core/hle/service/olsc/olsc.cpp
@@ -48,7 +48,7 @@ private:
 
         initialized = true;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -58,7 +58,7 @@ private:
         // backup_setting is set to 0 since real value is unknown
         constexpr u64 backup_setting = 0;
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(backup_setting);
     }
@@ -66,7 +66,7 @@ private:
     void SetSaveDataBackupSettingEnabled(HLERequestContext& ctx) {
         LOG_WARNING(Service_OLSC, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -129,7 +129,7 @@ private:
     void GetNativeHandleHolder(HLERequestContext& ctx) {
         LOG_INFO(Service_OLSC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<INativeHandleHolder>(system);
     }
@@ -208,7 +208,7 @@ private:
     void OpenTransferTaskListController(HLERequestContext& ctx) {
         LOG_INFO(Service_OLSC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ITransferTaskListController>(system);
     }

--- a/src/core/hle/service/pctl/pctl_module.cpp
+++ b/src/core/hle/service/pctl/pctl_module.cpp
@@ -193,7 +193,7 @@ private:
 
     void Initialize(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PCTL, "called");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
 
         if (False(capability & (Capability::Application | Capability::System))) {
             LOG_ERROR(Service_PCTL, "Invalid capability! capability={:X}", capability);
@@ -232,7 +232,7 @@ private:
     void CheckFreeCommunicationPermission(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         if (!CheckFreeCommunicationPermissionImpl()) {
             rb.Push(Error::ResultNoFreeCommunication);
         } else {
@@ -245,7 +245,7 @@ private:
     void ConfirmSnsPostPermission(HLERequestContext& ctx) {
         LOG_WARNING(Service_PCTL, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Error::ResultNoFreeCommunication);
     }
 
@@ -255,7 +255,7 @@ private:
         LOG_WARNING(Service_PCTL, "(STUBBED) called, is_temporary_unlocked={}",
                     is_temporary_unlocked);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u8>(is_temporary_unlocked);
     }
@@ -264,21 +264,21 @@ private:
         LOG_DEBUG(Service_PCTL, "called");
         states.stereo_vision = true;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void EndFreeCommunication(HLERequestContext& ctx) {
         LOG_WARNING(Service_PCTL, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void IsFreeCommunicationAvailable(HLERequestContext& ctx) {
         LOG_WARNING(Service_PCTL, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         if (!CheckFreeCommunicationPermissionImpl()) {
             rb.Push(Error::ResultNoFreeCommunication);
         } else {
@@ -289,7 +289,7 @@ private:
     void IsRestrictionEnabled(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         if (False(capability & (Capability::Status | Capability::Recovery))) {
             LOG_ERROR(Service_PCTL, "Application does not have Status or Recovery capabilities!");
             rb.Push(Error::ResultNoCapability);
@@ -305,7 +305,7 @@ private:
 
         LOG_WARNING(Service_PCTL, "(STUBBED) called, safety_level={}", safety_level);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(safety_level);
     }
@@ -313,7 +313,7 @@ private:
     void GetCurrentSettings(HLERequestContext& ctx) {
         LOG_INFO(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(restriction_settings);
     }
@@ -323,7 +323,7 @@ private:
 
         LOG_WARNING(Service_PCTL, "(STUBBED) called, count={}", count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(count);
     }
@@ -331,7 +331,7 @@ private:
     void ConfirmStereoVisionRestrictionConfigurable(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
 
         if (False(capability & Capability::StereoVision)) {
             LOG_ERROR(Service_PCTL, "Application does not have StereoVision capability!");
@@ -350,7 +350,7 @@ private:
     void IsStereoVisionPermitted(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         if (!ConfirmStereoVisionPermissionImpl()) {
             rb.Push(Error::ResultStereoVisionRestricted);
             rb.Push(false);
@@ -365,7 +365,7 @@ private:
 
         LOG_WARNING(Service_PCTL, "(STUBBED) called, is_pairing_active={}", is_pairing_active);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u8>(is_pairing_active);
     }
@@ -373,7 +373,7 @@ private:
     void GetSynchronizationEvent(HLERequestContext& ctx) {
         LOG_INFO(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(synchronization_event->GetReadableEvent());
     }
@@ -383,7 +383,7 @@ private:
 
         const PlayTimerSettings timer_settings{};
 
-        IPC::ResponseBuilder rb{ctx, 15};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(timer_settings);
     }
@@ -391,7 +391,7 @@ private:
     void GetPlayTimerEventToRequestSuspension(HLERequestContext& ctx) {
         LOG_INFO(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(request_suspension_event->GetReadableEvent());
     }
@@ -402,7 +402,7 @@ private:
         LOG_INFO(Service_PCTL, "called, is_play_timer_alarm_disabled={}",
                  is_play_timer_alarm_disabled);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u8>(is_play_timer_alarm_disabled);
     }
@@ -410,7 +410,7 @@ private:
     void GetUnlinkedEvent(HLERequestContext& ctx) {
         LOG_INFO(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(unlinked_event->GetReadableEvent());
     }
@@ -420,7 +420,7 @@ private:
         const auto can_use = rp.Pop<bool>();
         LOG_DEBUG(Service_PCTL, "called, can_use={}", can_use);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         if (False(capability & Capability::StereoVision)) {
             LOG_ERROR(Service_PCTL, "Application does not have StereoVision capability!");
             rb.Push(Error::ResultNoCapability);
@@ -434,7 +434,7 @@ private:
     void GetStereoVisionRestriction(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PCTL, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         if (False(capability & Capability::StereoVision)) {
             LOG_ERROR(Service_PCTL, "Application does not have StereoVision capability!");
             rb.Push(Error::ResultNoCapability);
@@ -451,7 +451,7 @@ private:
 
         states.stereo_vision = false;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -508,7 +508,7 @@ private:
 void Module::Interface::CreateService(HLERequestContext& ctx) {
     LOG_DEBUG(Service_PCTL, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     // TODO(ogniK): Get TID from process
 
@@ -518,7 +518,7 @@ void Module::Interface::CreateService(HLERequestContext& ctx) {
 void Module::Interface::CreateServiceWithoutInitialize(HLERequestContext& ctx) {
     LOG_DEBUG(Service_PCTL, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IParentalControlService>(system, capability);
 }

--- a/src/core/hle/service/pcv/pcv.cpp
+++ b/src/core/hle/service/pcv/pcv.cpp
@@ -81,14 +81,14 @@ private:
         clock_rate = rp.Pop<u32>();
         LOG_DEBUG(Service_PCV, "(STUBBED) called, clock_rate={}", clock_rate);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetClockRate(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PCV, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u32>(clock_rate);
     }
@@ -122,7 +122,7 @@ private:
 
         LOG_DEBUG(Service_PCV, "called, device_code={}, input={}", device_code, unkonwn_input);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IClkrstSession>(system, device_code);
     }

--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -40,7 +40,7 @@ void GetApplicationPidGeneric(HLERequestContext& ctx,
         return proc->GetProcessId() == Kernel::KProcess::ProcessIdMin;
     });
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(process.has_value() ? (*process)->GetProcessId() : NO_PROCESS_FOUND_PID);
 }
@@ -61,7 +61,7 @@ private:
     void GetBootMode(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushEnum(boot_mode);
     }
@@ -71,7 +71,7 @@ private:
 
         boot_mode = SystemBootMode::Maintenance;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -112,12 +112,12 @@ private:
             });
 
         if (!process.has_value()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultProcessNotFound);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push((*process)->GetProcessId());
     }
@@ -140,7 +140,7 @@ private:
         });
 
         if (!process.has_value()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultProcessNotFound);
             return;
         }
@@ -163,7 +163,7 @@ private:
             .storage_id = 0,
         };
 
-        IPC::ResponseBuilder rb{ctx, 10, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(*process);
         rb.PushRaw(program_location);
@@ -198,12 +198,12 @@ private:
         });
 
         if (!process.has_value()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultProcessNotFound);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push((*process)->GetProgramId());
     }
@@ -219,12 +219,12 @@ private:
         });
 
         if (!process.has_value()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultProcessNotFound);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push((*process)->GetProcessId());
     }

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -69,7 +69,7 @@ private:
         reporter.SavePlayReport(Type, system.GetApplicationProcessProgramID(), {data1, data2},
                                 process_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -91,14 +91,14 @@ private:
         reporter.SavePlayReport(Type, system.GetApplicationProcessProgramID(), {data1, data2},
                                 process_id, user_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void RequestImmediateTransmission(HLERequestContext& ctx) {
         LOG_WARNING(Service_PREPO, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -107,7 +107,7 @@ private:
 
         constexpr s32 status = 0;
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(status);
     }
@@ -116,7 +116,7 @@ private:
         LOG_WARNING(Service_PREPO, "(STUBBED) called");
 
         constexpr u64 system_session_id = 0;
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(system_session_id);
     }
@@ -134,7 +134,7 @@ private:
         const auto& reporter{system.GetReporter()};
         reporter.SavePlayReport(Core::Reporter::PlayReportType::System, title_id, {data1, data2});
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -155,7 +155,7 @@ private:
         reporter.SavePlayReport(Core::Reporter::PlayReportType::System, title_id, {data1, data2},
                                 std::nullopt, user_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };

--- a/src/core/hle/service/psc/psc.cpp
+++ b/src/core/hle/service/psc/psc.cpp
@@ -65,7 +65,7 @@ private:
     void GetPmModule(HLERequestContext& ctx) {
         LOG_DEBUG(Service_PSC, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IPmModule>(system);
     }

--- a/src/core/hle/service/ptm/psm.cpp
+++ b/src/core/hle/service/ptm/psm.cpp
@@ -59,7 +59,7 @@ private:
 
         should_signal = true;
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(state_change_event->GetReadableEvent());
     }
@@ -69,7 +69,7 @@ private:
 
         should_signal = false;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -80,7 +80,7 @@ private:
 
         should_signal_charger_type = state;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -91,7 +91,7 @@ private:
 
         should_signal_power_supply = state;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -102,7 +102,7 @@ private:
 
         should_signal_battery_voltage = state;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -148,7 +148,7 @@ PSM::~PSM() = default;
 void PSM::GetBatteryChargePercentage(HLERequestContext& ctx) {
     LOG_DEBUG(Service_PTM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(battery_charge_percentage);
 }
@@ -156,7 +156,7 @@ void PSM::GetBatteryChargePercentage(HLERequestContext& ctx) {
 void PSM::GetChargerType(HLERequestContext& ctx) {
     LOG_DEBUG(Service_PTM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(charger_type);
 }
@@ -164,7 +164,7 @@ void PSM::GetChargerType(HLERequestContext& ctx) {
 void PSM::OpenSession(HLERequestContext& ctx) {
     LOG_DEBUG(Service_PTM, "called");
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IPsmSession>(system);
 }

--- a/src/core/hle/service/ptm/ts.cpp
+++ b/src/core/hle/service/ptm/ts.cpp
@@ -32,7 +32,7 @@ private:
     void GetTemperature(HLERequestContext& ctx) {
         constexpr f32 temperature = 35;
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(temperature);
     }
@@ -60,7 +60,7 @@ void TS::GetTemperature(HLERequestContext& ctx) {
 
     const s32 temperature = location == Location::Internal ? 35 : 20;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(temperature);
 }
@@ -71,7 +71,7 @@ void TS::GetTemperatureMilliC(HLERequestContext& ctx) {
 
     const s32 temperature = location == Location::Internal ? 35000 : 20000;
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(temperature);
 }
@@ -80,7 +80,7 @@ void TS::OpenSession(HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     [[maybe_unused]] const u32 device_code = rp.Pop<u32>();
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISession>(system);
 }

--- a/src/core/hle/service/ro/ro.cpp
+++ b/src/core/hle/service/ro/ro.cpp
@@ -593,7 +593,7 @@ private:
                                                           params.nro_address, params.nro_size,
                                                           params.bss_address, params.bss_size);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.Push(load_address);
     }
@@ -610,7 +610,7 @@ private:
         auto params = rp.PopRaw<InputParameters>();
         auto result = interface.UnmapManualLoadModuleMemory(ctx.GetPID(), params.nro_address);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -628,7 +628,7 @@ private:
         auto result =
             interface.RegisterModuleInfo(ctx.GetPID(), params.nrr_address, params.nrr_size);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -644,7 +644,7 @@ private:
         auto params = rp.PopRaw<InputParameters>();
         auto result = interface.UnregisterModuleInfo(ctx.GetPID(), params.nrr_address);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -655,7 +655,7 @@ private:
         auto client_pid = ctx.GetPID();
         auto result = interface.RegisterProcessHandle(client_pid, process.GetPointerUnsafe());
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -676,7 +676,7 @@ private:
         auto result = interface.RegisterProcessModuleInfo(
             client_pid, params.nrr_address, params.nrr_size, process.GetPointerUnsafe());
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -136,7 +136,7 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(HLERequestContext& ctx,
     UNIMPLEMENTED_MSG("Unknown / unimplemented {}", fmt::to_string(buf));
     if (Settings::values.use_auto_stub) {
         LOG_WARNING(Service, "Using auto stub fallback!");
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 }
@@ -175,7 +175,7 @@ Result ServiceFrameworkBase::HandleSyncRequest(Kernel::KServerSession& session,
     switch (ctx.GetCommandType()) {
     case IPC::CommandType::Close:
     case IPC::CommandType::TIPC_Close: {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         result = IPC::ResultSessionClosed;
         break;

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -17,7 +17,7 @@ constexpr std::size_t POST_4_0_0_MAX_ENTRIES = 0x40;
 constexpr Result ResultInvalidLanguage{ErrorModule::Settings, 625};
 
 void PushResponseLanguageCode(HLERequestContext& ctx, std::size_t num_language_codes) {
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(num_language_codes));
 }
@@ -49,7 +49,7 @@ void GetKeyCodeMapImpl(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(layout);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 } // Anonymous namespace
@@ -70,12 +70,12 @@ void SET::MakeLanguageCode(HLERequestContext& ctx) {
 
     if (index >= available_language_codes.size()) {
         LOG_ERROR(Service_SET, "Invalid language code index! index={}", index);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(Set::ResultInvalidLanguage);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(available_language_codes[index]);
 }
@@ -101,7 +101,7 @@ void SET::GetAvailableLanguageCodeCount2(HLERequestContext& ctx) {
 void SET::GetQuestFlag(HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<s32>(Settings::values.quest_flag.GetValue()));
 }
@@ -109,7 +109,7 @@ void SET::GetQuestFlag(HLERequestContext& ctx) {
 void SET::GetLanguageCode(HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called {}", Settings::values.language_index.GetValue());
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(
         available_language_codes[static_cast<s32>(Settings::values.language_index.GetValue())]);
@@ -118,7 +118,7 @@ void SET::GetLanguageCode(HLERequestContext& ctx) {
 void SET::GetRegionCode(HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(Settings::values.region_index.GetValue()));
 }
@@ -135,7 +135,7 @@ void SET::GetKeyCodeMap2(HLERequestContext& ctx) {
 
 void SET::GetDeviceNickName(HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     ctx.WriteBuffer(Settings::values.device_name.GetValue());
 }

--- a/src/core/hle/service/set/set_sys.cpp
+++ b/src/core/hle/service/set/set_sys.cpp
@@ -202,7 +202,7 @@ void SET_SYS::SetLanguageCode(HLERequestContext& ctx) {
 
     LOG_INFO(Service_SET, "called, language_code={}", m_system_settings.language_code);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -217,7 +217,7 @@ void SET_SYS::GetFirmwareVersion(HLERequestContext& ctx) {
         ctx.WriteBuffer(firmware_data);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -232,7 +232,7 @@ void SET_SYS::GetFirmwareVersion2(HLERequestContext& ctx) {
         ctx.WriteBuffer(firmware_data);
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -242,7 +242,7 @@ void SET_SYS::GetExternalSteadyClockSourceId(HLERequestContext& ctx) {
     Common::UUID id{};
     auto res = GetExternalSteadyClockSourceId(id);
 
-    IPC::ResponseBuilder rb{ctx, 2 + sizeof(Common::UUID) / sizeof(u32)};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.PushRaw(id);
 }
@@ -255,7 +255,7 @@ void SET_SYS::SetExternalSteadyClockSourceId(HLERequestContext& ctx) {
 
     auto res = SetExternalSteadyClockSourceId(id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
@@ -265,8 +265,7 @@ void SET_SYS::GetUserSystemClockContext(HLERequestContext& ctx) {
     Service::Time::Clock::SystemClockContext context{};
     auto res = GetUserSystemClockContext(context);
 
-    IPC::ResponseBuilder rb{ctx,
-                            2 + sizeof(Service::Time::Clock::SystemClockContext) / sizeof(u32)};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.PushRaw(context);
 }
@@ -279,14 +278,14 @@ void SET_SYS::SetUserSystemClockContext(HLERequestContext& ctx) {
 
     auto res = SetUserSystemClockContext(context);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
 void SET_SYS::GetAccountSettings(HLERequestContext& ctx) {
     LOG_INFO(Service_SET, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(m_system_settings.account_settings);
 }
@@ -299,7 +298,7 @@ void SET_SYS::SetAccountSettings(HLERequestContext& ctx) {
     LOG_INFO(Service_SET, "called, account_settings_flags={}",
              m_system_settings.account_settings.flags);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -308,7 +307,7 @@ void SET_SYS::GetEulaVersions(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(m_system_settings.eula_versions);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(m_system_settings.eula_version_count);
 }
@@ -325,14 +324,14 @@ void SET_SYS::SetEulaVersions(HLERequestContext& ctx) {
                 sizeof(EulaVersion) * elements);
     SetSaveNeeded();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void SET_SYS::GetColorSetId(HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(m_system_settings.color_set_id);
 }
@@ -344,14 +343,14 @@ void SET_SYS::SetColorSetId(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_SET, "called, color_set={}", m_system_settings.color_set_id);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void SET_SYS::GetNotificationSettings(HLERequestContext& ctx) {
     LOG_INFO(Service_SET, "called");
 
-    IPC::ResponseBuilder rb{ctx, 8};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(m_system_settings.notification_settings);
 }
@@ -369,7 +368,7 @@ void SET_SYS::SetNotificationSettings(HLERequestContext& ctx) {
              m_system_settings.notification_settings.stop_time.hour,
              m_system_settings.notification_settings.stop_time.minute);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -378,7 +377,7 @@ void SET_SYS::GetAccountNotificationSettings(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(m_system_settings.account_notification_settings);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(m_system_settings.account_notification_settings_count);
 }
@@ -396,7 +395,7 @@ void SET_SYS::SetAccountNotificationSettings(HLERequestContext& ctx) {
                 elements * sizeof(AccountNotificationSettings));
     SetSaveNeeded();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -452,7 +451,7 @@ void SET_SYS::GetSettingsItemValueSize(HLERequestContext& ctx) {
         response_size = settings[setting_category][setting_name].size();
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(response_size == 0 ? ResultUnknown : ResultSuccess);
     rb.Push(response_size);
 }
@@ -476,14 +475,14 @@ void SET_SYS::GetSettingsItemValue(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(value.data(), value.size());
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(response);
 }
 
 void SET_SYS::GetTvSettings(HLERequestContext& ctx) {
     LOG_INFO(Service_SET, "called");
 
-    IPC::ResponseBuilder rb{ctx, 10};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(m_system_settings.tv_settings);
 }
@@ -503,14 +502,14 @@ void SET_SYS::SetTvSettings(HLERequestContext& ctx) {
              m_system_settings.tv_settings.tv_resolution,
              m_system_settings.tv_settings.tv_underscan);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void SET_SYS::GetDebugModeFlag(HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(0);
 }
@@ -518,7 +517,7 @@ void SET_SYS::GetDebugModeFlag(HLERequestContext& ctx) {
 void SET_SYS::GetQuestFlag(HLERequestContext& ctx) {
     LOG_WARNING(Service_SET, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(QuestFlag::Retail);
 }
@@ -529,7 +528,7 @@ void SET_SYS::GetDeviceTimeZoneLocationName(HLERequestContext& ctx) {
     Service::Time::TimeZone::LocationName name{};
     auto res = GetDeviceTimeZoneLocationName(name);
 
-    IPC::ResponseBuilder rb{ctx, 2 + sizeof(Service::Time::TimeZone::LocationName) / sizeof(u32)};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.PushRaw<Service::Time::TimeZone::LocationName>(name);
 }
@@ -542,7 +541,7 @@ void SET_SYS::SetDeviceTimeZoneLocationName(HLERequestContext& ctx) {
 
     auto res = SetDeviceTimeZoneLocationName(name);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
@@ -553,7 +552,7 @@ void SET_SYS::SetRegionCode(HLERequestContext& ctx) {
 
     LOG_INFO(Service_SET, "called, region_code={}", m_system_settings.region_code);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -563,8 +562,7 @@ void SET_SYS::GetNetworkSystemClockContext(HLERequestContext& ctx) {
     Service::Time::Clock::SystemClockContext context{};
     auto res = GetNetworkSystemClockContext(context);
 
-    IPC::ResponseBuilder rb{ctx,
-                            2 + sizeof(Service::Time::Clock::SystemClockContext) / sizeof(u32)};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.PushRaw(context);
 }
@@ -577,7 +575,7 @@ void SET_SYS::SetNetworkSystemClockContext(HLERequestContext& ctx) {
 
     auto res = SetNetworkSystemClockContext(context);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
@@ -587,7 +585,7 @@ void SET_SYS::IsUserSystemClockAutomaticCorrectionEnabled(HLERequestContext& ctx
     bool enabled{};
     auto res = IsUserSystemClockAutomaticCorrectionEnabled(enabled);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.PushRaw(enabled);
 }
@@ -600,14 +598,14 @@ void SET_SYS::SetUserSystemClockAutomaticCorrectionEnabled(HLERequestContext& ct
 
     auto res = SetUserSystemClockAutomaticCorrectionEnabled(enabled);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
 void SET_SYS::GetPrimaryAlbumStorage(HLERequestContext& ctx) {
     LOG_WARNING(Service_SET, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(PrimaryAlbumStorage::SdCard);
 }
@@ -615,7 +613,7 @@ void SET_SYS::GetPrimaryAlbumStorage(HLERequestContext& ctx) {
 void SET_SYS::GetSleepSettings(HLERequestContext& ctx) {
     LOG_INFO(Service_SET, "called");
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(m_system_settings.sleep_settings);
 }
@@ -630,13 +628,13 @@ void SET_SYS::SetSleepSettings(HLERequestContext& ctx) {
              m_system_settings.sleep_settings.handheld_sleep_plan,
              m_system_settings.sleep_settings.console_sleep_plan);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void SET_SYS::GetInitialLaunchSettings(HLERequestContext& ctx) {
     LOG_INFO(Service_SET, "called");
-    IPC::ResponseBuilder rb{ctx, 10};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(m_system_settings.initial_launch_settings_packed);
 }
@@ -653,7 +651,7 @@ void SET_SYS::SetInitialLaunchSettings(HLERequestContext& ctx) {
              m_system_settings.initial_launch_settings_packed.flags.raw,
              m_system_settings.initial_launch_settings_packed.timestamp.time_point);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -662,7 +660,7 @@ void SET_SYS::GetDeviceNickName(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(::Settings::values.device_name.GetValue());
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -673,7 +671,7 @@ void SET_SYS::SetDeviceNickName(HLERequestContext& ctx) {
 
     ::Settings::values.device_name = device_name;
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -681,7 +679,7 @@ void SET_SYS::GetProductModel(HLERequestContext& ctx) {
     const u32 product_model = 1;
 
     LOG_WARNING(Service_SET, "(STUBBED) called, product_model={}", product_model);
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(product_model);
 }
@@ -691,7 +689,7 @@ void SET_SYS::GetMiiAuthorId(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_SET, "(STUBBED) called, author_id={}", author_id.FormattedString());
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(author_id);
 }
@@ -701,7 +699,7 @@ void SET_SYS::GetAutoUpdateEnableFlag(HLERequestContext& ctx) {
 
     LOG_WARNING(Service_SET, "(STUBBED) called, auto_update_flag={}", auto_update_flag);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(auto_update_flag);
 }
@@ -712,7 +710,7 @@ void SET_SYS::GetBatteryPercentageFlag(HLERequestContext& ctx) {
     LOG_WARNING(Service_SET, "(STUBBED) called, battery_percentage_flag={}",
                 battery_percentage_flag);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(battery_percentage_flag);
 }
@@ -725,7 +723,7 @@ void SET_SYS::SetExternalSteadyClockInternalOffset(HLERequestContext& ctx) {
 
     auto res = SetExternalSteadyClockInternalOffset(offset);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
@@ -735,7 +733,7 @@ void SET_SYS::GetExternalSteadyClockInternalOffset(HLERequestContext& ctx) {
     s64 offset{};
     auto res = GetExternalSteadyClockInternalOffset(offset);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.Push(offset);
 }
@@ -743,7 +741,7 @@ void SET_SYS::GetExternalSteadyClockInternalOffset(HLERequestContext& ctx) {
 void SET_SYS::GetErrorReportSharePermission(HLERequestContext& ctx) {
     LOG_WARNING(Service_SET, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(ErrorReportSharePermission::Denied);
 }
@@ -751,7 +749,7 @@ void SET_SYS::GetErrorReportSharePermission(HLERequestContext& ctx) {
 void SET_SYS::GetAppletLaunchFlags(HLERequestContext& ctx) {
     LOG_INFO(Service_SET, "called, applet_launch_flag={}", m_system_settings.applet_launch_flag);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(m_system_settings.applet_launch_flag);
 }
@@ -763,7 +761,7 @@ void SET_SYS::SetAppletLaunchFlags(HLERequestContext& ctx) {
 
     LOG_INFO(Service_SET, "called, applet_launch_flag={}", m_system_settings.applet_launch_flag);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -781,7 +779,7 @@ void SET_SYS::GetKeyboardLayout(HLERequestContext& ctx) {
 
     LOG_INFO(Service_SET, "called, selected_keyboard_layout={}", selected_keyboard_layout);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(selected_keyboard_layout));
 }
@@ -792,7 +790,7 @@ void SET_SYS::GetDeviceTimeZoneLocationUpdatedTime(HLERequestContext& ctx) {
     Service::Time::Clock::SteadyClockTimePoint time_point{};
     auto res = GetDeviceTimeZoneLocationUpdatedTime(time_point);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.PushRaw<Service::Time::Clock::SteadyClockTimePoint>(time_point);
 }
@@ -805,7 +803,7 @@ void SET_SYS::SetDeviceTimeZoneLocationUpdatedTime(HLERequestContext& ctx) {
 
     auto res = SetDeviceTimeZoneLocationUpdatedTime(time_point);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
@@ -815,7 +813,7 @@ void SET_SYS::GetUserSystemClockAutomaticCorrectionUpdatedTime(HLERequestContext
     Service::Time::Clock::SteadyClockTimePoint time_point{};
     auto res = GetUserSystemClockAutomaticCorrectionUpdatedTime(time_point);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
     rb.PushRaw<Service::Time::Clock::SteadyClockTimePoint>(time_point);
 }
@@ -828,14 +826,14 @@ void SET_SYS::SetUserSystemClockAutomaticCorrectionUpdatedTime(HLERequestContext
 
     auto res = SetUserSystemClockAutomaticCorrectionUpdatedTime(time_point);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
 void SET_SYS::GetChineseTraditionalInputMethod(HLERequestContext& ctx) {
     LOG_WARNING(Service_SET, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushEnum(ChineseTraditionalInputMethod::Unknown0);
 }
@@ -851,7 +849,7 @@ void SET_SYS::GetHomeMenuScheme(HLERequestContext& ctx) {
         .extra = 0xFF000000,
     };
 
-    IPC::ResponseBuilder rb{ctx, 2 + sizeof(HomeMenuScheme) / sizeof(u32)};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(default_color);
 }
@@ -859,7 +857,7 @@ void SET_SYS::GetHomeMenuScheme(HLERequestContext& ctx) {
 void SET_SYS::GetHomeMenuSchemeModel(HLERequestContext& ctx) {
     LOG_WARNING(Service_SET, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(0);
 }
@@ -867,7 +865,7 @@ void SET_SYS::GetHomeMenuSchemeModel(HLERequestContext& ctx) {
 void SET_SYS::GetFieldTestingFlag(HLERequestContext& ctx) {
     LOG_WARNING(Service_SET, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u8>(false);
 }

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -121,7 +121,7 @@ void SM::Initialize(HLERequestContext& ctx) {
 
     ctx.GetManager()->SetIsInitializedForSm();
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -134,11 +134,11 @@ void SM::GetServiceCmif(HLERequestContext& ctx) {
     }
 
     if (result == ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
+        IPC::ResponseBuilder rb{ctx, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
         rb.Push(result);
         rb.PushMoveObjects(client_session);
     } else {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 }
@@ -151,7 +151,7 @@ void SM::GetServiceTipc(HLERequestContext& ctx) {
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
+    IPC::ResponseBuilder rb{ctx, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
     rb.Push(result);
     rb.PushMoveObjects(result == ResultSuccess ? client_session : nullptr);
 }
@@ -230,12 +230,12 @@ void SM::RegisterServiceImpl(HLERequestContext& ctx, std::string name, u32 max_s
                                                             max_session_count, nullptr);
         result.IsError()) {
         LOG_ERROR(Service_SM, "failed to register service with error_code={:08X}", result.raw);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
+    IPC::ResponseBuilder rb{ctx, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
     rb.Push(ResultSuccess);
     rb.PushMoveObjects(server_port);
 }
@@ -246,7 +246,7 @@ void SM::UnregisterService(HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_SM, "called with name={}", name);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(service_manager.UnregisterService(name));
 }
 

--- a/src/core/hle/service/sm/sm_controller.cpp
+++ b/src/core/hle/service/sm/sm_controller.cpp
@@ -20,7 +20,7 @@ void Controller::ConvertCurrentObjectToDomain(HLERequestContext& ctx) {
     LOG_DEBUG(Service, "called, server_session={}", ctx.Session()->GetId());
     ctx.GetManager()->ConvertToDomainOnRequestEnd();
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(1); // Converted sessions start with 1 request handler
 }
@@ -56,7 +56,7 @@ void Controller::CloneCurrentObject(HLERequestContext& ctx) {
                                                         session_manager);
 
     // We succeeded.
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
+    IPC::ResponseBuilder rb{ctx, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
     rb.Push(ResultSuccess);
     rb.PushMoveObjects(session->GetClientSession());
 }
@@ -70,7 +70,7 @@ void Controller::CloneCurrentObjectEx(HLERequestContext& ctx) {
 void Controller::QueryPointerBufferSize(HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u16>(0x8000);
 }

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -62,7 +62,7 @@ void BSD::PollWork::Response(HLERequestContext& ctx) {
         ctx.WriteBuffer(write_buffer);
     }
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(ret);
     rb.PushEnum(bsd_errno);
@@ -77,7 +77,7 @@ void BSD::AcceptWork::Response(HLERequestContext& ctx) {
         ctx.WriteBuffer(write_buffer);
     }
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(ret);
     rb.PushEnum(bsd_errno);
@@ -89,7 +89,7 @@ void BSD::ConnectWork::Execute(BSD* bsd) {
 }
 
 void BSD::ConnectWork::Response(HLERequestContext& ctx) {
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(bsd_errno == Errno::SUCCESS ? 0 : -1);
     rb.PushEnum(bsd_errno);
@@ -102,7 +102,7 @@ void BSD::RecvWork::Execute(BSD* bsd) {
 void BSD::RecvWork::Response(HLERequestContext& ctx) {
     ctx.WriteBuffer(message);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(ret);
     rb.PushEnum(bsd_errno);
@@ -118,7 +118,7 @@ void BSD::RecvFromWork::Response(HLERequestContext& ctx) {
         ctx.WriteBuffer(addr, 1);
     }
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(ret);
     rb.PushEnum(bsd_errno);
@@ -130,7 +130,7 @@ void BSD::SendWork::Execute(BSD* bsd) {
 }
 
 void BSD::SendWork::Response(HLERequestContext& ctx) {
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(ret);
     rb.PushEnum(bsd_errno);
@@ -141,7 +141,7 @@ void BSD::SendToWork::Execute(BSD* bsd) {
 }
 
 void BSD::SendToWork::Response(HLERequestContext& ctx) {
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(ret);
     rb.PushEnum(bsd_errno);
@@ -150,7 +150,7 @@ void BSD::SendToWork::Response(HLERequestContext& ctx) {
 void BSD::RegisterClient(HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.Push<s32>(0); // bsd errno
@@ -159,7 +159,7 @@ void BSD::RegisterClient(HLERequestContext& ctx) {
 void BSD::StartMonitoring(HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
 }
@@ -175,7 +175,7 @@ void BSD::Socket(HLERequestContext& ctx) {
     const auto [fd, bsd_errno] = SocketImpl(static_cast<Domain>(domain), static_cast<Type>(type),
                                             static_cast<Protocol>(protocol));
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(fd);
     rb.PushEnum(bsd_errno);
@@ -184,7 +184,7 @@ void BSD::Socket(HLERequestContext& ctx) {
 void BSD::Select(HLERequestContext& ctx) {
     LOG_DEBUG(Service, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.Push<u32>(0); // ret
@@ -249,7 +249,7 @@ void BSD::GetPeerName(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(write_buffer);
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(bsd_errno != Errno::SUCCESS ? -1 : 0);
     rb.PushEnum(bsd_errno);
@@ -267,7 +267,7 @@ void BSD::GetSockName(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(write_buffer);
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(bsd_errno != Errno::SUCCESS ? -1 : 0);
     rb.PushEnum(bsd_errno);
@@ -289,7 +289,7 @@ void BSD::GetSockOpt(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(optval);
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(err == Errno::SUCCESS ? 0 : -1);
     rb.PushEnum(err);
@@ -316,7 +316,7 @@ void BSD::Fcntl(HLERequestContext& ctx) {
 
     const auto [ret, bsd_errno] = FcntlImpl(fd, static_cast<FcntlCmd>(cmd), arg);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<s32>(ret);
     rb.PushEnum(bsd_errno);
@@ -429,7 +429,7 @@ void BSD::Read(HLERequestContext& ctx) {
 
     LOG_WARNING(Service, "(STUBBED) called. fd={} len={}", fd, ctx.GetWriteBufferSize());
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(0); // ret
     rb.Push<u32>(0); // bsd errno
@@ -461,7 +461,7 @@ void BSD::DuplicateSocket(HLERequestContext& ctx) {
     auto input = rp.PopRaw<InputParameters>();
 
     Expected<s32, Errno> res = DuplicateSocketImpl(input.fd);
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(OutputParameters{
         .ret = res.value_or(0),
@@ -952,7 +952,7 @@ bool BSD::IsFileDescriptorValid(s32 fd) const noexcept {
 }
 
 void BSD::BuildErrnoResponse(HLERequestContext& ctx, Errno bsd_errno) const noexcept {
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.Push<s32>(bsd_errno == Errno::SUCCESS ? 0 : -1);

--- a/src/core/hle/service/sockets/nsd.cpp
+++ b/src/core/hle/service/sockets/nsd.cpp
@@ -84,7 +84,7 @@ void NSD::Resolve(HLERequestContext& ctx) {
     const Result res = ResolveCommon(fqdn_in, fqdn_out);
 
     ctx.WriteBuffer(fqdn_out);
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(res);
 }
 
@@ -95,13 +95,13 @@ void NSD::ResolveEx(HLERequestContext& ctx) {
     const Result res = ResolveCommon(fqdn_in, fqdn_out);
 
     if (res.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         return;
     }
 
     ctx.WriteBuffer(fqdn_out);
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(ResultSuccess);
 }
@@ -111,12 +111,12 @@ void NSD::GetEnvironmentIdentifier(HLERequestContext& ctx) {
         .identifier = {'l', 'p', '1', '\0', '\0', '\0', '\0', '\0'}};
     ctx.WriteBuffer(lp1);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void NSD::GetApplicationServerEnvironmentType(HLERequestContext& ctx) {
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(ServerEnvironmentType::Lp));
 }

--- a/src/core/hle/service/sockets/sfdnsres.cpp
+++ b/src/core/hle/service/sockets/sfdnsres.cpp
@@ -178,7 +178,7 @@ void SFDNSRES::GetHostByNameRequest(HLERequestContext& ctx) {
     };
     static_assert(sizeof(OutputParameters) == 0xc);
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(OutputParameters{
         .netdb_error = GetAddrInfoErrorToNetDbError(emu_gai_err),
@@ -197,7 +197,7 @@ void SFDNSRES::GetHostByNameRequestWithOptions(HLERequestContext& ctx) {
     };
     static_assert(sizeof(OutputParameters) == 0xc);
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(OutputParameters{
         .data_size = data_size,
@@ -303,7 +303,7 @@ void SFDNSRES::GetAddrInfoRequest(HLERequestContext& ctx) {
     };
     static_assert(sizeof(OutputParameters) == 0xc);
 
-    IPC::ResponseBuilder rb{ctx, 5};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(OutputParameters{
         .bsd_errno = GetAddrInfoErrorToErrno(emu_gai_err),
@@ -322,7 +322,7 @@ void SFDNSRES::GetGaiStringErrorRequest(HLERequestContext& ctx) {
     const std::string result = Translate(input.gai_errno);
     ctx.WriteBuffer(result);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -338,7 +338,7 @@ void SFDNSRES::GetAddrInfoRequestWithOptions(HLERequestContext& ctx) {
     };
     static_assert(sizeof(OutputParameters) == 0x10);
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(OutputParameters{
         .data_size = data_size,
@@ -351,7 +351,7 @@ void SFDNSRES::GetAddrInfoRequestWithOptions(HLERequestContext& ctx) {
 void SFDNSRES::ResolverSetOptionRequest(HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
 
     rb.Push(ResultSuccess);
     rb.Push<s32>(0); // bsd errno

--- a/src/core/hle/service/spl/spl_module.cpp
+++ b/src/core/hle/service/spl/spl_module.cpp
@@ -37,14 +37,14 @@ void Module::Interface::GetConfig(HLERequestContext& ctx) {
         LOG_ERROR(Service_SPL, "called, config_item={}, result_code={}", config_item,
                   result_code.raw);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result_code);
     }
 
     LOG_DEBUG(Service_SPL, "called, config_item={}, result_code={}, smc_result={}", config_item,
               result_code.raw, smc_result);
 
-    IPC::ResponseBuilder rb{ctx, 4};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result_code);
     rb.Push(smc_result);
 }
@@ -52,14 +52,14 @@ void Module::Interface::GetConfig(HLERequestContext& ctx) {
 void Module::Interface::ModularExponentiate(HLERequestContext& ctx) {
     UNIMPLEMENTED_MSG("ModularExponentiate is not implemented!");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSecureMonitorNotImplemented);
 }
 
 void Module::Interface::SetConfig(HLERequestContext& ctx) {
     UNIMPLEMENTED_MSG("SetConfig is not implemented!");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSecureMonitorNotImplemented);
 }
 
@@ -74,28 +74,28 @@ void Module::Interface::GenerateRandomBytes(HLERequestContext& ctx) {
 
     ctx.WriteBuffer(data);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
 void Module::Interface::IsDevelopment(HLERequestContext& ctx) {
     UNIMPLEMENTED_MSG("IsDevelopment is not implemented!");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSecureMonitorNotImplemented);
 }
 
 void Module::Interface::SetBootReason(HLERequestContext& ctx) {
     UNIMPLEMENTED_MSG("SetBootReason is not implemented!");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSecureMonitorNotImplemented);
 }
 
 void Module::Interface::GetBootReason(HLERequestContext& ctx) {
     UNIMPLEMENTED_MSG("GetBootReason is not implemented!");
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSecureMonitorNotImplemented);
 }
 

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -267,7 +267,7 @@ private:
         const s32 in_fd = rp.Pop<s32>();
         s32 out_fd{-1};
         const Result res = SetSocketDescriptorImpl(&out_fd, in_fd);
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         rb.Push<s32>(out_fd);
     }
@@ -275,7 +275,7 @@ private:
     void SetHostName(HLERequestContext& ctx) {
         const std::string hostname = Common::StringFromBuffer(ctx.ReadBuffer());
         const Result res = SetHostNameImpl(hostname);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
     }
 
@@ -283,7 +283,7 @@ private:
         IPC::RequestParser rp{ctx};
         const u32 option = rp.Pop<u32>();
         const Result res = SetVerifyOptionImpl(option);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
     }
 
@@ -291,13 +291,13 @@ private:
         IPC::RequestParser rp{ctx};
         const u32 mode = rp.Pop<u32>();
         const Result res = SetIoModeImpl(mode);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
     }
 
     void DoHandshake(HLERequestContext& ctx) {
         const Result res = DoHandshakeImpl();
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
     }
 
@@ -320,7 +320,7 @@ private:
                 out.certs_size = static_cast<u32>(certs_buf.size());
             }
         }
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         rb.PushRaw(out);
     }
@@ -328,7 +328,7 @@ private:
     void Read(HLERequestContext& ctx) {
         std::vector<u8> output_bytes(ctx.GetWriteBufferSize());
         const Result res = ReadImpl(&output_bytes);
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         if (res == ResultSuccess) {
             rb.Push(static_cast<u32>(output_bytes.size()));
@@ -341,7 +341,7 @@ private:
     void Write(HLERequestContext& ctx) {
         size_t write_size{0};
         const Result res = WriteImpl(&write_size, ctx.ReadBuffer());
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         rb.Push(static_cast<u32>(write_size));
     }
@@ -349,7 +349,7 @@ private:
     void Pending(HLERequestContext& ctx) {
         s32 pending_size{0};
         const Result res = PendingImpl(&pending_size);
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         rb.Push<s32>(pending_size);
     }
@@ -358,7 +358,7 @@ private:
         IPC::RequestParser rp{ctx};
         const u32 mode = rp.Pop<u32>();
         const Result res = SetSessionCacheModeImpl(mode);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
     }
 
@@ -384,7 +384,7 @@ private:
                         parameters.value);
         }
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };
@@ -430,7 +430,7 @@ private:
         LOG_WARNING(Service_SSL, "(STUBBED) called. option={}, value={}", parameters.option,
                     parameters.value);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -440,7 +440,7 @@ private:
         std::unique_ptr<SSLConnectionBackend> backend;
         const Result res = CreateSSLConnectionBackend(&backend);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(res);
         if (res == ResultSuccess) {
             rb.PushIpcInterface<ISslConnection>(system, ssl_version, shared_data,
@@ -451,7 +451,7 @@ private:
     void GetConnectionCount(HLERequestContext& ctx) {
         LOG_DEBUG(Service_SSL, "connection_count={}", shared_data->connection_count);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(shared_data->connection_count);
     }
@@ -465,7 +465,7 @@ private:
 
         LOG_WARNING(Service_SSL, "(STUBBED) called, certificate_format={}", certificate_format);
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(server_id);
     }
@@ -484,7 +484,7 @@ private:
 
         LOG_WARNING(Service_SSL, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(client_id);
     }
@@ -526,7 +526,7 @@ private:
         LOG_WARNING(Service_SSL, "(STUBBED) called, api_version={}, pid_placeholder={}",
                     parameters.ssl_version.api_version, parameters.pid_placeholder);
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISslContext>(system, parameters.ssl_version);
     }
@@ -537,7 +537,7 @@ private:
 
         LOG_DEBUG(Service_SSL, "called, ssl_version={}", ssl_version);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 };

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -38,19 +38,19 @@ private:
         LOG_DEBUG(Service_Time, "called");
 
         if (!clock_core.IsInitialized()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_UNINITIALIZED_CLOCK);
             return;
         }
 
         s64 posix_time{};
         if (const Result result{clock_core.GetCurrentTime(system, posix_time)}; result.IsError()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<s64>(posix_time);
     }
@@ -59,7 +59,7 @@ private:
         LOG_DEBUG(Service_Time, "called");
 
         if (!clock_core.IsInitialized()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_UNINITIALIZED_CLOCK);
             return;
         }
@@ -67,12 +67,12 @@ private:
         Clock::SystemClockContext system_clock_context{};
         if (const Result result{clock_core.GetClockContext(system, system_clock_context)};
             result.IsError()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, sizeof(Clock::SystemClockContext) / 4 + 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(system_clock_context);
     }
@@ -102,13 +102,13 @@ private:
         LOG_DEBUG(Service_Time, "called");
 
         if (!clock_core.IsInitialized()) {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_UNINITIALIZED_CLOCK);
             return;
         }
 
         const Clock::SteadyClockTimePoint time_point{clock_core.GetCurrentTimePoint(system)};
-        IPC::ResponseBuilder rb{ctx, (sizeof(Clock::SteadyClockTimePoint) / 4) + 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(time_point);
     }
@@ -180,7 +180,7 @@ Result Module::Interface::GetClockSnapshotFromSystemClockContextInternal(
 
 void Module::Interface::GetStandardUserSystemClock(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISystemClock>(system.GetTimeManager().GetStandardUserSystemClockCore(),
                                       system);
@@ -188,7 +188,7 @@ void Module::Interface::GetStandardUserSystemClock(HLERequestContext& ctx) {
 
 void Module::Interface::GetStandardNetworkSystemClock(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISystemClock>(system.GetTimeManager().GetStandardNetworkSystemClockCore(),
                                       system);
@@ -196,14 +196,14 @@ void Module::Interface::GetStandardNetworkSystemClock(HLERequestContext& ctx) {
 
 void Module::Interface::GetStandardSteadyClock(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISteadyClock>(system.GetTimeManager().GetStandardSteadyClockCore(), system);
 }
 
 void Module::Interface::GetTimeZoneService(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ITimeZoneService>(system,
                                           system.GetTimeManager().GetTimeZoneContentManager());
@@ -211,7 +211,7 @@ void Module::Interface::GetTimeZoneService(HLERequestContext& ctx) {
 
 void Module::Interface::GetStandardLocalSystemClock(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<ISystemClock>(system.GetTimeManager().GetStandardLocalSystemClockCore(),
                                       system);
@@ -220,7 +220,7 @@ void Module::Interface::GetStandardLocalSystemClock(HLERequestContext& ctx) {
 void Module::Interface::IsStandardNetworkSystemClockAccuracySufficient(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
     auto& clock_core{system.GetTimeManager().GetStandardNetworkSystemClockCore()};
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push<u32>(clock_core.IsStandardNetworkSystemClockAccuracySufficient(system));
 }
@@ -230,7 +230,7 @@ void Module::Interface::CalculateMonotonicSystemClockBaseTimePoint(HLERequestCon
 
     auto& steady_clock_core{system.GetTimeManager().GetStandardSteadyClockCore()};
     if (!steady_clock_core.IsInitialized()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ERROR_UNINITIALIZED_CLOCK);
         return;
     }
@@ -244,13 +244,13 @@ void Module::Interface::CalculateMonotonicSystemClockBaseTimePoint(HLERequestCon
             system.CoreTiming().GetClockTicks())};
         const s64 base_time_point{context.offset + current_time_point.time_point -
                                   ticks.ToSeconds()};
-        IPC::ResponseBuilder rb{ctx, (sizeof(s64) / 4) + 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushRaw(base_time_point);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ERROR_TIME_MISMATCH);
 }
 
@@ -265,7 +265,7 @@ void Module::Interface::GetClockSnapshot(HLERequestContext& ctx) {
             system.GetTimeManager().GetStandardUserSystemClockCore().GetClockContext(system,
                                                                                      user_context)};
         result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
@@ -275,7 +275,7 @@ void Module::Interface::GetClockSnapshot(HLERequestContext& ctx) {
             system.GetTimeManager().GetStandardNetworkSystemClockCore().GetClockContext(
                 system, network_context)};
         result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
@@ -284,14 +284,14 @@ void Module::Interface::GetClockSnapshot(HLERequestContext& ctx) {
     if (const Result result{GetClockSnapshotFromSystemClockContextInternal(
             &ctx.GetThread(), user_context, network_context, type, clock_snapshot)};
         result.IsError()) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
     ctx.WriteBuffer(clock_snapshot);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -310,14 +310,14 @@ void Module::Interface::GetClockSnapshotFromSystemClockContext(HLERequestContext
     if (const Result result{GetClockSnapshotFromSystemClockContextInternal(
             &ctx.GetThread(), user_context, network_context, type, clock_snapshot)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
     ctx.WriteBuffer(clock_snapshot);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
 }
 
@@ -343,7 +343,7 @@ void Module::Interface::CalculateStandardUserSystemClockDifferenceByUser(HLERequ
         time_span_type.nanoseconds = 0;
     }
 
-    IPC::ResponseBuilder rb{ctx, (sizeof(s64) / 4) + 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(time_span_type.nanoseconds);
 }
@@ -370,7 +370,7 @@ void Module::Interface::CalculateSpanBetween(HLERequestContext& ctx) {
             time_span_type =
                 Clock::TimeSpanType::FromSeconds(snapshot_b.network_time - snapshot_a.network_time);
         } else {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ERROR_TIME_NOT_FOUND);
             return;
         }
@@ -378,14 +378,14 @@ void Module::Interface::CalculateSpanBetween(HLERequestContext& ctx) {
         time_span_type = Clock::TimeSpanType::FromSeconds(span);
     }
 
-    IPC::ResponseBuilder rb{ctx, (sizeof(s64) / 4) + 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(time_span_type.nanoseconds);
 }
 
 void Module::Interface::GetSharedMemoryNativeHandle(HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
-    IPC::ResponseBuilder rb{ctx, 2, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushCopyObjects(&system.Kernel().GetTimeSharedMem());
 }

--- a/src/core/hle/service/time/time_zone_service.cpp
+++ b/src/core/hle/service/time/time_zone_service.cpp
@@ -35,12 +35,12 @@ void ITimeZoneService::GetDeviceLocationName(HLERequestContext& ctx) {
     if (const Result result{
             time_zone_content_manager.GetTimeZoneManager().GetDeviceLocationName(location_name)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, (sizeof(location_name) / 4) + 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(location_name);
 }
@@ -52,12 +52,12 @@ void ITimeZoneService::GetTotalLocationNameCount(HLERequestContext& ctx) {
     if (const Result result{
             time_zone_content_manager.GetTimeZoneManager().GetTotalLocationNameCount(count)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(count);
 }
@@ -69,13 +69,13 @@ void ITimeZoneService::LoadLocationNameList(HLERequestContext& ctx) {
     if (const Result result{
             time_zone_content_manager.GetTimeZoneManager().LoadLocationNameList(location_names)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
     ctx.WriteBuffer(location_names);
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.Push(static_cast<s32>(location_names.size()));
 }
@@ -86,12 +86,12 @@ void ITimeZoneService::GetTimeZoneRuleVersion(HLERequestContext& ctx) {
     if (const Result result{
             time_zone_content_manager.GetTimeZoneManager().GetTimeZoneRuleVersion(rule_version)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 6};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(rule_version);
 }
@@ -118,7 +118,7 @@ void ITimeZoneService::LoadTimeZoneRule(HLERequestContext& ctx) {
     std::memcpy(time_zone_rule_outbuffer.data(), &time_zone_rule, sizeof(TimeZone::TimeZoneRule));
     ctx.WriteBuffer(time_zone_rule_outbuffer);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(result);
 }
 
@@ -136,12 +136,12 @@ void ITimeZoneService::ToCalendarTime(HLERequestContext& ctx) {
     if (const Result result{time_zone_content_manager.GetTimeZoneManager().ToCalendarTime(
             time_zone_rule, posix_time, calendar_info)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2 + (sizeof(TimeZone::CalendarInfo) / 4)};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(calendar_info);
 }
@@ -157,12 +157,12 @@ void ITimeZoneService::ToCalendarTimeWithMyRule(HLERequestContext& ctx) {
             time_zone_content_manager.GetTimeZoneManager().ToCalendarTimeWithMyRules(
                 posix_time, calendar_info)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2 + (sizeof(TimeZone::CalendarInfo) / 4)};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw(calendar_info);
 }
@@ -179,7 +179,7 @@ void ITimeZoneService::ToPosixTime(HLERequestContext& ctx) {
     if (const Result result{time_zone_content_manager.GetTimeZoneManager().ToPosixTime(
             time_zone_rule, calendar_time, posix_time)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
@@ -187,7 +187,7 @@ void ITimeZoneService::ToPosixTime(HLERequestContext& ctx) {
     ctx.WriteBuffer(posix_time);
 
     // TODO(bunnei): Handle multiple times
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw<u32>(1); // Number of times we're returning
 }
@@ -202,14 +202,14 @@ void ITimeZoneService::ToPosixTimeWithMyRule(HLERequestContext& ctx) {
     if (const Result result{time_zone_content_manager.GetTimeZoneManager().ToPosixTimeWithMyRule(
             calendar_time, posix_time)};
         result != ResultSuccess) {
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         return;
     }
 
     ctx.WriteBuffer(posix_time);
 
-    IPC::ResponseBuilder rb{ctx, 3};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushRaw<u32>(1); // Number of times we're returning
 }

--- a/src/core/hle/service/usb/usb.cpp
+++ b/src/core/hle/service/usb/usb.cpp
@@ -150,7 +150,7 @@ private:
     void OpenSession(HLERequestContext& ctx) {
         LOG_DEBUG(Service_USB, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IPdSession>(system);
     }
@@ -194,7 +194,7 @@ private:
     void OpenCradleSession(HLERequestContext& ctx) {
         LOG_DEBUG(Service_USB, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IPdCradleSession>(system);
     }

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -99,7 +99,7 @@ private:
 
         server.TryGetProducer(id)->Transact(ctx, transaction, flags);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -112,7 +112,7 @@ private:
         LOG_WARNING(Service_VI, "(STUBBED) called id={}, addval={:08X}, type={:08X}", id, addval,
                     type);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -123,7 +123,7 @@ private:
 
         LOG_WARNING(Service_VI, "(STUBBED) called id={}, unknown={:08X}", id, unknown);
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(server.TryGetProducer(id)->GetNativeHandle());
     }
@@ -209,7 +209,7 @@ private:
 
         ctx.WriteBuffer(&layout, sizeof(layout));
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.PushRaw(out);
     }
@@ -220,7 +220,7 @@ private:
 
         LOG_INFO(Service_VI, "(STUBBED) called. layer_id={:#x}", layer_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -230,7 +230,7 @@ private:
 
         LOG_INFO(Service_VI, "(STUBBED) called. layer_id={:#x}", layer_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -244,7 +244,7 @@ private:
         const auto result = nvnflinger.GetSystemBufferManager().GetSharedFrameBufferAcquirableEvent(
             &event, layer_id);
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.PushCopyObjects(event);
     }
@@ -266,7 +266,7 @@ private:
         const auto result = nvnflinger.GetSystemBufferManager().AcquireSharedFrameBuffer(
             &out.fence, out.slots, &out.target_slot, layer_id);
 
-        IPC::ResponseBuilder rb{ctx, 18};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
         rb.PushRaw(out);
     }
@@ -290,7 +290,7 @@ private:
         const auto result = nvnflinger.GetSystemBufferManager().PresentSharedFrameBuffer(
             input.fence, input.crop_region, input.window_transform, input.swap_interval,
             input.layer_id, input.surface_id);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(result);
     }
 
@@ -302,7 +302,7 @@ private:
         LOG_WARNING(Service_VI, "(STUBBED) called. layer_id=0x{:016X}, z_value=0x{:016X}", layer_id,
                     z_value);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -315,14 +315,14 @@ private:
 
         LOG_DEBUG(Service_VI, "called, layer_id=0x{:08X}, visibility={}", layer_id, visibility);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
     void GetDisplayMode(HLERequestContext& ctx) {
         LOG_WARNING(Service_VI, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         if (Settings::IsDockedMode()) {
@@ -442,7 +442,7 @@ private:
 
         const Result rc = nv_flinger.CloseDisplay(display) ? ResultSuccess : ResultUnknown;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(rc);
     }
 
@@ -460,12 +460,12 @@ private:
         const auto layer_id = nv_flinger.CreateLayer(display);
         if (!layer_id) {
             LOG_ERROR(Service_VI, "Layer not found! display=0x{:016X}", display);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultNotFound);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(*layer_id);
     }
@@ -478,7 +478,7 @@ private:
         LOG_WARNING(Service_VI, "(STUBBED) called. stack=0x{:08X}, layer_id=0x{:016X}", stack,
                     layer_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -490,7 +490,7 @@ private:
         LOG_WARNING(Service_VI, "(STUBBED) called, layer_id=0x{:X}, visibility={}", layer_id,
                     visibility);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -554,7 +554,7 @@ private:
     void GetRelayService(HLERequestContext& ctx) {
         LOG_WARNING(Service_VI, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IHOSBinderDriver>(system, hos_binder_driver_server);
     }
@@ -562,7 +562,7 @@ private:
     void GetSystemDisplayService(HLERequestContext& ctx) {
         LOG_WARNING(Service_VI, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<ISystemDisplayService>(system, nv_flinger);
     }
@@ -570,7 +570,7 @@ private:
     void GetManagerDisplayService(HLERequestContext& ctx) {
         LOG_WARNING(Service_VI, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IManagerDisplayService>(system, nv_flinger);
     }
@@ -578,7 +578,7 @@ private:
     void GetIndirectDisplayTransactionService(HLERequestContext& ctx) {
         LOG_WARNING(Service_VI, "(STUBBED) called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushIpcInterface<IHOSBinderDriver>(system, hos_binder_driver_server);
     }
@@ -610,12 +610,12 @@ private:
         const auto display_id = nv_flinger.OpenDisplay(name);
         if (!display_id) {
             LOG_ERROR(Service_VI, "Display not found! display_name={}", name);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultNotFound);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(*display_id);
     }
@@ -626,7 +626,7 @@ private:
 
         const Result rc = nv_flinger.CloseDisplay(display_id) ? ResultSuccess : ResultUnknown;
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(rc);
     }
 
@@ -635,7 +635,7 @@ private:
     void SetDisplayEnabled(HLERequestContext& ctx) {
         LOG_DEBUG(Service_VI, "called.");
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -645,7 +645,7 @@ private:
 
         LOG_DEBUG(Service_VI, "called. display_id=0x{:016X}", display_id);
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
 
         // This only returns the fixed values of 1280x720 and makes no distinguishing
@@ -663,7 +663,7 @@ private:
         LOG_DEBUG(Service_VI, "called. scaling_mode=0x{:08X}, unknown=0x{:016X}", scaling_mode,
                   unknown);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
 
         if (scaling_mode > NintendoScaleMode::PreserveAspectRatio) {
             LOG_ERROR(Service_VI, "Invalid scaling mode provided.");
@@ -686,7 +686,7 @@ private:
 
         const DisplayInfo display_info;
         ctx.WriteBuffer(&display_info, sizeof(DisplayInfo));
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(1);
     }
@@ -706,7 +706,7 @@ private:
         const auto display_id = nv_flinger.OpenDisplay(display_name);
         if (!display_id) {
             LOG_ERROR(Service_VI, "Layer not found! layer_id={}", layer_id);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultNotFound);
             return;
         }
@@ -714,7 +714,7 @@ private:
         const auto buffer_queue_id = nv_flinger.FindBufferQueueId(*display_id, layer_id);
         if (!buffer_queue_id) {
             LOG_ERROR(Service_VI, "Buffer queue id not found! display_id={}", *display_id);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultNotFound);
             return;
         }
@@ -726,7 +726,7 @@ private:
 
         const auto buffer_size = ctx.WriteBuffer(parcel.Serialize());
 
-        IPC::ResponseBuilder rb{ctx, 4};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push<u64>(buffer_size);
     }
@@ -739,7 +739,7 @@ private:
 
         nv_flinger.CloseLayer(layer_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -756,7 +756,7 @@ private:
         const auto layer_id = nv_flinger.CreateLayer(display_id);
         if (!layer_id) {
             LOG_ERROR(Service_VI, "Layer not found! display_id={}", display_id);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultNotFound);
             return;
         }
@@ -764,7 +764,7 @@ private:
         const auto buffer_queue_id = nv_flinger.FindBufferQueueId(display_id, *layer_id);
         if (!buffer_queue_id) {
             LOG_ERROR(Service_VI, "Buffer queue id not found! display_id={}", display_id);
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultNotFound);
             return;
         }
@@ -774,7 +774,7 @@ private:
 
         const auto buffer_size = ctx.WriteBuffer(parcel.Serialize());
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(*layer_id);
         rb.Push<u64>(buffer_size);
@@ -787,7 +787,7 @@ private:
         LOG_WARNING(Service_VI, "(STUBBED) called. layer_id=0x{:016X}", layer_id);
         nv_flinger.DestroyLayer(layer_id);
 
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
     }
 
@@ -804,12 +804,12 @@ private:
                 LOG_ERROR(Service_VI, "Vsync event was not found for display_id={}", display_id);
             }
 
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
             return;
         }
 
-        IPC::ResponseBuilder rb{ctx, 2, 1};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.PushCopyObjects(vsync_event);
     }
@@ -823,11 +823,11 @@ private:
         const auto result = ConvertScalingModeImpl(&converted_mode, mode);
 
         if (result == ResultSuccess) {
-            IPC::ResponseBuilder rb{ctx, 4};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(ResultSuccess);
             rb.PushEnum(converted_mode);
         } else {
-            IPC::ResponseBuilder rb{ctx, 2};
+            IPC::ResponseBuilder rb{ctx};
             rb.Push(result);
         }
     }
@@ -852,7 +852,7 @@ private:
         constexpr s64 unknown_result_1 = 0;
         constexpr s64 unknown_result_2 = 0;
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(unknown_result_1);
         rb.Push(unknown_result_2);
         rb.Push(ResultSuccess);
@@ -869,7 +869,7 @@ private:
         const auto texture_size = width * height * 4;
         const auto out_size = (texture_size + base_size - 1) / base_size * base_size;
 
-        IPC::ResponseBuilder rb{ctx, 6};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultSuccess);
         rb.Push(out_size);
         rb.Push(alignment);
@@ -924,12 +924,12 @@ void detail::GetDisplayServiceImpl(HLERequestContext& ctx, Core::System& system,
 
     if (!IsValidServiceAccess(permission, policy)) {
         LOG_ERROR(Service_VI, "Permission denied for policy {}", policy);
-        IPC::ResponseBuilder rb{ctx, 2};
+        IPC::ResponseBuilder rb{ctx};
         rb.Push(ResultPermissionDenied);
         return;
     }
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    IPC::ResponseBuilder rb{ctx};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IApplicationDisplayService>(system, nv_flinger, hos_binder_driver_server);
 }


### PR DESCRIPTION
This removes the need to manually specify the IPC output sizes, which has been a common source of IPC errors. Definitely needs a lot of testing, because I'm not confident it works in all cases.