### PR TITLE
service: hid: Make sure there's an active aruid handle

### DIFF
--- a/src/hid_core/resources/npad/npad.cpp
+++ b/src/hid_core/resources/npad/npad.cpp
@@ -870,6 +870,11 @@ void NPad::InitializeVibrationDevice(
     const auto aruid = applet_resource_holder.applet_resource->GetActiveAruid();
     const auto npad_index = static_cast<Core::HID::NpadIdType>(vibration_device_handle.npad_id);
     const auto device_index = static_cast<std::size_t>(vibration_device_handle.device_index);
+
+    if (aruid == 0) {
+        return;
+    }
+
     InitializeVibrationDeviceAtIndex(aruid, npad_index, device_index);
 }
 


### PR DESCRIPTION
We still have issues with Rocket league. Now that npad is initialized properly at boot the game still tries to register a vibration device before creating the applet resource. Creating again the same crash but in a different spot.

Here I prevent this from happening.