### PR TITLE
service: hid: Fully implement abstract vibration

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -26,6 +26,7 @@ void LoopProcess(Core::System& system) {
     resource_manager->Initialize();
     resource_manager->RegisterAppletResourceUserId(system.ApplicationProcess()->GetProcessId(),
                                                    true);
+    resource_manager->SetAruidValidForVibration(system.ApplicationProcess()->GetProcessId(), true);
 
     server_manager->RegisterNamedService(
         "hid", std::make_shared<IHidServer>(system, resource_manager, firmware_settings));

--- a/src/core/hle/service/hid/hid_server.h
+++ b/src/core/hle/service/hid/hid_server.h
@@ -97,6 +97,7 @@ private:
     void BeginPermitVibrationSession(HLERequestContext& ctx);
     void EndPermitVibrationSession(HLERequestContext& ctx);
     void IsVibrationDeviceMounted(HLERequestContext& ctx);
+    void SendVibrationValueInBool(HLERequestContext& ctx);
     void ActivateConsoleSixAxisSensor(HLERequestContext& ctx);
     void StartConsoleSixAxisSensor(HLERequestContext& ctx);
     void StopConsoleSixAxisSensor(HLERequestContext& ctx);

--- a/src/core/hle/service/hid/hid_system_server.h
+++ b/src/core/hle/service/hid/hid_system_server.h
@@ -42,9 +42,14 @@ private:
     void RegisterAppletResourceUserId(HLERequestContext& ctx);
     void UnregisterAppletResourceUserId(HLERequestContext& ctx);
     void EnableAppletToGetInput(HLERequestContext& ctx);
+    void SetAruidValidForVibration(HLERequestContext& ctx);
     void EnableAppletToGetSixAxisSensor(HLERequestContext& ctx);
     void EnableAppletToGetPadInput(HLERequestContext& ctx);
     void EnableAppletToGetTouchScreen(HLERequestContext& ctx);
+    void SetVibrationMasterVolume(HLERequestContext& ctx);
+    void GetVibrationMasterVolume(HLERequestContext& ctx);
+    void BeginPermitVibrationSession(HLERequestContext& ctx);
+    void EndPermitVibrationSession(HLERequestContext& ctx);
     void IsJoyConAttachedOnAllRail(HLERequestContext& ctx);
     void AcquireConnectionTriggerTimeoutEvent(HLERequestContext& ctx);
     void AcquireDeviceRegisteredEventForControllerSupport(HLERequestContext& ctx);
@@ -61,6 +66,7 @@ private:
     void FinalizeUsbFirmwareUpdate(HLERequestContext& ctx);
     void InitializeUsbFirmwareUpdateWithoutMemory(HLERequestContext& ctx);
     void GetTouchScreenDefaultConfiguration(HLERequestContext& ctx);
+    void SetForceHandheldStyleVibration(HLERequestContext& ctx);
     void IsUsingCustomButtonConfig(HLERequestContext& ctx);
 
     std::shared_ptr<ResourceManager> GetResourceManager();

--- a/src/hid_core/frontend/emulated_controller.h
+++ b/src/hid_core/frontend/emulated_controller.h
@@ -356,10 +356,27 @@ public:
     const NfcState& GetNfc() const;
 
     /**
+     * Sends an on/off vibration to the left device
+     * @return true if vibration had no errors
+     */
+    bool SetVibration(bool should_vibrate);
+
+    /**
+     * Sends an GC vibration to the left device
+     * @return true if vibration had no errors
+     */
+    bool SetVibration(u32 slot, Core::HID::VibrationGcErmCommand erm_command);
+
+    /**
      * Sends a specific vibration to the output device
      * @return true if vibration had no errors
      */
-    bool SetVibration(std::size_t device_index, VibrationValue vibration);
+    bool SetVibration(DeviceIndex device_index, const VibrationValue& vibration);
+
+    /**
+     * @return The last sent vibration
+     */
+    VibrationValue GetActualVibrationValue(DeviceIndex device_index) const;
 
     /**
      * Sends a small vibration to the output device
@@ -564,6 +581,7 @@ private:
     f32 motion_sensitivity{Core::HID::MotionInput::IsAtRestStandard};
     u32 turbo_button_state{0};
     std::size_t nfc_handles{0};
+    VibrationValue last_vibration_value{DEFAULT_VIBRATION_VALUE};
 
     // Temporary values to avoid doing changes while the controller is in configuring mode
     NpadStyleIndex tmp_npad_type{NpadStyleIndex::None};

--- a/src/hid_core/resource_manager.h
+++ b/src/hid_core/resource_manager.h
@@ -10,6 +10,12 @@ namespace Core {
 class System;
 }
 
+namespace Core::HID {
+struct VibrationDeviceHandle;
+struct VibrationValue;
+struct VibrationDeviceInfo;
+} // namespace Core::HID
+
 namespace Core::Timing {
 struct EventType;
 }
@@ -37,6 +43,11 @@ class SixAxis;
 class SleepButton;
 class TouchScreen;
 class UniquePad;
+class NpadVibrationBase;
+class NpadN64VibrationDevice;
+class NpadGcVibrationDevice;
+class NpadVibrationDevice;
+struct HandheldConfig;
 
 class ResourceManager {
 
@@ -79,6 +90,18 @@ public:
     void EnablePadInput(u64 aruid, bool is_enabled);
     void EnableTouchScreen(u64 aruid, bool is_enabled);
 
+    NpadVibrationBase* GetVibrationDevice(const Core::HID::VibrationDeviceHandle& handle);
+    NpadN64VibrationDevice* GetN64VibrationDevice(const Core::HID::VibrationDeviceHandle& handle);
+    NpadVibrationDevice* GetNSVibrationDevice(const Core::HID::VibrationDeviceHandle& handle);
+    NpadGcVibrationDevice* GetGcVibrationDevice(const Core::HID::VibrationDeviceHandle& handle);
+    Result SetAruidValidForVibration(u64 aruid, bool is_enabled);
+    void SetForceHandheldStyleVibration(bool is_forced);
+    Result IsVibrationAruidActive(u64 aruid, bool& is_active) const;
+    Result GetVibrationDeviceInfo(Core::HID::VibrationDeviceInfo& device_info,
+                                  const Core::HID::VibrationDeviceHandle& handle);
+    Result SendVibrationValue(u64 aruid, const Core::HID::VibrationDeviceHandle& handle,
+                              const Core::HID::VibrationValue& value);
+
     void UpdateControllers(std::chrono::nanoseconds ns_late);
     void UpdateNpad(std::chrono::nanoseconds ns_late);
     void UpdateMouseKeyboard(std::chrono::nanoseconds ns_late);
@@ -112,6 +135,8 @@ private:
     std::shared_ptr<SleepButton> sleep_button = nullptr;
     std::shared_ptr<TouchScreen> touch_screen = nullptr;
     std::shared_ptr<UniquePad> unique_pad = nullptr;
+
+    std::shared_ptr<HandheldConfig> handheld_config = nullptr;
 
     // TODO: Create these resources
     // std::shared_ptr<AudioControl> audio_control = nullptr;

--- a/src/hid_core/resources/abstracted_pad/abstract_ir_sensor_handler.cpp
+++ b/src/hid_core/resources/abstracted_pad/abstract_ir_sensor_handler.cpp
@@ -115,7 +115,7 @@ Result NpadAbstractIrSensorHandler::GetXcdHandleForNpadWithIrSensor(u64& handle)
     if (sensor_state < NpadIrSensorState::Available) {
         return ResultIrSensorIsNotReady;
     }
-    handle = xcd_handle;
+    // handle = xcd_handle;
     return ResultSuccess;
 }
 

--- a/src/hid_core/resources/abstracted_pad/abstract_ir_sensor_handler.h
+++ b/src/hid_core/resources/abstracted_pad/abstract_ir_sensor_handler.h
@@ -7,6 +7,10 @@
 #include "core/hle/result.h"
 #include "hid_core/hid_types.h"
 
+namespace Core::HID {
+class EmulatedController;
+}
+
 namespace Kernel {
 class KEvent;
 class KReadableEvent;
@@ -50,7 +54,7 @@ private:
 
     s32 ref_counter{};
     Kernel::KEvent* ir_sensor_event{nullptr};
-    u64 xcd_handle{};
+    Core::HID::EmulatedController* xcd_handle{};
     NpadIrSensorState sensor_state{};
 };
 } // namespace Service::HID

--- a/src/hid_core/resources/abstracted_pad/abstract_pad.cpp
+++ b/src/hid_core/resources/abstracted_pad/abstract_pad.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "hid_core/hid_core.h"
 #include "hid_core/hid_result.h"
 #include "hid_core/resources/abstracted_pad/abstract_pad.h"
 #include "hid_core/resources/applet_resource.h"
@@ -16,7 +17,7 @@ void AbstractPad::SetExternals(AppletResourceHolder* applet_resource,
                                CaptureButtonResource* capture_button_resource,
                                HomeButtonResource* home_button_resource,
                                SixAxisResource* sixaxis_resource, PalmaResource* palma_resource,
-                               VibrationHandler* vibration) {
+                               NpadVibration* vibration, Core::HID::HIDCore* core) {
     applet_resource_holder = applet_resource;
 
     properties_handler.SetAppletResource(applet_resource_holder);
@@ -35,13 +36,14 @@ void AbstractPad::SetExternals(AppletResourceHolder* applet_resource,
     mcu_handler.SetAbstractPadHolder(&abstract_pad_holder);
     mcu_handler.SetPropertiesHandler(&properties_handler);
 
-    std::array<NpadVibrationDevice*, 2> vibration_devices{&vibration_left, &vibration_right};
     vibration_handler.SetAppletResource(applet_resource_holder);
     vibration_handler.SetAbstractPadHolder(&abstract_pad_holder);
     vibration_handler.SetPropertiesHandler(&properties_handler);
     vibration_handler.SetN64Vibration(&vibration_n64);
-    vibration_handler.SetVibration(vibration_devices);
+    vibration_handler.SetVibration(&vibration_left, &vibration_right);
     vibration_handler.SetGcVibration(&vibration_gc);
+    vibration_handler.SetVibrationHandler(vibration);
+    vibration_handler.SetHidCore(core);
 
     sixaxis_handler.SetAppletResource(applet_resource_holder);
     sixaxis_handler.SetAbstractPadHolder(&abstract_pad_holder);
@@ -237,11 +239,6 @@ NpadVibrationDevice* AbstractPad::GetVibrationDevice(Core::HID::DeviceIndex devi
         return &vibration_right;
     }
     return &vibration_left;
-}
-
-void AbstractPad::GetLeftRightVibrationDevice(std::vector<NpadVibrationDevice*> list) {
-    list.emplace_back(&vibration_left);
-    list.emplace_back(&vibration_right);
 }
 
 NpadGcVibrationDevice* AbstractPad::GetGCVibrationDevice() {

--- a/src/hid_core/resources/abstracted_pad/abstract_pad.h
+++ b/src/hid_core/resources/abstracted_pad/abstract_pad.h
@@ -32,7 +32,6 @@ class AppletResource;
 class SixAxisResource;
 class PalmaResource;
 class NPadResource;
-class AbstractPad;
 class NpadLastActiveHandler;
 class NpadIrNfcHandler;
 class UniquePads;
@@ -44,7 +43,6 @@ class NpadGcVibration;
 
 class CaptureButtonResource;
 class HomeButtonResource;
-class VibrationHandler;
 
 struct HandheldConfig;
 
@@ -57,7 +55,8 @@ public:
     void SetExternals(AppletResourceHolder* applet_resource,
                       CaptureButtonResource* capture_button_resource,
                       HomeButtonResource* home_button_resource, SixAxisResource* sixaxis_resource,
-                      PalmaResource* palma_resource, VibrationHandler* vibration);
+                      PalmaResource* palma_resource, NpadVibration* vibration,
+                      Core::HID::HIDCore* core);
     void SetNpadId(Core::HID::NpadIdType npad_id);
 
     Result Activate();
@@ -78,7 +77,6 @@ public:
 
     NpadN64VibrationDevice* GetN64VibrationDevice();
     NpadVibrationDevice* GetVibrationDevice(Core::HID::DeviceIndex device_index);
-    void GetLeftRightVibrationDevice(std::vector<NpadVibrationDevice*> list);
     NpadGcVibrationDevice* GetGCVibrationDevice();
 
     Core::HID::NpadIdType GetLastActiveNpad();

--- a/src/hid_core/resources/abstracted_pad/abstract_vibration_handler.h
+++ b/src/hid_core/resources/abstracted_pad/abstract_vibration_handler.h
@@ -9,6 +9,10 @@
 #include "core/hle/result.h"
 #include "hid_core/hid_types.h"
 
+namespace Core::HID {
+class HIDCore;
+}
+
 namespace Service::HID {
 struct AppletResourceHolder;
 class NpadAbstractedPadHolder;
@@ -27,9 +31,11 @@ public:
     void SetAbstractPadHolder(NpadAbstractedPadHolder* holder);
     void SetAppletResource(AppletResourceHolder* applet_resource);
     void SetPropertiesHandler(NpadAbstractPropertiesHandler* handler);
+    void SetVibrationHandler(NpadVibration* handler);
+    void SetHidCore(Core::HID::HIDCore* core);
 
     void SetN64Vibration(NpadN64VibrationDevice* n64_device);
-    void SetVibration(std::span<NpadVibrationDevice*> device);
+    void SetVibration(NpadVibrationDevice* left_device, NpadVibrationDevice* right_device);
     void SetGcVibration(NpadGcVibrationDevice* gc_device);
 
     Result IncrementRefCounter();
@@ -41,9 +47,11 @@ private:
     AppletResourceHolder* applet_resource_holder{nullptr};
     NpadAbstractedPadHolder* abstract_pad_holder{nullptr};
     NpadAbstractPropertiesHandler* properties_handler{nullptr};
+    Core::HID::HIDCore* hid_core{nullptr};
 
     NpadN64VibrationDevice* n64_vibration_device{nullptr};
-    std::array<NpadVibrationDevice*, 2> vibration_device{};
+    NpadVibrationDevice* left_vibration_device{};
+    NpadVibrationDevice* right_vibration_device{};
     NpadGcVibrationDevice* gc_vibration_device{nullptr};
     NpadVibration* vibration_handler{nullptr};
     s32 ref_counter{};

--- a/src/hid_core/resources/applet_resource.cpp
+++ b/src/hid_core/resources/applet_resource.cpp
@@ -200,6 +200,25 @@ void AppletResource::EnableInput(u64 aruid, bool is_enabled) {
     data[index].flag.enable_touchscreen.Assign(is_enabled);
 }
 
+bool AppletResource::SetAruidValidForVibration(u64 aruid, bool is_enabled) {
+    const u64 index = GetIndexFromAruid(aruid);
+    if (index >= AruidIndexMax) {
+        return false;
+    }
+
+    if (!is_enabled && aruid == active_vibration_aruid) {
+        active_vibration_aruid = SystemAruid;
+        return true;
+    }
+
+    if (is_enabled && aruid != active_vibration_aruid) {
+        active_vibration_aruid = aruid;
+        return true;
+    }
+
+    return false;
+}
+
 void AppletResource::EnableSixAxisSensor(u64 aruid, bool is_enabled) {
     const u64 index = GetIndexFromAruid(aruid);
     if (index >= AruidIndexMax) {

--- a/src/hid_core/resources/applet_resource.h
+++ b/src/hid_core/resources/applet_resource.h
@@ -101,6 +101,7 @@ public:
     Result DestroySevenSixAxisTransferMemory();
 
     void EnableInput(u64 aruid, bool is_enabled);
+    bool SetAruidValidForVibration(u64 aruid, bool is_enabled);
     void EnableSixAxisSensor(u64 aruid, bool is_enabled);
     void EnablePadInput(u64 aruid, bool is_enabled);
     void EnableTouchScreen(u64 aruid, bool is_enabled);

--- a/src/hid_core/resources/npad/npad.cpp
+++ b/src/hid_core/resources/npad/npad.cpp
@@ -21,6 +21,7 @@
 #include "hid_core/hid_util.h"
 #include "hid_core/resources/applet_resource.h"
 #include "hid_core/resources/npad/npad.h"
+#include "hid_core/resources/npad/npad_vibration.h"
 #include "hid_core/resources/shared_memory_format.h"
 
 namespace Service::HID {
@@ -31,10 +32,6 @@ NPad::NPad(Core::HID::HIDCore& hid_core_, KernelHelpers::ServiceContext& service
         for (std::size_t i = 0; i < controller_data[aruid_index].size(); ++i) {
             auto& controller = controller_data[aruid_index][i];
             controller.device = hid_core.GetEmulatedControllerByIndex(i);
-            controller.vibration[Core::HID::EmulatedDeviceIndex::LeftIndex].latest_vibration_value =
-                Core::HID::DEFAULT_VIBRATION_VALUE;
-            controller.vibration[Core::HID::EmulatedDeviceIndex::RightIndex]
-                .latest_vibration_value = Core::HID::DEFAULT_VIBRATION_VALUE;
             Core::HID::ControllerUpdateCallback engine_callback{
                 .on_change =
                     [this, i](Core::HID::ControllerTriggerType type) { ControllerUpdate(type, i); },
@@ -42,6 +39,10 @@ NPad::NPad(Core::HID::HIDCore& hid_core_, KernelHelpers::ServiceContext& service
             };
             controller.callback_key = controller.device->SetCallback(engine_callback);
         }
+    }
+    for (std::size_t i = 0; i < abstracted_pads.size(); ++i) {
+        abstracted_pads[i] = AbstractPad{};
+        abstracted_pads[i].SetNpadId(IndexToNpadIdType(i));
     }
 }
 
@@ -359,6 +360,7 @@ void NPad::InitNewlyAddedController(u64 aruid, Core::HID::NpadIdType npad_id) {
     npad_resource.SignalStyleSetUpdateEvent(aruid, npad_id);
     WriteEmptyEntry(controller.shared_memory);
     hid_core.SetLastActiveController(npad_id);
+    abstracted_pads[NpadIdTypeToIndex(npad_id)].Update();
 }
 
 void NPad::WriteEmptyEntry(NpadInternalState* npad) {
@@ -740,171 +742,6 @@ bool NPad::SetNpadMode(u64 aruid, Core::HID::NpadIdType& new_npad_id, Core::HID:
     return true;
 }
 
-bool NPad::VibrateControllerAtIndex(u64 aruid, Core::HID::NpadIdType npad_id,
-                                    std::size_t device_index,
-                                    const Core::HID::VibrationValue& vibration_value) {
-    auto& controller = GetControllerFromNpadIdType(aruid, npad_id);
-    if (!controller.device->IsConnected()) {
-        return false;
-    }
-
-    if (!controller.device->IsVibrationEnabled(device_index)) {
-        if (controller.vibration[device_index].latest_vibration_value.low_amplitude != 0.0f ||
-            controller.vibration[device_index].latest_vibration_value.high_amplitude != 0.0f) {
-            // Send an empty vibration to stop any vibrations.
-            Core::HID::VibrationValue vibration{0.0f, 160.0f, 0.0f, 320.0f};
-            controller.device->SetVibration(device_index, vibration);
-            // Then reset the vibration value to its default value.
-            controller.vibration[device_index].latest_vibration_value =
-                Core::HID::DEFAULT_VIBRATION_VALUE;
-        }
-
-        return false;
-    }
-
-    if (!Settings::values.enable_accurate_vibrations.GetValue()) {
-        using std::chrono::duration_cast;
-        using std::chrono::milliseconds;
-        using std::chrono::steady_clock;
-
-        const auto now = steady_clock::now();
-
-        // Filter out non-zero vibrations that are within 15ms of each other.
-        if ((vibration_value.low_amplitude != 0.0f || vibration_value.high_amplitude != 0.0f) &&
-            duration_cast<milliseconds>(
-                now - controller.vibration[device_index].last_vibration_timepoint) <
-                milliseconds(15)) {
-            return false;
-        }
-
-        controller.vibration[device_index].last_vibration_timepoint = now;
-    }
-
-    Core::HID::VibrationValue vibration{
-        vibration_value.low_amplitude, vibration_value.low_frequency,
-        vibration_value.high_amplitude, vibration_value.high_frequency};
-    return controller.device->SetVibration(device_index, vibration);
-}
-
-void NPad::VibrateController(u64 aruid,
-                             const Core::HID::VibrationDeviceHandle& vibration_device_handle,
-                             const Core::HID::VibrationValue& vibration_value) {
-    if (IsVibrationHandleValid(vibration_device_handle).IsError()) {
-        return;
-    }
-
-    if (!Settings::values.vibration_enabled.GetValue() && !permit_vibration_session_enabled) {
-        return;
-    }
-
-    auto& controller = GetControllerFromHandle(aruid, vibration_device_handle);
-    const auto device_index = static_cast<std::size_t>(vibration_device_handle.device_index);
-
-    if (!controller.vibration[device_index].device_mounted || !controller.device->IsConnected()) {
-        return;
-    }
-
-    if (vibration_device_handle.device_index == Core::HID::DeviceIndex::None) {
-        ASSERT_MSG(false, "DeviceIndex should never be None!");
-        return;
-    }
-
-    // Some games try to send mismatched parameters in the device handle, block these.
-    if ((controller.device->GetNpadStyleIndex() == Core::HID::NpadStyleIndex::JoyconLeft &&
-         (vibration_device_handle.npad_type == Core::HID::NpadStyleIndex::JoyconRight ||
-          vibration_device_handle.device_index == Core::HID::DeviceIndex::Right)) ||
-        (controller.device->GetNpadStyleIndex() == Core::HID::NpadStyleIndex::JoyconRight &&
-         (vibration_device_handle.npad_type == Core::HID::NpadStyleIndex::JoyconLeft ||
-          vibration_device_handle.device_index == Core::HID::DeviceIndex::Left))) {
-        return;
-    }
-
-    // Filter out vibrations with equivalent values to reduce unnecessary state changes.
-    if (vibration_value.low_amplitude ==
-            controller.vibration[device_index].latest_vibration_value.low_amplitude &&
-        vibration_value.high_amplitude ==
-            controller.vibration[device_index].latest_vibration_value.high_amplitude) {
-        return;
-    }
-
-    if (VibrateControllerAtIndex(aruid, controller.device->GetNpadIdType(), device_index,
-                                 vibration_value)) {
-        controller.vibration[device_index].latest_vibration_value = vibration_value;
-    }
-}
-
-void NPad::VibrateControllers(
-    u64 aruid, std::span<const Core::HID::VibrationDeviceHandle> vibration_device_handles,
-    std::span<const Core::HID::VibrationValue> vibration_values) {
-    if (!Settings::values.vibration_enabled.GetValue() && !permit_vibration_session_enabled) {
-        return;
-    }
-
-    ASSERT_OR_EXECUTE_MSG(
-        vibration_device_handles.size() == vibration_values.size(), { return; },
-        "The amount of device handles does not match with the amount of vibration values,"
-        "this is undefined behavior!");
-
-    for (std::size_t i = 0; i < vibration_device_handles.size(); ++i) {
-        VibrateController(aruid, vibration_device_handles[i], vibration_values[i]);
-    }
-}
-
-Core::HID::VibrationValue NPad::GetLastVibration(
-    u64 aruid, const Core::HID::VibrationDeviceHandle& vibration_device_handle) const {
-    if (IsVibrationHandleValid(vibration_device_handle).IsError()) {
-        return {};
-    }
-
-    const auto& controller = GetControllerFromHandle(aruid, vibration_device_handle);
-    const auto device_index = static_cast<std::size_t>(vibration_device_handle.device_index);
-    return controller.vibration[device_index].latest_vibration_value;
-}
-
-void NPad::InitializeVibrationDevice(
-    const Core::HID::VibrationDeviceHandle& vibration_device_handle) {
-    if (IsVibrationHandleValid(vibration_device_handle).IsError()) {
-        return;
-    }
-
-    const auto aruid = applet_resource_holder.applet_resource->GetActiveAruid();
-    const auto npad_index = static_cast<Core::HID::NpadIdType>(vibration_device_handle.npad_id);
-    const auto device_index = static_cast<std::size_t>(vibration_device_handle.device_index);
-
-    if (aruid == 0) {
-        return;
-    }
-
-    InitializeVibrationDeviceAtIndex(aruid, npad_index, device_index);
-}
-
-void NPad::InitializeVibrationDeviceAtIndex(u64 aruid, Core::HID::NpadIdType npad_id,
-                                            std::size_t device_index) {
-    auto& controller = GetControllerFromNpadIdType(aruid, npad_id);
-    if (!Settings::values.vibration_enabled.GetValue()) {
-        controller.vibration[device_index].device_mounted = false;
-        return;
-    }
-
-    controller.vibration[device_index].device_mounted =
-        controller.device->IsVibrationEnabled(device_index);
-}
-
-void NPad::SetPermitVibrationSession(bool permit_vibration_session) {
-    permit_vibration_session_enabled = permit_vibration_session;
-}
-
-bool NPad::IsVibrationDeviceMounted(
-    u64 aruid, const Core::HID::VibrationDeviceHandle& vibration_device_handle) const {
-    if (IsVibrationHandleValid(vibration_device_handle).IsError()) {
-        return false;
-    }
-
-    const auto& controller = GetControllerFromHandle(aruid, vibration_device_handle);
-    const auto device_index = static_cast<std::size_t>(vibration_device_handle.device_index);
-    return controller.vibration[device_index].device_mounted;
-}
-
 Result NPad::AcquireNpadStyleSetUpdateEventHandle(u64 aruid, Kernel::KReadableEvent** out_event,
                                                   Core::HID::NpadIdType npad_id) {
     std::scoped_lock lock{mutex};
@@ -936,11 +773,6 @@ Result NPad::DisconnectNpad(u64 aruid, Core::HID::NpadIdType npad_id) {
 
     LOG_DEBUG(Service_HID, "Npad disconnected {}", npad_id);
     auto& controller = GetControllerFromNpadIdType(aruid, npad_id);
-    for (std::size_t device_idx = 0; device_idx < controller.vibration.size(); ++device_idx) {
-        // Send an empty vibration to stop any vibrations.
-        VibrateControllerAtIndex(aruid, npad_id, device_idx, {});
-        controller.vibration[device_idx].device_mounted = false;
-    }
 
     auto* shared_memory = controller.shared_memory;
     // Don't reset shared_memory->assignment_mode this value is persistent
@@ -1236,22 +1068,17 @@ void NPad::UnregisterAppletResourceUserId(u64 aruid) {
 }
 
 void NPad::SetNpadExternals(std::shared_ptr<AppletResource> resource,
-                            std::recursive_mutex* shared_mutex) {
+                            std::recursive_mutex* shared_mutex,
+                            std::shared_ptr<HandheldConfig> handheld_config) {
     applet_resource_holder.applet_resource = resource;
     applet_resource_holder.shared_mutex = shared_mutex;
     applet_resource_holder.shared_npad_resource = &npad_resource;
-}
+    applet_resource_holder.handheld_config = handheld_config;
 
-NPad::NpadControllerData& NPad::GetControllerFromHandle(
-    u64 aruid, const Core::HID::VibrationDeviceHandle& device_handle) {
-    const auto npad_id = static_cast<Core::HID::NpadIdType>(device_handle.npad_id);
-    return GetControllerFromNpadIdType(aruid, npad_id);
-}
-
-const NPad::NpadControllerData& NPad::GetControllerFromHandle(
-    u64 aruid, const Core::HID::VibrationDeviceHandle& device_handle) const {
-    const auto npad_id = static_cast<Core::HID::NpadIdType>(device_handle.npad_id);
-    return GetControllerFromNpadIdType(aruid, npad_id);
+    for (auto& abstract_pad : abstracted_pads) {
+        abstract_pad.SetExternals(&applet_resource_holder, nullptr, nullptr, nullptr, nullptr,
+                                  &vibration_handler, &hid_core);
+    }
 }
 
 NPad::NpadControllerData& NPad::GetControllerFromHandle(
@@ -1387,6 +1214,99 @@ Result NPad::GetLastActiveNpad(Core::HID::NpadIdType& out_npad_id) const {
     std::scoped_lock lock{mutex};
     out_npad_id = hid_core.GetLastActiveController();
     return ResultSuccess;
+}
+
+NpadVibration* NPad::GetVibrationHandler() {
+    return &vibration_handler;
+}
+
+std::vector<NpadVibrationBase*> NPad::GetAllVibrationDevices() {
+    std::vector<NpadVibrationBase*> vibration_devices;
+
+    for (auto& abstract_pad : abstracted_pads) {
+        auto* left_device = abstract_pad.GetVibrationDevice(Core::HID::DeviceIndex::Left);
+        auto* right_device = abstract_pad.GetVibrationDevice(Core::HID::DeviceIndex::Right);
+        auto* n64_device = abstract_pad.GetGCVibrationDevice();
+        auto* gc_device = abstract_pad.GetGCVibrationDevice();
+
+        if (left_device != nullptr) {
+            vibration_devices.emplace_back(left_device);
+        }
+        if (right_device != nullptr) {
+            vibration_devices.emplace_back(right_device);
+        }
+        if (n64_device != nullptr) {
+            vibration_devices.emplace_back(n64_device);
+        }
+        if (gc_device != nullptr) {
+            vibration_devices.emplace_back(gc_device);
+        }
+    }
+
+    return vibration_devices;
+}
+
+NpadVibrationBase* NPad::GetVibrationDevice(const Core::HID::VibrationDeviceHandle& handle) {
+    if (IsVibrationHandleValid(handle).IsError()) {
+        return nullptr;
+    }
+
+    const auto npad_index = NpadIdTypeToIndex(static_cast<Core::HID::NpadIdType>(handle.npad_id));
+    const auto style_inde = static_cast<Core::HID::NpadStyleIndex>(handle.npad_type);
+    if (style_inde == Core::HID::NpadStyleIndex::GameCube) {
+        return abstracted_pads[npad_index].GetGCVibrationDevice();
+    }
+    if (style_inde == Core::HID::NpadStyleIndex::N64) {
+        return abstracted_pads[npad_index].GetN64VibrationDevice();
+    }
+    return abstracted_pads[npad_index].GetVibrationDevice(handle.device_index);
+}
+
+NpadN64VibrationDevice* NPad::GetN64VibrationDevice(
+    const Core::HID::VibrationDeviceHandle& handle) {
+    if (IsVibrationHandleValid(handle).IsError()) {
+        return nullptr;
+    }
+
+    const auto npad_index = NpadIdTypeToIndex(static_cast<Core::HID::NpadIdType>(handle.npad_id));
+    const auto style_inde = static_cast<Core::HID::NpadStyleIndex>(handle.npad_type);
+    if (style_inde != Core::HID::NpadStyleIndex::N64) {
+        return nullptr;
+    }
+    return abstracted_pads[npad_index].GetN64VibrationDevice();
+}
+
+NpadVibrationDevice* NPad::GetNSVibrationDevice(const Core::HID::VibrationDeviceHandle& handle) {
+    if (IsVibrationHandleValid(handle).IsError()) {
+        return nullptr;
+    }
+
+    const auto npad_index = NpadIdTypeToIndex(static_cast<Core::HID::NpadIdType>(handle.npad_id));
+    const auto style_inde = static_cast<Core::HID::NpadStyleIndex>(handle.npad_type);
+    if (style_inde == Core::HID::NpadStyleIndex::GameCube ||
+        style_inde == Core::HID::NpadStyleIndex::N64) {
+        return nullptr;
+    }
+
+    return abstracted_pads[npad_index].GetVibrationDevice(handle.device_index);
+}
+
+NpadGcVibrationDevice* NPad::GetGcVibrationDevice(const Core::HID::VibrationDeviceHandle& handle) {
+    if (IsVibrationHandleValid(handle).IsError()) {
+        return nullptr;
+    }
+
+    const auto npad_index = NpadIdTypeToIndex(static_cast<Core::HID::NpadIdType>(handle.npad_id));
+    const auto style_inde = static_cast<Core::HID::NpadStyleIndex>(handle.npad_type);
+    if (style_inde != Core::HID::NpadStyleIndex::GameCube) {
+        return nullptr;
+    }
+    return abstracted_pads[npad_index].GetGCVibrationDevice();
+}
+
+void NPad::UpdateHandheldAbstractState() {
+    std::scoped_lock lock{mutex};
+    abstracted_pads[NpadIdTypeToIndex(Core::HID::NpadIdType::Handheld)].Update();
 }
 
 } // namespace Service::HID

--- a/src/hid_core/resources/npad/npad_types.h
+++ b/src/hid_core/resources/npad/npad_types.h
@@ -8,6 +8,10 @@
 #include "common/common_types.h"
 #include "hid_core/hid_types.h"
 
+namespace Core::HID {
+class EmulatedController;
+}
+
 namespace Service::HID {
 static constexpr std::size_t MaxSupportedNpadIdTypes = 10;
 static constexpr std::size_t StyleIndexCount = 7;
@@ -348,7 +352,7 @@ struct IAbstractedPad {
     u8 indicator;
     std::vector<f32> virtual_six_axis_sensor_acceleration;
     std::vector<f32> virtual_six_axis_sensor_angle;
-    u64 xcd_handle;
+    Core::HID::EmulatedController* xcd_handle;
     u64 color;
 };
 } // namespace Service::HID

--- a/src/hid_core/resources/npad/npad_vibration.cpp
+++ b/src/hid_core/resources/npad/npad_vibration.cpp
@@ -77,4 +77,8 @@ Result NpadVibration::EndPermitVibrationSession() {
     return ResultSuccess;
 }
 
+u64 NpadVibration::GetSessionAruid() const {
+    return session_aruid;
+}
+
 } // namespace Service::HID

--- a/src/hid_core/resources/npad/npad_vibration.h
+++ b/src/hid_core/resources/npad/npad_vibration.h
@@ -25,6 +25,8 @@ public:
     Result BeginPermitVibrationSession(u64 aruid);
     Result EndPermitVibrationSession();
 
+    u64 GetSessionAruid() const;
+
 private:
     f32 volume{};
     u64 session_aruid{};

--- a/src/hid_core/resources/vibration/gc_vibration_device.h
+++ b/src/hid_core/resources/vibration/gc_vibration_device.h
@@ -20,12 +20,18 @@ class NpadGcVibrationDevice final : public NpadVibrationBase {
 public:
     explicit NpadGcVibrationDevice();
 
-    Result IncrementRefCounter() override;
-    Result DecrementRefCounter() override;
+    Result Activate() override;
+    Result Deactivate() override;
+
+    Result Mount(IAbstractedPad& abstracted_pad, u32 slot, NpadVibration* handler);
+    Result Unmount();
 
     Result SendVibrationGcErmCommand(Core::HID::VibrationGcErmCommand command);
 
     Result GetActualVibrationGcErmCommand(Core::HID::VibrationGcErmCommand& out_command);
     Result SendVibrationNotificationPattern(Core::HID::VibrationGcErmCommand command);
+
+private:
+    u32 adapter_slot;
 };
 } // namespace Service::HID

--- a/src/hid_core/resources/vibration/n64_vibration_device.h
+++ b/src/hid_core/resources/vibration/n64_vibration_device.h
@@ -14,14 +14,18 @@
 
 namespace Service::HID {
 class NpadVibration;
+struct IAbstractedPad;
 
 /// Handles Npad request from HID interfaces
 class NpadN64VibrationDevice final : public NpadVibrationBase {
 public:
     explicit NpadN64VibrationDevice();
 
-    Result IncrementRefCounter() override;
-    Result DecrementRefCounter() override;
+    Result Activate() override;
+    Result Deactivate() override;
+
+    Result Mount(IAbstractedPad& abstracted_pad, NpadVibration* handler);
+    Result Unmount();
 
     Result SendValueInBool(bool is_vibrating);
     Result SendVibrationNotificationPattern(u32 pattern);

--- a/src/hid_core/resources/vibration/vibration_base.cpp
+++ b/src/hid_core/resources/vibration/vibration_base.cpp
@@ -10,12 +10,12 @@ namespace Service::HID {
 
 NpadVibrationBase::NpadVibrationBase() {}
 
-Result NpadVibrationBase::IncrementRefCounter() {
+Result NpadVibrationBase::Activate() {
     ref_counter++;
     return ResultSuccess;
 }
 
-Result NpadVibrationBase::DecrementRefCounter() {
+Result NpadVibrationBase::Deactivate() {
     if (ref_counter > 0) {
         ref_counter--;
     }

--- a/src/hid_core/resources/vibration/vibration_base.h
+++ b/src/hid_core/resources/vibration/vibration_base.h
@@ -6,6 +6,10 @@
 #include "common/common_types.h"
 #include "core/hle/result.h"
 
+namespace Core::HID {
+class EmulatedController;
+}
+
 namespace Service::HID {
 class NpadVibration;
 
@@ -14,13 +18,13 @@ class NpadVibrationBase {
 public:
     explicit NpadVibrationBase();
 
-    virtual Result IncrementRefCounter();
-    virtual Result DecrementRefCounter();
+    virtual Result Activate();
+    virtual Result Deactivate();
 
     bool IsVibrationMounted() const;
 
 protected:
-    u64 xcd_handle{};
+    Core::HID::EmulatedController* xcd_handle{nullptr};
     s32 ref_counter{};
     bool is_mounted{};
     NpadVibration* vibration_handler{nullptr};

--- a/src/hid_core/resources/vibration/vibration_device.h
+++ b/src/hid_core/resources/vibration/vibration_device.h
@@ -12,6 +12,10 @@
 #include "hid_core/resources/npad/npad_types.h"
 #include "hid_core/resources/vibration/vibration_base.h"
 
+namespace Core::HID {
+enum class DeviceIndex : u8;
+}
+
 namespace Service::HID {
 class NpadVibration;
 
@@ -20,16 +24,20 @@ class NpadVibrationDevice final : public NpadVibrationBase {
 public:
     explicit NpadVibrationDevice();
 
-    Result IncrementRefCounter();
-    Result DecrementRefCounter();
+    Result Activate();
+    Result Deactivate();
+
+    Result Mount(IAbstractedPad& abstracted_pad, Core::HID::DeviceIndex index,
+                 NpadVibration* handler);
+    Result Unmount();
 
     Result SendVibrationValue(const Core::HID::VibrationValue& value);
     Result SendVibrationNotificationPattern(u32 pattern);
 
-    Result GetActualVibrationValue(Core::HID::VibrationValue& out_value);
+    Result GetActualVibrationValue(Core::HID::VibrationValue& out_value) const;
 
 private:
-    u32 device_index{};
+    Core::HID::DeviceIndex device_index{};
 };
 
 } // namespace Service::HID

--- a/src/yuzu/configuration/configure_vibration.cpp
+++ b/src/yuzu/configuration/configure_vibration.cpp
@@ -116,8 +116,8 @@ void ConfigureVibration::VibrateController(Core::HID::ControllerTriggerType type
         .high_amplitude = 1.0f,
         .high_frequency = 320.0f,
     };
-    controller->SetVibration(0, vibration);
-    controller->SetVibration(1, vibration);
+    controller->SetVibration(Core::HID::DeviceIndex::Left, vibration);
+    controller->SetVibration(Core::HID::DeviceIndex::Right, vibration);
 
     // Restore previous values
     player.vibration_enabled = old_vibration_enabled;
@@ -127,7 +127,7 @@ void ConfigureVibration::VibrateController(Core::HID::ControllerTriggerType type
 void ConfigureVibration::StopVibrations() {
     for (std::size_t i = 0; i < NUM_PLAYERS; ++i) {
         auto controller = hid_core.GetEmulatedControllerByIndex(i);
-        controller->SetVibration(0, Core::HID::DEFAULT_VIBRATION_VALUE);
-        controller->SetVibration(1, Core::HID::DEFAULT_VIBRATION_VALUE);
+        controller->SetVibration(Core::HID::DeviceIndex::Left, Core::HID::DEFAULT_VIBRATION_VALUE);
+        controller->SetVibration(Core::HID::DeviceIndex::Right, Core::HID::DEFAULT_VIBRATION_VALUE);
     }
 }


### PR DESCRIPTION
This PR fully removes old inaccurate npad code for vibration and makes use of the abstract vibration. This matches behavior with FW16.

There are two things missing. NotificationPatterns and proper NpadAbstractPropertiesHandler emulation. I doubt they will cause issues but is something I have to eventually fix. I also removed the vibration filter which might need to add back since that's an issue with oversaturation of controllers but that should be technically be addressed on input_common.