### PR TITLE
Use high swap interval values as speed scale override

### DIFF
--- a/src/core/hle/service/nvnflinger/nvnflinger.cpp
+++ b/src/core/hle/service/nvnflinger/nvnflinger.cpp
@@ -332,7 +332,7 @@ s64 Nvnflinger::GetNextTicks() const {
     f32 effective_fps;
     if (swap_interval >= 5) {
         // As an extension, treat high swap intervals as speed limit override
-        speed_scale = 100.f / swap_interval;
+        speed_scale = 100.f / static_cast<f32>(swap_interval);
         effective_fps = 60.f;
     } else if (swap_interval <= 0) {
         // As an extension, treat nonpositive swap interval as framerate multiplier.

--- a/src/core/hle/service/nvnflinger/nvnflinger.cpp
+++ b/src/core/hle/service/nvnflinger/nvnflinger.cpp
@@ -329,9 +329,17 @@ s64 Nvnflinger::GetNextTicks() const {
         speed_scale = 1.f;
     }
 
-    // As an extension, treat nonpositive swap interval as framerate multiplier.
-    const f32 effective_fps = swap_interval <= 0 ? 120.f * static_cast<f32>(1 - swap_interval)
-                                                 : 60.f / static_cast<f32>(swap_interval);
+    f32 effective_fps;
+    if (swap_interval >= 5) {
+        // As an extension, treat high swap intervals as speed limit override
+        speed_scale = 100.f / swap_interval;
+        effective_fps = 60.f;
+    } else if (swap_interval <= 0) {
+        // As an extension, treat nonpositive swap interval as framerate multiplier.
+        effective_fps = 120.f * static_cast<f32>(1 - swap_interval);
+    } else {
+        effective_fps = 60.f / static_cast<f32>(swap_interval);
+    }
 
     return static_cast<s64>(speed_scale * (1000000000.f / effective_fps));
 }


### PR DESCRIPTION
Previously, for fps mods, we had to set 0 or negative swap interval values to unlock the framerate above 60. However, this means we can only lock to mulitples of 120, So to get more granular control we use high swap interval values as a speed limit override. Realistically, no game will ever set the swap interval to a value more than 4, so we use any value of 5 or above as a speed limit override.

So for example setting the swap interval to 150 means that we are effectively setting the speed limit to 150%.