### PR TITLE
frontend_common: config: Only write setting related to opened config file

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/GamesViewModel.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/GamesViewModel.kt
@@ -167,13 +167,14 @@ class GamesViewModel : ViewModel() {
             }
         }
 
-    fun onCloseGameFoldersFragment() =
+    fun onCloseGameFoldersFragment() {
+        NativeConfig.saveGlobalConfig()
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
-                NativeConfig.saveGlobalConfig()
                 getGameDirs(true)
             }
         }
+    }
 
     private fun getGameDirs(reloadList: Boolean = false) {
         val gameDirs = NativeConfig.getGameDirs()

--- a/src/android/app/src/main/jni/android_config.cpp
+++ b/src/android/app/src/main/jni/android_config.cpp
@@ -14,12 +14,6 @@ AndroidConfig::AndroidConfig(const std::string& config_name, ConfigType config_t
     }
 }
 
-AndroidConfig::~AndroidConfig() {
-    if (global) {
-        AndroidConfig::SaveAllValues();
-    }
-}
-
 void AndroidConfig::ReloadAllValues() {
     Reload();
     ReadAndroidValues();

--- a/src/android/app/src/main/jni/android_config.h
+++ b/src/android/app/src/main/jni/android_config.h
@@ -9,7 +9,6 @@ class AndroidConfig final : public Config {
 public:
     explicit AndroidConfig(const std::string& config_name = "config",
                            ConfigType config_type = ConfigType::GlobalConfig);
-    ~AndroidConfig() override;
 
     void ReloadAllValues() override;
     void SaveAllValues() override;

--- a/src/frontend_common/config.cpp
+++ b/src/frontend_common/config.cpp
@@ -894,9 +894,10 @@ void Config::WriteSettingGeneric(const Settings::BasicSetting* const setting) {
             WriteBooleanSetting(std::string(key).append("\\use_global"), setting->UsingGlobal());
         }
         if (global || !setting->UsingGlobal()) {
+            auto value = global ? setting->ToStringGlobal() : setting->ToString();
             WriteBooleanSetting(std::string(key).append("\\default"),
-                                setting->ToString() == setting->DefaultToString());
-            WriteStringSetting(key, setting->ToString());
+                                value == setting->DefaultToString());
+            WriteStringSetting(key, value);
         }
     } else if (global) {
         WriteBooleanSetting(std::string(key).append("\\default"),


### PR DESCRIPTION
Fixes a couple issues with config saving on android (and potentially PC but I haven't seen reports there)
- Fixes an issue where global settings could be overwritten by previously loaded per-game settings
- Fixes an issue where multiple global config saves could happen at once when leaving the games folder fragment repeatedly