### PR TITLE
 ci: make verify format workflow output more helpful 

### DIFF
--- a/.ci/scripts/format/script.sh
+++ b/.ci/scripts/format/script.sh
@@ -3,38 +3,33 @@
 # SPDX-FileCopyrightText: 2019 yuzu Emulator Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-if grep -nrI '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .ci* dist/*.desktop \
+shopt -s nullglob globstar
+
+if grep -nrI '\s$' src **/*.yml **/*.txt **/*.md Doxyfile .gitignore .gitmodules .ci* dist/*.desktop \
                  dist/*.svg dist/*.xml; then
     echo Trailing whitespace found, aborting
     exit 1
 fi
 
 # Default clang-format points to default 3.5 version one
-CLANG_FORMAT=${CLANG_FORMAT:-clang-format-15}
-$CLANG_FORMAT --version
-
-if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
-    # Get list of every file modified in this pull request
-    files_to_lint="$(git diff --name-only --diff-filter=ACMRTUXB $TRAVIS_COMMIT_RANGE | grep '^src/[^.]*[.]\(cpp\|h\)$' || true)"
-else
-    # Check everything for branch pushes
-    files_to_lint="$(find src/ -name '*.cpp' -or -name '*.h')"
-fi
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format-15}"
+"$CLANG_FORMAT" --version
 
 # Turn off tracing for this because it's too verbose
 set +x
 
-for f in $files_to_lint; do
-    d=$(diff -u "$f" <($CLANG_FORMAT "$f") || true)
-    if ! [ -z "$d" ]; then
-        echo "!!! $f not compliant to coding style, here is the fix:"
-        echo "$d"
-        fail=1
-    fi
+# Check everything for branch pushes
+FILES_TO_LINT="$(find src/ -name '*.cpp' -or -name '*.h')"
+
+for f in $FILES_TO_LINT; do
+    echo "$f"
+    "$CLANG_FORMAT" -i "$f"
 done
 
-set -x
+DIFF=$(git diff)
 
-if [ "$fail" = 1 ]; then
+if [ ! -z "$DIFF" ]; then
+    echo "!!! Not compliant to coding style, here is the fix:"
+    echo "$DIFF"
     exit 1
 fi

--- a/.ci/scripts/linux/exec.sh
+++ b/.ci/scripts/linux/exec.sh
@@ -9,7 +9,7 @@ chmod a+x ./.ci/scripts/linux/docker.sh
 sudo chown -R 1027 ./
 
 # The environment variables listed below:
-# AZURECIREPO TITLEBARFORMATIDLE TITLEBARFORMATRUNNING DISPLAYVERSION 
+# AZURECIREPO TITLEBARFORMATIDLE TITLEBARFORMATRUNNING DISPLAYVERSION
 #  are requested in src/common/CMakeLists.txt and appear to be provided somewhere in Azure DevOps
 
 docker run -e AZURECIREPO -e TITLEBARFORMATIDLE -e TITLEBARFORMATRUNNING -e DISPLAYVERSION -e ENABLE_COMPATIBILITY_REPORTING -e CCACHE_DIR=/yuzu/ccache -v "$(pwd):/yuzu" -w /yuzu yuzuemu/build-environments:linux-fresh /bin/bash /yuzu/.ci/scripts/linux/docker.sh "$1"

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <year> <owner> 
+Copyright (c) <year> <owner>
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <year> <owner>. 
+Copyright (c) <year> <owner>.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -35,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/externals/ffmpeg/CMakeLists.txt
+++ b/externals/ffmpeg/CMakeLists.txt
@@ -138,7 +138,7 @@ if (NOT WIN32 AND NOT ANDROID)
             --cross-prefix=${TOOLCHAIN}/bin/aarch64-linux-android-
             --sysroot=${SYSROOT}
             --target-os=android
-            --extra-ldflags="--ld-path=${TOOLCHAIN}/bin/ld.lld" 
+            --extra-ldflags="--ld-path=${TOOLCHAIN}/bin/ld.lld"
             --extra-ldflags="-nostdlib"
         )
     endif()


### PR DESCRIPTION
Currently there are some problems with this workflow:
- The grep command that is intended to find trailing whitespace doesn't actually work, because it doesn't use recursive globs.
- TRAVIS_EVENT_TYPE isn't supported by GitHub, and even if we check for GITHUB_EVENT_TYPE instead, we would need to do a non-shallow clone to verify format over the file range, which we don't really care about. So we should always check every source file.
- The format output doesn't lend itself easy use with `git apply`, requiring manually fixing up the generated diffs in order to apply.

This fixes all of these issues.