### PR TITLE
general: workarounds for SMMU syncing issues

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1546,7 +1546,10 @@ void BufferCache<P>::ImmediateUploadMemory([[maybe_unused]] Buffer& buffer,
             std::span<const u8> upload_span;
             const DAddr device_addr = buffer.CpuAddr() + copy.dst_offset;
             if (IsRangeGranular(device_addr, copy.size)) {
-                upload_span = std::span(device_memory.GetPointer<u8>(device_addr), copy.size);
+                auto* const ptr = device_memory.GetPointer<u8>(device_addr);
+                if (ptr != nullptr) {
+                    upload_span = std::span(ptr, copy.size);
+                }
             } else {
                 if (immediate_buffer.empty()) {
                     immediate_buffer = ImmediateBuffer(largest_copy);

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -1064,8 +1064,6 @@ public:
                 }
             });
         }
-        auto* ptr = device_memory.GetPointer<u8>(new_query->dependant_address);
-        ASSERT(ptr != nullptr);
 
         new_query->dependant_manage = must_manage_dependance;
         pending_flush_queries.push_back(index);
@@ -1104,9 +1102,11 @@ public:
                 tfb_streamer.Free(query->dependant_index);
             } else {
                 u8* pointer = device_memory.GetPointer<u8>(query->dependant_address);
-                u32 result;
-                std::memcpy(&result, pointer, sizeof(u32));
-                num_vertices = static_cast<u64>(result) / query->stride;
+                if (pointer != nullptr) {
+                    u32 result;
+                    std::memcpy(&result, pointer, sizeof(u32));
+                    num_vertices = static_cast<u64>(result) / query->stride;
+                }
             }
             query->value = [&]() -> u64 {
                 switch (query->topology) {
@@ -1360,7 +1360,9 @@ bool QueryCacheRuntime::HostConditionalRenderingCompareValues(VideoCommon::Looku
     const auto check_value = [&](DAddr address) {
         u8* ptr = impl->device_memory.GetPointer<u8>(address);
         u64 value{};
-        std::memcpy(&value, ptr, sizeof(value));
+        if (ptr != nullptr) {
+            std::memcpy(&value, ptr, sizeof(value));
+        }
         return value == 0;
     };
     std::array<VideoCommon::LookupData*, 2> objects{&object_1, &object_2};


### PR DESCRIPTION
Drafting as these are workarounds for a general pattern of behavior where a resource is unmapped from the SMMU before the GPU has released it, which will take more time to fix.

1. ~~Counters can still trigger reprotection when they are not supposed to due to incomplete locking and wrong use of atomics. Protect the entire range before performing any mapping operation.~~
2. ~~Some resources can get stuck in a state where they are still marked as protected but are no longer device mapped. I investigated this for a while but couldn't find the cause.~~
3. Fix crashes resulting from unmapped usages. Fixes #12741

Hacky workarounds removed, can now be merged.