### PR TITLE
android: Disable compression for zip exports

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GamePropertiesFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GamePropertiesFragment.kt
@@ -445,7 +445,8 @@ class GamePropertiesFragment : Fragment() {
             val zipResult = FileUtil.zipFromInternalStorage(
                 File(saveLocation),
                 saveLocation.replaceAfterLast("/", ""),
-                BufferedOutputStream(requireContext().contentResolver.openOutputStream(result))
+                BufferedOutputStream(requireContext().contentResolver.openOutputStream(result)),
+                compression = false
             )
             return@newInstance when (zipResult) {
                 TaskState.Completed -> getString(R.string.export_success)

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/main/MainActivity.kt
@@ -625,7 +625,8 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 File(DirectoryInitialization.userDirectory!!),
                 DirectoryInitialization.userDirectory!!,
                 BufferedOutputStream(contentResolver.openOutputStream(result)),
-                taskViewModel.cancelled
+                taskViewModel.cancelled,
+                compression = false
             )
             return@newInstance when (zipResult) {
                 TaskState.Completed -> getString(R.string.user_data_export_success)


### PR DESCRIPTION
Disables compression for user data and save exports

Testing with firmware and an update installed saw user data export time decrease from 3 minutes to 1