### PR TITLE
service: set: Implement more settings functions for Qlaunch

### DIFF
--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -283,7 +283,7 @@ public:
             {17, &IBtmSystemCore::GetConnectedAudioDevices, "GetConnectedAudioDevices"},
             {18, nullptr, "DisconnectAudioDevice"},
             {19, nullptr, "AcquirePairedAudioDeviceInfoChangedEvent"},
-            {20, nullptr, "GetPairedAudioDevices"},
+            {20, &IBtmSystemCore::GetPairedAudioDevices, "GetPairedAudioDevices"},
             {21, nullptr, "RemoveAudioDevicePairing"},
             {22, &IBtmSystemCore::RequestAudioDeviceConnectionRejection, "RequestAudioDeviceConnectionRejection"},
             {23, &IBtmSystemCore::CancelAudioDeviceConnectionRejection, "CancelAudioDeviceConnectionRejection"}
@@ -321,6 +321,13 @@ private:
     }
 
     void GetConnectedAudioDevices(HLERequestContext& ctx) {
+        LOG_WARNING(Service_BTM, "(STUBBED) called");
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push<u32>(0);
+    }
+
+    void GetPairedAudioDevices(HLERequestContext& ctx) {
         LOG_WARNING(Service_BTM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -33,7 +33,7 @@ void LoopProcess(Core::System& system) {
     server_manager->RegisterNamedService(
         "hid:dbg", std::make_shared<IHidDebugServer>(system, resource_manager));
     server_manager->RegisterNamedService(
-        "hid:sys", std::make_shared<IHidSystemServer>(system, resource_manager));
+        "hid:sys", std::make_shared<IHidSystemServer>(system, resource_manager, firmware_settings));
 
     server_manager->RegisterNamedService("hidbus", std::make_shared<HidBus>(system));
 

--- a/src/core/hle/service/hid/hid_server.cpp
+++ b/src/core/hle/service/hid/hid_server.cpp
@@ -1419,8 +1419,8 @@ void IHidServer::EnableUnintendedHomeButtonInputProtection(HLERequestContext& ct
 
     const auto parameters{rp.PopRaw<Parameters>()};
 
-    LOG_INFO(Service_HID, "called, is_enabled={}, npad_id={}, applet_resource_user_id={}",
-             parameters.is_enabled, parameters.npad_id, parameters.applet_resource_user_id);
+    LOG_DEBUG(Service_HID, "called, is_enabled={}, npad_id={}, applet_resource_user_id={}",
+              parameters.is_enabled, parameters.npad_id, parameters.applet_resource_user_id);
 
     if (!IsNpadIdValid(parameters.npad_id)) {
         IPC::ResponseBuilder rb{ctx, 3};

--- a/src/core/hle/service/hid/hid_system_server.h
+++ b/src/core/hle/service/hid/hid_system_server.h
@@ -16,13 +16,16 @@ class KEvent;
 
 namespace Service::HID {
 class ResourceManager;
+class HidFirmwareSettings;
 
 class IHidSystemServer final : public ServiceFramework<IHidSystemServer> {
 public:
-    explicit IHidSystemServer(Core::System& system_, std::shared_ptr<ResourceManager> resource);
+    explicit IHidSystemServer(Core::System& system_, std::shared_ptr<ResourceManager> resource,
+                              std::shared_ptr<HidFirmwareSettings> settings);
     ~IHidSystemServer() override;
 
 private:
+    void GetPlatformConfig(HLERequestContext& ctx);
     void ApplyNpadSystemCommonPolicy(HLERequestContext& ctx);
     void EnableAssigningSingleOnSlSrPress(HLERequestContext& ctx);
     void DisableAssigningSingleOnSlSrPress(HLERequestContext& ctx);
@@ -50,6 +53,7 @@ private:
     void GetVibrationMasterVolume(HLERequestContext& ctx);
     void BeginPermitVibrationSession(HLERequestContext& ctx);
     void EndPermitVibrationSession(HLERequestContext& ctx);
+    void IsJoyConRailEnabled(HLERequestContext& ctx);
     void IsJoyConAttachedOnAllRail(HLERequestContext& ctx);
     void AcquireConnectionTriggerTimeoutEvent(HLERequestContext& ctx);
     void AcquireDeviceRegisteredEventForControllerSupport(HLERequestContext& ctx);
@@ -58,12 +62,14 @@ private:
     void GetUniquePadIds(HLERequestContext& ctx);
     void AcquireJoyDetachOnBluetoothOffEventHandle(HLERequestContext& ctx);
     void IsUsbFullKeyControllerEnabled(HLERequestContext& ctx);
+    void EnableUsbFullKeyController(HLERequestContext& ctx);
     void IsHandheldButtonPressedOnConsoleMode(HLERequestContext& ctx);
     void InitializeFirmwareUpdate(HLERequestContext& ctx);
     void CheckFirmwareUpdateRequired(HLERequestContext& ctx);
     void SetFirmwareHotfixUpdateSkipEnabled(HLERequestContext& ctx);
     void InitializeUsbFirmwareUpdate(HLERequestContext& ctx);
     void FinalizeUsbFirmwareUpdate(HLERequestContext& ctx);
+    void CheckUsbFirmwareUpdateRequired(HLERequestContext& ctx);
     void InitializeUsbFirmwareUpdateWithoutMemory(HLERequestContext& ctx);
     void GetTouchScreenDefaultConfiguration(HLERequestContext& ctx);
     void SetForceHandheldStyleVibration(HLERequestContext& ctx);
@@ -77,6 +83,7 @@ private:
     Kernel::KEvent* unique_pad_connection_event;
     KernelHelpers::ServiceContext service_context;
     std::shared_ptr<ResourceManager> resource_manager;
+    std::shared_ptr<HidFirmwareSettings> firmware_settings;
 };
 
 } // namespace Service::HID

--- a/src/core/hle/service/set/setting_formats/system_settings.cpp
+++ b/src/core/hle/service/set/setting_formats/system_settings.cpp
@@ -50,6 +50,7 @@ SystemSettings DefaultSystemSettings() {
     settings.primary_album_storage = PrimaryAlbumStorage::SdCard;
     settings.battery_percentage_flag = true;
     settings.chinese_traditional_input_method = ChineseTraditionalInputMethod::Unknown0;
+    settings.vibration_master_volume = 1.0f;
 
     return settings;
 }

--- a/src/core/hle/service/set/settings_types.h
+++ b/src/core/hle/service/set/settings_types.h
@@ -323,6 +323,15 @@ struct NotificationFlag {
 };
 static_assert(sizeof(NotificationFlag) == 4, "NotificationFlag is an invalid size");
 
+struct PlatformConfig {
+    union {
+        u32 raw{};
+        BitField<0, 1, u32> has_rail_interface;
+        BitField<1, 1, u32> has_sio_mcu;
+    };
+};
+static_assert(sizeof(PlatformConfig) == 0x4, "PlatformConfig is an invalid size");
+
 /// This is nn::settings::system::TvFlag
 struct TvFlag {
     union {

--- a/src/core/hle/service/set/system_settings_server.h
+++ b/src/core/hle/service/set/system_settings_server.h
@@ -48,26 +48,28 @@ public:
         return result;
     }
 
-    Result GetExternalSteadyClockSourceId(Common::UUID& out_id);
-    Result SetExternalSteadyClockSourceId(Common::UUID id);
-    Result GetUserSystemClockContext(Service::PSC::Time::SystemClockContext& out_context);
-    Result SetUserSystemClockContext(Service::PSC::Time::SystemClockContext& context);
-    Result GetDeviceTimeZoneLocationName(Service::PSC::Time::LocationName& out_name);
-    Result SetDeviceTimeZoneLocationName(Service::PSC::Time::LocationName& name);
-    Result GetNetworkSystemClockContext(Service::PSC::Time::SystemClockContext& out_context);
-    Result SetNetworkSystemClockContext(Service::PSC::Time::SystemClockContext& context);
-    Result IsUserSystemClockAutomaticCorrectionEnabled(bool& out_enabled);
+    Result GetVibrationMasterVolume(f32& out_volume) const;
+    Result SetVibrationMasterVolume(f32 volume);
+    Result GetExternalSteadyClockSourceId(Common::UUID& out_id) const;
+    Result SetExternalSteadyClockSourceId(const Common::UUID& id);
+    Result GetUserSystemClockContext(Service::PSC::Time::SystemClockContext& out_context) const;
+    Result SetUserSystemClockContext(const Service::PSC::Time::SystemClockContext& context);
+    Result GetDeviceTimeZoneLocationName(Service::PSC::Time::LocationName& out_name) const;
+    Result SetDeviceTimeZoneLocationName(const Service::PSC::Time::LocationName& name);
+    Result GetNetworkSystemClockContext(Service::PSC::Time::SystemClockContext& out_context) const;
+    Result SetNetworkSystemClockContext(const Service::PSC::Time::SystemClockContext& context);
+    Result IsUserSystemClockAutomaticCorrectionEnabled(bool& out_enabled) const;
     Result SetUserSystemClockAutomaticCorrectionEnabled(bool enabled);
     Result SetExternalSteadyClockInternalOffset(s64 offset);
-    Result GetExternalSteadyClockInternalOffset(s64& out_offset);
+    Result GetExternalSteadyClockInternalOffset(s64& out_offset) const;
     Result GetDeviceTimeZoneLocationUpdatedTime(
-        Service::PSC::Time::SteadyClockTimePoint& out_time_point);
+        Service::PSC::Time::SteadyClockTimePoint& out_time_point) const;
     Result SetDeviceTimeZoneLocationUpdatedTime(
-        Service::PSC::Time::SteadyClockTimePoint& time_point);
+        const Service::PSC::Time::SteadyClockTimePoint& time_point);
     Result GetUserSystemClockAutomaticCorrectionUpdatedTime(
-        Service::PSC::Time::SteadyClockTimePoint& out_time_point);
+        Service::PSC::Time::SteadyClockTimePoint& out_time_point) const;
     Result SetUserSystemClockAutomaticCorrectionUpdatedTime(
-        Service::PSC::Time::SteadyClockTimePoint time_point);
+        const Service::PSC::Time::SteadyClockTimePoint& time_point);
 
 private:
     void SetLanguageCode(HLERequestContext& ctx);
@@ -89,12 +91,17 @@ private:
     void SetNotificationSettings(HLERequestContext& ctx);
     void GetAccountNotificationSettings(HLERequestContext& ctx);
     void SetAccountNotificationSettings(HLERequestContext& ctx);
+    void GetVibrationMasterVolume(HLERequestContext& ctx);
+    void SetVibrationMasterVolume(HLERequestContext& ctx);
     void GetSettingsItemValueSize(HLERequestContext& ctx);
     void GetSettingsItemValue(HLERequestContext& ctx);
     void GetTvSettings(HLERequestContext& ctx);
     void SetTvSettings(HLERequestContext& ctx);
+    void IsForceMuteOnHeadphoneRemoved(HLERequestContext& ctx);
+    void SetForceMuteOnHeadphoneRemoved(HLERequestContext& ctx);
     void GetDebugModeFlag(HLERequestContext& ctx);
     void GetQuestFlag(HLERequestContext& ctx);
+    void SetQuestFlag(HLERequestContext& ctx);
     void GetDeviceTimeZoneLocationName(HLERequestContext& ctx);
     void SetDeviceTimeZoneLocationName(HLERequestContext& ctx);
     void SetRegionCode(HLERequestContext& ctx);
@@ -103,6 +110,7 @@ private:
     void IsUserSystemClockAutomaticCorrectionEnabled(HLERequestContext& ctx);
     void SetUserSystemClockAutomaticCorrectionEnabled(HLERequestContext& ctx);
     void GetPrimaryAlbumStorage(HLERequestContext& ctx);
+    void SetPrimaryAlbumStorage(HLERequestContext& ctx);
     void GetNfcEnableFlag(HLERequestContext& ctx);
     void SetNfcEnableFlag(HLERequestContext& ctx);
     void GetSleepSettings(HLERequestContext& ctx);

--- a/src/hid_core/resource_manager.cpp
+++ b/src/hid_core/resource_manager.cpp
@@ -6,6 +6,8 @@
 #include "core/core_timing.h"
 #include "core/hle/kernel/k_shared_memory.h"
 #include "core/hle/service/ipc_helpers.h"
+#include "core/hle/service/set/system_settings_server.h"
+#include "core/hle/service/sm/sm.h"
 #include "hid_core/hid_core.h"
 #include "hid_core/hid_util.h"
 #include "hid_core/resource_manager.h"
@@ -180,7 +182,11 @@ void ResourceManager::InitializeHidCommonSampler() {
     debug_pad->SetAppletResource(applet_resource, &shared_mutex);
     digitizer->SetAppletResource(applet_resource, &shared_mutex);
     keyboard->SetAppletResource(applet_resource, &shared_mutex);
-    npad->SetNpadExternals(applet_resource, &shared_mutex, handheld_config);
+
+    const auto settings =
+        system.ServiceManager().GetService<Service::Set::ISystemSettingsServer>("set:sys");
+    npad->SetNpadExternals(applet_resource, &shared_mutex, handheld_config, settings);
+
     six_axis->SetAppletResource(applet_resource, &shared_mutex);
     mouse->SetAppletResource(applet_resource, &shared_mutex);
     debug_mouse->SetAppletResource(applet_resource, &shared_mutex);

--- a/src/hid_core/resources/hid_firmware_settings.cpp
+++ b/src/hid_core/resources/hid_firmware_settings.cpp
@@ -40,6 +40,13 @@ void HidFirmwareSettings::LoadSettings(bool reload_config) {
     m_set_sys->GetSettingsItemValue<bool>(is_touch_firmware_auto_update_disabled, "hid_debug",
                                           "touch_firmware_auto_update_disabled");
 
+    bool has_rail_interface{};
+    bool has_sio_mcu{};
+    m_set_sys->GetSettingsItemValue<bool>(has_rail_interface, "hid", "has_rail_interface");
+    m_set_sys->GetSettingsItemValue<bool>(has_sio_mcu, "hid", "has_sio_mcu");
+    platform_config.has_rail_interface.Assign(has_rail_interface);
+    platform_config.has_sio_mcu.Assign(has_sio_mcu);
+
     is_initialized = true;
 }
 
@@ -101,6 +108,11 @@ HidFirmwareSettings::FirmwareSetting HidFirmwareSettings::GetFirmwareUpdateFailu
 HidFirmwareSettings::FeaturesPerId HidFirmwareSettings::FeaturesDisabledPerId() {
     LoadSettings(false);
     return features_per_id_disabled;
+}
+
+Set::PlatformConfig HidFirmwareSettings::GetPlatformConfig() {
+    LoadSettings(false);
+    return platform_config;
 }
 
 } // namespace Service::HID

--- a/src/hid_core/resources/hid_firmware_settings.h
+++ b/src/hid_core/resources/hid_firmware_settings.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/common_types.h"
+#include "core/hle/service/set/settings_types.h"
 
 namespace Core {
 class System;
@@ -39,6 +40,7 @@ public:
 
     FirmwareSetting GetFirmwareUpdateFailure();
     FeaturesPerId FeaturesDisabledPerId();
+    Set::PlatformConfig GetPlatformConfig();
 
 private:
     bool is_initialized{};
@@ -57,6 +59,7 @@ private:
     bool is_touch_firmware_auto_update_disabled{};
     FirmwareSetting is_firmware_update_failure{};
     FeaturesPerId features_per_id_disabled{};
+    Set::PlatformConfig platform_config{};
 
     std::shared_ptr<Service::Set::ISystemSettingsServer> m_set_sys;
 };

--- a/src/hid_core/resources/npad/npad.cpp
+++ b/src/hid_core/resources/npad/npad.cpp
@@ -1080,11 +1080,14 @@ void NPad::UnregisterAppletResourceUserId(u64 aruid) {
 
 void NPad::SetNpadExternals(std::shared_ptr<AppletResource> resource,
                             std::recursive_mutex* shared_mutex,
-                            std::shared_ptr<HandheldConfig> handheld_config) {
+                            std::shared_ptr<HandheldConfig> handheld_config,
+                            std::shared_ptr<Service::Set::ISystemSettingsServer> settings) {
     applet_resource_holder.applet_resource = resource;
     applet_resource_holder.shared_mutex = shared_mutex;
     applet_resource_holder.shared_npad_resource = &npad_resource;
     applet_resource_holder.handheld_config = handheld_config;
+
+    vibration_handler.SetSettingsService(settings);
 
     for (auto& abstract_pad : abstracted_pads) {
         abstract_pad.SetExternals(&applet_resource_holder, nullptr, nullptr, nullptr, nullptr,

--- a/src/hid_core/resources/npad/npad.h
+++ b/src/hid_core/resources/npad/npad.h
@@ -34,6 +34,10 @@ namespace Service::KernelHelpers {
 class ServiceContext;
 } // namespace Service::KernelHelpers
 
+namespace Service::Set {
+class ISystemSettingsServer;
+}
+
 union Result;
 
 namespace Service::HID {
@@ -128,7 +132,8 @@ public:
     void UnregisterAppletResourceUserId(u64 aruid);
     void SetNpadExternals(std::shared_ptr<AppletResource> resource,
                           std::recursive_mutex* shared_mutex,
-                          std::shared_ptr<HandheldConfig> handheld_config);
+                          std::shared_ptr<HandheldConfig> handheld_config,
+                          std::shared_ptr<Service::Set::ISystemSettingsServer> settings);
 
     AppletDetailedUiType GetAppletDetailedUiType(Core::HID::NpadIdType npad_id);
 

--- a/src/hid_core/resources/npad/npad_vibration.cpp
+++ b/src/hid_core/resources/npad/npad_vibration.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "core/hle/service/set/system_settings_server.h"
 #include "hid_core/hid_result.h"
 #include "hid_core/resources/npad/npad_vibration.h"
 
@@ -13,16 +14,23 @@ NpadVibration::~NpadVibration() = default;
 Result NpadVibration::Activate() {
     std::scoped_lock lock{mutex};
 
-    const f32 master_volume = 1.0f; // nn::settings::system::GetVibrationMasterVolume();
-    // if (master_volume < 0.0f || master_volume > 1.0f) {
-    //     return ResultVibrationStrengthOutOfRange;
-    // }
+    f32 master_volume = 1.0f;
+    m_set_sys->GetVibrationMasterVolume(master_volume);
+    if (master_volume < 0.0f || master_volume > 1.0f) {
+        return ResultVibrationStrengthOutOfRange;
+    }
 
     volume = master_volume;
     return ResultSuccess;
 }
 
 Result NpadVibration::Deactivate() {
+    return ResultSuccess;
+}
+
+Result NpadVibration::SetSettingsService(
+    std::shared_ptr<Service::Set::ISystemSettingsServer> settings) {
+    m_set_sys = settings;
     return ResultSuccess;
 }
 
@@ -34,7 +42,7 @@ Result NpadVibration::SetVibrationMasterVolume(f32 master_volume) {
     }
 
     volume = master_volume;
-    // nn::settings::system::SetVibrationMasterVolume(master_volume);
+    m_set_sys->SetVibrationMasterVolume(master_volume);
 
     return ResultSuccess;
 }
@@ -48,10 +56,11 @@ Result NpadVibration::GetVibrationVolume(f32& out_volume) const {
 Result NpadVibration::GetVibrationMasterVolume(f32& out_volume) const {
     std::scoped_lock lock{mutex};
 
-    const f32 master_volume = 1.0f; // nn::settings::system::GetVibrationMasterVolume();
-    // if (master_volume < 0.0f || master_volume > 1.0f) {
-    //     return ResultVibrationStrengthOutOfRange;
-    // }
+    f32 master_volume = 1.0f;
+    m_set_sys->GetVibrationMasterVolume(master_volume);
+    if (master_volume < 0.0f || master_volume > 1.0f) {
+        return ResultVibrationStrengthOutOfRange;
+    }
 
     out_volume = master_volume;
     return ResultSuccess;
@@ -67,10 +76,11 @@ Result NpadVibration::BeginPermitVibrationSession(u64 aruid) {
 Result NpadVibration::EndPermitVibrationSession() {
     std::scoped_lock lock{mutex};
 
-    const f32 master_volume = 1.0f; // nn::settings::system::GetVibrationMasterVolume();
-    // if (master_volume < 0.0f || master_volume > 1.0f) {
-    //     return ResultVibrationStrengthOutOfRange;
-    // }
+    f32 master_volume = 1.0f;
+    m_set_sys->GetVibrationMasterVolume(master_volume);
+    if (master_volume < 0.0f || master_volume > 1.0f) {
+        return ResultVibrationStrengthOutOfRange;
+    }
 
     volume = master_volume;
     session_aruid = 0;

--- a/src/hid_core/resources/npad/npad_vibration.h
+++ b/src/hid_core/resources/npad/npad_vibration.h
@@ -8,6 +8,10 @@
 #include "common/common_types.h"
 #include "core/hle/result.h"
 
+namespace Service::Set {
+class ISystemSettingsServer;
+}
+
 namespace Service::HID {
 
 class NpadVibration final {
@@ -18,6 +22,7 @@ public:
     Result Activate();
     Result Deactivate();
 
+    Result SetSettingsService(std::shared_ptr<Service::Set::ISystemSettingsServer> settings);
     Result SetVibrationMasterVolume(f32 master_volume);
     Result GetVibrationVolume(f32& out_volume) const;
     Result GetVibrationMasterVolume(f32& out_volume) const;
@@ -31,6 +36,8 @@ private:
     f32 volume{};
     u64 session_aruid{};
     mutable std::mutex mutex;
+
+    std::shared_ptr<Service::Set::ISystemSettingsServer> m_set_sys;
 };
 
 } // namespace Service::HID


### PR DESCRIPTION
Mostly used by Qlaunch. Implements a few more settings needed mostly on HID. There are still more to implement but reduces the need for auto stub.