### PR TITLE
service: hid: Handle pending delete

### DIFF
--- a/src/hid_core/resource_manager.cpp
+++ b/src/hid_core/resource_manager.cpp
@@ -224,6 +224,7 @@ Result ResourceManager::RegisterAppletResourceUserId(u64 aruid, bool bool_value)
 void ResourceManager::UnregisterAppletResourceUserId(u64 aruid) {
     std::scoped_lock lock{shared_mutex};
     applet_resource->UnregisterAppletResourceUserId(aruid);
+    npad->UnregisterAppletResourceUserId(aruid);
 }
 
 Result ResourceManager::GetSharedMemoryHandle(Kernel::KSharedMemory** out_handle, u64 aruid) {

--- a/src/hid_core/resources/npad/npad_resource.cpp
+++ b/src/hid_core/resources/npad/npad_resource.cpp
@@ -46,7 +46,9 @@ Result NPadResource::RegisterAppletResourceUserId(u64 aruid) {
             data_index = i;
             break;
         }
-        if (registration_list.flag[i] == RegistrationStatus::None) {
+        // TODO: Don't Handle pending delete here
+        if (registration_list.flag[i] == RegistrationStatus::None ||
+            registration_list.flag[i] == RegistrationStatus::PendingDelete) {
             data_index = i;
             break;
         }


### PR DESCRIPTION
We need to handle pending delete entries. I don't have the RE for this part. So currently I'm just going to assume at the moment that not assigned and pending delete are the same.

This fixes a crash that happened when registering multiple aruid handles while deleting old ones. Besides this I did some minor cleanup of the code.