### PR TITLE
core: hid: Disable special features before disconnecting the controllers

### DIFF
--- a/src/hid_core/frontend/emulated_controller.cpp
+++ b/src/hid_core/frontend/emulated_controller.cpp
@@ -110,6 +110,7 @@ void EmulatedController::ReloadFromSettings() {
         original_npad_type = npad_type;
     }
 
+    SetPollingMode(EmulatedDeviceIndex::RightIndex, Common::Input::PollingMode::Active);
     Disconnect();
     if (player.connected) {
         Connect();


### PR DESCRIPTION
Disconnecting the controller while special features are still active will cause a double lock. To prevent this disable anything before disconnecting. This fixes a crash when using nfc and trying to open the config menu.