### PR TITLE
externals: fix simpleini link error

### DIFF
--- a/CMakeModules/FindSimpleIni.cmake
+++ b/CMakeModules/FindSimpleIni.cmake
@@ -2,18 +2,40 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-find_path(SimpleIni_INCLUDE_DIR SimpleIni.h)
+find_path(SimpleIni_INCLUDE_DIR NAMES SimpleIni.h
+    PATHS
+    /usr/include
+    /usr/include/simpleini
+    )
+
+find_library(SimpleIni_LIBRARIES NAMES simpleini
+    PATHS
+    /usr/lib
+    /usr/local/lib
+    )
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SimpleIni
-    REQUIRED_VARS SimpleIni_INCLUDE_DIR
-)
+if(SimpleIni_LIBRARIES)
+    find_package_handle_standard_args(SimpleIni
+        REQUIRED_VARS SimpleIni_INCLUDE_DIR SimpleIni_LIBRARIES
+    )
+else()
+    find_package_handle_standard_args(SimpleIni
+        REQUIRED_VARS SimpleIni_INCLUDE_DIR
+    )
+endif()
 
 if (SimpleIni_FOUND AND NOT TARGET SimpleIni::SimpleIni)
     add_library(SimpleIni::SimpleIni INTERFACE IMPORTED)
     set_target_properties(SimpleIni::SimpleIni PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${SimpleIni_INCLUDE_DIR}"
     )
+    if(SimpleIni_LIBRARIES)
+        set_target_properties(SimpleIni::SimpleIni PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${SimpleIni_LIBRARIES}"
+            IMPORTED_LOCATION "${SimpleIni_LIBRARIES}"
+        )
+    endif()
 endif()
 
 mark_as_advanced(SimpleIni_INCLUDE_DIR)


### PR DESCRIPTION
This implicitly links the simpleini shared object library in the FindSimpleini module. This works in Debian but I have retained the original code path just in case it breaks anything.

Possible fix for #12791 