### PR TITLE
fs/file: Explicitly convert std::u8string to std::filesystem::path

### DIFF
--- a/src/common/fs/file.h
+++ b/src/common/fs/file.h
@@ -37,7 +37,7 @@ void OpenFileStream(FileStream& file_stream, const std::filesystem::path& path,
 template <typename FileStream, typename Path>
 void OpenFileStream(FileStream& file_stream, const Path& path, std::ios_base::openmode open_mode) {
     if constexpr (IsChar<typename Path::value_type>) {
-        file_stream.open(ToU8String(path), open_mode);
+        file_stream.open(std::filesystem::path{ToU8String(path)}, open_mode);
     } else {
         file_stream.open(std::filesystem::path{path}, open_mode);
     }


### PR DESCRIPTION
Closes #12723.

std::fstream::open takes a std::filesystem::path as a first argument. [MSVC correctly accepts this, but libc++/libstdc++ does not](https://twitter.com/__phantomderp/status/1748763826479091742). Explicitly convert for better compiler compatibility.