### PR TITLE
actions: android: Allow for manually triggering Android builds

### DIFF
--- a/.github/workflows/android-merge.js
+++ b/.github/workflows/android-merge.js
@@ -90,8 +90,8 @@ async function tagAndPush(github, owner, repo, execa, commit=false) {
     console.log(`New tag: ${newTag}`);
     if (commit) {
         let channelName = channel[0].toUpperCase() + channel.slice(1);
-        console.info(`Committing pending commit as ${channelName} #${tagNumber + 1}`);
-        await execa("git", ['commit', '-m', `${channelName} #${tagNumber + 1}`]);
+        console.info(`Committing pending commit as ${channelName} ${tagNumber + 1}`);
+        await execa("git", ['commit', '-m', `${channelName} ${tagNumber + 1}`]);
     }
     console.info('Pushing tags to GitHub ...');
     await execa("git", ['tag', newTag]);

--- a/.github/workflows/android-merge.js
+++ b/.github/workflows/android-merge.js
@@ -157,7 +157,7 @@ async function mergePullRequests(pulls, execa) {
             process1.stdout.pipe(process.stdout);
             await process1;
 
-            const process2 = execa("git", ["commit", "-m", `Merge PR ${pr}`]);
+            const process2 = execa("git", ["commit", "-m", `Merge yuzu-emu#${pr}`]);
             process2.stdout.pipe(process.stdout);
             await process2;
 

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   android:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.android != 'false' && github.repository == 'yuzu-emu/yuzu' }}
+    if: ${{ github.event.inputs.android != 'false' && github.repository == 'yuzu-emu/yuzu-android' }}
     steps:
       # this checkout is required to make sure the GitHub Actions scripts are available
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
           script: |
             if (context.payload.inputs && context.payload.inputs.android === 'true') return true;
             const checkAndroidChanges = require('./.github/workflows/android-merge.js').checkAndroidChanges;
-            return checkAndroidChanges(github, context);
+            return checkAndroidChanges(github);
       - run: npm install execa@5
         if: ${{ steps.check-changes.outputs.result == 'true' }}
       - uses: actions/checkout@v3


### PR DESCRIPTION
Shifts automation responsibility from yuzu-emu/yuzu to yuzu-emu/yuzu-android and allows for triggering builds from the yuzu-emu/yuzu-android repo.

Additionally links to the merged PR in the related commit
![image](https://github.com/yuzu-emu/yuzu/assets/14132249/bf62ee8c-0e46-4eaa-b5b9-8e048d861231)

And prevents linking to an unrelated PR in the tag commit (Ex. "Android #180" linking to PR 180)