### PR TITLE
video_core: simplify accelerated surface fetch and crop handling between APIs

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(video_core STATIC
     engines/maxwell_dma.h
     engines/puller.cpp
     engines/puller.h
+    framebuffer_config.cpp
     framebuffer_config.h
     fsr.cpp
     fsr.h

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -117,6 +117,8 @@ add_library(video_core STATIC
     renderer_null/renderer_null.h
     renderer_opengl/blit_image.cpp
     renderer_opengl/blit_image.h
+    renderer_opengl/gl_blit_screen.cpp
+    renderer_opengl/gl_blit_screen.h
     renderer_opengl/gl_buffer_cache_base.cpp
     renderer_opengl/gl_buffer_cache.cpp
     renderer_opengl/gl_buffer_cache.h

--- a/src/video_core/framebuffer_config.cpp
+++ b/src/video_core/framebuffer_config.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright 2024 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/assert.h"
+#include "video_core/framebuffer_config.h"
+
+namespace Tegra {
+
+Common::Rectangle<f32> NormalizeCrop(const FramebufferConfig& framebuffer, u32 texture_width,
+                                     u32 texture_height) {
+    f32 left, top, right, bottom;
+
+    if (!framebuffer.crop_rect.IsEmpty()) {
+        // If crop rectangle is not empty, apply properties from rectangle.
+        left = static_cast<f32>(framebuffer.crop_rect.left);
+        top = static_cast<f32>(framebuffer.crop_rect.top);
+        right = static_cast<f32>(framebuffer.crop_rect.right);
+        bottom = static_cast<f32>(framebuffer.crop_rect.bottom);
+    } else {
+        // Otherwise, fall back to framebuffer dimensions.
+        left = 0;
+        top = 0;
+        right = static_cast<f32>(framebuffer.width);
+        bottom = static_cast<f32>(framebuffer.height);
+    }
+
+    // Apply transformation flags.
+    auto framebuffer_transform_flags = framebuffer.transform_flags;
+
+    if (True(framebuffer_transform_flags & Service::android::BufferTransformFlags::FlipH)) {
+        // Switch left and right.
+        std::swap(left, right);
+    }
+    if (True(framebuffer_transform_flags & Service::android::BufferTransformFlags::FlipV)) {
+        // Switch top and bottom.
+        std::swap(top, bottom);
+    }
+
+    framebuffer_transform_flags &= ~Service::android::BufferTransformFlags::FlipH;
+    framebuffer_transform_flags &= ~Service::android::BufferTransformFlags::FlipV;
+    if (True(framebuffer_transform_flags)) {
+        UNIMPLEMENTED_MSG("Unsupported framebuffer_transform_flags={}",
+                          static_cast<u32>(framebuffer_transform_flags));
+    }
+
+    // Normalize coordinate space.
+    left /= static_cast<f32>(texture_width);
+    top /= static_cast<f32>(texture_height);
+    right /= static_cast<f32>(texture_width);
+    bottom /= static_cast<f32>(texture_height);
+
+    return Common::Rectangle<f32>(left, top, right, bottom);
+}
+
+} // namespace Tegra

--- a/src/video_core/framebuffer_config.h
+++ b/src/video_core/framebuffer_config.h
@@ -24,4 +24,7 @@ struct FramebufferConfig {
     Common::Rectangle<int> crop_rect;
 };
 
+Common::Rectangle<f32> NormalizeCrop(const FramebufferConfig& framebuffer, u32 texture_width,
+                                     u32 texture_height);
+
 } // namespace Tegra

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -155,12 +155,6 @@ public:
     virtual void AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
                                           std::span<const u8> memory) = 0;
 
-    /// Attempt to use a faster method to display the framebuffer to screen
-    [[nodiscard]] virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config,
-                                                 VAddr framebuffer_addr, u32 pixel_stride) {
-        return false;
-    }
-
     /// Increase/decrease the number of object in pages touching the specified region
     virtual void UpdatePagesCachedCount(VAddr addr, u64 size, int delta) {}
 

--- a/src/video_core/renderer_null/null_rasterizer.cpp
+++ b/src/video_core/renderer_null/null_rasterizer.cpp
@@ -94,10 +94,6 @@ bool RasterizerNull::AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Surfac
 }
 void RasterizerNull::AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
                                               std::span<const u8> memory) {}
-bool RasterizerNull::AccelerateDisplay(const Tegra::FramebufferConfig& config,
-                                       VAddr framebuffer_addr, u32 pixel_stride) {
-    return true;
-}
 void RasterizerNull::LoadDiskResources(u64 title_id, std::stop_token stop_loading,
                                        const VideoCore::DiskResourceLoadCallback& callback) {}
 void RasterizerNull::InitializeChannel(Tegra::Control::ChannelState& channel) {

--- a/src/video_core/renderer_null/null_rasterizer.h
+++ b/src/video_core/renderer_null/null_rasterizer.h
@@ -78,8 +78,6 @@ public:
     Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() override;
     void AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
                                   std::span<const u8> memory) override;
-    bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
-                           u32 pixel_stride) override;
     void LoadDiskResources(u64 title_id, std::stop_token stop_loading,
                            const VideoCore::DiskResourceLoadCallback& callback) override;
     void InitializeChannel(Tegra::Control::ChannelState& channel) override;

--- a/src/video_core/renderer_opengl/gl_blit_screen.cpp
+++ b/src/video_core/renderer_opengl/gl_blit_screen.cpp
@@ -1,0 +1,517 @@
+// SPDX-FileCopyrightText: Copyright 2024 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "video_core/framebuffer_config.h"
+#include "video_core/host_shaders/ffx_a_h.h"
+#include "video_core/host_shaders/ffx_fsr1_h.h"
+#include "video_core/host_shaders/full_screen_triangle_vert.h"
+#include "video_core/host_shaders/fxaa_frag.h"
+#include "video_core/host_shaders/fxaa_vert.h"
+#include "video_core/host_shaders/opengl_fidelityfx_fsr_easu_frag.h"
+#include "video_core/host_shaders/opengl_fidelityfx_fsr_frag.h"
+#include "video_core/host_shaders/opengl_fidelityfx_fsr_rcas_frag.h"
+#include "video_core/host_shaders/opengl_present_frag.h"
+#include "video_core/host_shaders/opengl_present_scaleforce_frag.h"
+#include "video_core/host_shaders/opengl_present_vert.h"
+#include "video_core/host_shaders/opengl_smaa_glsl.h"
+#include "video_core/host_shaders/present_bicubic_frag.h"
+#include "video_core/host_shaders/present_gaussian_frag.h"
+#include "video_core/host_shaders/smaa_blending_weight_calculation_frag.h"
+#include "video_core/host_shaders/smaa_blending_weight_calculation_vert.h"
+#include "video_core/host_shaders/smaa_edge_detection_frag.h"
+#include "video_core/host_shaders/smaa_edge_detection_vert.h"
+#include "video_core/host_shaders/smaa_neighborhood_blending_frag.h"
+#include "video_core/host_shaders/smaa_neighborhood_blending_vert.h"
+#include "video_core/renderer_opengl/gl_blit_screen.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
+#include "video_core/renderer_opengl/gl_shader_manager.h"
+#include "video_core/renderer_opengl/gl_shader_util.h"
+#include "video_core/renderer_opengl/gl_state_tracker.h"
+#include "video_core/smaa_area_tex.h"
+#include "video_core/smaa_search_tex.h"
+#include "video_core/textures/decoders.h"
+
+namespace OpenGL {
+
+namespace {
+constexpr GLint PositionLocation = 0;
+constexpr GLint TexCoordLocation = 1;
+constexpr GLint ModelViewMatrixLocation = 0;
+
+struct ScreenRectVertex {
+    constexpr ScreenRectVertex(u32 x, u32 y, GLfloat u, GLfloat v)
+        : position{{static_cast<GLfloat>(x), static_cast<GLfloat>(y)}}, tex_coord{{u, v}} {}
+
+    std::array<GLfloat, 2> position;
+    std::array<GLfloat, 2> tex_coord;
+};
+
+/**
+ * Defines a 1:1 pixel ortographic projection matrix with (0,0) on the top-left
+ * corner and (width, height) on the lower-bottom.
+ *
+ * The projection part of the matrix is trivial, hence these operations are represented
+ * by a 3x2 matrix.
+ */
+std::array<GLfloat, 3 * 2> MakeOrthographicMatrix(float width, float height) {
+    std::array<GLfloat, 3 * 2> matrix; // Laid out in column-major order
+
+    // clang-format off
+    matrix[0] = 2.f / width; matrix[2] =  0.f;          matrix[4] = -1.f;
+    matrix[1] = 0.f;         matrix[3] = -2.f / height; matrix[5] =  1.f;
+    // Last matrix row is implicitly assumed to be [0, 0, 1].
+    // clang-format on
+
+    return matrix;
+}
+} // namespace
+
+BlitScreen::BlitScreen(RasterizerOpenGL& rasterizer_, Core::Memory::Memory& cpu_memory_,
+                       StateTracker& state_tracker_, ProgramManager& program_manager_,
+                       Device& device_)
+    : rasterizer(rasterizer_), cpu_memory(cpu_memory_), state_tracker(state_tracker_),
+      program_manager(program_manager_), device(device_) {
+    // Create shader programs
+    fxaa_vertex = CreateProgram(HostShaders::FXAA_VERT, GL_VERTEX_SHADER);
+    fxaa_fragment = CreateProgram(HostShaders::FXAA_FRAG, GL_FRAGMENT_SHADER);
+
+    const auto replace_include = [](std::string& shader_source, std::string_view include_name,
+                                    std::string_view include_content) {
+        const std::string include_string = fmt::format("#include \"{}\"", include_name);
+        const std::size_t pos = shader_source.find(include_string);
+        ASSERT(pos != std::string::npos);
+        shader_source.replace(pos, include_string.size(), include_content);
+    };
+
+    const auto SmaaShader = [&](std::string_view specialized_source, GLenum stage) {
+        std::string shader_source{specialized_source};
+        replace_include(shader_source, "opengl_smaa.glsl", HostShaders::OPENGL_SMAA_GLSL);
+        return CreateProgram(shader_source, stage);
+    };
+
+    smaa_edge_detection_vert = SmaaShader(HostShaders::SMAA_EDGE_DETECTION_VERT, GL_VERTEX_SHADER);
+    smaa_edge_detection_frag =
+        SmaaShader(HostShaders::SMAA_EDGE_DETECTION_FRAG, GL_FRAGMENT_SHADER);
+    smaa_blending_weight_calculation_vert =
+        SmaaShader(HostShaders::SMAA_BLENDING_WEIGHT_CALCULATION_VERT, GL_VERTEX_SHADER);
+    smaa_blending_weight_calculation_frag =
+        SmaaShader(HostShaders::SMAA_BLENDING_WEIGHT_CALCULATION_FRAG, GL_FRAGMENT_SHADER);
+    smaa_neighborhood_blending_vert =
+        SmaaShader(HostShaders::SMAA_NEIGHBORHOOD_BLENDING_VERT, GL_VERTEX_SHADER);
+    smaa_neighborhood_blending_frag =
+        SmaaShader(HostShaders::SMAA_NEIGHBORHOOD_BLENDING_FRAG, GL_FRAGMENT_SHADER);
+
+    present_vertex = CreateProgram(HostShaders::OPENGL_PRESENT_VERT, GL_VERTEX_SHADER);
+    present_bilinear_fragment = CreateProgram(HostShaders::OPENGL_PRESENT_FRAG, GL_FRAGMENT_SHADER);
+    present_bicubic_fragment = CreateProgram(HostShaders::PRESENT_BICUBIC_FRAG, GL_FRAGMENT_SHADER);
+    present_gaussian_fragment =
+        CreateProgram(HostShaders::PRESENT_GAUSSIAN_FRAG, GL_FRAGMENT_SHADER);
+    present_scaleforce_fragment =
+        CreateProgram(fmt::format("#version 460\n{}", HostShaders::OPENGL_PRESENT_SCALEFORCE_FRAG),
+                      GL_FRAGMENT_SHADER);
+
+    std::string fsr_source{HostShaders::OPENGL_FIDELITYFX_FSR_FRAG};
+    replace_include(fsr_source, "ffx_a.h", HostShaders::FFX_A_H);
+    replace_include(fsr_source, "ffx_fsr1.h", HostShaders::FFX_FSR1_H);
+
+    std::string fsr_easu_frag_source{HostShaders::OPENGL_FIDELITYFX_FSR_EASU_FRAG};
+    std::string fsr_rcas_frag_source{HostShaders::OPENGL_FIDELITYFX_FSR_RCAS_FRAG};
+    replace_include(fsr_easu_frag_source, "opengl_fidelityfx_fsr.frag", fsr_source);
+    replace_include(fsr_rcas_frag_source, "opengl_fidelityfx_fsr.frag", fsr_source);
+
+    fsr = std::make_unique<FSR>(HostShaders::FULL_SCREEN_TRIANGLE_VERT, fsr_easu_frag_source,
+                                fsr_rcas_frag_source);
+
+    // Generate presentation sampler
+    present_sampler.Create();
+    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+
+    present_sampler_nn.Create();
+    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+
+    // Generate VBO handle for drawing
+    vertex_buffer.Create();
+
+    // Attach vertex data to VAO
+    glNamedBufferData(vertex_buffer.handle, sizeof(ScreenRectVertex) * 4, nullptr, GL_STREAM_DRAW);
+
+    // Allocate textures for the screen
+    framebuffer_texture.resource.Create(GL_TEXTURE_2D);
+
+    const GLuint texture = framebuffer_texture.resource.handle;
+    glTextureStorage2D(texture, 1, GL_RGBA8, 1, 1);
+
+    // Clear screen to black
+    const u8 framebuffer_data[4] = {0, 0, 0, 0};
+    glClearTexImage(framebuffer_texture.resource.handle, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                    framebuffer_data);
+
+    aa_framebuffer.Create();
+
+    smaa_area_tex.Create(GL_TEXTURE_2D);
+    glTextureStorage2D(smaa_area_tex.handle, 1, GL_RG8, AREATEX_WIDTH, AREATEX_HEIGHT);
+    glTextureSubImage2D(smaa_area_tex.handle, 0, 0, 0, AREATEX_WIDTH, AREATEX_HEIGHT, GL_RG,
+                        GL_UNSIGNED_BYTE, areaTexBytes);
+    smaa_search_tex.Create(GL_TEXTURE_2D);
+    glTextureStorage2D(smaa_search_tex.handle, 1, GL_R8, SEARCHTEX_WIDTH, SEARCHTEX_HEIGHT);
+    glTextureSubImage2D(smaa_search_tex.handle, 0, 0, 0, SEARCHTEX_WIDTH, SEARCHTEX_HEIGHT, GL_RED,
+                        GL_UNSIGNED_BYTE, searchTexBytes);
+
+    // Enable unified vertex attributes and query vertex buffer address when the driver supports it
+    if (device.HasVertexBufferUnifiedMemory()) {
+        glEnableClientState(GL_VERTEX_ATTRIB_ARRAY_UNIFIED_NV);
+        glEnableClientState(GL_ELEMENT_ARRAY_UNIFIED_NV);
+        glMakeNamedBufferResidentNV(vertex_buffer.handle, GL_READ_ONLY);
+        glGetNamedBufferParameterui64vNV(vertex_buffer.handle, GL_BUFFER_GPU_ADDRESS_NV,
+                                         &vertex_buffer_address);
+    }
+}
+
+FramebufferTextureInfo BlitScreen::PrepareRenderTarget(
+    const Tegra::FramebufferConfig& framebuffer) {
+    // If framebuffer is provided, reload it from memory to a texture
+    if (framebuffer_texture.width != static_cast<GLsizei>(framebuffer.width) ||
+        framebuffer_texture.height != static_cast<GLsizei>(framebuffer.height) ||
+        framebuffer_texture.pixel_format != framebuffer.pixel_format ||
+        gl_framebuffer_data.empty()) {
+        // Reallocate texture if the framebuffer size has changed.
+        // This is expected to not happen very often and hence should not be a
+        // performance problem.
+        ConfigureFramebufferTexture(framebuffer);
+    }
+
+    // Load the framebuffer from memory if needed
+    return LoadFBToScreenInfo(framebuffer);
+}
+
+FramebufferTextureInfo BlitScreen::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer) {
+    const VAddr framebuffer_addr{framebuffer.address + framebuffer.offset};
+    const auto accelerated_info =
+        rasterizer.AccelerateDisplay(framebuffer, framebuffer_addr, framebuffer.stride);
+    if (accelerated_info) {
+        return *accelerated_info;
+    }
+
+    // Reset the screen info's display texture to its own permanent texture
+    FramebufferTextureInfo info{};
+    info.display_texture = framebuffer_texture.resource.handle;
+    info.width = framebuffer.width;
+    info.height = framebuffer.height;
+
+    // TODO(Rodrigo): Read this from HLE
+    constexpr u32 block_height_log2 = 4;
+    const auto pixel_format{
+        VideoCore::Surface::PixelFormatFromGPUPixelFormat(framebuffer.pixel_format)};
+    const u32 bytes_per_pixel{VideoCore::Surface::BytesPerBlock(pixel_format)};
+    const u64 size_in_bytes{Tegra::Texture::CalculateSize(
+        true, bytes_per_pixel, framebuffer.stride, framebuffer.height, 1, block_height_log2, 0)};
+    const u8* const host_ptr{cpu_memory.GetPointer(framebuffer_addr)};
+    const std::span<const u8> input_data(host_ptr, size_in_bytes);
+    Tegra::Texture::UnswizzleTexture(gl_framebuffer_data, input_data, bytes_per_pixel,
+                                     framebuffer.width, framebuffer.height, 1, block_height_log2,
+                                     0);
+
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<GLint>(framebuffer.stride));
+
+    // Update existing texture
+    // TODO: Test what happens on hardware when you change the framebuffer dimensions so that
+    //       they differ from the LCD resolution.
+    // TODO: Applications could theoretically crash yuzu here by specifying too large
+    //       framebuffer sizes. We should make sure that this cannot happen.
+    glTextureSubImage2D(framebuffer_texture.resource.handle, 0, 0, 0, framebuffer.width,
+                        framebuffer.height, framebuffer_texture.gl_format,
+                        framebuffer_texture.gl_type, gl_framebuffer_data.data());
+
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+    return info;
+}
+
+void BlitScreen::ConfigureFramebufferTexture(const Tegra::FramebufferConfig& framebuffer) {
+    framebuffer_texture.width = framebuffer.width;
+    framebuffer_texture.height = framebuffer.height;
+    framebuffer_texture.pixel_format = framebuffer.pixel_format;
+
+    const auto pixel_format{
+        VideoCore::Surface::PixelFormatFromGPUPixelFormat(framebuffer.pixel_format)};
+    const u32 bytes_per_pixel{VideoCore::Surface::BytesPerBlock(pixel_format)};
+    gl_framebuffer_data.resize(framebuffer_texture.width * framebuffer_texture.height *
+                               bytes_per_pixel);
+
+    GLint internal_format;
+    switch (framebuffer.pixel_format) {
+    case Service::android::PixelFormat::Rgba8888:
+        internal_format = GL_RGBA8;
+        framebuffer_texture.gl_format = GL_RGBA;
+        framebuffer_texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
+        break;
+    case Service::android::PixelFormat::Rgb565:
+        internal_format = GL_RGB565;
+        framebuffer_texture.gl_format = GL_RGB;
+        framebuffer_texture.gl_type = GL_UNSIGNED_SHORT_5_6_5;
+        break;
+    default:
+        internal_format = GL_RGBA8;
+        framebuffer_texture.gl_format = GL_RGBA;
+        framebuffer_texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
+        // UNIMPLEMENTED_MSG("Unknown framebuffer pixel format: {}",
+        //                   static_cast<u32>(framebuffer.pixel_format));
+        break;
+    }
+
+    framebuffer_texture.resource.Release();
+    framebuffer_texture.resource.Create(GL_TEXTURE_2D);
+    glTextureStorage2D(framebuffer_texture.resource.handle, 1, internal_format,
+                       framebuffer_texture.width, framebuffer_texture.height);
+    aa_texture.Release();
+    aa_texture.Create(GL_TEXTURE_2D);
+    glTextureStorage2D(aa_texture.handle, 1, GL_RGBA16F,
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
+    glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0, aa_texture.handle, 0);
+    smaa_edges_tex.Release();
+    smaa_edges_tex.Create(GL_TEXTURE_2D);
+    glTextureStorage2D(smaa_edges_tex.handle, 1, GL_RG16F,
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
+    smaa_blend_tex.Release();
+    smaa_blend_tex.Create(GL_TEXTURE_2D);
+    glTextureStorage2D(smaa_blend_tex.handle, 1, GL_RGBA16F,
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
+}
+
+void BlitScreen::DrawScreen(const Tegra::FramebufferConfig& framebuffer,
+                            const Layout::FramebufferLayout& layout) {
+    FramebufferTextureInfo info = PrepareRenderTarget(framebuffer);
+    const auto crop = Tegra::NormalizeCrop(framebuffer, info.width, info.height);
+
+    // TODO: Signal state tracker about these changes
+    state_tracker.NotifyScreenDrawVertexArray();
+    state_tracker.NotifyPolygonModes();
+    state_tracker.NotifyViewport0();
+    state_tracker.NotifyScissor0();
+    state_tracker.NotifyColorMask(0);
+    state_tracker.NotifyBlend0();
+    state_tracker.NotifyFramebuffer();
+    state_tracker.NotifyFrontFace();
+    state_tracker.NotifyCullTest();
+    state_tracker.NotifyDepthTest();
+    state_tracker.NotifyStencilTest();
+    state_tracker.NotifyPolygonOffset();
+    state_tracker.NotifyRasterizeEnable();
+    state_tracker.NotifyFramebufferSRGB();
+    state_tracker.NotifyLogicOp();
+    state_tracker.NotifyClipControl();
+    state_tracker.NotifyAlphaTest();
+
+    state_tracker.ClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
+
+    glEnable(GL_CULL_FACE);
+    glDisable(GL_COLOR_LOGIC_OP);
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_STENCIL_TEST);
+    glDisable(GL_POLYGON_OFFSET_FILL);
+    glDisable(GL_RASTERIZER_DISCARD);
+    glDisable(GL_ALPHA_TEST);
+    glDisablei(GL_BLEND, 0);
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    glCullFace(GL_BACK);
+    glFrontFace(GL_CW);
+    glColorMaski(0, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glDepthRangeIndexed(0, 0.0, 0.0);
+
+    glBindTextureUnit(0, info.display_texture);
+
+    auto anti_aliasing = Settings::values.anti_aliasing.GetValue();
+    if (anti_aliasing >= Settings::AntiAliasing::MaxEnum) {
+        LOG_ERROR(Render_OpenGL, "Invalid antialiasing option selected {}", anti_aliasing);
+        anti_aliasing = Settings::AntiAliasing::None;
+        Settings::values.anti_aliasing.SetValue(anti_aliasing);
+    }
+
+    if (anti_aliasing != Settings::AntiAliasing::None) {
+        glEnablei(GL_SCISSOR_TEST, 0);
+        auto viewport_width = Settings::values.resolution_info.ScaleUp(framebuffer.width);
+        auto viewport_height = Settings::values.resolution_info.ScaleUp(framebuffer.height);
+
+        glScissorIndexed(0, 0, 0, viewport_width, viewport_height);
+        glViewportIndexedf(0, 0.0f, 0.0f, static_cast<GLfloat>(viewport_width),
+                           static_cast<GLfloat>(viewport_height));
+
+        glBindSampler(0, present_sampler.handle);
+        GLint old_read_fb;
+        GLint old_draw_fb;
+        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &old_read_fb);
+        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &old_draw_fb);
+
+        switch (anti_aliasing) {
+        case Settings::AntiAliasing::Fxaa: {
+            program_manager.BindPresentPrograms(fxaa_vertex.handle, fxaa_fragment.handle);
+            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, aa_framebuffer.handle);
+            glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+        } break;
+        case Settings::AntiAliasing::Smaa: {
+            glClearColor(0, 0, 0, 0);
+            glFrontFace(GL_CCW);
+            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, aa_framebuffer.handle);
+            glBindSampler(1, present_sampler.handle);
+            glBindSampler(2, present_sampler.handle);
+
+            glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0,
+                                      smaa_edges_tex.handle, 0);
+            glClear(GL_COLOR_BUFFER_BIT);
+            program_manager.BindPresentPrograms(smaa_edge_detection_vert.handle,
+                                                smaa_edge_detection_frag.handle);
+            glDrawArrays(GL_TRIANGLES, 0, 3);
+
+            glBindTextureUnit(0, smaa_edges_tex.handle);
+            glBindTextureUnit(1, smaa_area_tex.handle);
+            glBindTextureUnit(2, smaa_search_tex.handle);
+            glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0,
+                                      smaa_blend_tex.handle, 0);
+            glClear(GL_COLOR_BUFFER_BIT);
+            program_manager.BindPresentPrograms(smaa_blending_weight_calculation_vert.handle,
+                                                smaa_blending_weight_calculation_frag.handle);
+            glDrawArrays(GL_TRIANGLES, 0, 3);
+
+            glBindTextureUnit(0, info.display_texture);
+            glBindTextureUnit(1, smaa_blend_tex.handle);
+            glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0,
+                                      aa_texture.handle, 0);
+            program_manager.BindPresentPrograms(smaa_neighborhood_blending_vert.handle,
+                                                smaa_neighborhood_blending_frag.handle);
+            glDrawArrays(GL_TRIANGLES, 0, 3);
+            glFrontFace(GL_CW);
+        } break;
+        default:
+            UNREACHABLE();
+        }
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, old_read_fb);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, old_draw_fb);
+
+        glBindTextureUnit(0, aa_texture.handle);
+    }
+    glDisablei(GL_SCISSOR_TEST, 0);
+
+    if (Settings::values.scaling_filter.GetValue() == Settings::ScalingFilter::Fsr) {
+        if (!fsr->AreBuffersInitialized()) {
+            fsr->InitBuffers();
+        }
+
+        const auto fsr_input_width = Settings::values.resolution_info.ScaleUp(info.width);
+        const auto fsr_input_height = Settings::values.resolution_info.ScaleUp(info.height);
+        glBindSampler(0, present_sampler.handle);
+        fsr->Draw(program_manager, layout.screen, fsr_input_width, fsr_input_height, crop);
+    } else {
+        if (fsr->AreBuffersInitialized()) {
+            fsr->ReleaseBuffers();
+        }
+    }
+
+    const std::array ortho_matrix =
+        MakeOrthographicMatrix(static_cast<float>(layout.width), static_cast<float>(layout.height));
+
+    const auto fragment_handle = [this]() {
+        switch (Settings::values.scaling_filter.GetValue()) {
+        case Settings::ScalingFilter::NearestNeighbor:
+        case Settings::ScalingFilter::Bilinear:
+            return present_bilinear_fragment.handle;
+        case Settings::ScalingFilter::Bicubic:
+            return present_bicubic_fragment.handle;
+        case Settings::ScalingFilter::Gaussian:
+            return present_gaussian_fragment.handle;
+        case Settings::ScalingFilter::ScaleForce:
+            return present_scaleforce_fragment.handle;
+        case Settings::ScalingFilter::Fsr:
+            return fsr->GetPresentFragmentProgram().handle;
+        default:
+            return present_bilinear_fragment.handle;
+        }
+    }();
+    program_manager.BindPresentPrograms(present_vertex.handle, fragment_handle);
+    glProgramUniformMatrix3x2fv(present_vertex.handle, ModelViewMatrixLocation, 1, GL_FALSE,
+                                ortho_matrix.data());
+
+    f32 left, top, right, bottom;
+    if (Settings::values.scaling_filter.GetValue() == Settings::ScalingFilter::Fsr) {
+        // FSR has already applied the crop, so we just want to render the image
+        // it has produced.
+        left = 0;
+        top = 0;
+        right = 1;
+        bottom = 1;
+    } else {
+        // Apply the precomputed crop.
+        left = crop.left;
+        top = crop.top;
+        right = crop.right;
+        bottom = crop.bottom;
+    }
+
+    // Map the coordinates to the screen.
+    const auto& screen = layout.screen;
+    const auto x = screen.left;
+    const auto y = screen.top;
+    const auto w = screen.GetWidth();
+    const auto h = screen.GetHeight();
+
+    const std::array vertices = {
+        ScreenRectVertex(x, y, left, top),
+        ScreenRectVertex(x + w, y, right, top),
+        ScreenRectVertex(x, y + h, left, bottom),
+        ScreenRectVertex(x + w, y + h, right, bottom),
+    };
+    glNamedBufferSubData(vertex_buffer.handle, 0, sizeof(vertices), std::data(vertices));
+
+    glDisable(GL_FRAMEBUFFER_SRGB);
+    glViewportIndexedf(0, 0.0f, 0.0f, static_cast<GLfloat>(layout.width),
+                       static_cast<GLfloat>(layout.height));
+
+    glEnableVertexAttribArray(PositionLocation);
+    glEnableVertexAttribArray(TexCoordLocation);
+    glVertexAttribDivisor(PositionLocation, 0);
+    glVertexAttribDivisor(TexCoordLocation, 0);
+    glVertexAttribFormat(PositionLocation, 2, GL_FLOAT, GL_FALSE,
+                         offsetof(ScreenRectVertex, position));
+    glVertexAttribFormat(TexCoordLocation, 2, GL_FLOAT, GL_FALSE,
+                         offsetof(ScreenRectVertex, tex_coord));
+    glVertexAttribBinding(PositionLocation, 0);
+    glVertexAttribBinding(TexCoordLocation, 0);
+    if (device.HasVertexBufferUnifiedMemory()) {
+        glBindVertexBuffer(0, 0, 0, sizeof(ScreenRectVertex));
+        glBufferAddressRangeNV(GL_VERTEX_ATTRIB_ARRAY_ADDRESS_NV, 0, vertex_buffer_address,
+                               sizeof(vertices));
+    } else {
+        glBindVertexBuffer(0, vertex_buffer.handle, 0, sizeof(ScreenRectVertex));
+    }
+
+    if (Settings::values.scaling_filter.GetValue() != Settings::ScalingFilter::NearestNeighbor) {
+        glBindSampler(0, present_sampler.handle);
+    } else {
+        glBindSampler(0, present_sampler_nn.handle);
+    }
+
+    // Update background color before drawing
+    glClearColor(Settings::values.bg_red.GetValue() / 255.0f,
+                 Settings::values.bg_green.GetValue() / 255.0f,
+                 Settings::values.bg_blue.GetValue() / 255.0f, 1.0f);
+
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    // TODO
+    // program_manager.RestoreGuestPipeline();
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_blit_screen.h
+++ b/src/video_core/renderer_opengl/gl_blit_screen.h
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright 2024 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "core/hle/service/nvnflinger/pixel_format.h"
+#include "video_core/renderer_opengl/gl_fsr.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+
+namespace Core::Memory {
+class Memory;
+}
+
+namespace Layout {
+struct FramebufferLayout;
+}
+
+namespace Tegra {
+struct FramebufferConfig;
+}
+
+namespace OpenGL {
+
+class Device;
+class RasterizerOpenGL;
+class StateTracker;
+
+/// Structure used for storing information about the textures for the Switch screen
+struct TextureInfo {
+    OGLTexture resource;
+    GLsizei width;
+    GLsizei height;
+    GLenum gl_format;
+    GLenum gl_type;
+    Service::android::PixelFormat pixel_format;
+};
+
+/// Structure used for storing information about the display target for the Switch screen
+struct FramebufferTextureInfo {
+    GLuint display_texture{};
+    u32 width;
+    u32 height;
+};
+
+class BlitScreen {
+public:
+    explicit BlitScreen(RasterizerOpenGL& rasterizer, Core::Memory::Memory& cpu_memory,
+                        StateTracker& state_tracker, ProgramManager& program_manager,
+                        Device& device);
+
+    void ConfigureFramebufferTexture(const Tegra::FramebufferConfig& framebuffer);
+
+    /// Draws the emulated screens to the emulator window.
+    void DrawScreen(const Tegra::FramebufferConfig& framebuffer,
+                    const Layout::FramebufferLayout& layout);
+
+    void RenderScreenshot(const Tegra::FramebufferConfig& framebuffer);
+
+    /// Loads framebuffer from emulated memory into the active OpenGL texture.
+    FramebufferTextureInfo LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer);
+
+    FramebufferTextureInfo PrepareRenderTarget(const Tegra::FramebufferConfig& framebuffer);
+
+private:
+    RasterizerOpenGL& rasterizer;
+    Core::Memory::Memory& cpu_memory;
+    StateTracker& state_tracker;
+    ProgramManager& program_manager;
+    Device& device;
+
+    OGLSampler present_sampler;
+    OGLSampler present_sampler_nn;
+    OGLBuffer vertex_buffer;
+    OGLProgram fxaa_vertex;
+    OGLProgram fxaa_fragment;
+    OGLProgram present_vertex;
+    OGLProgram present_bilinear_fragment;
+    OGLProgram present_bicubic_fragment;
+    OGLProgram present_gaussian_fragment;
+    OGLProgram present_scaleforce_fragment;
+
+    /// Display information for Switch screen
+    TextureInfo framebuffer_texture;
+    OGLTexture aa_texture;
+    OGLFramebuffer aa_framebuffer;
+
+    OGLProgram smaa_edge_detection_vert;
+    OGLProgram smaa_blending_weight_calculation_vert;
+    OGLProgram smaa_neighborhood_blending_vert;
+    OGLProgram smaa_edge_detection_frag;
+    OGLProgram smaa_blending_weight_calculation_frag;
+    OGLProgram smaa_neighborhood_blending_frag;
+    OGLTexture smaa_area_tex;
+    OGLTexture smaa_search_tex;
+    OGLTexture smaa_edges_tex;
+    OGLTexture smaa_blend_tex;
+
+    std::unique_ptr<FSR> fsr;
+
+    /// OpenGL framebuffer data
+    std::vector<u8> gl_framebuffer_data;
+
+    // GPU address of the vertex buffer
+    GLuint64EXT vertex_buffer_address = 0;
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_fsr.cpp
+++ b/src/video_core/renderer_opengl/gl_fsr.cpp
@@ -25,7 +25,7 @@ FSR::~FSR() = default;
 
 void FSR::Draw(ProgramManager& program_manager, const Common::Rectangle<u32>& screen,
                u32 input_image_width, u32 input_image_height,
-               const Common::Rectangle<int>& crop_rect) {
+               const Common::Rectangle<f32>& crop_rect) {
 
     const auto output_image_width = screen.GetWidth();
     const auto output_image_height = screen.GetHeight();
@@ -57,14 +57,19 @@ void FSR::Draw(ProgramManager& program_manager, const Common::Rectangle<u32>& sc
     glViewportIndexedf(0, 0.0f, 0.0f, static_cast<GLfloat>(output_image_width),
                        static_cast<GLfloat>(output_image_height));
 
-    FsrConstants constants;
-    FsrEasuConOffset(
-        constants.data() + 0, constants.data() + 4, constants.data() + 8, constants.data() + 12,
+    const f32 input_width = static_cast<f32>(input_image_width);
+    const f32 input_height = static_cast<f32>(input_image_height);
+    const f32 output_width = static_cast<f32>(screen.GetWidth());
+    const f32 output_height = static_cast<f32>(screen.GetHeight());
+    const f32 viewport_width = (crop_rect.right - crop_rect.left) * input_width;
+    const f32 viewport_x = crop_rect.left * input_width;
+    const f32 viewport_height = (crop_rect.bottom - crop_rect.top) * input_height;
+    const f32 viewport_y = crop_rect.top * input_height;
 
-        static_cast<f32>(crop_rect.GetWidth()), static_cast<f32>(crop_rect.GetHeight()),
-        static_cast<f32>(input_image_width), static_cast<f32>(input_image_height),
-        static_cast<f32>(output_image_width), static_cast<f32>(output_image_height),
-        static_cast<f32>(crop_rect.left), static_cast<f32>(crop_rect.top));
+    FsrConstants constants;
+    FsrEasuConOffset(constants.data() + 0, constants.data() + 4, constants.data() + 8,
+                     constants.data() + 12, viewport_width, viewport_height, input_width,
+                     input_height, output_width, output_height, viewport_x, viewport_y);
 
     glProgramUniform4uiv(fsr_easu_frag.handle, 0, sizeof(constants), std::data(constants));
 

--- a/src/video_core/renderer_opengl/gl_fsr.h
+++ b/src/video_core/renderer_opengl/gl_fsr.h
@@ -22,7 +22,7 @@ public:
 
     void Draw(ProgramManager& program_manager, const Common::Rectangle<u32>& screen,
               u32 input_image_width, u32 input_image_height,
-              const Common::Rectangle<int>& crop_rect);
+              const Common::Rectangle<f32>& crop_rect);
 
     void InitBuffers();
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -71,9 +71,8 @@ std::optional<VideoCore::QueryType> MaxwellToVideoCoreQuery(VideoCommon::QueryTy
 
 RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& emu_window_, Tegra::GPU& gpu_,
                                    Core::Memory::Memory& cpu_memory_, const Device& device_,
-                                   ScreenInfo& screen_info_, ProgramManager& program_manager_,
-                                   StateTracker& state_tracker_)
-    : RasterizerAccelerated(cpu_memory_), gpu(gpu_), device(device_), screen_info(screen_info_),
+                                   ProgramManager& program_manager_, StateTracker& state_tracker_)
+    : RasterizerAccelerated(cpu_memory_), gpu(gpu_), device(device_),
       program_manager(program_manager_), state_tracker(state_tracker_),
       texture_cache_runtime(device, program_manager, state_tracker, staging_buffer_pool),
       texture_cache(texture_cache_runtime, *this),
@@ -738,10 +737,10 @@ void RasterizerOpenGL::AccelerateInlineToMemory(GPUVAddr address, size_t copy_si
     query_cache.InvalidateRegion(*cpu_addr, copy_size);
 }
 
-bool RasterizerOpenGL::AccelerateDisplay(const Tegra::FramebufferConfig& config,
-                                         VAddr framebuffer_addr, u32 pixel_stride) {
+std::optional<FramebufferTextureInfo> RasterizerOpenGL::AccelerateDisplay(
+    const Tegra::FramebufferConfig& config, VAddr framebuffer_addr, u32 pixel_stride) {
     if (framebuffer_addr == 0) {
-        return false;
+        return {};
     }
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
 
@@ -749,16 +748,14 @@ bool RasterizerOpenGL::AccelerateDisplay(const Tegra::FramebufferConfig& config,
     ImageView* const image_view{
         texture_cache.TryFindFramebufferImageView(config, framebuffer_addr)};
     if (!image_view) {
-        return false;
+        return {};
     }
-    // Verify that the cached surface is the same size and format as the requested framebuffer
-    // ASSERT_MSG(image_view->size.width == config.width, "Framebuffer width is different");
-    // ASSERT_MSG(image_view->size.height == config.height, "Framebuffer height is different");
 
-    screen_info.texture.width = image_view->size.width;
-    screen_info.texture.height = image_view->size.height;
-    screen_info.display_texture = image_view->Handle(Shader::TextureType::Color2D);
-    return true;
+    FramebufferTextureInfo info{};
+    info.display_texture = image_view->Handle(Shader::TextureType::Color2D);
+    info.width = image_view->size.width;
+    info.height = image_view->size.height;
+    return info;
 }
 
 void RasterizerOpenGL::SyncState() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -17,6 +17,7 @@
 #include "video_core/rasterizer_accelerated.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/blit_image.h"
+#include "video_core/renderer_opengl/gl_blit_screen.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
 #include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_fence_manager.h"

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -38,7 +38,7 @@ class MemoryManager;
 
 namespace OpenGL {
 
-struct ScreenInfo;
+struct FramebufferTextureInfo;
 struct ShaderEntries;
 
 struct BindlessSSBO {
@@ -77,8 +77,7 @@ class RasterizerOpenGL : public VideoCore::RasterizerAccelerated,
 public:
     explicit RasterizerOpenGL(Core::Frontend::EmuWindow& emu_window_, Tegra::GPU& gpu_,
                               Core::Memory::Memory& cpu_memory_, const Device& device_,
-                              ScreenInfo& screen_info_, ProgramManager& program_manager_,
-                              StateTracker& state_tracker_);
+                              ProgramManager& program_manager_, StateTracker& state_tracker_);
     ~RasterizerOpenGL() override;
 
     void Draw(bool is_indexed, u32 instance_count) override;
@@ -123,8 +122,6 @@ public:
     Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() override;
     void AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
                                   std::span<const u8> memory) override;
-    bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
-                           u32 pixel_stride) override;
     void LoadDiskResources(u64 title_id, std::stop_token stop_loading,
                            const VideoCore::DiskResourceLoadCallback& callback) override;
 
@@ -144,6 +141,10 @@ public:
     bool HasDrawTransformFeedback() override {
         return true;
     }
+
+    std::optional<FramebufferTextureInfo> AccelerateDisplay(const Tegra::FramebufferConfig& config,
+                                                            VAddr framebuffer_addr,
+                                                            u32 pixel_stride);
 
 private:
     static constexpr size_t MAX_TEXTURES = 192;
@@ -237,7 +238,6 @@ private:
     Tegra::GPU& gpu;
 
     const Device& device;
-    ScreenInfo& screen_info;
     ProgramManager& program_manager;
     StateTracker& state_tracker;
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -149,7 +149,7 @@ RendererOpenGL::RendererOpenGL(Core::TelemetrySession& telemetry_session_,
     : RendererBase{emu_window_, std::move(context_)}, telemetry_session{telemetry_session_},
       emu_window{emu_window_}, cpu_memory{cpu_memory_}, gpu{gpu_}, device{emu_window_},
       state_tracker{}, program_manager{device},
-      rasterizer(emu_window, gpu, cpu_memory, device, screen_info, program_manager, state_tracker) {
+      rasterizer(emu_window, gpu, cpu_memory, device, program_manager, state_tracker) {
     if (Settings::values.renderer_debug && GLAD_GL_KHR_debug) {
         glEnable(GL_DEBUG_OUTPUT);
         glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
@@ -184,11 +184,11 @@ void RendererOpenGL::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
     if (!framebuffer) {
         return;
     }
-    PrepareRendertarget(framebuffer);
-    RenderScreenshot();
+
+    RenderScreenshot(*framebuffer);
 
     state_tracker.BindFramebuffer(0);
-    DrawScreen(emu_window.GetFramebufferLayout());
+    DrawScreen(*framebuffer, emu_window.GetFramebufferLayout());
 
     ++m_current_frame;
 
@@ -199,41 +199,37 @@ void RendererOpenGL::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
     render_window.OnFrameDisplayed();
 }
 
-void RendererOpenGL::PrepareRendertarget(const Tegra::FramebufferConfig* framebuffer) {
-    if (!framebuffer) {
-        return;
-    }
+FramebufferTextureInfo RendererOpenGL::PrepareRenderTarget(
+    const Tegra::FramebufferConfig& framebuffer) {
     // If framebuffer is provided, reload it from memory to a texture
-    if (screen_info.texture.width != static_cast<GLsizei>(framebuffer->width) ||
-        screen_info.texture.height != static_cast<GLsizei>(framebuffer->height) ||
-        screen_info.texture.pixel_format != framebuffer->pixel_format ||
+    if (framebuffer_texture.width != static_cast<GLsizei>(framebuffer.width) ||
+        framebuffer_texture.height != static_cast<GLsizei>(framebuffer.height) ||
+        framebuffer_texture.pixel_format != framebuffer.pixel_format ||
         gl_framebuffer_data.empty()) {
         // Reallocate texture if the framebuffer size has changed.
         // This is expected to not happen very often and hence should not be a
         // performance problem.
-        ConfigureFramebufferTexture(screen_info.texture, *framebuffer);
+        ConfigureFramebufferTexture(framebuffer);
     }
 
-    // Load the framebuffer from memory, draw it to the screen, and swap buffers
-    LoadFBToScreenInfo(*framebuffer);
+    // Load the framebuffer from memory if needed
+    return LoadFBToScreenInfo(framebuffer);
 }
 
-void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer) {
-    // Framebuffer orientation handling
-    framebuffer_transform_flags = framebuffer.transform_flags;
-    framebuffer_crop_rect = framebuffer.crop_rect;
-    framebuffer_width = framebuffer.width;
-    framebuffer_height = framebuffer.height;
-
+FramebufferTextureInfo RendererOpenGL::LoadFBToScreenInfo(
+    const Tegra::FramebufferConfig& framebuffer) {
     const VAddr framebuffer_addr{framebuffer.address + framebuffer.offset};
-    screen_info.was_accelerated =
+    const auto accelerated_info =
         rasterizer.AccelerateDisplay(framebuffer, framebuffer_addr, framebuffer.stride);
-    if (screen_info.was_accelerated) {
-        return;
+    if (accelerated_info) {
+        return *accelerated_info;
     }
 
     // Reset the screen info's display texture to its own permanent texture
-    screen_info.display_texture = screen_info.texture.resource.handle;
+    FramebufferTextureInfo info{};
+    info.display_texture = framebuffer_texture.resource.handle;
+    info.width = framebuffer.width;
+    info.height = framebuffer.height;
 
     // TODO(Rodrigo): Read this from HLE
     constexpr u32 block_height_log2 = 4;
@@ -256,17 +252,13 @@ void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuf
     //       they differ from the LCD resolution.
     // TODO: Applications could theoretically crash yuzu here by specifying too large
     //       framebuffer sizes. We should make sure that this cannot happen.
-    glTextureSubImage2D(screen_info.texture.resource.handle, 0, 0, 0, framebuffer.width,
-                        framebuffer.height, screen_info.texture.gl_format,
-                        screen_info.texture.gl_type, gl_framebuffer_data.data());
+    glTextureSubImage2D(framebuffer_texture.resource.handle, 0, 0, 0, framebuffer.width,
+                        framebuffer.height, framebuffer_texture.gl_format,
+                        framebuffer_texture.gl_type, gl_framebuffer_data.data());
 
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-}
 
-void RendererOpenGL::LoadColorToActiveGLTexture(u8 color_r, u8 color_g, u8 color_b, u8 color_a,
-                                                const TextureInfo& texture) {
-    const u8 framebuffer_data[4] = {color_a, color_b, color_g, color_r};
-    glClearTexImage(texture.resource.handle, 0, GL_RGBA, GL_UNSIGNED_BYTE, framebuffer_data);
+    return info;
 }
 
 void RendererOpenGL::InitOpenGLObjects() {
@@ -343,15 +335,15 @@ void RendererOpenGL::InitOpenGLObjects() {
     glNamedBufferData(vertex_buffer.handle, sizeof(ScreenRectVertex) * 4, nullptr, GL_STREAM_DRAW);
 
     // Allocate textures for the screen
-    screen_info.texture.resource.Create(GL_TEXTURE_2D);
+    framebuffer_texture.resource.Create(GL_TEXTURE_2D);
 
-    const GLuint texture = screen_info.texture.resource.handle;
+    const GLuint texture = framebuffer_texture.resource.handle;
     glTextureStorage2D(texture, 1, GL_RGBA8, 1, 1);
 
-    screen_info.display_texture = screen_info.texture.resource.handle;
-
     // Clear screen to black
-    LoadColorToActiveGLTexture(0, 0, 0, 0, screen_info.texture);
+    const u8 framebuffer_data[4] = {0, 0, 0, 0};
+    glClearTexImage(framebuffer_texture.resource.handle, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                    framebuffer_data);
 
     aa_framebuffer.Create();
 
@@ -380,60 +372,65 @@ void RendererOpenGL::AddTelemetryFields() {
     telemetry_session.AddField(user_system, "GPU_OpenGL_Version", std::string(gl_version));
 }
 
-void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
-                                                 const Tegra::FramebufferConfig& framebuffer) {
-    texture.width = framebuffer.width;
-    texture.height = framebuffer.height;
-    texture.pixel_format = framebuffer.pixel_format;
+void RendererOpenGL::ConfigureFramebufferTexture(const Tegra::FramebufferConfig& framebuffer) {
+    framebuffer_texture.width = framebuffer.width;
+    framebuffer_texture.height = framebuffer.height;
+    framebuffer_texture.pixel_format = framebuffer.pixel_format;
 
     const auto pixel_format{
         VideoCore::Surface::PixelFormatFromGPUPixelFormat(framebuffer.pixel_format)};
     const u32 bytes_per_pixel{VideoCore::Surface::BytesPerBlock(pixel_format)};
-    gl_framebuffer_data.resize(texture.width * texture.height * bytes_per_pixel);
+    gl_framebuffer_data.resize(framebuffer_texture.width * framebuffer_texture.height *
+                               bytes_per_pixel);
 
     GLint internal_format;
     switch (framebuffer.pixel_format) {
     case Service::android::PixelFormat::Rgba8888:
         internal_format = GL_RGBA8;
-        texture.gl_format = GL_RGBA;
-        texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
+        framebuffer_texture.gl_format = GL_RGBA;
+        framebuffer_texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
         break;
     case Service::android::PixelFormat::Rgb565:
         internal_format = GL_RGB565;
-        texture.gl_format = GL_RGB;
-        texture.gl_type = GL_UNSIGNED_SHORT_5_6_5;
+        framebuffer_texture.gl_format = GL_RGB;
+        framebuffer_texture.gl_type = GL_UNSIGNED_SHORT_5_6_5;
         break;
     default:
         internal_format = GL_RGBA8;
-        texture.gl_format = GL_RGBA;
-        texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
+        framebuffer_texture.gl_format = GL_RGBA;
+        framebuffer_texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
         // UNIMPLEMENTED_MSG("Unknown framebuffer pixel format: {}",
         //                   static_cast<u32>(framebuffer.pixel_format));
         break;
     }
 
-    texture.resource.Release();
-    texture.resource.Create(GL_TEXTURE_2D);
-    glTextureStorage2D(texture.resource.handle, 1, internal_format, texture.width, texture.height);
+    framebuffer_texture.resource.Release();
+    framebuffer_texture.resource.Create(GL_TEXTURE_2D);
+    glTextureStorage2D(framebuffer_texture.resource.handle, 1, internal_format,
+                       framebuffer_texture.width, framebuffer_texture.height);
     aa_texture.Release();
     aa_texture.Create(GL_TEXTURE_2D);
     glTextureStorage2D(aa_texture.handle, 1, GL_RGBA16F,
-                       Settings::values.resolution_info.ScaleUp(screen_info.texture.width),
-                       Settings::values.resolution_info.ScaleUp(screen_info.texture.height));
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
     glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0, aa_texture.handle, 0);
     smaa_edges_tex.Release();
     smaa_edges_tex.Create(GL_TEXTURE_2D);
     glTextureStorage2D(smaa_edges_tex.handle, 1, GL_RG16F,
-                       Settings::values.resolution_info.ScaleUp(screen_info.texture.width),
-                       Settings::values.resolution_info.ScaleUp(screen_info.texture.height));
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
     smaa_blend_tex.Release();
     smaa_blend_tex.Create(GL_TEXTURE_2D);
     glTextureStorage2D(smaa_blend_tex.handle, 1, GL_RGBA16F,
-                       Settings::values.resolution_info.ScaleUp(screen_info.texture.width),
-                       Settings::values.resolution_info.ScaleUp(screen_info.texture.height));
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
+                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
 }
 
-void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
+void RendererOpenGL::DrawScreen(const Tegra::FramebufferConfig& framebuffer,
+                                const Layout::FramebufferLayout& layout) {
+    FramebufferTextureInfo info = PrepareRenderTarget(framebuffer);
+    const auto crop = Tegra::NormalizeCrop(framebuffer, info.width, info.height);
+
     // TODO: Signal state tracker about these changes
     state_tracker.NotifyScreenDrawVertexArray();
     state_tracker.NotifyPolygonModes();
@@ -469,7 +466,7 @@ void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
     glColorMaski(0, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     glDepthRangeIndexed(0, 0.0, 0.0);
 
-    glBindTextureUnit(0, screen_info.display_texture);
+    glBindTextureUnit(0, info.display_texture);
 
     auto anti_aliasing = Settings::values.anti_aliasing.GetValue();
     if (anti_aliasing >= Settings::AntiAliasing::MaxEnum) {
@@ -480,22 +477,22 @@ void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
 
     if (anti_aliasing != Settings::AntiAliasing::None) {
         glEnablei(GL_SCISSOR_TEST, 0);
-        auto viewport_width = screen_info.texture.width;
-        auto scissor_width = framebuffer_crop_rect.GetWidth();
+        auto viewport_width = info.width;
+        auto scissor_width = static_cast<u32>(crop.GetWidth());
         if (scissor_width <= 0) {
             scissor_width = viewport_width;
         }
-        auto viewport_height = screen_info.texture.height;
-        auto scissor_height = framebuffer_crop_rect.GetHeight();
+        auto viewport_height = info.height;
+        auto scissor_height = static_cast<u32>(crop.GetHeight());
         if (scissor_height <= 0) {
             scissor_height = viewport_height;
         }
-        if (screen_info.was_accelerated) {
-            viewport_width = Settings::values.resolution_info.ScaleUp(viewport_width);
-            scissor_width = Settings::values.resolution_info.ScaleUp(scissor_width);
-            viewport_height = Settings::values.resolution_info.ScaleUp(viewport_height);
-            scissor_height = Settings::values.resolution_info.ScaleUp(scissor_height);
-        }
+
+        viewport_width = Settings::values.resolution_info.ScaleUp(viewport_width);
+        scissor_width = Settings::values.resolution_info.ScaleUp(scissor_width);
+        viewport_height = Settings::values.resolution_info.ScaleUp(viewport_height);
+        scissor_height = Settings::values.resolution_info.ScaleUp(scissor_height);
+
         glScissorIndexed(0, 0, 0, scissor_width, scissor_height);
         glViewportIndexedf(0, 0.0f, 0.0f, static_cast<GLfloat>(viewport_width),
                            static_cast<GLfloat>(viewport_height));
@@ -536,7 +533,7 @@ void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
                                                 smaa_blending_weight_calculation_frag.handle);
             glDrawArrays(GL_TRIANGLES, 0, 3);
 
-            glBindTextureUnit(0, screen_info.display_texture);
+            glBindTextureUnit(0, info.display_texture);
             glBindTextureUnit(1, smaa_blend_tex.handle);
             glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0,
                                       aa_texture.handle, 0);
@@ -561,18 +558,10 @@ void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
             fsr->InitBuffers();
         }
 
-        auto crop_rect = framebuffer_crop_rect;
-        if (crop_rect.GetWidth() == 0) {
-            crop_rect.right = framebuffer_width;
-        }
-        if (crop_rect.GetHeight() == 0) {
-            crop_rect.bottom = framebuffer_height;
-        }
-        crop_rect = crop_rect.Scale(Settings::values.resolution_info.up_factor);
-        const auto fsr_input_width = Settings::values.resolution_info.ScaleUp(framebuffer_width);
-        const auto fsr_input_height = Settings::values.resolution_info.ScaleUp(framebuffer_height);
+        const auto fsr_input_width = Settings::values.resolution_info.ScaleUp(info.width);
+        const auto fsr_input_height = Settings::values.resolution_info.ScaleUp(info.height);
         glBindSampler(0, present_sampler.handle);
-        fsr->Draw(program_manager, layout.screen, fsr_input_width, fsr_input_height, crop_rect);
+        fsr->Draw(program_manager, layout.screen, fsr_input_width, fsr_input_height, crop);
     } else {
         if (fsr->AreBuffersInitialized()) {
             fsr->ReleaseBuffers();
@@ -603,61 +592,34 @@ void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
     glProgramUniformMatrix3x2fv(present_vertex.handle, ModelViewMatrixLocation, 1, GL_FALSE,
                                 ortho_matrix.data());
 
-    const auto& texcoords = screen_info.display_texcoords;
-    auto left = texcoords.left;
-    auto right = texcoords.right;
-    if (framebuffer_transform_flags != Service::android::BufferTransformFlags::Unset) {
-        if (framebuffer_transform_flags == Service::android::BufferTransformFlags::FlipV) {
-            // Flip the framebuffer vertically
-            left = texcoords.right;
-            right = texcoords.left;
-        } else {
-            // Other transformations are unsupported
-            LOG_CRITICAL(Render_OpenGL, "Unsupported framebuffer_transform_flags={}",
-                         framebuffer_transform_flags);
-            UNIMPLEMENTED();
-        }
+    f32 left, top, right, bottom;
+    if (Settings::values.scaling_filter.GetValue() == Settings::ScalingFilter::Fsr) {
+        // FSR has already applied the crop, so we just want to render the image
+        // it has produced.
+        left = 0;
+        top = 0;
+        right = 1;
+        bottom = 1;
+    } else {
+        // Apply the precomputed crop.
+        left = crop.left;
+        top = crop.top;
+        right = crop.right;
+        bottom = crop.bottom;
     }
 
-    ASSERT_MSG(framebuffer_crop_rect.left == 0, "Unimplemented");
-
-    f32 left_start{};
-    if (framebuffer_crop_rect.Top() > 0) {
-        left_start = static_cast<f32>(framebuffer_crop_rect.Top()) /
-                     static_cast<f32>(framebuffer_crop_rect.Bottom());
-    }
-    f32 scale_u = static_cast<f32>(framebuffer_width) / static_cast<f32>(screen_info.texture.width);
-    f32 scale_v =
-        static_cast<f32>(framebuffer_height) / static_cast<f32>(screen_info.texture.height);
-
-    if (Settings::values.scaling_filter.GetValue() != Settings::ScalingFilter::Fsr) {
-        // Scale the output by the crop width/height. This is commonly used with 1280x720 rendering
-        // (e.g. handheld mode) on a 1920x1080 framebuffer.
-        if (framebuffer_crop_rect.GetWidth() > 0) {
-            scale_u = static_cast<f32>(framebuffer_crop_rect.GetWidth()) /
-                      static_cast<f32>(screen_info.texture.width);
-        }
-        if (framebuffer_crop_rect.GetHeight() > 0) {
-            scale_v = static_cast<f32>(framebuffer_crop_rect.GetHeight()) /
-                      static_cast<f32>(screen_info.texture.height);
-        }
-    }
-    if (Settings::values.anti_aliasing.GetValue() == Settings::AntiAliasing::Fxaa &&
-        !screen_info.was_accelerated) {
-        scale_u /= Settings::values.resolution_info.up_factor;
-        scale_v /= Settings::values.resolution_info.up_factor;
-    }
-
+    // Map the coordinates to the screen.
     const auto& screen = layout.screen;
+    const auto x = screen.left;
+    const auto y = screen.top;
+    const auto w = screen.GetWidth();
+    const auto h = screen.GetHeight();
+
     const std::array vertices = {
-        ScreenRectVertex(screen.left, screen.top, texcoords.top * scale_u,
-                         left_start + left * scale_v),
-        ScreenRectVertex(screen.right, screen.top, texcoords.bottom * scale_u,
-                         left_start + left * scale_v),
-        ScreenRectVertex(screen.left, screen.bottom, texcoords.top * scale_u,
-                         left_start + right * scale_v),
-        ScreenRectVertex(screen.right, screen.bottom, texcoords.bottom * scale_u,
-                         left_start + right * scale_v),
+        ScreenRectVertex(x, y, left, top),
+        ScreenRectVertex(x + w, y, right, top),
+        ScreenRectVertex(x, y + h, left, bottom),
+        ScreenRectVertex(x + w, y + h, right, bottom),
     };
     glNamedBufferSubData(vertex_buffer.handle, 0, sizeof(vertices), std::data(vertices));
 
@@ -701,7 +663,7 @@ void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
     // program_manager.RestoreGuestPipeline();
 }
 
-void RendererOpenGL::RenderScreenshot() {
+void RendererOpenGL::RenderScreenshot(const Tegra::FramebufferConfig& framebuffer) {
     if (!renderer_settings.screenshot_requested) {
         return;
     }
@@ -723,7 +685,7 @@ void RendererOpenGL::RenderScreenshot() {
     glRenderbufferStorage(GL_RENDERBUFFER, GL_SRGB8, layout.width, layout.height);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, renderbuffer);
 
-    DrawScreen(layout);
+    DrawScreen(framebuffer, layout);
 
     glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
     glPixelStorei(GL_PACK_ROW_LENGTH, 0);

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -17,68 +17,16 @@
 #include "core/frontend/emu_window.h"
 #include "core/memory.h"
 #include "core/telemetry_session.h"
-#include "video_core/host_shaders/ffx_a_h.h"
-#include "video_core/host_shaders/ffx_fsr1_h.h"
-#include "video_core/host_shaders/full_screen_triangle_vert.h"
-#include "video_core/host_shaders/fxaa_frag.h"
-#include "video_core/host_shaders/fxaa_vert.h"
-#include "video_core/host_shaders/opengl_fidelityfx_fsr_easu_frag.h"
-#include "video_core/host_shaders/opengl_fidelityfx_fsr_frag.h"
-#include "video_core/host_shaders/opengl_fidelityfx_fsr_rcas_frag.h"
-#include "video_core/host_shaders/opengl_present_frag.h"
-#include "video_core/host_shaders/opengl_present_scaleforce_frag.h"
-#include "video_core/host_shaders/opengl_present_vert.h"
-#include "video_core/host_shaders/opengl_smaa_glsl.h"
-#include "video_core/host_shaders/present_bicubic_frag.h"
-#include "video_core/host_shaders/present_gaussian_frag.h"
-#include "video_core/host_shaders/smaa_blending_weight_calculation_frag.h"
-#include "video_core/host_shaders/smaa_blending_weight_calculation_vert.h"
-#include "video_core/host_shaders/smaa_edge_detection_frag.h"
-#include "video_core/host_shaders/smaa_edge_detection_vert.h"
-#include "video_core/host_shaders/smaa_neighborhood_blending_frag.h"
-#include "video_core/host_shaders/smaa_neighborhood_blending_vert.h"
+#include "video_core/renderer_opengl/gl_blit_screen.h"
 #include "video_core/renderer_opengl/gl_fsr.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_manager.h"
 #include "video_core/renderer_opengl/gl_shader_util.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
-#include "video_core/smaa_area_tex.h"
-#include "video_core/smaa_search_tex.h"
 #include "video_core/textures/decoders.h"
 
 namespace OpenGL {
 namespace {
-constexpr GLint PositionLocation = 0;
-constexpr GLint TexCoordLocation = 1;
-constexpr GLint ModelViewMatrixLocation = 0;
-
-struct ScreenRectVertex {
-    constexpr ScreenRectVertex(u32 x, u32 y, GLfloat u, GLfloat v)
-        : position{{static_cast<GLfloat>(x), static_cast<GLfloat>(y)}}, tex_coord{{u, v}} {}
-
-    std::array<GLfloat, 2> position;
-    std::array<GLfloat, 2> tex_coord;
-};
-
-/**
- * Defines a 1:1 pixel ortographic projection matrix with (0,0) on the top-left
- * corner and (width, height) on the lower-bottom.
- *
- * The projection part of the matrix is trivial, hence these operations are represented
- * by a 3x2 matrix.
- */
-std::array<GLfloat, 3 * 2> MakeOrthographicMatrix(float width, float height) {
-    std::array<GLfloat, 3 * 2> matrix; // Laid out in column-major order
-
-    // clang-format off
-    matrix[0] = 2.f / width; matrix[2] =  0.f;          matrix[4] = -1.f;
-    matrix[1] = 0.f;         matrix[3] = -2.f / height; matrix[5] =  1.f;
-    // Last matrix row is implicitly assumed to be [0, 0, 1].
-    // clang-format on
-
-    return matrix;
-}
-
 const char* GetSource(GLenum source) {
     switch (source) {
     case GL_DEBUG_SOURCE_API:
@@ -156,7 +104,6 @@ RendererOpenGL::RendererOpenGL(Core::TelemetrySession& telemetry_session_,
         glDebugMessageCallback(DebugHandler, nullptr);
     }
     AddTelemetryFields();
-    InitOpenGLObjects();
 
     // Initialize default attributes to match hardware's disabled attributes
     GLint max_attribs{};
@@ -168,14 +115,8 @@ RendererOpenGL::RendererOpenGL(Core::TelemetrySession& telemetry_session_,
     if (!GLAD_GL_ARB_seamless_cubemap_per_texture && !GLAD_GL_AMD_seamless_cubemap_per_texture) {
         glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
     }
-    // Enable unified vertex attributes and query vertex buffer address when the driver supports it
-    if (device.HasVertexBufferUnifiedMemory()) {
-        glEnableClientState(GL_VERTEX_ATTRIB_ARRAY_UNIFIED_NV);
-        glEnableClientState(GL_ELEMENT_ARRAY_UNIFIED_NV);
-        glMakeNamedBufferResidentNV(vertex_buffer.handle, GL_READ_ONLY);
-        glGetNamedBufferParameterui64vNV(vertex_buffer.handle, GL_BUFFER_GPU_ADDRESS_NV,
-                                         &vertex_buffer_address);
-    }
+    blit_screen = std::make_unique<BlitScreen>(rasterizer, cpu_memory, state_tracker,
+                                               program_manager, device);
 }
 
 RendererOpenGL::~RendererOpenGL() = default;
@@ -188,7 +129,7 @@ void RendererOpenGL::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
     RenderScreenshot(*framebuffer);
 
     state_tracker.BindFramebuffer(0);
-    DrawScreen(*framebuffer, emu_window.GetFramebufferLayout());
+    blit_screen->DrawScreen(*framebuffer, emu_window.GetFramebufferLayout());
 
     ++m_current_frame;
 
@@ -197,164 +138,6 @@ void RendererOpenGL::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
 
     context->SwapBuffers();
     render_window.OnFrameDisplayed();
-}
-
-FramebufferTextureInfo RendererOpenGL::PrepareRenderTarget(
-    const Tegra::FramebufferConfig& framebuffer) {
-    // If framebuffer is provided, reload it from memory to a texture
-    if (framebuffer_texture.width != static_cast<GLsizei>(framebuffer.width) ||
-        framebuffer_texture.height != static_cast<GLsizei>(framebuffer.height) ||
-        framebuffer_texture.pixel_format != framebuffer.pixel_format ||
-        gl_framebuffer_data.empty()) {
-        // Reallocate texture if the framebuffer size has changed.
-        // This is expected to not happen very often and hence should not be a
-        // performance problem.
-        ConfigureFramebufferTexture(framebuffer);
-    }
-
-    // Load the framebuffer from memory if needed
-    return LoadFBToScreenInfo(framebuffer);
-}
-
-FramebufferTextureInfo RendererOpenGL::LoadFBToScreenInfo(
-    const Tegra::FramebufferConfig& framebuffer) {
-    const VAddr framebuffer_addr{framebuffer.address + framebuffer.offset};
-    const auto accelerated_info =
-        rasterizer.AccelerateDisplay(framebuffer, framebuffer_addr, framebuffer.stride);
-    if (accelerated_info) {
-        return *accelerated_info;
-    }
-
-    // Reset the screen info's display texture to its own permanent texture
-    FramebufferTextureInfo info{};
-    info.display_texture = framebuffer_texture.resource.handle;
-    info.width = framebuffer.width;
-    info.height = framebuffer.height;
-
-    // TODO(Rodrigo): Read this from HLE
-    constexpr u32 block_height_log2 = 4;
-    const auto pixel_format{
-        VideoCore::Surface::PixelFormatFromGPUPixelFormat(framebuffer.pixel_format)};
-    const u32 bytes_per_pixel{VideoCore::Surface::BytesPerBlock(pixel_format)};
-    const u64 size_in_bytes{Tegra::Texture::CalculateSize(
-        true, bytes_per_pixel, framebuffer.stride, framebuffer.height, 1, block_height_log2, 0)};
-    const u8* const host_ptr{cpu_memory.GetPointer(framebuffer_addr)};
-    const std::span<const u8> input_data(host_ptr, size_in_bytes);
-    Tegra::Texture::UnswizzleTexture(gl_framebuffer_data, input_data, bytes_per_pixel,
-                                     framebuffer.width, framebuffer.height, 1, block_height_log2,
-                                     0);
-
-    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<GLint>(framebuffer.stride));
-
-    // Update existing texture
-    // TODO: Test what happens on hardware when you change the framebuffer dimensions so that
-    //       they differ from the LCD resolution.
-    // TODO: Applications could theoretically crash yuzu here by specifying too large
-    //       framebuffer sizes. We should make sure that this cannot happen.
-    glTextureSubImage2D(framebuffer_texture.resource.handle, 0, 0, 0, framebuffer.width,
-                        framebuffer.height, framebuffer_texture.gl_format,
-                        framebuffer_texture.gl_type, gl_framebuffer_data.data());
-
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-
-    return info;
-}
-
-void RendererOpenGL::InitOpenGLObjects() {
-    // Create shader programs
-    fxaa_vertex = CreateProgram(HostShaders::FXAA_VERT, GL_VERTEX_SHADER);
-    fxaa_fragment = CreateProgram(HostShaders::FXAA_FRAG, GL_FRAGMENT_SHADER);
-
-    const auto replace_include = [](std::string& shader_source, std::string_view include_name,
-                                    std::string_view include_content) {
-        const std::string include_string = fmt::format("#include \"{}\"", include_name);
-        const std::size_t pos = shader_source.find(include_string);
-        ASSERT(pos != std::string::npos);
-        shader_source.replace(pos, include_string.size(), include_content);
-    };
-
-    const auto SmaaShader = [&](std::string_view specialized_source, GLenum stage) {
-        std::string shader_source{specialized_source};
-        replace_include(shader_source, "opengl_smaa.glsl", HostShaders::OPENGL_SMAA_GLSL);
-        return CreateProgram(shader_source, stage);
-    };
-
-    smaa_edge_detection_vert = SmaaShader(HostShaders::SMAA_EDGE_DETECTION_VERT, GL_VERTEX_SHADER);
-    smaa_edge_detection_frag =
-        SmaaShader(HostShaders::SMAA_EDGE_DETECTION_FRAG, GL_FRAGMENT_SHADER);
-    smaa_blending_weight_calculation_vert =
-        SmaaShader(HostShaders::SMAA_BLENDING_WEIGHT_CALCULATION_VERT, GL_VERTEX_SHADER);
-    smaa_blending_weight_calculation_frag =
-        SmaaShader(HostShaders::SMAA_BLENDING_WEIGHT_CALCULATION_FRAG, GL_FRAGMENT_SHADER);
-    smaa_neighborhood_blending_vert =
-        SmaaShader(HostShaders::SMAA_NEIGHBORHOOD_BLENDING_VERT, GL_VERTEX_SHADER);
-    smaa_neighborhood_blending_frag =
-        SmaaShader(HostShaders::SMAA_NEIGHBORHOOD_BLENDING_FRAG, GL_FRAGMENT_SHADER);
-
-    present_vertex = CreateProgram(HostShaders::OPENGL_PRESENT_VERT, GL_VERTEX_SHADER);
-    present_bilinear_fragment = CreateProgram(HostShaders::OPENGL_PRESENT_FRAG, GL_FRAGMENT_SHADER);
-    present_bicubic_fragment = CreateProgram(HostShaders::PRESENT_BICUBIC_FRAG, GL_FRAGMENT_SHADER);
-    present_gaussian_fragment =
-        CreateProgram(HostShaders::PRESENT_GAUSSIAN_FRAG, GL_FRAGMENT_SHADER);
-    present_scaleforce_fragment =
-        CreateProgram(fmt::format("#version 460\n{}", HostShaders::OPENGL_PRESENT_SCALEFORCE_FRAG),
-                      GL_FRAGMENT_SHADER);
-
-    std::string fsr_source{HostShaders::OPENGL_FIDELITYFX_FSR_FRAG};
-    replace_include(fsr_source, "ffx_a.h", HostShaders::FFX_A_H);
-    replace_include(fsr_source, "ffx_fsr1.h", HostShaders::FFX_FSR1_H);
-
-    std::string fsr_easu_frag_source{HostShaders::OPENGL_FIDELITYFX_FSR_EASU_FRAG};
-    std::string fsr_rcas_frag_source{HostShaders::OPENGL_FIDELITYFX_FSR_RCAS_FRAG};
-    replace_include(fsr_easu_frag_source, "opengl_fidelityfx_fsr.frag", fsr_source);
-    replace_include(fsr_rcas_frag_source, "opengl_fidelityfx_fsr.frag", fsr_source);
-
-    fsr = std::make_unique<FSR>(HostShaders::FULL_SCREEN_TRIANGLE_VERT, fsr_easu_frag_source,
-                                fsr_rcas_frag_source);
-
-    // Generate presentation sampler
-    present_sampler.Create();
-    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glSamplerParameteri(present_sampler.handle, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-
-    present_sampler_nn.Create();
-    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glSamplerParameteri(present_sampler_nn.handle, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-
-    // Generate VBO handle for drawing
-    vertex_buffer.Create();
-
-    // Attach vertex data to VAO
-    glNamedBufferData(vertex_buffer.handle, sizeof(ScreenRectVertex) * 4, nullptr, GL_STREAM_DRAW);
-
-    // Allocate textures for the screen
-    framebuffer_texture.resource.Create(GL_TEXTURE_2D);
-
-    const GLuint texture = framebuffer_texture.resource.handle;
-    glTextureStorage2D(texture, 1, GL_RGBA8, 1, 1);
-
-    // Clear screen to black
-    const u8 framebuffer_data[4] = {0, 0, 0, 0};
-    glClearTexImage(framebuffer_texture.resource.handle, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-                    framebuffer_data);
-
-    aa_framebuffer.Create();
-
-    smaa_area_tex.Create(GL_TEXTURE_2D);
-    glTextureStorage2D(smaa_area_tex.handle, 1, GL_RG8, AREATEX_WIDTH, AREATEX_HEIGHT);
-    glTextureSubImage2D(smaa_area_tex.handle, 0, 0, 0, AREATEX_WIDTH, AREATEX_HEIGHT, GL_RG,
-                        GL_UNSIGNED_BYTE, areaTexBytes);
-    smaa_search_tex.Create(GL_TEXTURE_2D);
-    glTextureStorage2D(smaa_search_tex.handle, 1, GL_R8, SEARCHTEX_WIDTH, SEARCHTEX_HEIGHT);
-    glTextureSubImage2D(smaa_search_tex.handle, 0, 0, 0, SEARCHTEX_WIDTH, SEARCHTEX_HEIGHT, GL_RED,
-                        GL_UNSIGNED_BYTE, searchTexBytes);
 }
 
 void RendererOpenGL::AddTelemetryFields() {
@@ -370,297 +153,6 @@ void RendererOpenGL::AddTelemetryFields() {
     telemetry_session.AddField(user_system, "GPU_Vendor", std::string(gpu_vendor));
     telemetry_session.AddField(user_system, "GPU_Model", std::string(gpu_model));
     telemetry_session.AddField(user_system, "GPU_OpenGL_Version", std::string(gl_version));
-}
-
-void RendererOpenGL::ConfigureFramebufferTexture(const Tegra::FramebufferConfig& framebuffer) {
-    framebuffer_texture.width = framebuffer.width;
-    framebuffer_texture.height = framebuffer.height;
-    framebuffer_texture.pixel_format = framebuffer.pixel_format;
-
-    const auto pixel_format{
-        VideoCore::Surface::PixelFormatFromGPUPixelFormat(framebuffer.pixel_format)};
-    const u32 bytes_per_pixel{VideoCore::Surface::BytesPerBlock(pixel_format)};
-    gl_framebuffer_data.resize(framebuffer_texture.width * framebuffer_texture.height *
-                               bytes_per_pixel);
-
-    GLint internal_format;
-    switch (framebuffer.pixel_format) {
-    case Service::android::PixelFormat::Rgba8888:
-        internal_format = GL_RGBA8;
-        framebuffer_texture.gl_format = GL_RGBA;
-        framebuffer_texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
-        break;
-    case Service::android::PixelFormat::Rgb565:
-        internal_format = GL_RGB565;
-        framebuffer_texture.gl_format = GL_RGB;
-        framebuffer_texture.gl_type = GL_UNSIGNED_SHORT_5_6_5;
-        break;
-    default:
-        internal_format = GL_RGBA8;
-        framebuffer_texture.gl_format = GL_RGBA;
-        framebuffer_texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
-        // UNIMPLEMENTED_MSG("Unknown framebuffer pixel format: {}",
-        //                   static_cast<u32>(framebuffer.pixel_format));
-        break;
-    }
-
-    framebuffer_texture.resource.Release();
-    framebuffer_texture.resource.Create(GL_TEXTURE_2D);
-    glTextureStorage2D(framebuffer_texture.resource.handle, 1, internal_format,
-                       framebuffer_texture.width, framebuffer_texture.height);
-    aa_texture.Release();
-    aa_texture.Create(GL_TEXTURE_2D);
-    glTextureStorage2D(aa_texture.handle, 1, GL_RGBA16F,
-                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
-                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
-    glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0, aa_texture.handle, 0);
-    smaa_edges_tex.Release();
-    smaa_edges_tex.Create(GL_TEXTURE_2D);
-    glTextureStorage2D(smaa_edges_tex.handle, 1, GL_RG16F,
-                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
-                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
-    smaa_blend_tex.Release();
-    smaa_blend_tex.Create(GL_TEXTURE_2D);
-    glTextureStorage2D(smaa_blend_tex.handle, 1, GL_RGBA16F,
-                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.width),
-                       Settings::values.resolution_info.ScaleUp(framebuffer_texture.height));
-}
-
-void RendererOpenGL::DrawScreen(const Tegra::FramebufferConfig& framebuffer,
-                                const Layout::FramebufferLayout& layout) {
-    FramebufferTextureInfo info = PrepareRenderTarget(framebuffer);
-    const auto crop = Tegra::NormalizeCrop(framebuffer, info.width, info.height);
-
-    // TODO: Signal state tracker about these changes
-    state_tracker.NotifyScreenDrawVertexArray();
-    state_tracker.NotifyPolygonModes();
-    state_tracker.NotifyViewport0();
-    state_tracker.NotifyScissor0();
-    state_tracker.NotifyColorMask(0);
-    state_tracker.NotifyBlend0();
-    state_tracker.NotifyFramebuffer();
-    state_tracker.NotifyFrontFace();
-    state_tracker.NotifyCullTest();
-    state_tracker.NotifyDepthTest();
-    state_tracker.NotifyStencilTest();
-    state_tracker.NotifyPolygonOffset();
-    state_tracker.NotifyRasterizeEnable();
-    state_tracker.NotifyFramebufferSRGB();
-    state_tracker.NotifyLogicOp();
-    state_tracker.NotifyClipControl();
-    state_tracker.NotifyAlphaTest();
-
-    state_tracker.ClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
-
-    glEnable(GL_CULL_FACE);
-    glDisable(GL_COLOR_LOGIC_OP);
-    glDisable(GL_DEPTH_TEST);
-    glDisable(GL_STENCIL_TEST);
-    glDisable(GL_POLYGON_OFFSET_FILL);
-    glDisable(GL_RASTERIZER_DISCARD);
-    glDisable(GL_ALPHA_TEST);
-    glDisablei(GL_BLEND, 0);
-    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-    glCullFace(GL_BACK);
-    glFrontFace(GL_CW);
-    glColorMaski(0, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-    glDepthRangeIndexed(0, 0.0, 0.0);
-
-    glBindTextureUnit(0, info.display_texture);
-
-    auto anti_aliasing = Settings::values.anti_aliasing.GetValue();
-    if (anti_aliasing >= Settings::AntiAliasing::MaxEnum) {
-        LOG_ERROR(Render_OpenGL, "Invalid antialiasing option selected {}", anti_aliasing);
-        anti_aliasing = Settings::AntiAliasing::None;
-        Settings::values.anti_aliasing.SetValue(anti_aliasing);
-    }
-
-    if (anti_aliasing != Settings::AntiAliasing::None) {
-        glEnablei(GL_SCISSOR_TEST, 0);
-        auto viewport_width = info.width;
-        auto scissor_width = static_cast<u32>(crop.GetWidth());
-        if (scissor_width <= 0) {
-            scissor_width = viewport_width;
-        }
-        auto viewport_height = info.height;
-        auto scissor_height = static_cast<u32>(crop.GetHeight());
-        if (scissor_height <= 0) {
-            scissor_height = viewport_height;
-        }
-
-        viewport_width = Settings::values.resolution_info.ScaleUp(viewport_width);
-        scissor_width = Settings::values.resolution_info.ScaleUp(scissor_width);
-        viewport_height = Settings::values.resolution_info.ScaleUp(viewport_height);
-        scissor_height = Settings::values.resolution_info.ScaleUp(scissor_height);
-
-        glScissorIndexed(0, 0, 0, scissor_width, scissor_height);
-        glViewportIndexedf(0, 0.0f, 0.0f, static_cast<GLfloat>(viewport_width),
-                           static_cast<GLfloat>(viewport_height));
-
-        glBindSampler(0, present_sampler.handle);
-        GLint old_read_fb;
-        GLint old_draw_fb;
-        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &old_read_fb);
-        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &old_draw_fb);
-
-        switch (anti_aliasing) {
-        case Settings::AntiAliasing::Fxaa: {
-            program_manager.BindPresentPrograms(fxaa_vertex.handle, fxaa_fragment.handle);
-            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, aa_framebuffer.handle);
-            glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-        } break;
-        case Settings::AntiAliasing::Smaa: {
-            glClearColor(0, 0, 0, 0);
-            glFrontFace(GL_CCW);
-            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, aa_framebuffer.handle);
-            glBindSampler(1, present_sampler.handle);
-            glBindSampler(2, present_sampler.handle);
-
-            glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0,
-                                      smaa_edges_tex.handle, 0);
-            glClear(GL_COLOR_BUFFER_BIT);
-            program_manager.BindPresentPrograms(smaa_edge_detection_vert.handle,
-                                                smaa_edge_detection_frag.handle);
-            glDrawArrays(GL_TRIANGLES, 0, 3);
-
-            glBindTextureUnit(0, smaa_edges_tex.handle);
-            glBindTextureUnit(1, smaa_area_tex.handle);
-            glBindTextureUnit(2, smaa_search_tex.handle);
-            glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0,
-                                      smaa_blend_tex.handle, 0);
-            glClear(GL_COLOR_BUFFER_BIT);
-            program_manager.BindPresentPrograms(smaa_blending_weight_calculation_vert.handle,
-                                                smaa_blending_weight_calculation_frag.handle);
-            glDrawArrays(GL_TRIANGLES, 0, 3);
-
-            glBindTextureUnit(0, info.display_texture);
-            glBindTextureUnit(1, smaa_blend_tex.handle);
-            glNamedFramebufferTexture(aa_framebuffer.handle, GL_COLOR_ATTACHMENT0,
-                                      aa_texture.handle, 0);
-            program_manager.BindPresentPrograms(smaa_neighborhood_blending_vert.handle,
-                                                smaa_neighborhood_blending_frag.handle);
-            glDrawArrays(GL_TRIANGLES, 0, 3);
-            glFrontFace(GL_CW);
-        } break;
-        default:
-            UNREACHABLE();
-        }
-
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, old_read_fb);
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, old_draw_fb);
-
-        glBindTextureUnit(0, aa_texture.handle);
-    }
-    glDisablei(GL_SCISSOR_TEST, 0);
-
-    if (Settings::values.scaling_filter.GetValue() == Settings::ScalingFilter::Fsr) {
-        if (!fsr->AreBuffersInitialized()) {
-            fsr->InitBuffers();
-        }
-
-        const auto fsr_input_width = Settings::values.resolution_info.ScaleUp(info.width);
-        const auto fsr_input_height = Settings::values.resolution_info.ScaleUp(info.height);
-        glBindSampler(0, present_sampler.handle);
-        fsr->Draw(program_manager, layout.screen, fsr_input_width, fsr_input_height, crop);
-    } else {
-        if (fsr->AreBuffersInitialized()) {
-            fsr->ReleaseBuffers();
-        }
-    }
-
-    const std::array ortho_matrix =
-        MakeOrthographicMatrix(static_cast<float>(layout.width), static_cast<float>(layout.height));
-
-    const auto fragment_handle = [this]() {
-        switch (Settings::values.scaling_filter.GetValue()) {
-        case Settings::ScalingFilter::NearestNeighbor:
-        case Settings::ScalingFilter::Bilinear:
-            return present_bilinear_fragment.handle;
-        case Settings::ScalingFilter::Bicubic:
-            return present_bicubic_fragment.handle;
-        case Settings::ScalingFilter::Gaussian:
-            return present_gaussian_fragment.handle;
-        case Settings::ScalingFilter::ScaleForce:
-            return present_scaleforce_fragment.handle;
-        case Settings::ScalingFilter::Fsr:
-            return fsr->GetPresentFragmentProgram().handle;
-        default:
-            return present_bilinear_fragment.handle;
-        }
-    }();
-    program_manager.BindPresentPrograms(present_vertex.handle, fragment_handle);
-    glProgramUniformMatrix3x2fv(present_vertex.handle, ModelViewMatrixLocation, 1, GL_FALSE,
-                                ortho_matrix.data());
-
-    f32 left, top, right, bottom;
-    if (Settings::values.scaling_filter.GetValue() == Settings::ScalingFilter::Fsr) {
-        // FSR has already applied the crop, so we just want to render the image
-        // it has produced.
-        left = 0;
-        top = 0;
-        right = 1;
-        bottom = 1;
-    } else {
-        // Apply the precomputed crop.
-        left = crop.left;
-        top = crop.top;
-        right = crop.right;
-        bottom = crop.bottom;
-    }
-
-    // Map the coordinates to the screen.
-    const auto& screen = layout.screen;
-    const auto x = screen.left;
-    const auto y = screen.top;
-    const auto w = screen.GetWidth();
-    const auto h = screen.GetHeight();
-
-    const std::array vertices = {
-        ScreenRectVertex(x, y, left, top),
-        ScreenRectVertex(x + w, y, right, top),
-        ScreenRectVertex(x, y + h, left, bottom),
-        ScreenRectVertex(x + w, y + h, right, bottom),
-    };
-    glNamedBufferSubData(vertex_buffer.handle, 0, sizeof(vertices), std::data(vertices));
-
-    glDisable(GL_FRAMEBUFFER_SRGB);
-    glViewportIndexedf(0, 0.0f, 0.0f, static_cast<GLfloat>(layout.width),
-                       static_cast<GLfloat>(layout.height));
-
-    glEnableVertexAttribArray(PositionLocation);
-    glEnableVertexAttribArray(TexCoordLocation);
-    glVertexAttribDivisor(PositionLocation, 0);
-    glVertexAttribDivisor(TexCoordLocation, 0);
-    glVertexAttribFormat(PositionLocation, 2, GL_FLOAT, GL_FALSE,
-                         offsetof(ScreenRectVertex, position));
-    glVertexAttribFormat(TexCoordLocation, 2, GL_FLOAT, GL_FALSE,
-                         offsetof(ScreenRectVertex, tex_coord));
-    glVertexAttribBinding(PositionLocation, 0);
-    glVertexAttribBinding(TexCoordLocation, 0);
-    if (device.HasVertexBufferUnifiedMemory()) {
-        glBindVertexBuffer(0, 0, 0, sizeof(ScreenRectVertex));
-        glBufferAddressRangeNV(GL_VERTEX_ATTRIB_ARRAY_ADDRESS_NV, 0, vertex_buffer_address,
-                               sizeof(vertices));
-    } else {
-        glBindVertexBuffer(0, vertex_buffer.handle, 0, sizeof(ScreenRectVertex));
-    }
-
-    if (Settings::values.scaling_filter.GetValue() != Settings::ScalingFilter::NearestNeighbor) {
-        glBindSampler(0, present_sampler.handle);
-    } else {
-        glBindSampler(0, present_sampler_nn.handle);
-    }
-
-    // Update background color before drawing
-    glClearColor(Settings::values.bg_red.GetValue() / 255.0f,
-                 Settings::values.bg_green.GetValue() / 255.0f,
-                 Settings::values.bg_blue.GetValue() / 255.0f, 1.0f);
-
-    glClear(GL_COLOR_BUFFER_BIT);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-    // TODO
-    // program_manager.RestoreGuestPipeline();
 }
 
 void RendererOpenGL::RenderScreenshot(const Tegra::FramebufferConfig& framebuffer) {
@@ -685,7 +177,7 @@ void RendererOpenGL::RenderScreenshot(const Tegra::FramebufferConfig& framebuffe
     glRenderbufferStorage(GL_RENDERBUFFER, GL_SRGB8, layout.width, layout.height);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, renderbuffer);
 
-    DrawScreen(framebuffer, layout);
+    blit_screen->DrawScreen(framebuffer, layout);
 
     glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
     glPixelStorei(GL_PACK_ROW_LENGTH, 0);

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -50,11 +50,10 @@ struct TextureInfo {
 };
 
 /// Structure used for storing information about the display target for the Switch screen
-struct ScreenInfo {
+struct FramebufferTextureInfo {
     GLuint display_texture{};
-    bool was_accelerated = false;
-    const Common::Rectangle<float> display_texcoords{0.0f, 0.0f, 1.0f, 1.0f};
-    TextureInfo texture;
+    u32 width;
+    u32 height;
 };
 
 class RendererOpenGL final : public VideoCore::RendererBase {
@@ -81,23 +80,18 @@ private:
 
     void AddTelemetryFields();
 
-    void ConfigureFramebufferTexture(TextureInfo& texture,
-                                     const Tegra::FramebufferConfig& framebuffer);
+    void ConfigureFramebufferTexture(const Tegra::FramebufferConfig& framebuffer);
 
     /// Draws the emulated screens to the emulator window.
-    void DrawScreen(const Layout::FramebufferLayout& layout);
+    void DrawScreen(const Tegra::FramebufferConfig& framebuffer,
+                    const Layout::FramebufferLayout& layout);
 
-    void RenderScreenshot();
+    void RenderScreenshot(const Tegra::FramebufferConfig& framebuffer);
 
     /// Loads framebuffer from emulated memory into the active OpenGL texture.
-    void LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer);
+    FramebufferTextureInfo LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer);
 
-    /// Fills active OpenGL texture with the given RGB color.Since the color is solid, the texture
-    /// can be 1x1 but will stretch across whatever it's rendered on.
-    void LoadColorToActiveGLTexture(u8 color_r, u8 color_g, u8 color_b, u8 color_a,
-                                    const TextureInfo& texture);
-
-    void PrepareRendertarget(const Tegra::FramebufferConfig* framebuffer);
+    FramebufferTextureInfo PrepareRenderTarget(const Tegra::FramebufferConfig& framebuffer);
 
     Core::TelemetrySession& telemetry_session;
     Core::Frontend::EmuWindow& emu_window;
@@ -126,7 +120,7 @@ private:
     GLuint64EXT vertex_buffer_address = 0;
 
     /// Display information for Switch screen
-    ScreenInfo screen_info;
+    TextureInfo framebuffer_texture;
     OGLTexture aa_texture;
     OGLFramebuffer aa_framebuffer;
 
@@ -145,12 +139,6 @@ private:
 
     /// OpenGL framebuffer data
     std::vector<u8> gl_framebuffer_data;
-
-    /// Used for transforming the framebuffer orientation
-    Service::android::BufferTransformFlags framebuffer_transform_flags{};
-    Common::Rectangle<int> framebuffer_crop_rect;
-    u32 framebuffer_width;
-    u32 framebuffer_height;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -25,36 +25,13 @@ namespace Core::Frontend {
 class EmuWindow;
 }
 
-namespace Core::Memory {
-class Memory;
-}
-
-namespace Layout {
-struct FramebufferLayout;
-}
-
 namespace Tegra {
 class GPU;
 }
 
 namespace OpenGL {
 
-/// Structure used for storing information about the textures for the Switch screen
-struct TextureInfo {
-    OGLTexture resource;
-    GLsizei width;
-    GLsizei height;
-    GLenum gl_format;
-    GLenum gl_type;
-    Service::android::PixelFormat pixel_format;
-};
-
-/// Structure used for storing information about the display target for the Switch screen
-struct FramebufferTextureInfo {
-    GLuint display_texture{};
-    u32 width;
-    u32 height;
-};
+class BlitScreen;
 
 class RendererOpenGL final : public VideoCore::RendererBase {
 public:
@@ -75,23 +52,8 @@ public:
     }
 
 private:
-    /// Initializes the OpenGL state and creates persistent objects.
-    void InitOpenGLObjects();
-
     void AddTelemetryFields();
-
-    void ConfigureFramebufferTexture(const Tegra::FramebufferConfig& framebuffer);
-
-    /// Draws the emulated screens to the emulator window.
-    void DrawScreen(const Tegra::FramebufferConfig& framebuffer,
-                    const Layout::FramebufferLayout& layout);
-
     void RenderScreenshot(const Tegra::FramebufferConfig& framebuffer);
-
-    /// Loads framebuffer from emulated memory into the active OpenGL texture.
-    FramebufferTextureInfo LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer);
-
-    FramebufferTextureInfo PrepareRenderTarget(const Tegra::FramebufferConfig& framebuffer);
 
     Core::TelemetrySession& telemetry_session;
     Core::Frontend::EmuWindow& emu_window;
@@ -102,43 +64,9 @@ private:
     StateTracker state_tracker;
     ProgramManager program_manager;
     RasterizerOpenGL rasterizer;
-
-    // OpenGL object IDs
-    OGLSampler present_sampler;
-    OGLSampler present_sampler_nn;
-    OGLBuffer vertex_buffer;
-    OGLProgram fxaa_vertex;
-    OGLProgram fxaa_fragment;
-    OGLProgram present_vertex;
-    OGLProgram present_bilinear_fragment;
-    OGLProgram present_bicubic_fragment;
-    OGLProgram present_gaussian_fragment;
-    OGLProgram present_scaleforce_fragment;
     OGLFramebuffer screenshot_framebuffer;
 
-    // GPU address of the vertex buffer
-    GLuint64EXT vertex_buffer_address = 0;
-
-    /// Display information for Switch screen
-    TextureInfo framebuffer_texture;
-    OGLTexture aa_texture;
-    OGLFramebuffer aa_framebuffer;
-
-    OGLProgram smaa_edge_detection_vert;
-    OGLProgram smaa_blending_weight_calculation_vert;
-    OGLProgram smaa_neighborhood_blending_vert;
-    OGLProgram smaa_edge_detection_frag;
-    OGLProgram smaa_blending_weight_calculation_frag;
-    OGLProgram smaa_neighborhood_blending_frag;
-    OGLTexture smaa_area_tex;
-    OGLTexture smaa_search_tex;
-    OGLTexture smaa_edges_tex;
-    OGLTexture smaa_blend_tex;
-
-    std::unique_ptr<FSR> fsr;
-
-    /// OpenGL framebuffer data
-    std::vector<u8> gl_framebuffer_data;
+    std::unique_ptr<BlitScreen> blit_screen;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -98,9 +98,9 @@ RendererVulkan::RendererVulkan(Core::TelemetrySession& telemetry_session_,
       present_manager(instance, render_window, device, memory_allocator, scheduler, swapchain,
                       surface),
       blit_screen(cpu_memory, render_window, device, memory_allocator, swapchain, present_manager,
-                  scheduler, screen_info),
-      rasterizer(render_window, gpu, cpu_memory, screen_info, device, memory_allocator,
-                 state_tracker, scheduler) {
+                  scheduler),
+      rasterizer(render_window, gpu, cpu_memory, device, memory_allocator, state_tracker,
+                 scheduler) {
     if (Settings::values.renderer_force_max_clock.GetValue() && device.ShouldBoostClocks()) {
         turbo_mode.emplace(instance, dld);
         scheduler.RegisterOnSubmit([this] { turbo_mode->QueueSubmitted(); });
@@ -124,17 +124,10 @@ void RendererVulkan::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
     if (!render_window.IsShown()) {
         return;
     }
-    // Update screen info if the framebuffer size has changed.
-    screen_info.width = framebuffer->width;
-    screen_info.height = framebuffer->height;
 
-    const VAddr framebuffer_addr = framebuffer->address + framebuffer->offset;
-    const bool use_accelerated =
-        rasterizer.AccelerateDisplay(*framebuffer, framebuffer_addr, framebuffer->stride);
-    RenderScreenshot(*framebuffer, use_accelerated);
-
+    RenderScreenshot(*framebuffer);
     Frame* frame = present_manager.GetRenderFrame();
-    blit_screen.DrawToSwapchain(frame, *framebuffer, use_accelerated);
+    blit_screen.DrawToSwapchain(rasterizer, frame, *framebuffer);
     scheduler.Flush(*frame->render_ready);
     present_manager.Present(frame);
 
@@ -168,8 +161,7 @@ void RendererVulkan::Report() const {
     telemetry_session.AddField(field, "GPU_Vulkan_Extensions", extensions);
 }
 
-void Vulkan::RendererVulkan::RenderScreenshot(const Tegra::FramebufferConfig& framebuffer,
-                                              bool use_accelerated) {
+void Vulkan::RendererVulkan::RenderScreenshot(const Tegra::FramebufferConfig& framebuffer) {
     if (!renderer_settings.screenshot_requested) {
         return;
     }
@@ -221,7 +213,7 @@ void Vulkan::RendererVulkan::RenderScreenshot(const Tegra::FramebufferConfig& fr
     });
     const VkExtent2D render_area{.width = layout.width, .height = layout.height};
     const vk::Framebuffer screenshot_fb = blit_screen.CreateFramebuffer(*dst_view, render_area);
-    blit_screen.Draw(framebuffer, *screenshot_fb, layout, render_area, use_accelerated);
+    blit_screen.Draw(rasterizer, framebuffer, *screenshot_fb, layout, render_area);
 
     const auto buffer_size = static_cast<VkDeviceSize>(layout.width * layout.height * 4);
     const VkBufferCreateInfo dst_buffer_info{

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -59,7 +59,7 @@ public:
 private:
     void Report() const;
 
-    void RenderScreenshot(const Tegra::FramebufferConfig& framebuffer, bool use_accelerated);
+    void RenderScreenshot(const Tegra::FramebufferConfig& framebuffer);
 
     Core::TelemetrySession& telemetry_session;
     Core::Memory::Memory& cpu_memory;
@@ -71,8 +71,6 @@ private:
     vk::Instance instance;
     vk::DebugUtilsMessenger debug_messenger;
     vk::SurfaceKHR surface;
-
-    ScreenInfo screen_info;
 
     Device device;
     MemoryAllocator memory_allocator;

--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -124,10 +124,10 @@ struct BlitScreen::BufferData {
 BlitScreen::BlitScreen(Core::Memory::Memory& cpu_memory_, Core::Frontend::EmuWindow& render_window_,
                        const Device& device_, MemoryAllocator& memory_allocator_,
                        Swapchain& swapchain_, PresentManager& present_manager_,
-                       Scheduler& scheduler_, const ScreenInfo& screen_info_)
+                       Scheduler& scheduler_)
     : cpu_memory{cpu_memory_}, render_window{render_window_}, device{device_},
       memory_allocator{memory_allocator_}, swapchain{swapchain_}, present_manager{present_manager_},
-      scheduler{scheduler_}, image_count{swapchain.GetImageCount()}, screen_info{screen_info_} {
+      scheduler{scheduler_}, image_count{swapchain.GetImageCount()} {
     resource_ticks.resize(image_count);
     swapchain_view_format = swapchain.GetImageViewFormat();
 
@@ -137,56 +137,6 @@ BlitScreen::BlitScreen(Core::Memory::Memory& cpu_memory_, Core::Frontend::EmuWin
 
 BlitScreen::~BlitScreen() = default;
 
-static Common::Rectangle<f32> NormalizeCrop(const Tegra::FramebufferConfig& framebuffer,
-                                            const ScreenInfo& screen_info) {
-    f32 left, top, right, bottom;
-
-    if (!framebuffer.crop_rect.IsEmpty()) {
-        // If crop rectangle is not empty, apply properties from rectangle.
-        left = static_cast<f32>(framebuffer.crop_rect.left);
-        top = static_cast<f32>(framebuffer.crop_rect.top);
-        right = static_cast<f32>(framebuffer.crop_rect.right);
-        bottom = static_cast<f32>(framebuffer.crop_rect.bottom);
-    } else {
-        // Otherwise, fall back to framebuffer dimensions.
-        left = 0;
-        top = 0;
-        right = static_cast<f32>(framebuffer.width);
-        bottom = static_cast<f32>(framebuffer.height);
-    }
-
-    // Apply transformation flags.
-    auto framebuffer_transform_flags = framebuffer.transform_flags;
-
-    if (True(framebuffer_transform_flags & Service::android::BufferTransformFlags::FlipH)) {
-        // Switch left and right.
-        std::swap(left, right);
-    }
-    if (True(framebuffer_transform_flags & Service::android::BufferTransformFlags::FlipV)) {
-        // Switch top and bottom.
-        std::swap(top, bottom);
-    }
-
-    framebuffer_transform_flags &= ~Service::android::BufferTransformFlags::FlipH;
-    framebuffer_transform_flags &= ~Service::android::BufferTransformFlags::FlipV;
-    if (True(framebuffer_transform_flags)) {
-        UNIMPLEMENTED_MSG("Unsupported framebuffer_transform_flags={}",
-                          static_cast<u32>(framebuffer_transform_flags));
-    }
-
-    // Get the screen properties.
-    const f32 screen_width = static_cast<f32>(screen_info.width);
-    const f32 screen_height = static_cast<f32>(screen_info.height);
-
-    // Normalize coordinate space.
-    left /= screen_width;
-    top /= screen_height;
-    right /= screen_width;
-    bottom /= screen_height;
-
-    return Common::Rectangle<f32>(left, top, right, bottom);
-}
-
 void BlitScreen::Recreate() {
     present_manager.WaitPresent();
     scheduler.Finish();
@@ -194,9 +144,16 @@ void BlitScreen::Recreate() {
     CreateDynamicResources();
 }
 
-void BlitScreen::Draw(const Tegra::FramebufferConfig& framebuffer,
+void BlitScreen::Draw(RasterizerVulkan& rasterizer, const Tegra::FramebufferConfig& framebuffer,
                       const VkFramebuffer& host_framebuffer, const Layout::FramebufferLayout layout,
-                      VkExtent2D render_area, bool use_accelerated) {
+                      VkExtent2D render_area) {
+
+    const auto texture_info = rasterizer.AccelerateDisplay(
+        framebuffer, framebuffer.address + framebuffer.offset, framebuffer.stride);
+    const u32 texture_width = texture_info ? texture_info->width : framebuffer.width;
+    const u32 texture_height = texture_info ? texture_info->height : framebuffer.height;
+    const bool use_accelerated = texture_info.has_value();
+
     RefreshResources(framebuffer);
 
     // Finish any pending renderpass
@@ -205,13 +162,13 @@ void BlitScreen::Draw(const Tegra::FramebufferConfig& framebuffer,
     scheduler.Wait(resource_ticks[image_index]);
     resource_ticks[image_index] = scheduler.CurrentTick();
 
-    VkImage source_image = use_accelerated ? screen_info.image : *raw_images[image_index];
+    VkImage source_image = texture_info ? texture_info->image : *raw_images[image_index];
     VkImageView source_image_view =
-        use_accelerated ? screen_info.image_view : *raw_image_views[image_index];
+        texture_info ? texture_info->image_view : *raw_image_views[image_index];
 
     BufferData data;
     SetUniformData(data, layout);
-    SetVertexData(data, framebuffer, layout);
+    SetVertexData(data, framebuffer, layout, texture_width, texture_height);
 
     const std::span<u8> mapped_span = buffer.Mapped();
     std::memcpy(mapped_span.data(), &data, sizeof(data));
@@ -404,10 +361,10 @@ void BlitScreen::Draw(const Tegra::FramebufferConfig& framebuffer,
         source_image_view = smaa->Draw(scheduler, image_index, source_image, source_image_view);
     }
     if (fsr) {
-        const auto crop_rect = NormalizeCrop(framebuffer, screen_info);
+        const auto crop_rect = Tegra::NormalizeCrop(framebuffer, texture_width, texture_height);
         const VkExtent2D fsr_input_size{
-            .width = Settings::values.resolution_info.ScaleUp(screen_info.width),
-            .height = Settings::values.resolution_info.ScaleUp(screen_info.height),
+            .width = Settings::values.resolution_info.ScaleUp(texture_width),
+            .height = Settings::values.resolution_info.ScaleUp(texture_height),
         };
         VkImageView fsr_image_view =
             fsr->Draw(scheduler, image_index, source_image_view, fsr_input_size, crop_rect);
@@ -479,8 +436,8 @@ void BlitScreen::Draw(const Tegra::FramebufferConfig& framebuffer,
     });
 }
 
-void BlitScreen::DrawToSwapchain(Frame* frame, const Tegra::FramebufferConfig& framebuffer,
-                                 bool use_accelerated) {
+void BlitScreen::DrawToSwapchain(RasterizerVulkan& rasterizer, Frame* frame,
+                                 const Tegra::FramebufferConfig& framebuffer) {
     // Recreate dynamic resources if the the image count or input format changed
     const VkFormat current_framebuffer_format =
         std::exchange(framebuffer_view_format, GetFormat(framebuffer));
@@ -499,7 +456,7 @@ void BlitScreen::DrawToSwapchain(Frame* frame, const Tegra::FramebufferConfig& f
     }
 
     const VkExtent2D render_area{frame->width, frame->height};
-    Draw(framebuffer, *frame->framebuffer, layout, render_area, use_accelerated);
+    Draw(rasterizer, framebuffer, *frame->framebuffer, layout, render_area);
     if (++image_index >= image_count) {
         image_index = 0;
     }
@@ -1433,7 +1390,8 @@ void BlitScreen::SetUniformData(BufferData& data, const Layout::FramebufferLayou
 }
 
 void BlitScreen::SetVertexData(BufferData& data, const Tegra::FramebufferConfig& framebuffer,
-                               const Layout::FramebufferLayout layout) const {
+                               const Layout::FramebufferLayout layout, u32 texture_width,
+                               u32 texture_height) const {
     f32 left, top, right, bottom;
 
     if (fsr) {
@@ -1445,7 +1403,7 @@ void BlitScreen::SetVertexData(BufferData& data, const Tegra::FramebufferConfig&
         bottom = 1;
     } else {
         // Get the normalized crop rectangle.
-        const auto crop = NormalizeCrop(framebuffer, screen_info);
+        const auto crop = Tegra::NormalizeCrop(framebuffer, texture_width, texture_height);
 
         // Apply the crop.
         left = crop.left;

--- a/src/video_core/renderer_vulkan/vk_blit_screen.h
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.h
@@ -35,8 +35,6 @@ enum class PixelFormat : u32;
 
 namespace Vulkan {
 
-struct ScreenInfo;
-
 class Device;
 class FSR;
 class RasterizerVulkan;
@@ -47,7 +45,7 @@ class PresentManager;
 
 struct Frame;
 
-struct ScreenInfo {
+struct FramebufferTextureInfo {
     VkImage image{};
     VkImageView image_view{};
     u32 width{};
@@ -58,17 +56,17 @@ class BlitScreen {
 public:
     explicit BlitScreen(Core::Memory::Memory& cpu_memory, Core::Frontend::EmuWindow& render_window,
                         const Device& device, MemoryAllocator& memory_manager, Swapchain& swapchain,
-                        PresentManager& present_manager, Scheduler& scheduler,
-                        const ScreenInfo& screen_info);
+                        PresentManager& present_manager, Scheduler& scheduler);
     ~BlitScreen();
 
     void Recreate();
 
-    void Draw(const Tegra::FramebufferConfig& framebuffer, const VkFramebuffer& host_framebuffer,
-              const Layout::FramebufferLayout layout, VkExtent2D render_area, bool use_accelerated);
+    void Draw(RasterizerVulkan& rasterizer, const Tegra::FramebufferConfig& framebuffer,
+              const VkFramebuffer& host_framebuffer, const Layout::FramebufferLayout layout,
+              VkExtent2D render_area);
 
-    void DrawToSwapchain(Frame* frame, const Tegra::FramebufferConfig& framebuffer,
-                         bool use_accelerated);
+    void DrawToSwapchain(RasterizerVulkan& rasterizer, Frame* frame,
+                         const Tegra::FramebufferConfig& framebuffer);
 
     [[nodiscard]] vk::Framebuffer CreateFramebuffer(const VkImageView& image_view,
                                                     VkExtent2D extent);
@@ -101,7 +99,8 @@ private:
     void UpdateAADescriptorSet(VkImageView image_view, bool nn) const;
     void SetUniformData(BufferData& data, const Layout::FramebufferLayout layout) const;
     void SetVertexData(BufferData& data, const Tegra::FramebufferConfig& framebuffer,
-                       const Layout::FramebufferLayout layout) const;
+                       const Layout::FramebufferLayout layout, u32 texture_width,
+                       u32 texture_height) const;
 
     void CreateSMAA(VkExtent2D smaa_size);
     void CreateFSR();
@@ -118,7 +117,6 @@ private:
     Scheduler& scheduler;
     std::size_t image_count;
     std::size_t image_index{};
-    const ScreenInfo& screen_info;
 
     vk::ShaderModule vertex_shader;
     vk::ShaderModule fxaa_vertex_shader;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -40,7 +40,7 @@ class Maxwell3D;
 
 namespace Vulkan {
 
-struct ScreenInfo;
+struct FramebufferTextureInfo;
 
 class StateTracker;
 
@@ -74,9 +74,9 @@ class RasterizerVulkan final : public VideoCore::RasterizerAccelerated,
                                protected VideoCommon::ChannelSetupCaches<VideoCommon::ChannelInfo> {
 public:
     explicit RasterizerVulkan(Core::Frontend::EmuWindow& emu_window_, Tegra::GPU& gpu_,
-                              Core::Memory::Memory& cpu_memory_, ScreenInfo& screen_info_,
-                              const Device& device_, MemoryAllocator& memory_allocator_,
-                              StateTracker& state_tracker_, Scheduler& scheduler_);
+                              Core::Memory::Memory& cpu_memory_, const Device& device_,
+                              MemoryAllocator& memory_allocator_, StateTracker& state_tracker_,
+                              Scheduler& scheduler_);
     ~RasterizerVulkan() override;
 
     void Draw(bool is_indexed, u32 instance_count) override;
@@ -122,8 +122,6 @@ public:
     Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() override;
     void AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
                                   std::span<const u8> memory) override;
-    bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
-                           u32 pixel_stride) override;
     void LoadDiskResources(u64 title_id, std::stop_token stop_loading,
                            const VideoCore::DiskResourceLoadCallback& callback) override;
 
@@ -132,6 +130,10 @@ public:
     void BindChannel(Tegra::Control::ChannelState& channel) override;
 
     void ReleaseChannel(s32 channel_id) override;
+
+    std::optional<FramebufferTextureInfo> AccelerateDisplay(const Tegra::FramebufferConfig& config,
+                                                            VAddr framebuffer_addr,
+                                                            u32 pixel_stride);
 
 private:
     static constexpr size_t MAX_TEXTURES = 192;
@@ -177,7 +179,6 @@ private:
 
     Tegra::GPU& gpu;
 
-    ScreenInfo& screen_info;
     const Device& device;
     MemoryAllocator& memory_allocator;
     StateTracker& state_tracker;


### PR DESCRIPTION
This attempts to bring the OpenGL backend up to speed with some recent changes to Vulkan presentation, and make the interface more similar between the two to aid in keeping them the same in the future.

Marking as draft due to conflict with #12579