### PR TITLE
ci: fix file mode check in format script

### DIFF
--- a/.ci/scripts/format/script.sh
+++ b/.ci/scripts/format/script.sh
@@ -25,7 +25,7 @@ for f in $FILES_TO_LINT; do
     "$CLANG_FORMAT" -i "$f"
 done
 
-DIFF=$(git diff)
+DIFF=$(git -c core.fileMode=false diff)
 
 if [ ! -z "$DIFF" ]; then
     echo "!!! Not compliant to coding style, here is the fix:"


### PR DESCRIPTION
Mainline stage 1 job sets the bash files in .ci/scripts to executable on demand, so ignore those file mode changes. Might be better to just make them executable in the repo.