### PR TITLE
android: Move ktlintCheck to yuzu-verify

### DIFF
--- a/.ci/scripts/format/script.sh
+++ b/.ci/scripts/format/script.sh
@@ -32,3 +32,6 @@ if [ ! -z "$DIFF" ]; then
     echo "$DIFF"
     exit 1
 fi
+
+cd src/android
+./gradlew ktlintCheck

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,13 +13,15 @@ jobs:
   format:
     name: 'verify format'
     runs-on: ubuntu-latest
-    container:
-      image: yuzuemu/build-environments:linux-clang-format
-      options: -u 1001
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: false
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
       - name: 'Verify Formatting'
         run: bash -ex ./.ci/scripts/format/script.sh
   build:

--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -188,8 +188,15 @@ tasks.create<Delete>("ktlintReset") {
     delete(File(buildDir.path + File.separator + "intermediates/ktLint"))
 }
 
+val showFormatHelp = {
+    logger.lifecycle(
+        "If this check fails, please try running \"gradlew ktlintFormat\" for automatic " +
+            "codestyle fixes"
+    )
+}
+tasks.getByPath("ktlintKotlinScriptCheck").doFirst { showFormatHelp.invoke() }
+tasks.getByPath("ktlintMainSourceSetCheck").doFirst { showFormatHelp.invoke() }
 tasks.getByPath("loadKtlintReporters").dependsOn("ktlintReset")
-tasks.getByPath("preBuild").dependsOn("ktlintCheck")
 
 ktlint {
     version.set("0.47.1")


### PR DESCRIPTION
Running the ktlint check every time you built the android project was pretty frustrating. This moves it to run in the `verify` step for PRs like clang-format.

 This also adds a hint to run `gradlew ktlintFormat` to automatically format your code if the verification steps fail.