### PR TITLE
renderer_vulkan: recreate swapchain when frame size changes

### DIFF
--- a/src/video_core/renderer_vulkan/vk_present_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_manager.cpp
@@ -329,7 +329,7 @@ void PresentManager::CopyToSwapchainImpl(Frame* frame) {
     // to account for that.
     const bool is_suboptimal = swapchain.NeedsRecreation();
     const bool size_changed =
-        swapchain.GetWidth() < frame->width || swapchain.GetHeight() < frame->height;
+        swapchain.GetWidth() != frame->width || swapchain.GetHeight() != frame->height;
     if (is_suboptimal || size_changed) {
         RecreateSwapchain(frame);
     }


### PR DESCRIPTION
Fixes #12684

Mutter has an issue where if you present a surface larger than the dimensions of your swapchain it just draws over random crap on the screen so that's lovely. Possibly should check if this is an issue in kwin or wlroots.

This reverts the change from #12543. Arguably it didn't make any sense there because the frame dimensions are always supposed to be based on the swapchain, not on the guest.