### PR TITLE
android: Expose more orientation options

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/Settings.kt
@@ -79,7 +79,18 @@ object Settings {
     const val PREF_THEME_MODE = "ThemeMode"
     const val PREF_BLACK_BACKGROUNDS = "BlackBackgrounds"
 
-    const val LayoutOption_Unspecified = 0
-    const val LayoutOption_MobilePortrait = 4
-    const val LayoutOption_MobileLandscape = 5
+    enum class EmulationOrientation(val int: Int) {
+        Unspecified(0),
+        SensorLandscape(5),
+        Landscape(1),
+        ReverseLandscape(2),
+        SensorPortrait(6),
+        Portrait(4),
+        ReversePortrait(3);
+
+        companion object {
+            fun from(int: Int): EmulationOrientation =
+                entries.firstOrNull { it.int == int } ?: Unspecified
+        }
+    }
 }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -50,6 +50,7 @@ import org.yuzu.yuzu_emu.databinding.FragmentEmulationBinding
 import org.yuzu.yuzu_emu.features.settings.model.BooleanSetting
 import org.yuzu.yuzu_emu.features.settings.model.IntSetting
 import org.yuzu.yuzu_emu.features.settings.model.Settings
+import org.yuzu.yuzu_emu.features.settings.model.Settings.EmulationOrientation
 import org.yuzu.yuzu_emu.features.settings.utils.SettingsFile
 import org.yuzu.yuzu_emu.model.DriverViewModel
 import org.yuzu.yuzu_emu.model.Game
@@ -458,13 +459,23 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     @SuppressLint("SourceLockedOrientationActivity")
     private fun updateOrientation() {
         emulationActivity?.let {
-            it.requestedOrientation = when (IntSetting.RENDERER_SCREEN_LAYOUT.getInt()) {
-                Settings.LayoutOption_MobileLandscape ->
+            val orientationSetting =
+                EmulationOrientation.from(IntSetting.RENDERER_SCREEN_LAYOUT.getInt())
+            it.requestedOrientation = when (orientationSetting) {
+                EmulationOrientation.Unspecified -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                EmulationOrientation.SensorLandscape ->
                     ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-                Settings.LayoutOption_MobilePortrait ->
-                    ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
-                Settings.LayoutOption_Unspecified -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-                else -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+
+                EmulationOrientation.Landscape -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                EmulationOrientation.ReverseLandscape ->
+                    ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+
+                EmulationOrientation.SensorPortrait ->
+                    ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+
+                EmulationOrientation.Portrait -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                EmulationOrientation.ReversePortrait ->
+                    ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
             }
         }
     }
@@ -651,7 +662,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     @SuppressLint("SourceLockedOrientationActivity")
     private fun startConfiguringControls() {
         // Lock the current orientation to prevent editing inconsistencies
-        if (IntSetting.RENDERER_SCREEN_LAYOUT.getInt() == Settings.LayoutOption_Unspecified) {
+        if (IntSetting.RENDERER_SCREEN_LAYOUT.getInt() == EmulationOrientation.Unspecified.int) {
             emulationActivity?.let {
                 it.requestedOrientation =
                     if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
@@ -669,7 +680,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
         binding.doneControlConfig.visibility = View.GONE
         binding.surfaceInputOverlay.setIsInEditMode(false)
         // Unlock the orientation if it was locked for editing
-        if (IntSetting.RENDERER_SCREEN_LAYOUT.getInt() == Settings.LayoutOption_Unspecified) {
+        if (IntSetting.RENDERER_SCREEN_LAYOUT.getInt() == EmulationOrientation.Unspecified.int) {
             emulationActivity?.let {
                 it.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
             }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -100,6 +100,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
      */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        updateOrientation()
 
         val intentUri: Uri? = requireActivity().intent.data
         var intentGame: Game? = null

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -118,15 +118,23 @@
     </integer-array>
 
     <string-array name="rendererScreenLayoutNames">
-        <item>@string/screen_layout_landscape</item>
-        <item>@string/screen_layout_portrait</item>
         <item>@string/screen_layout_auto</item>
+        <item>@string/screen_layout_sensor_landscape</item>
+        <item>@string/screen_layout_landscape</item>
+        <item>@string/screen_layout_reverse_landscape</item>
+        <item>@string/screen_layout_sensor_portrait</item>
+        <item>@string/screen_layout_portrait</item>
+        <item>@string/screen_layout_reverse_portrait</item>
     </string-array>
 
     <integer-array name="rendererScreenLayoutValues">
-        <item>5</item>
-        <item>4</item>
         <item>0</item>
+        <item>5</item>
+        <item>1</item>
+        <item>2</item>
+        <item>6</item>
+        <item>4</item>
+        <item>3</item>
     </integer-array>
 
     <string-array name="rendererAspectRatioNames">

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -463,9 +463,13 @@
     <string name="anti_aliasing_smaa">SMAA</string>
 
     <!-- Screen Layouts -->
-    <string name="screen_layout_landscape">Landscape</string>
-    <string name="screen_layout_portrait">Portrait</string>
     <string name="screen_layout_auto">Auto</string>
+    <string name="screen_layout_sensor_landscape">Sensor landscape</string>
+    <string name="screen_layout_landscape">Landscape</string>
+    <string name="screen_layout_reverse_landscape">Reverse landscape</string>
+    <string name="screen_layout_sensor_portrait">Sensor portrait</string>
+    <string name="screen_layout_portrait">Portrait</string>
+    <string name="screen_layout_reverse_portrait">Reverse portrait</string>
 
     <!-- Aspect Ratios -->
     <string name="ratio_default">Default (16:9)</string>


### PR DESCRIPTION
You can now use the following orientation options during emulation
- Auto
- Sensor Landscape
- Landscape
- Reverse Landscape
- Sensor Portrait
- Portrait
- Reverse Portrait

yuzu in reverse portrait - the way it was meant to be played...
![Screenshot 2024-01-03 182714](https://github.com/yuzu-emu/yuzu/assets/14132249/1217efca-4153-4b64-b747-744cf22d8c17)

Additionally, fixed a bug where we would apply custom orientation only once emulation had started