### PR TITLE
android: Show version name instead of build hash in about fragment

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AboutFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AboutFragment.kt
@@ -76,8 +76,8 @@ class AboutFragment : Fragment() {
             binding.root.findNavController().navigate(R.id.action_aboutFragment_to_licensesFragment)
         }
 
-        binding.textBuildHash.text = BuildConfig.GIT_HASH
-        binding.buttonBuildHash.setOnClickListener {
+        binding.textVersionName.text = BuildConfig.VERSION_NAME
+        binding.textVersionName.setOnClickListener {
             val clipBoard =
                 requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
             val clip = ClipData.newPlainText(getString(R.string.build), BuildConfig.GIT_HASH)

--- a/src/android/app/src/main/res/layout-w600dp/fragment_about.xml
+++ b/src/android/app/src/main/res/layout-w600dp/fragment_about.xml
@@ -147,7 +147,7 @@
                     android:layout_marginHorizontal="20dp" />
 
                 <LinearLayout
-                    android:id="@+id/button_build_hash"
+                    android:id="@+id/button_version_name"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="?attr/selectableItemBackground"
@@ -164,7 +164,7 @@
                         android:textAlignment="viewStart" />
 
                     <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/text_build_hash"
+                        android:id="@+id/text_version_name"
                         style="@style/TextAppearance.Material3.BodyMedium"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/src/android/app/src/main/res/layout/fragment_about.xml
+++ b/src/android/app/src/main/res/layout/fragment_about.xml
@@ -148,7 +148,7 @@
                 android:layout_marginHorizontal="20dp" />
 
             <LinearLayout
-                android:id="@+id/button_build_hash"
+                android:id="@+id/button_version_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingVertical="16dp"
@@ -165,7 +165,7 @@
                     android:text="@string/build" />
 
                 <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_build_hash"
+                    android:id="@+id/text_version_name"
                     style="@style/TextAppearance.Material3.BodyMedium"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
Allows you to see the git tag (Ex. "android-190") used for our android mainline builds and the build hash plus the release variant (Ex. "15d8a4052-relWithDebInfo") for all other builds under "Build" in the about page.