### PR TITLE
Demote dozen to the bottom of the device list

### DIFF
--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -39,6 +39,10 @@ void SortPhysicalDevicesPerVendor(std::vector<VkPhysicalDevice>& devices,
     }
 }
 
+bool IsMicrosoftDozen(const char* device_name) {
+    return std::strstr(device_name, "Microsoft") != nullptr;
+}
+
 void SortPhysicalDevices(std::vector<VkPhysicalDevice>& devices, const InstanceDispatch& dld) {
     // Sort by name, this will set a base and make GPUs with higher numbers appear first
     // (e.g. GTX 1650 will intentionally be listed before a GTX 1080).
@@ -52,6 +56,12 @@ void SortPhysicalDevices(std::vector<VkPhysicalDevice>& devices, const InstanceD
     });
     // Prefer Nvidia over AMD, AMD over Intel, Intel over the rest.
     SortPhysicalDevicesPerVendor(devices, dld, {0x10DE, 0x1002, 0x8086});
+    // Demote Microsoft's Dozen devices to the bottom.
+    SortPhysicalDevices(
+        devices, dld,
+        [](const VkPhysicalDeviceProperties& lhs, const VkPhysicalDeviceProperties& rhs) {
+            return IsMicrosoftDozen(rhs.deviceName) && !IsMicrosoftDozen(lhs.deviceName);
+        });
 }
 
 template <typename T>


### PR DESCRIPTION
Recently, Windows started shipping an OpenCL/OpenGL/Vulkan compatibility pack, which includes dozen, Mesa's D3D12 to Vulkan compatibility layer.

Those new Vulkan devices are called "Microsoft Direct3D (device name)", making them take priority over AMD and Intel devices in yuzu's Vulkan device list due to how the list is ordered (inverse alphabetical order takes priority).
This change checks for the Microsoft string and pushes those devices to the bottom of the list, following the other rules in the ordering process.