### PR TITLE
service: acc: Only save profiles when profiles have changed

### DIFF
--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -103,6 +103,7 @@ private:
     std::optional<std::size_t> AddToProfiles(const ProfileInfo& profile);
     bool RemoveProfileAtIndex(std::size_t index);
 
+    bool is_save_needed{};
     std::array<ProfileInfo, MAX_USERS> profiles{};
     std::array<ProfileInfo, MAX_USERS> stored_opened_profiles{};
     std::size_t user_count{};

--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -205,6 +205,7 @@ void ConfigureProfileManager::AddUser() {
 
     const auto uuid = Common::UUID::MakeRandom();
     profile_manager.CreateNewUser(uuid, username.toStdString());
+    profile_manager.WriteUserSaveFile();
 
     item_model->appendRow(new QStandardItem{GetIcon(uuid), FormatUserEntryText(username, uuid)});
 }
@@ -228,6 +229,7 @@ void ConfigureProfileManager::RenameUser() {
     std::copy(username_std.begin(), username_std.end(), profile.username.begin());
 
     profile_manager.SetProfileBase(*uuid, profile);
+    profile_manager.WriteUserSaveFile();
 
     item_model->setItem(
         user, 0,
@@ -255,6 +257,8 @@ void ConfigureProfileManager::DeleteUser(const Common::UUID& uuid) {
     if (!profile_manager.RemoveUser(uuid)) {
         return;
     }
+
+    profile_manager.WriteUserSaveFile();
 
     item_model->removeRows(tree_view->currentIndex().row(), 1);
     tree_view->clearSelection();


### PR DESCRIPTION
I finally got an instance where the profile data corrupted. The issue here is that we save when the profile manager is destroyed, normally this works fine but on a crash it might not flush the contents on time. Leaving you with a 0 byte file. Next session will detect the file is empty and create a new user. 

To fix that I removed the save on destruction, we don't need that. Instead I save only when the contents change. This should permanently fix this long standing bug.