### PR TITLE
android: Use elevated card style for home setting card

### DIFF
--- a/src/android/app/src/main/res/layout/card_home_option.xml
+++ b/src/android/app/src/main/res/layout/card_home_option.xml
@@ -2,16 +2,16 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="?attr/materialCardViewFilledStyle"
+    style="?attr/materialCardViewElevatedStyle"
     android:id="@+id/option_card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="24dp"
     android:layout_marginHorizontal="12dp"
     android:background="?attr/selectableItemBackground"
-    android:backgroundTint="?attr/colorSurfaceVariant"
     android:clickable="true"
-    android:focusable="true">
+    android:focusable="true"
+    app:cardElevation="4dp">
 
     <LinearLayout
         android:id="@+id/option_layout"


### PR DESCRIPTION
Works better with the Material You theme in dark mode, black backgrounds, and just generally looks nice

![card_elevation](https://github.com/yuzu-emu/yuzu/assets/14132249/201c7507-d8f3-4d68-ba9f-a12dd4f95521)
