### PR TITLE
shader_recompiler: emulate 8-bit and 16-bit storage writes with cas loop

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -325,6 +325,8 @@ public:
     Id f32x2_min_cas{};
     Id f32x2_max_cas{};
 
+    Id write_storage_cas_loop_func{};
+
     Id load_global_func_u32{};
     Id load_global_func_u32x2{};
     Id load_global_func_u32x4{};
@@ -372,6 +374,7 @@ private:
     void DefineTextures(const Info& info, u32& binding, u32& scaling_index);
     void DefineImages(const Info& info, u32& binding, u32& scaling_index);
     void DefineAttributeMemAccess(const Info& info);
+    void DefineWriteStorageCasLoopFunction(const Info& info);
     void DefineGlobalMemoryFunctions(const Info& info);
     void DefineRescalingInput(const Info& info);
     void DefineRescalingInputPushConstant();


### PR DESCRIPTION
Fixes one of the issues in #12643, there is still at least one more shader compiler crash regarding missing support for StorageImageExtendedFormats
Probably fixes a bunch of shader compiler crashes in other games. The emitted shader was basically not parseable at all before this fix, and I had to view it in a hex editor to figure out the issue.