### PR TITLE
android: Change "Clear" to "Use global setting" for per-game settings

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/DriverManagerFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/DriverManagerFragment.kt
@@ -75,7 +75,7 @@ class DriverManagerFragment : Fragment() {
             driverViewModel.showClearButton(!StringSetting.DRIVER_PATH.global)
             binding.toolbarDrivers.setOnMenuItemClickListener {
                 when (it.itemId) {
-                    R.id.menu_driver_clear -> {
+                    R.id.menu_driver_use_global -> {
                         StringSetting.DRIVER_PATH.global = true
                         driverViewModel.updateDriverList()
                         (binding.listDrivers.adapter as DriverAdapter)
@@ -93,7 +93,7 @@ class DriverManagerFragment : Fragment() {
                     repeatOnLifecycle(Lifecycle.State.STARTED) {
                         driverViewModel.showClearButton.collect {
                             binding.toolbarDrivers.menu
-                                .findItem(R.id.menu_driver_clear).isVisible = it
+                                .findItem(R.id.menu_driver_use_global).isVisible = it
                         }
                     }
                 }

--- a/src/android/app/src/main/res/layout/list_item_setting.xml
+++ b/src/android/app/src/main/res/layout/list_item_setting.xml
@@ -69,7 +69,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:visibility="gone"
-                android:text="@string/clear"
+                android:text="@string/use_global_setting"
                 tools:visibility="visible" />
 
         </LinearLayout>

--- a/src/android/app/src/main/res/layout/list_item_setting_switch.xml
+++ b/src/android/app/src/main/res/layout/list_item_setting_switch.xml
@@ -63,7 +63,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="@string/clear"
+            android:text="@string/use_global_setting"
             android:visibility="gone"
             tools:visibility="visible" />
 

--- a/src/android/app/src/main/res/menu/menu_driver_manager.xml
+++ b/src/android/app/src/main/res/menu/menu_driver_manager.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/menu_driver_clear"
-        android:icon="@drawable/ic_clear"
-        android:title="@string/clear"
-        app:showAsAction="always" />
+        android:id="@+id/menu_driver_use_global"
+        android:title="@string/use_global_setting" />
 
 </menu>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -287,6 +287,7 @@
     <string name="notice">Notice</string>
     <string name="import_complete">Import complete</string>
     <string name="more_options">More options</string>
+    <string name="use_global_setting">Use global setting</string>
 
     <!-- GPU driver installation -->
     <string name="select_gpu_driver">Select GPU driver</string>


### PR DESCRIPTION
Changed the wording for returning to the global setting to make things a little clearer

![use_global_driver](https://github.com/yuzu-emu/yuzu/assets/14132249/332f8530-5ad2-47c3-a472-caf5a439b030)

![use_global_settings](https://github.com/yuzu-emu/yuzu/assets/14132249/06290095-513c-443a-a2bf-4170051d3759)
