### PR TITLE
android: Re-add global save manager

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/NativeLibrary.kt
@@ -548,6 +548,15 @@ object NativeLibrary {
     external fun getSavePath(programId: String): String
 
     /**
+     * Gets the root save directory for the default profile as either
+     * /user/save/account/<user id raw string> or /user/save/000...000/<user id>
+     *
+     * @param future If true, returns the /user/save/account/... directory
+     * @return Save data path that may not exist yet
+     */
+    external fun getDefaultProfileSaveDataRoot(future: Boolean): String
+
+    /**
      * Adds a file to the manual filesystem provider in our EmulationSession instance
      * @param path Path to the file we're adding. Can be a string representation of a [Uri] or
      * a normal path

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -862,6 +862,9 @@ jobjectArray Java_org_yuzu_yuzu_1emu_NativeLibrary_getAddonsForFile(JNIEnv* env,
 jstring Java_org_yuzu_yuzu_1emu_NativeLibrary_getSavePath(JNIEnv* env, jobject jobj,
                                                           jstring jprogramId) {
     auto program_id = EmulationSession::GetProgramId(env, jprogramId);
+    if (program_id == 0) {
+        return ToJString(env, "");
+    }
 
     auto& system = EmulationSession::GetInstance().System();
 
@@ -878,6 +881,19 @@ jstring Java_org_yuzu_yuzu_1emu_NativeLibrary_getSavePath(JNIEnv* env, jobject j
         system, vfsNandDir, FileSys::SaveDataSpaceId::NandUser, FileSys::SaveDataType::SaveData,
         program_id, user_id->AsU128(), 0);
     return ToJString(env, user_save_data_path);
+}
+
+jstring Java_org_yuzu_yuzu_1emu_NativeLibrary_getDefaultProfileSaveDataRoot(JNIEnv* env,
+                                                                            jobject jobj,
+                                                                            jboolean jfuture) {
+    Service::Account::ProfileManager manager;
+    // TODO: Pass in a selected user once we get the relevant UI working
+    const auto user_id = manager.GetUser(static_cast<std::size_t>(0));
+    ASSERT(user_id);
+
+    const auto user_save_data_root =
+        FileSys::SaveDataFactory::GetUserGameSaveDataRoot(user_id->AsU128(), jfuture);
+    return ToJString(env, user_save_data_root);
 }
 
 void Java_org_yuzu_yuzu_1emu_NativeLibrary_addFileToFilesystemProvider(JNIEnv* env, jobject jobj,

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -133,6 +133,15 @@
     <string name="add_game_folder">Add game folder</string>
     <string name="folder_already_added">This folder was already added!</string>
     <string name="game_folder_properties">Game folder properties</string>
+    <plurals name="saves_import_failed">
+        <item quantity="one">Failed to import %d save</item>
+        <item quantity="other">Failed to import %d saves</item>
+    </plurals>
+    <plurals name="saves_import_success">
+        <item quantity="one">Successfully imported %d save</item>
+        <item quantity="other">Successfully imported %d saves</item>
+    </plurals>
+    <string name="no_save_data_found">No save data found</string>
 
     <!-- Applet launcher strings -->
     <string name="applets">Applet launcher</string>
@@ -276,6 +285,7 @@
     <string name="global">Global</string>
     <string name="custom">Custom</string>
     <string name="notice">Notice</string>
+    <string name="import_complete">Import complete</string>
 
     <!-- GPU driver installation -->
     <string name="select_gpu_driver">Select GPU driver</string>

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -189,6 +189,15 @@ std::string SaveDataFactory::GetFullPath(Core::System& system, VirtualDir dir,
     }
 }
 
+std::string SaveDataFactory::GetUserGameSaveDataRoot(u128 user_id, bool future) {
+    if (future) {
+        Common::UUID uuid;
+        std::memcpy(uuid.uuid.data(), user_id.data(), sizeof(Common::UUID));
+        return fmt::format("/user/save/account/{}", uuid.RawString());
+    }
+    return fmt::format("/user/save/{:016X}/{:016X}{:016X}", 0, user_id[1], user_id[0]);
+}
+
 SaveDataSize SaveDataFactory::ReadSaveDataSize(SaveDataType type, u64 title_id,
                                                u128 user_id) const {
     const auto path =

--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -101,6 +101,7 @@ public:
     static std::string GetSaveDataSpaceIdPath(SaveDataSpaceId space);
     static std::string GetFullPath(Core::System& system, VirtualDir dir, SaveDataSpaceId space,
                                    SaveDataType type, u64 title_id, u128 user_id, u64 save_id);
+    static std::string GetUserGameSaveDataRoot(u128 user_id, bool future);
 
     SaveDataSize ReadSaveDataSize(SaveDataType type, u64 title_id, u128 user_id) const;
     void WriteSaveDataSize(SaveDataType type, u64 title_id, u128 user_id,


### PR DESCRIPTION
Reworked to correctly collect and import/export saves that could exist in either /nand/user/save/000...000/<user id> or /nand/user/save/account/<user id raw string>

Compatible with all previous save data backups, regardless of whether they were exported per-game or globally.