### PR TITLE
kernel: fix resource management issues

### DIFF
--- a/src/common/page_table.cpp
+++ b/src/common/page_table.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/page_table.h"
+#include "common/scope_exit.h"
 
 namespace Common {
 
@@ -11,35 +12,22 @@ PageTable::~PageTable() noexcept = default;
 
 bool PageTable::BeginTraversal(TraversalEntry* out_entry, TraversalContext* out_context,
                                Common::ProcessAddress address) const {
-    // Setup invalid defaults.
-    out_entry->phys_addr = 0;
-    out_entry->block_size = page_size;
-    out_context->next_page = 0;
+    out_context->next_offset = GetInteger(address);
+    out_context->next_page = address / page_size;
 
-    // Validate that we can read the actual entry.
-    const auto page = address / page_size;
-    if (page >= backing_addr.size()) {
-        return false;
-    }
-
-    // Validate that the entry is mapped.
-    const auto phys_addr = backing_addr[page];
-    if (phys_addr == 0) {
-        return false;
-    }
-
-    // Populate the results.
-    out_entry->phys_addr = phys_addr + GetInteger(address);
-    out_context->next_page = page + 1;
-    out_context->next_offset = GetInteger(address) + page_size;
-
-    return true;
+    return this->ContinueTraversal(out_entry, out_context);
 }
 
 bool PageTable::ContinueTraversal(TraversalEntry* out_entry, TraversalContext* context) const {
     // Setup invalid defaults.
     out_entry->phys_addr = 0;
     out_entry->block_size = page_size;
+
+    // Regardless of whether the page was mapped, advance on exit.
+    SCOPE_EXIT({
+        context->next_page += 1;
+        context->next_offset += page_size;
+    });
 
     // Validate that we can read the actual entry.
     const auto page = context->next_page;
@@ -55,8 +43,6 @@ bool PageTable::ContinueTraversal(TraversalEntry* out_entry, TraversalContext* c
 
     // Populate the results.
     out_entry->phys_addr = phys_addr + context->next_offset;
-    context->next_page = page + 1;
-    context->next_offset += page_size;
 
     return true;
 }

--- a/src/core/debugger/gdbstub.cpp
+++ b/src/core/debugger/gdbstub.cpp
@@ -108,9 +108,9 @@ static std::string EscapeXML(std::string_view data) {
     return escaped;
 }
 
-GDBStub::GDBStub(DebuggerBackend& backend_, Core::System& system_)
-    : DebuggerFrontend(backend_), system{system_} {
-    if (system.ApplicationProcess()->Is64Bit()) {
+GDBStub::GDBStub(DebuggerBackend& backend_, Core::System& system_, Kernel::KProcess* debug_process_)
+    : DebuggerFrontend(backend_), system{system_}, debug_process{debug_process_} {
+    if (GetProcess()->Is64Bit()) {
         arch = std::make_unique<GDBStubA64>();
     } else {
         arch = std::make_unique<GDBStubA32>();
@@ -276,7 +276,7 @@ void GDBStub::ExecuteCommand(std::string_view packet, std::vector<DebuggerAction
         const size_t size{static_cast<size_t>(strtoll(command.data() + sep, nullptr, 16))};
 
         std::vector<u8> mem(size);
-        if (system.ApplicationMemory().ReadBlock(addr, mem.data(), size)) {
+        if (GetMemory().ReadBlock(addr, mem.data(), size)) {
             // Restore any bytes belonging to replaced instructions.
             auto it = replaced_instructions.lower_bound(addr);
             for (; it != replaced_instructions.end() && it->first < addr + size; it++) {
@@ -310,8 +310,8 @@ void GDBStub::ExecuteCommand(std::string_view packet, std::vector<DebuggerAction
         const auto mem_substr{std::string_view(command).substr(mem_sep)};
         const auto mem{Common::HexStringToVector(mem_substr, false)};
 
-        if (system.ApplicationMemory().WriteBlock(addr, mem.data(), size)) {
-            Core::InvalidateInstructionCacheRange(system.ApplicationProcess(), addr, size);
+        if (GetMemory().WriteBlock(addr, mem.data(), size)) {
+            Core::InvalidateInstructionCacheRange(GetProcess(), addr, size);
             SendReply(GDB_STUB_REPLY_OK);
         } else {
             SendReply(GDB_STUB_REPLY_ERR);
@@ -353,7 +353,7 @@ void GDBStub::HandleBreakpointInsert(std::string_view command) {
     const size_t addr{static_cast<size_t>(strtoll(command.data() + addr_sep, nullptr, 16))};
     const size_t size{static_cast<size_t>(strtoll(command.data() + size_sep, nullptr, 16))};
 
-    if (!system.ApplicationMemory().IsValidVirtualAddressRange(addr, size)) {
+    if (!GetMemory().IsValidVirtualAddressRange(addr, size)) {
         SendReply(GDB_STUB_REPLY_ERR);
         return;
     }
@@ -362,22 +362,20 @@ void GDBStub::HandleBreakpointInsert(std::string_view command) {
 
     switch (type) {
     case BreakpointType::Software:
-        replaced_instructions[addr] = system.ApplicationMemory().Read32(addr);
-        system.ApplicationMemory().Write32(addr, arch->BreakpointInstruction());
-        Core::InvalidateInstructionCacheRange(system.ApplicationProcess(), addr, sizeof(u32));
+        replaced_instructions[addr] = GetMemory().Read32(addr);
+        GetMemory().Write32(addr, arch->BreakpointInstruction());
+        Core::InvalidateInstructionCacheRange(GetProcess(), addr, sizeof(u32));
         success = true;
         break;
     case BreakpointType::WriteWatch:
-        success = system.ApplicationProcess()->InsertWatchpoint(addr, size,
-                                                                Kernel::DebugWatchpointType::Write);
+        success = GetProcess()->InsertWatchpoint(addr, size, Kernel::DebugWatchpointType::Write);
         break;
     case BreakpointType::ReadWatch:
-        success = system.ApplicationProcess()->InsertWatchpoint(addr, size,
-                                                                Kernel::DebugWatchpointType::Read);
+        success = GetProcess()->InsertWatchpoint(addr, size, Kernel::DebugWatchpointType::Read);
         break;
     case BreakpointType::AccessWatch:
-        success = system.ApplicationProcess()->InsertWatchpoint(
-            addr, size, Kernel::DebugWatchpointType::ReadOrWrite);
+        success =
+            GetProcess()->InsertWatchpoint(addr, size, Kernel::DebugWatchpointType::ReadOrWrite);
         break;
     case BreakpointType::Hardware:
     default:
@@ -400,7 +398,7 @@ void GDBStub::HandleBreakpointRemove(std::string_view command) {
     const size_t addr{static_cast<size_t>(strtoll(command.data() + addr_sep, nullptr, 16))};
     const size_t size{static_cast<size_t>(strtoll(command.data() + size_sep, nullptr, 16))};
 
-    if (!system.ApplicationMemory().IsValidVirtualAddressRange(addr, size)) {
+    if (!GetMemory().IsValidVirtualAddressRange(addr, size)) {
         SendReply(GDB_STUB_REPLY_ERR);
         return;
     }
@@ -411,24 +409,22 @@ void GDBStub::HandleBreakpointRemove(std::string_view command) {
     case BreakpointType::Software: {
         const auto orig_insn{replaced_instructions.find(addr)};
         if (orig_insn != replaced_instructions.end()) {
-            system.ApplicationMemory().Write32(addr, orig_insn->second);
-            Core::InvalidateInstructionCacheRange(system.ApplicationProcess(), addr, sizeof(u32));
+            GetMemory().Write32(addr, orig_insn->second);
+            Core::InvalidateInstructionCacheRange(GetProcess(), addr, sizeof(u32));
             replaced_instructions.erase(addr);
             success = true;
         }
         break;
     }
     case BreakpointType::WriteWatch:
-        success = system.ApplicationProcess()->RemoveWatchpoint(addr, size,
-                                                                Kernel::DebugWatchpointType::Write);
+        success = GetProcess()->RemoveWatchpoint(addr, size, Kernel::DebugWatchpointType::Write);
         break;
     case BreakpointType::ReadWatch:
-        success = system.ApplicationProcess()->RemoveWatchpoint(addr, size,
-                                                                Kernel::DebugWatchpointType::Read);
+        success = GetProcess()->RemoveWatchpoint(addr, size, Kernel::DebugWatchpointType::Read);
         break;
     case BreakpointType::AccessWatch:
-        success = system.ApplicationProcess()->RemoveWatchpoint(
-            addr, size, Kernel::DebugWatchpointType::ReadOrWrite);
+        success =
+            GetProcess()->RemoveWatchpoint(addr, size, Kernel::DebugWatchpointType::ReadOrWrite);
         break;
     case BreakpointType::Hardware:
     default:
@@ -466,10 +462,10 @@ void GDBStub::HandleQuery(std::string_view command) {
         const auto target_xml{arch->GetTargetXML()};
         SendReply(PaginateBuffer(target_xml, command.substr(30)));
     } else if (command.starts_with("Offsets")) {
-        const auto main_offset = Core::FindMainModuleEntrypoint(system.ApplicationProcess());
+        const auto main_offset = Core::FindMainModuleEntrypoint(GetProcess());
         SendReply(fmt::format("TextSeg={:x}", GetInteger(main_offset)));
     } else if (command.starts_with("Xfer:libraries:read::")) {
-        auto modules = Core::FindModules(system.ApplicationProcess());
+        auto modules = Core::FindModules(GetProcess());
 
         std::string buffer;
         buffer += R"(<?xml version="1.0"?>)";
@@ -483,7 +479,7 @@ void GDBStub::HandleQuery(std::string_view command) {
         SendReply(PaginateBuffer(buffer, command.substr(21)));
     } else if (command.starts_with("fThreadInfo")) {
         // beginning of list
-        const auto& threads = system.ApplicationProcess()->GetThreadList();
+        const auto& threads = GetProcess()->GetThreadList();
         std::vector<std::string> thread_ids;
         for (const auto& thread : threads) {
             thread_ids.push_back(fmt::format("{:x}", thread.GetThreadId()));
@@ -497,7 +493,7 @@ void GDBStub::HandleQuery(std::string_view command) {
         buffer += R"(<?xml version="1.0"?>)";
         buffer += "<threads>";
 
-        const auto& threads = system.ApplicationProcess()->GetThreadList();
+        const auto& threads = GetProcess()->GetThreadList();
         for (const auto& thread : threads) {
             auto thread_name{Core::GetThreadName(&thread)};
             if (!thread_name) {
@@ -613,7 +609,7 @@ void GDBStub::HandleRcmd(const std::vector<u8>& command) {
     std::string_view command_str{reinterpret_cast<const char*>(&command[0]), command.size()};
     std::string reply;
 
-    auto* process = system.ApplicationProcess();
+    auto* process = GetProcess();
     auto& page_table = process->GetPageTable();
 
     const char* commands = "Commands:\n"
@@ -714,7 +710,7 @@ void GDBStub::HandleRcmd(const std::vector<u8>& command) {
 }
 
 Kernel::KThread* GDBStub::GetThreadByID(u64 thread_id) {
-    auto& threads{system.ApplicationProcess()->GetThreadList()};
+    auto& threads{GetProcess()->GetThreadList()};
     for (auto& thread : threads) {
         if (thread.GetThreadId() == thread_id) {
             return std::addressof(thread);
@@ -781,6 +777,14 @@ void GDBStub::SendStatus(char status) {
     std::array<u8, 1> buf = {static_cast<u8>(status)};
     LOG_TRACE(Debug_GDBStub, "Writing status: {}", status);
     backend.WriteToClient(buf);
+}
+
+Kernel::KProcess* GDBStub::GetProcess() {
+    return debug_process;
+}
+
+Core::Memory::Memory& GDBStub::GetMemory() {
+    return GetProcess()->GetMemory();
 }
 
 } // namespace Core

--- a/src/core/debugger/gdbstub.h
+++ b/src/core/debugger/gdbstub.h
@@ -12,13 +12,22 @@
 #include "core/debugger/debugger_interface.h"
 #include "core/debugger/gdbstub_arch.h"
 
+namespace Kernel {
+class KProcess;
+}
+
+namespace Core::Memory {
+class Memory;
+}
+
 namespace Core {
 
 class System;
 
 class GDBStub : public DebuggerFrontend {
 public:
-    explicit GDBStub(DebuggerBackend& backend, Core::System& system);
+    explicit GDBStub(DebuggerBackend& backend, Core::System& system,
+                     Kernel::KProcess* debug_process);
     ~GDBStub() override;
 
     void Connected() override;
@@ -42,8 +51,12 @@ private:
     void SendReply(std::string_view data);
     void SendStatus(char status);
 
+    Kernel::KProcess* GetProcess();
+    Core::Memory::Memory& GetMemory();
+
 private:
     Core::System& system;
+    Kernel::KProcess* debug_process;
     std::unique_ptr<GDBStubArch> arch;
     std::vector<char> current_command;
     std::map<VAddr, u32> replaced_instructions;

--- a/src/core/hle/kernel/k_memory_block_manager.cpp
+++ b/src/core/hle/kernel/k_memory_block_manager.cpp
@@ -28,14 +28,14 @@ Result KMemoryBlockManager::Initialize(KProcessAddress st, KProcessAddress nd,
 }
 
 void KMemoryBlockManager::Finalize(KMemoryBlockSlabManager* slab_manager,
-                                   HostUnmapCallback&& host_unmap_callback) {
+                                   BlockCallback&& block_callback) {
     // Erase every block until we have none left.
     auto it = m_memory_block_tree.begin();
     while (it != m_memory_block_tree.end()) {
         KMemoryBlock* block = std::addressof(*it);
         it = m_memory_block_tree.erase(it);
+        block_callback(block->GetAddress(), block->GetSize());
         slab_manager->Free(block);
-        host_unmap_callback(block->GetAddress(), block->GetSize());
     }
 
     ASSERT(m_memory_block_tree.empty());

--- a/src/core/hle/kernel/k_memory_block_manager.h
+++ b/src/core/hle/kernel/k_memory_block_manager.h
@@ -85,11 +85,11 @@ public:
 public:
     KMemoryBlockManager();
 
-    using HostUnmapCallback = std::function<void(Common::ProcessAddress, u64)>;
+    using BlockCallback = std::function<void(Common::ProcessAddress, u64)>;
 
     Result Initialize(KProcessAddress st, KProcessAddress nd,
                       KMemoryBlockSlabManager* slab_manager);
-    void Finalize(KMemoryBlockSlabManager* slab_manager, HostUnmapCallback&& host_unmap_callback);
+    void Finalize(KMemoryBlockSlabManager* slab_manager, BlockCallback&& block_callback);
 
     iterator end() {
         return m_memory_block_tree.end();

--- a/src/core/hle/kernel/k_page_table_base.cpp
+++ b/src/core/hle/kernel/k_page_table_base.cpp
@@ -431,9 +431,82 @@ Result KPageTableBase::InitializeForProcess(Svc::CreateProcessFlag as_type, bool
                                                m_memory_block_slab_manager));
 }
 
+Result KPageTableBase::FinalizeProcess() {
+    // Only process tables should be finalized.
+    ASSERT(!this->IsKernel());
+
+    // HLE processes don't have memory mapped.
+    R_SUCCEED_IF(m_impl == nullptr);
+
+    // NOTE: Here Nintendo calls an unknown OnFinalize function.
+    // this->OnFinalize();
+
+    // NOTE: Here Nintendo calls a second unknown OnFinalize function.
+    // this->OnFinalize2();
+
+    // Get implementation objects.
+    auto& impl = this->GetImpl();
+    auto& mm = m_kernel.MemoryManager();
+
+    // Traverse, freeing all pages.
+    {
+        // Get the address space size.
+        const size_t as_size = this->GetAddressSpaceSize();
+
+        // Begin the traversal.
+        TraversalContext context;
+        TraversalEntry cur_entry = {
+            .phys_addr = 0,
+            .block_size = 0,
+        };
+
+        bool cur_valid = false;
+        TraversalEntry next_entry;
+        bool next_valid;
+        size_t tot_size = 0;
+
+        next_valid = impl.BeginTraversal(std::addressof(next_entry), std::addressof(context),
+                                         this->GetAddressSpaceStart());
+
+        // Iterate over entries.
+        while (true) {
+            if ((!next_valid && !cur_valid) ||
+                (next_valid && cur_valid &&
+                 next_entry.phys_addr == cur_entry.phys_addr + cur_entry.block_size)) {
+                cur_entry.block_size += next_entry.block_size;
+            } else {
+                if (cur_valid && IsHeapPhysicalAddressForFinalize(cur_entry.phys_addr)) {
+                    mm.Close(cur_entry.phys_addr, cur_entry.block_size / PageSize);
+                }
+
+                // Update tracking variables.
+                tot_size += cur_entry.block_size;
+                cur_entry = next_entry;
+                cur_valid = next_valid;
+            }
+
+            if (cur_entry.block_size + tot_size >= as_size) {
+                break;
+            }
+
+            next_valid =
+                impl.ContinueTraversal(std::addressof(next_entry), std::addressof(context));
+        }
+
+        // Handle the last block.
+        if (cur_valid && IsHeapPhysicalAddressForFinalize(cur_entry.phys_addr)) {
+            mm.Close(cur_entry.phys_addr, cur_entry.block_size / PageSize);
+        }
+    }
+
+    R_SUCCEED();
+}
+
 void KPageTableBase::Finalize() {
+    this->FinalizeProcess();
+
     auto HostUnmapCallback = [&](KProcessAddress addr, u64 size) {
-        if (Settings::IsFastmemEnabled()) {
+        if (m_impl->fastmem_arena) {
             m_system.DeviceMemory().buffer.Unmap(GetInteger(addr), size, false);
         }
     };

--- a/src/core/hle/kernel/k_page_table_base.h
+++ b/src/core/hle/kernel/k_page_table_base.h
@@ -241,6 +241,7 @@ public:
                                 KResourceLimit* resource_limit, Core::Memory::Memory& memory,
                                 KProcessAddress aslr_space_start);
 
+    Result FinalizeProcess();
     void Finalize();
 
     bool IsKernel() const {

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -171,6 +171,12 @@ void KProcess::Finalize() {
         m_resource_limit->Close();
     }
 
+    // Clear expensive resources, as the destructor is not called for guest objects.
+    for (auto& interface : m_arm_interfaces) {
+        interface.reset();
+    }
+    m_exclusive_monitor.reset();
+
     // Perform inherited finalization.
     KSynchronizationObject::Finalize();
 }

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <functional>
+#include <list>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -116,8 +117,9 @@ public:
     /// Retrieves a shared pointer to the system resource limit instance.
     KResourceLimit* GetSystemResourceLimit();
 
-    /// Adds the given shared pointer to an internal list of active processes.
+    /// Adds/removes the given pointer to an internal list of active processes.
     void AppendNewProcess(KProcess* process);
+    void RemoveProcess(KProcess* process);
 
     /// Makes the given process the new application process.
     void MakeApplicationProcess(KProcess* process);
@@ -129,7 +131,7 @@ public:
     const KProcess* ApplicationProcess() const;
 
     /// Retrieves the list of processes.
-    const std::vector<KProcess*>& GetProcessList() const;
+    std::list<KScopedAutoObject<KProcess>> GetProcessList();
 
     /// Gets the sole instance of the global scheduler
     Kernel::GlobalSchedulerContext& GlobalSchedulerContext();

--- a/src/core/hle/kernel/svc/svc_process.cpp
+++ b/src/core/hle/kernel/svc/svc_process.cpp
@@ -74,13 +74,15 @@ Result GetProcessList(Core::System& system, s32* out_num_processes, u64 out_proc
     }
 
     auto& memory = GetCurrentMemory(kernel);
-    const auto& process_list = kernel.GetProcessList();
+    auto process_list = kernel.GetProcessList();
+    auto it = process_list.begin();
+
     const auto num_processes = process_list.size();
     const auto copy_amount =
         std::min(static_cast<std::size_t>(out_process_ids_size), num_processes);
 
-    for (std::size_t i = 0; i < copy_amount; ++i) {
-        memory.Write64(out_process_ids, process_list[i]->GetProcessId());
+    for (std::size_t i = 0; i < copy_amount && it != process_list.end(); ++i, ++it) {
+        memory.Write64(out_process_ids, (*it)->GetProcessId());
         out_process_ids += sizeof(u64);
     }
 

--- a/src/core/hle/service/glue/arp.cpp
+++ b/src/core/hle/service/glue/arp.cpp
@@ -15,9 +15,10 @@
 namespace Service::Glue {
 
 namespace {
-std::optional<u64> GetTitleIDForProcessID(const Core::System& system, u64 process_id) {
-    const auto& list = system.Kernel().GetProcessList();
-    const auto iter = std::find_if(list.begin(), list.end(), [&process_id](const auto& process) {
+std::optional<u64> GetTitleIDForProcessID(Core::System& system, u64 process_id) {
+    auto list = system.Kernel().GetProcessList();
+
+    const auto iter = std::find_if(list.begin(), list.end(), [&process_id](auto& process) {
         return process->GetProcessId() == process_id;
     });
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -22,12 +22,10 @@ void LoopProcess(Core::System& system) {
     std::shared_ptr<HidFirmwareSettings> firmware_settings =
         std::make_shared<HidFirmwareSettings>();
 
-    // TODO: Remove this hack until this service is emulated properly.
-    const auto process_list = system.Kernel().GetProcessList();
-    if (!process_list.empty()) {
-        resource_manager->Initialize();
-        resource_manager->RegisterAppletResourceUserId(process_list[0]->GetId(), true);
-    }
+    // TODO: Remove this hack when am is emulated properly.
+    resource_manager->Initialize();
+    resource_manager->RegisterAppletResourceUserId(system.ApplicationProcess()->GetProcessId(),
+                                                   true);
 
     server_manager->RegisterNamedService(
         "hid", std::make_shared<IHidServer>(system, resource_manager, firmware_settings));


### PR DESCRIPTION
Blinkhawk informed me that KProcess was leaking some memory on shutdown, so I had a quick look. Slab heap objects don't have their destructors called, so the destruction of the unique_ptrs was not occurring and leaking the ARM interface pointers and exclusive monitor, as well as leaking all of the allocated heap pages (though these would normally have been reset after the slab heap was cleared, so it wasn't a huge deal).

Additionally, I found and fixed a bunch of lifetime management surrounding holding references to the process object. It's unlikely that these would have ever resulted in a crash, but better to refactor to handle this correctly.