### PR TITLE
audio: fetch process object from handle table

### DIFF
--- a/src/audio_core/device/device_session.h
+++ b/src/audio_core/device/device_session.h
@@ -20,6 +20,10 @@ struct EventType;
 } // namespace Timing
 } // namespace Core
 
+namespace Kernel {
+class KProcess;
+} // namespace Kernel
+
 namespace AudioCore {
 
 namespace Sink {
@@ -44,13 +48,13 @@ public:
      * @param sample_format           - Sample format for this device's output.
      * @param channel_count           - Number of channels for this device (2 or 6).
      * @param session_id              - This session's id.
-     * @param handle                  - Handle for this device session (unused).
+     * @param handle                  - Process handle for this device session.
      * @param applet_resource_user_id - Applet resource user id for this device session (unused).
      * @param type                    - Type of this stream (Render, In, Out).
      * @return Result code for this call.
      */
     Result Initialize(std::string_view name, SampleFormat sample_format, u16 channel_count,
-                      size_t session_id, u32 handle, u64 applet_resource_user_id,
+                      size_t session_id, Kernel::KProcess* handle, u64 applet_resource_user_id,
                       Sink::StreamType type);
 
     /**
@@ -137,8 +141,8 @@ private:
     u16 channel_count{};
     /// Session id of this device session
     size_t session_id{};
-    /// Handle of this device session
-    u32 handle{};
+    /// Process handle of device memory owner
+    Kernel::KProcess* handle{};
     /// Applet resource user id of this device session
     u64 applet_resource_user_id{};
     /// Total number of samples played by this device session

--- a/src/audio_core/in/audio_in_system.cpp
+++ b/src/audio_core/in/audio_in_system.cpp
@@ -57,7 +57,7 @@ Result System::IsConfigValid(const std::string_view device_name,
 }
 
 Result System::Initialize(std::string device_name, const AudioInParameter& in_params,
-                          const u32 handle_, const u64 applet_resource_user_id_) {
+                          Kernel::KProcess* handle_, const u64 applet_resource_user_id_) {
     auto result{IsConfigValid(device_name, in_params)};
     if (result.IsError()) {
         return result;

--- a/src/audio_core/in/audio_in_system.h
+++ b/src/audio_core/in/audio_in_system.h
@@ -19,7 +19,8 @@ class System;
 
 namespace Kernel {
 class KEvent;
-}
+class KProcess;
+} // namespace Kernel
 
 namespace AudioCore::AudioIn {
 
@@ -93,12 +94,12 @@ public:
      *
      * @param device_name             - The name of the requested input device.
      * @param in_params               - Input parameters, see AudioInParameter.
-     * @param handle                  - Unused.
+     * @param handle                  - Process handle.
      * @param applet_resource_user_id - Unused.
      * @return Result code.
      */
-    Result Initialize(std::string device_name, const AudioInParameter& in_params, u32 handle,
-                      u64 applet_resource_user_id);
+    Result Initialize(std::string device_name, const AudioInParameter& in_params,
+                      Kernel::KProcess* handle, u64 applet_resource_user_id);
 
     /**
      * Start this system.
@@ -244,8 +245,8 @@ public:
 private:
     /// Core system
     Core::System& system;
-    /// (Unused)
-    u32 handle{};
+    /// Process handle
+    Kernel::KProcess* handle{};
     /// (Unused)
     u64 applet_resource_user_id{};
     /// Buffer event, signalled when a buffer is ready

--- a/src/audio_core/out/audio_out_system.cpp
+++ b/src/audio_core/out/audio_out_system.cpp
@@ -48,8 +48,8 @@ Result System::IsConfigValid(std::string_view device_name,
     return Service::Audio::ResultInvalidChannelCount;
 }
 
-Result System::Initialize(std::string device_name, const AudioOutParameter& in_params, u32 handle_,
-                          u64 applet_resource_user_id_) {
+Result System::Initialize(std::string device_name, const AudioOutParameter& in_params,
+                          Kernel::KProcess* handle_, u64 applet_resource_user_id_) {
     auto result = IsConfigValid(device_name, in_params);
     if (result.IsError()) {
         return result;

--- a/src/audio_core/out/audio_out_system.h
+++ b/src/audio_core/out/audio_out_system.h
@@ -19,7 +19,8 @@ class System;
 
 namespace Kernel {
 class KEvent;
-}
+class KProcess;
+} // namespace Kernel
 
 namespace AudioCore::AudioOut {
 
@@ -84,12 +85,12 @@ public:
      *
      * @param device_name             - The name of the requested output device.
      * @param in_params               - Input parameters, see AudioOutParameter.
-     * @param handle                  - Unused.
+     * @param handle                  - Process handle.
      * @param applet_resource_user_id - Unused.
      * @return Result code.
      */
-    Result Initialize(std::string device_name, const AudioOutParameter& in_params, u32 handle,
-                      u64 applet_resource_user_id);
+    Result Initialize(std::string device_name, const AudioOutParameter& in_params,
+                      Kernel::KProcess* handle, u64 applet_resource_user_id);
 
     /**
      * Start this system.
@@ -228,8 +229,8 @@ public:
 private:
     /// Core system
     Core::System& system;
-    /// (Unused)
-    u32 handle{};
+    /// Process handle
+    Kernel::KProcess* handle{};
     /// (Unused)
     u64 applet_resource_user_id{};
     /// Buffer event, signalled when a buffer is ready


### PR DESCRIPTION
The information is provided by the sync request that sets up audio in/out sessions, and is used to device map the memory. Therefore it doesn't need to be fetched from globals.