### PR TITLE
Allow -u to accept a username string in addition to index

### DIFF
--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -169,10 +169,10 @@ std::optional<std::size_t> ProfileManager::GetUserIndex(const ProfileInfo& user)
 std::optional<std::size_t> ProfileManager::GetUserIndex(const std::string& username) const {
     const auto iter =
         std::find_if(profiles.begin(), profiles.end(), [&username](const ProfileInfo& p) {
-            const std::string pusername = Common::StringFromFixedZeroTerminatedBuffer(
+            const std::string profile_username = Common::StringFromFixedZeroTerminatedBuffer(
                 reinterpret_cast<const char*>(p.username.data()), p.username.size());
 
-            return username.compare(pusername) == 0;
+            return username.compare(profile_username) == 0;
         });
     if (iter == profiles.end()) {
         return std::nullopt;

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -70,6 +70,7 @@ public:
     std::optional<Common::UUID> GetUser(std::size_t index) const;
     std::optional<std::size_t> GetUserIndex(const Common::UUID& uuid) const;
     std::optional<std::size_t> GetUserIndex(const ProfileInfo& user) const;
+    std::optional<std::size_t> GetUserIndex(const std::string& username) const;
     bool GetProfileBase(std::optional<std::size_t> index, ProfileBase& profile) const;
     bool GetProfileBase(Common::UUID uuid, ProfileBase& profile) const;
     bool GetProfileBase(const ProfileInfo& user, ProfileBase& profile) const;

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -523,6 +523,8 @@ private:
     std::unique_ptr<EmuThread> emu_thread;
     // The path to the game currently running
     QString current_game_path;
+    // Whether a user was set on the command line (skips UserSelector if it's forced to show up)
+    bool user_flag_cmd_line = false;
 
     bool auto_paused = false;
     bool auto_muted = false;


### PR DESCRIPTION
Allow -u to accept a username string in addition to index, and suppress the User selector even if settings requires it to be shown for one instance only.