### PR TITLE
macOS: Bump MoltenVK to v1.2.7

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -351,7 +351,7 @@ if (APPLE)
 
     if (NOT USE_SYSTEM_MOLTENVK)
         set(MOLTENVK_PLATFORM "macOS")
-        set(MOLTENVK_VERSION "v1.2.5")
+        set(MOLTENVK_VERSION "v1.2.7")
         download_moltenvk_external(${MOLTENVK_PLATFORM} ${MOLTENVK_VERSION})
     endif()
     find_library(MOLTENVK_LIBRARY MoltenVK REQUIRED)


### PR DESCRIPTION
Bumps MVK from 1.2.5 to 1.2.7  (Vulkan SDK 1.3.275)

I have tested with a few games and didn't notice any regressions. 

Here is the [changelog for 1.2.7](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.7): 
<details>
  <summary>Changelog 1.2.7</summary>

- Add support for extensions:
  - `VK_KHR_calibrated_timestamp`
  - `VK_KHR_format_feature_flags2`
  - `VK_KHR_vertex_attribute_divisor`
  - `VK_EXT_extended_dynamic_state3` (Metal does not support `VK_POLYGON_MODE_POINT`)
  - `VK_EXT_headless_surface`
  - `VK_EXT_layer_settings`
- Add support for format `VK_FORMAT_B4G4R4A4_UNORM_PACK16`.
- Add support for vertex formats `VK_FORMAT_B10G11R11_UFLOAT_PACK32` & `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32`.
- Fix regression that broke `VK_POLYGON_MODE_LINE`.
- Fix regression in marking rendering state dirty after `vkCmdClearAttachments()`.
- Fix regression error in argument buffer runtime arrays.
- Fix rare deadlock during launch via `dlopen()`.
- Fix initial value of `VkPhysicalDeviceLimits::timestampPeriod` on non-Apple Silicon GPUs.
- Fix swapchain and surface bugs when windowing system is accessed from off the main thread.
- Fix system memory size of tvOS.
- Fix `heapUsage` query for non-unified memory devices.
- Add a defensive guard to ensure `heapUsage[0]` calculation is correct.
- Clamp max per-set descriptor limit to minimum `1024`.
- Enable the cube texture gradient workaround for Apple Silicon.
- Ensure `lineWidthGranularity` is zero if the wideLines feature isn't supported.
- Ensure `maxDrawIndexedIndexValue` set to `UINT32_MAX`.
- Ignore no external handle types specified for buffers and images.
- Expose `VK_EXT_debug_utils` device functions as device functions, not instance functions.
- Emit `primitiveRestartEnable` disabled warning only for strip topology.
- Enable `mandatory VK_EXT_descriptor_indexing` features, and don't advertise extension if they are not supported.
- Reduce disk space consumed after running `fetchDependencies` script by removing intermediate file caches.
- Deprecate `vkSetMoltenVKConfigurationMVK()`.
- Deprecate `mvk_config.h` and move content to `mvk_private_api.h` and `mvk_deprecated_api.h`.
- The Cube demo is now based on Volk, with dynamic library linking, and dynamic function pointer calls.
- Update copyright notices to year 2024.
- Update dependency libraries to match Vulkan SDK 1.3.275.
- Update to latest SPIRV-Cross:
  - MSL: Fix regression error in argument buffer runtime arrays.
  - MSL: Work around broken cube texture gradients on Apple Silicon.
  - MSL: Ensure discrete runtime arrays of buffers have known length.
  - MSL: Implement Metal 3.1 image atomics natively.
  - MSL: Fix patch vertex count with raw buffer tese input.
  - MSL: Improve handling of sample masks.
  - MSL: Add divide to reserved function names.
  - MSL: Support std140 half matrices and arrays.
  - MSL: Use more appropriate padded types.
  - MSL: Don't use swizzle if we have wrapper.
  - MSL: Add ray-cull mask
  - MSL: Consider PtrAccessChain on array types.
  - MSL: Use LHS expression to determine whether or not to do array copy.
  - MSL: Only do address-of expression when needed.
  - MSL: Improve PtrAccessChain handling.
  - MSL: Use powr instead of pow.
  - MSL: Remove special case for threadgroup array wrapper.
  - MSL: Added an `Op` field to `SPIRType` and refactor.

</details>


Here is the [changelog for 1.2.6](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.6): 
<details>
  <summary>Changelog 1.2.6</summary>

- Add support for extensions:
    - `VK_KHR_synchronization2`
    - `VK_EXT_extended_dynamic_state` (requires Metal 3.1 for `VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE`)
    - `VK_EXT_extended_dynamic_state2`
- Fix rare case where vertex attribute buffers are not bound to Metal when no other bindings change between pipelines.
- Ensure objects retained for life of `MTLCommandBuffer` during `vkCmdBlitImage()` & `vkQueuePresentKHR()`.
- Fix case where a `CAMetalDrawable` with invalid pixel format causes onscreen flickering.
- Fix deadlock when reporting debug message on `MVKInstance` destruction.
- Fix MSL code used in `vkCmdBlitImage()` on depth-stencil formats.
- Improve behavior of swapchain image presentation stalls caused by Metal regression.
- `VkPhysicalDeviceLimits::timestampPeriod` set to 1.0 on Apple GPUs, and calculated dynamically on non-Apple GPUs.
- Add `MVKConfiguration::timestampPeriodLowPassAlpha` and environment variable `MVK_CONFIG_TIMESTAMP_PERIOD_LOWPASS_ALPHA`, to add a configurable lowpass filter for varying `VkPhysicalDeviceLimits::timestampPeriod` on non-Apple GPUs.
- Add several additional performance trackers, available via logging, or the `mvk_private_api.h` API.
- Deprecate `MVK_DEBUG` env var, and add `MVK_CONFIG_DEBUG` env var to replace it.
- Update `MVK_CONFIGURATION_API_VERSION` and `MVK_PRIVATE_API_VERSION` to 38.
- Update dependency libraries to match Vulkan SDK 1.3.268.
- Update to latest SPIRV-Cross:
    - MSL: Workaround Metal 3.1 regression bug on recursive input structs.
    - MSL: fix extraction of global variables, in case of atomics.
    - MSL: Workaround bizarre crash on macOS.
    - MSL: runtime array over argument buffers.
    - MSL: Make rw texture fences optional.
    - MSL: Prevent RAW hazards on read_write textures.

</details>