### PR TITLE
service: properly convert buffers to strings

### DIFF
--- a/src/core/hle/service/nvdrv/nvdrv_interface.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv_interface.cpp
@@ -4,6 +4,7 @@
 
 #include "common/logging/log.h"
 #include "common/scope_exit.h"
+#include "common/string_util.h"
 #include "core/core.h"
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/kernel/k_process.h"
@@ -29,7 +30,7 @@ void NVDRV::Open(HLERequestContext& ctx) {
     }
 
     const auto& buffer = ctx.ReadBuffer();
-    const std::string device_name(buffer.begin(), buffer.end());
+    const std::string device_name(Common::StringFromBuffer(buffer));
 
     if (device_name == "/dev/nvhost-prof-gpu") {
         rb.Push<DeviceFD>(0);

--- a/src/core/hle/service/set/system_settings_server.cpp
+++ b/src/core/hle/service/set/system_settings_server.cpp
@@ -710,12 +710,12 @@ void ISystemSettingsServer::GetSettingsItemValueSize(HLERequestContext& ctx) {
     // The category of the setting. This corresponds to the top-level keys of
     // system_settings.ini.
     const auto setting_category_buf{ctx.ReadBuffer(0)};
-    const std::string setting_category{setting_category_buf.begin(), setting_category_buf.end()};
+    const std::string setting_category{Common::StringFromBuffer(setting_category_buf)};
 
     // The name of the setting. This corresponds to the second-level keys of
     // system_settings.ini.
     const auto setting_name_buf{ctx.ReadBuffer(1)};
-    const std::string setting_name{setting_name_buf.begin(), setting_name_buf.end()};
+    const std::string setting_name{Common::StringFromBuffer(setting_name_buf)};
 
     auto settings{GetSettings()};
     u64 response_size{0};
@@ -733,12 +733,12 @@ void ISystemSettingsServer::GetSettingsItemValue(HLERequestContext& ctx) {
     // The category of the setting. This corresponds to the top-level keys of
     // system_settings.ini.
     const auto setting_category_buf{ctx.ReadBuffer(0)};
-    const std::string setting_category{setting_category_buf.begin(), setting_category_buf.end()};
+    const std::string setting_category{Common::StringFromBuffer(setting_category_buf)};
 
     // The name of the setting. This corresponds to the second-level keys of
     // system_settings.ini.
     const auto setting_name_buf{ctx.ReadBuffer(1)};
-    const std::string setting_name{setting_name_buf.begin(), setting_name_buf.end()};
+    const std::string setting_name{Common::StringFromBuffer(setting_name_buf)};
 
     std::vector<u8> value;
     auto response = GetSettingsItemValue(value, setting_category, setting_name);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -15,6 +15,7 @@
 #include "common/logging/log.h"
 #include "common/math_util.h"
 #include "common/settings.h"
+#include "common/string_util.h"
 #include "common/swap.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/k_readable_event.h"
@@ -694,9 +695,7 @@ private:
     void OpenLayer(HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
         const auto name_buf = rp.PopRaw<std::array<u8, 0x40>>();
-        const auto end = std::find(name_buf.begin(), name_buf.end(), '\0');
-
-        const std::string display_name(name_buf.begin(), end);
+        const std::string display_name(Common::StringFromBuffer(name_buf));
 
         const u64 layer_id = rp.Pop<u64>();
         const u64 aruid = rp.Pop<u64>();


### PR DESCRIPTION
Found this issue while debugging the setting service. We can't convert from buffer to string directly with begin()...end() since that will include trailing zeroes on the string and any comparison with another string will fail. It also causes issues with logging as the parser doesn't handle this well either.