### PR TITLE
android: Fix overlay toggle ordering

### DIFF
--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -228,10 +228,10 @@
         <item>R</item>
         <item>ZL</item>
         <item>ZR</item>
-        <item>@string/gamepad_left_stick</item>
-        <item>@string/gamepad_right_stick</item>
         <item>L3</item>
         <item>R3</item>
+        <item>@string/gamepad_left_stick</item>
+        <item>@string/gamepad_right_stick</item>
         <item>@string/gamepad_d_pad</item>
     </string-array>
 


### PR DESCRIPTION
Fixes an issue where the L3/R3 and Left Stick/Right Stick buttons in the toggle buttons menu would be swapped