### PR TITLE
externals/dynarmic: Reduce Android compilation stutter

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/BooleanSetting.kt
@@ -10,6 +10,7 @@ enum class BooleanSetting(override val key: String) : AbstractBooleanSetting {
     CPU_DEBUG_MODE("cpu_debug_mode"),
     FASTMEM("cpuopt_fastmem"),
     FASTMEM_EXCLUSIVES("cpuopt_fastmem_exclusives"),
+    MULTIBLOCK_COMPILATION("cpuopt_multiblock_compilation"),
     RENDERER_USE_SPEED_LIMIT("use_speed_limit"),
     USE_DOCKED_MODE("use_docked_mode"),
     RENDERER_USE_DISK_SHADER_CACHE("use_disk_shader_cache"),

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
@@ -337,7 +337,7 @@ abstract class SettingsItem(
                     BooleanSetting.MULTIBLOCK_COMPILATION.setBoolean(value)
                 }
 
-                override val key: String = MULTIBLOCK_COMPILATION
+                override val key: String = BooleanSetting.MULTIBLOCK_COMPILATION.key
                 override val isRuntimeModifiable: Boolean = false
                 override val pairedSettingKey = BooleanSetting.CPU_DEBUG_MODE.key
                 override val defaultValue: Boolean = true

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
@@ -328,6 +328,36 @@ abstract class SettingsItem(
                 override fun reset() = setBoolean(defaultValue)
             }
             put(SwitchSetting(fastmem, R.string.fastmem, 0))
+
+            val multiblock_compilation = object : AbstractBooleanSetting {
+                override fun getBoolean(needsGlobal: Boolean): Boolean =
+                    BooleanSetting.MULTIBLOCK_COMPILATION.getBoolean()
+
+                override fun setBoolean(value: Boolean) {
+                    BooleanSetting.MULTIBLOCK_COMPILATION.setBoolean(value)
+                }
+
+                override val key: String = MULTIBLOCK_COMPILATION
+                override val isRuntimeModifiable: Boolean = false
+                override val pairedSettingKey = BooleanSetting.CPU_DEBUG_MODE.key
+                override val defaultValue: Boolean = true
+                override val isSwitchable: Boolean = true
+                override var global: Boolean
+                    get() {
+                        return BooleanSetting.MULTIBLOCK_COMPILATION.global
+                    }
+                    set(value) {
+                        BooleanSetting.MULTIBLOCK_COMPILATION.global = value
+                    }
+
+                override val isSaveable = true
+
+                override fun getValueAsString(needsGlobal: Boolean): String =
+                    getBoolean().toString()
+
+                override fun reset() = setBoolean(defaultValue)
+            }
+            put(SwitchSetting(multiblock_compilation, R.string.multiblock_compilation, 0))
         }
     }
 }

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="renderer_debug">Graphics debugging</string>
     <string name="renderer_debug_description">Sets the graphics API to a slow debugging mode.</string>
     <string name="fastmem">Fastmem</string>
+    <string name="multiblock_compilation">Accelerated boot</string>
 
     <!-- Audio settings strings -->
     <string name="audio_output_engine">Output engine</string>

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(common STATIC
     address_space.h
     algorithm.h
     alignment.h
+    always_false.h
     announce_multiplayer_room.h
     assert.cpp
     assert.h

--- a/src/common/always_false.h
+++ b/src/common/always_false.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2024 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace Common {
+
+template <typename T>
+struct always_false {
+    static constexpr bool value = false;
+};
+
+template <typename T>
+inline constexpr bool always_false_v = false;
+
+} // namespace Common

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -218,6 +218,8 @@ struct Values {
                                               Category::CpuDebug};
     Setting<bool> cpuopt_ignore_memory_aborts{linkage, true, "cpuopt_ignore_memory_aborts",
                                               Category::CpuDebug};
+    Setting<bool> cpuopt_multiblock_compilation{linkage, true, "cpuopt_multiblock_compilation",
+                                                Category::CpuDebug};
 
     SwitchableSetting<bool> cpuopt_unsafe_unfuse_fma{linkage, true, "cpuopt_unsafe_unfuse_fma",
                                                      Category::CpuUnsafe};

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -913,6 +913,7 @@ if (ARCHITECTURE_x86_64 OR ARCHITECTURE_arm64)
         arm/dynarmic/dynarmic_cp15.h
         arm/dynarmic/dynarmic_exclusive_monitor.cpp
         arm/dynarmic/dynarmic_exclusive_monitor.h
+        arm/dynarmic/dynarmic_settings.h
         hle/service/jit/jit_code_memory.cpp
         hle/service/jit/jit_code_memory.h
         hle/service/jit/jit_context.cpp

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -5,6 +5,7 @@
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #include "core/arm/dynarmic/arm_dynarmic_64.h"
 #include "core/arm/dynarmic/dynarmic_exclusive_monitor.h"
+#include "core/arm/dynarmic/dynarmic_settings.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/k_process.h"
 
@@ -283,80 +284,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ArmDynarmic64::MakeJit(Common::PageTable* pa
         config.code_cache_size = 8_MiB;
     }
 
-    // Safe optimizations
-    if (Settings::values.cpu_debug_mode) {
-        if (!Settings::values.cpuopt_page_tables) {
-            config.page_table = nullptr;
-        }
-        if (!Settings::values.cpuopt_block_linking) {
-            config.optimizations &= ~Dynarmic::OptimizationFlag::BlockLinking;
-        }
-        if (!Settings::values.cpuopt_return_stack_buffer) {
-            config.optimizations &= ~Dynarmic::OptimizationFlag::ReturnStackBuffer;
-        }
-        if (!Settings::values.cpuopt_fast_dispatcher) {
-            config.optimizations &= ~Dynarmic::OptimizationFlag::FastDispatch;
-        }
-        if (!Settings::values.cpuopt_context_elimination) {
-            config.optimizations &= ~Dynarmic::OptimizationFlag::GetSetElimination;
-        }
-        if (!Settings::values.cpuopt_const_prop) {
-            config.optimizations &= ~Dynarmic::OptimizationFlag::ConstProp;
-        }
-        if (!Settings::values.cpuopt_misc_ir) {
-            config.optimizations &= ~Dynarmic::OptimizationFlag::MiscIROpt;
-        }
-        if (!Settings::values.cpuopt_reduce_misalign_checks) {
-            config.only_detect_misalignment_via_page_table_on_page_boundary = false;
-        }
-        if (!Settings::values.cpuopt_fastmem) {
-            config.fastmem_pointer = nullptr;
-            config.fastmem_exclusive_access = false;
-        }
-        if (!Settings::values.cpuopt_fastmem_exclusives) {
-            config.fastmem_exclusive_access = false;
-        }
-        if (!Settings::values.cpuopt_recompile_exclusives) {
-            config.recompile_on_exclusive_fastmem_failure = false;
-        }
-        if (!Settings::values.cpuopt_ignore_memory_aborts) {
-            config.check_halt_on_memory_access = true;
-        }
-    } else {
-        // Unsafe optimizations
-        if (Settings::values.cpu_accuracy.GetValue() == Settings::CpuAccuracy::Unsafe) {
-            config.unsafe_optimizations = true;
-            if (Settings::values.cpuopt_unsafe_unfuse_fma) {
-                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-            }
-            if (Settings::values.cpuopt_unsafe_reduce_fp_error) {
-                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
-            }
-            if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
-                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
-            }
-            if (Settings::values.cpuopt_unsafe_fastmem_check) {
-                config.fastmem_address_space_bits = 64;
-            }
-            if (Settings::values.cpuopt_unsafe_ignore_global_monitor) {
-                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
-            }
-        }
-
-        // Curated optimizations
-        if (Settings::values.cpu_accuracy.GetValue() == Settings::CpuAccuracy::Auto) {
-            config.unsafe_optimizations = true;
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-            config.fastmem_address_space_bits = 64;
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
-        }
-
-        // Paranoia mode for debugging optimizations
-        if (Settings::values.cpu_accuracy.GetValue() == Settings::CpuAccuracy::Paranoid) {
-            config.unsafe_optimizations = false;
-            config.optimizations = Dynarmic::no_optimizations;
-        }
-    }
+    ConfigureOptimizationSettings(config);
 
     return std::make_shared<Dynarmic::A64::Jit>(config);
 }

--- a/src/core/arm/dynarmic/dynarmic_settings.h
+++ b/src/core/arm/dynarmic/dynarmic_settings.h
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <type_traits>
+
+#include "common/always_false.h"
+#include "common/assert.h"
+#include "common/settings.h"
+
+namespace Dynarmic::A32 {
+struct UserConfig;
+}
+
+namespace Dynarmic::A64 {
+struct UserConfig;
+}
+
+namespace Core {
+
+template <typename Config>
+void ConfigureOptimizationSettings(Config& config) {
+    // Safe optimizations
+    if (Settings::values.cpu_debug_mode) {
+        if (!Settings::values.cpuopt_page_tables) {
+            config.page_table = nullptr;
+        }
+        if (!Settings::values.cpuopt_block_linking) {
+            config.optimizations &= ~Dynarmic::OptimizationFlag::BlockLinking;
+        }
+        if (!Settings::values.cpuopt_return_stack_buffer) {
+            config.optimizations &= ~Dynarmic::OptimizationFlag::ReturnStackBuffer;
+        }
+        if (!Settings::values.cpuopt_fast_dispatcher) {
+            config.optimizations &= ~Dynarmic::OptimizationFlag::FastDispatch;
+        }
+        if (!Settings::values.cpuopt_context_elimination) {
+            config.optimizations &= ~Dynarmic::OptimizationFlag::GetSetElimination;
+        }
+        if (!Settings::values.cpuopt_const_prop) {
+            config.optimizations &= ~Dynarmic::OptimizationFlag::ConstProp;
+        }
+        if (!Settings::values.cpuopt_misc_ir) {
+            config.optimizations &= ~Dynarmic::OptimizationFlag::MiscIROpt;
+        }
+        if (!Settings::values.cpuopt_reduce_misalign_checks) {
+            config.only_detect_misalignment_via_page_table_on_page_boundary = false;
+        }
+        if (!Settings::values.cpuopt_fastmem) {
+            config.fastmem_pointer = nullptr;
+            config.fastmem_exclusive_access = false;
+        }
+        if (!Settings::values.cpuopt_fastmem_exclusives) {
+            config.fastmem_exclusive_access = false;
+        }
+        if (!Settings::values.cpuopt_recompile_exclusives) {
+            config.recompile_on_exclusive_fastmem_failure = false;
+        }
+        if (!Settings::values.cpuopt_ignore_memory_aborts) {
+            config.check_halt_on_memory_access = true;
+        }
+    } else {
+        // Unsafe optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CpuAccuracy::Unsafe) {
+            config.unsafe_optimizations = true;
+            if (Settings::values.cpuopt_unsafe_unfuse_fma) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+            }
+            if (Settings::values.cpuopt_unsafe_reduce_fp_error) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
+            }
+            if (Settings::values.cpuopt_unsafe_ignore_standard_fpcr) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
+            }
+            if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
+            }
+            if (Settings::values.cpuopt_unsafe_ignore_global_monitor) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
+            }
+        }
+
+        // Curated optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CpuAccuracy::Auto) {
+            if constexpr (std::is_same_v<Config, Dynarmic::A32::UserConfig>) {
+                config.unsafe_optimizations = true;
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
+            } else if constexpr (std::is_same_v<Config, Dynarmic::A64::UserConfig>) {
+                config.unsafe_optimizations = true;
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+                config.fastmem_address_space_bits = 64;
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
+            } else {
+                static_assert(Common::always_false_v<Config>);
+            }
+        }
+
+        // Paranoia mode for debugging optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CpuAccuracy::Paranoid) {
+            config.unsafe_optimizations = false;
+            config.optimizations = Dynarmic::no_optimizations;
+        }
+    }
+}
+
+} // namespace Core

--- a/src/core/arm/dynarmic/dynarmic_settings.h
+++ b/src/core/arm/dynarmic/dynarmic_settings.h
@@ -42,6 +42,9 @@ void ConfigureOptimizationSettings(Config& config) {
         if (!Settings::values.cpuopt_misc_ir) {
             config.optimizations &= ~Dynarmic::OptimizationFlag::MiscIROpt;
         }
+        if (!Settings::values.cpuopt_multiblock_compilation) {
+            config.optimizations &= ~Dynarmic::OptimizationFlag::MultiBlockCompilation;
+        }
         if (!Settings::values.cpuopt_reduce_misalign_checks) {
             config.only_detect_misalignment_via_page_table_on_page_boundary = false;
         }


### PR DESCRIPTION
An attempt to reduce startup time (untested).

This compiles multiple basic blocks at a time (i.e. all blocks directly reachable from the current one), and thus tries to reduce W^X overhead.

This currently doesn't attempt to follow blocks at predicted return sites, but this an area for potential future work. (One can implement this by scanning a block for `PushRSB` and adding the referenced location descriptor to the compilation queue.)

This currently references a dynarmic dev branch, and thus should not be merged.