### PR TITLE
android: add basic support for google game dashboard

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
         android:dataExtractionRules="@xml/data_extraction_rules_api_31"
         android:enableOnBackInvokedCallback="true">
 
+        <meta-data android:name="android.game_mode_config"
+            android:resource="@xml/game_mode_config" />
+
         <activity
             android:name="org.yuzu.yuzu_emu.ui.main.MainActivity"
             android:exported="true"

--- a/src/android/app/src/main/res/xml/game_mode_config.xml
+++ b/src/android/app/src/main/res/xml/game_mode_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<game-mode-config
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsBatteryGameMode="true"
+    android:supportsPerformanceGameMode="true"
+    android:allowGameDownscaling="false"
+    android:allowGameFpsOverride="false"/>


### PR DESCRIPTION
This adds support for the Performance and Battery Saver modes in the Game Dashboard mostly found on Google Pixel devices.

This does not yet define the specifics for the performance modes but does provide the initial basic support