### PR TITLE
ci: Remove format step from mainline builds

### DIFF
--- a/.ci/yuzu-mainline-step2.yml
+++ b/.ci/yuzu-mainline-step2.yml
@@ -8,17 +8,7 @@ variables:
   DisplayVersion: $[counter(variables['DisplayPrefix'], 1)]
 
 stages:
-- stage: format
-  displayName: 'format'
-  jobs:
-  - job: format
-    displayName: 'clang'
-    pool:
-      vmImage: ubuntu-latest
-    steps:
-    - template: ./templates/format-check.yml
 - stage: build
-  dependsOn: format
   displayName: 'build'
   jobs:
   - job: build


### PR DESCRIPTION
Broke after moving the ktlint checks to CI but this should only be happening for PRs anyways.