### PR TITLE
service: set: Don't allow invalid mii author id

### DIFF
--- a/src/core/hle/service/set/system_settings_server.cpp
+++ b/src/core/hle/service/set/system_settings_server.cpp
@@ -1038,6 +1038,11 @@ void ISystemSettingsServer::SetBluetoothEnableFlag(HLERequestContext& ctx) {
 }
 
 void ISystemSettingsServer::GetMiiAuthorId(HLERequestContext& ctx) {
+    if (m_system_settings.mii_author_id.IsInvalid()) {
+        m_system_settings.mii_author_id = Common::UUID::MakeDefault();
+        SetSaveNeeded();
+    }
+
     LOG_INFO(Service_SET, "called, author_id={}",
              m_system_settings.mii_author_id.FormattedString());
 


### PR DESCRIPTION
Mii edit is broken because some settings config have invalid UUID. This should fix these issues