### PR TITLE
android: Controller focus optimizations

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
@@ -193,6 +193,10 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
             return super.dispatchKeyEvent(event)
         }
 
+        if (emulationViewModel.drawerOpen.value) {
+            return super.dispatchKeyEvent(event)
+        }
+
         return InputHandler.dispatchKeyEvent(event)
     }
 
@@ -200,6 +204,10 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
         if (event.source and InputDevice.SOURCE_JOYSTICK != InputDevice.SOURCE_JOYSTICK &&
             event.source and InputDevice.SOURCE_GAMEPAD != InputDevice.SOURCE_GAMEPAD
         ) {
+            return super.dispatchGenericMotionEvent(event)
+        }
+
+        if (emulationViewModel.drawerOpen.value) {
             return super.dispatchGenericMotionEvent(event)
         }
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AboutFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AboutFragment.kt
@@ -77,7 +77,7 @@ class AboutFragment : Fragment() {
         }
 
         binding.textVersionName.text = BuildConfig.VERSION_NAME
-        binding.textVersionName.setOnClickListener {
+        binding.buttonVersionName.setOnClickListener {
             val clipBoard =
                 requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
             val clip = ClipData.newPlainText(getString(R.string.build), BuildConfig.GIT_HASH)

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/EmulationViewModel.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/EmulationViewModel.kt
@@ -6,6 +6,7 @@ package org.yuzu.yuzu_emu.model
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class EmulationViewModel : ViewModel() {
     val emulationStarted: StateFlow<Boolean> get() = _emulationStarted
@@ -22,6 +23,9 @@ class EmulationViewModel : ViewModel() {
 
     val shaderMessage: StateFlow<String> get() = _shaderMessage
     private val _shaderMessage = MutableStateFlow("")
+
+    private val _drawerOpen = MutableStateFlow(false)
+    val drawerOpen = _drawerOpen.asStateFlow()
 
     fun setEmulationStarted(started: Boolean) {
         _emulationStarted.value = started
@@ -47,6 +51,10 @@ class EmulationViewModel : ViewModel() {
         setShaderMessage(msg)
         setShaderProgress(progress)
         setTotalShaders(max)
+    }
+
+    fun setDrawerOpen(value: Boolean) {
+        _drawerOpen.value = value
     }
 
     fun clear() {

--- a/src/android/app/src/main/res/layout-w600dp/fragment_about.xml
+++ b/src/android/app/src/main/res/layout-w600dp/fragment_about.xml
@@ -11,12 +11,14 @@
         android:id="@+id/appbar_about"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_about"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
             app:navigationIcon="@drawable/ic_back"
             app:title="@string/about" />
 

--- a/src/android/app/src/main/res/layout-w600dp/fragment_about.xml
+++ b/src/android/app/src/main/res/layout-w600dp/fragment_about.xml
@@ -30,6 +30,7 @@
         android:layout_height="match_parent"
         android:fadeScrollbars="false"
         android:scrollbars="vertical"
+        android:defaultFocusHighlightEnabled="false"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout

--- a/src/android/app/src/main/res/layout-w600dp/fragment_game_info.xml
+++ b/src/android/app/src/main/res/layout-w600dp/fragment_game_info.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_about"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_info"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
+            app:navigationIcon="@drawable/ic_back" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:defaultFocusHighlightEnabled="false"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:id="@+id/content_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingHorizontal="16dp"
+            android:baselineAligned="false">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:layout_weight="3"
+                android:gravity="top|center_horizontal"
+                android:paddingHorizontal="16dp">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/button_copy"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/copy_details" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/button_verify_integrity"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/verify_integrity" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:layout_weight="1">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/path"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="16dp">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/path_field"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:editable="false"
+                        android:importantForAutofill="no"
+                        android:inputType="none"
+                        android:minHeight="48dp"
+                        android:textAlignment="viewStart"
+                        tools:text="1.0.0" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/program_id"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="16dp">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/program_id_field"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:editable="false"
+                        android:importantForAutofill="no"
+                        android:inputType="none"
+                        android:minHeight="48dp"
+                        android:textAlignment="viewStart"
+                        tools:text="1.0.0" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/developer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="16dp">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/developer_field"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:editable="false"
+                        android:importantForAutofill="no"
+                        android:inputType="none"
+                        android:minHeight="48dp"
+                        android:textAlignment="viewStart"
+                        tools:text="1.0.0" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/version"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="16dp">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/version_field"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:editable="false"
+                        android:importantForAutofill="no"
+                        android:inputType="none"
+                        android:minHeight="48dp"
+                        android:textAlignment="viewStart"
+                        tools:text="1.0.0" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/android/app/src/main/res/layout-w600dp/fragment_game_properties.xml
+++ b/src/android/app/src/main/res/layout-w600dp/fragment_game_properties.xml
@@ -14,6 +14,7 @@
         android:clipToPadding="false"
         android:fadeScrollbars="false"
         android:scrollbars="vertical"
+        android:defaultFocusHighlightEnabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/icon_layout"
         app:layout_constraintTop_toTopOf="parent">

--- a/src/android/app/src/main/res/layout/card_driver_option.xml
+++ b/src/android/app/src/main/res/layout/card_driver_option.xml
@@ -23,6 +23,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
+            android:focusable="false"
             android:clickable="false"
             android:checked="false" />
 

--- a/src/android/app/src/main/res/layout/card_folder.xml
+++ b/src/android/app/src/main/res/layout/card_folder.xml
@@ -6,16 +6,14 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="16dp"
-    android:layout_marginVertical="12dp"
-    android:focusable="true">
+    android:layout_marginVertical="12dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:padding="16dp"
-        android:layout_gravity="center_vertical"
-        android:animateLayoutChanges="true">
+        android:layout_gravity="center_vertical">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/path"

--- a/src/android/app/src/main/res/layout/fragment_about.xml
+++ b/src/android/app/src/main/res/layout/fragment_about.xml
@@ -30,6 +30,7 @@
         android:layout_height="match_parent"
         android:scrollbars="vertical"
         android:fadeScrollbars="false"
+        android:defaultFocusHighlightEnabled="false"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout

--- a/src/android/app/src/main/res/layout/fragment_about.xml
+++ b/src/android/app/src/main/res/layout/fragment_about.xml
@@ -11,12 +11,14 @@
         android:id="@+id/appbar_about"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_about"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
             app:title="@string/about"
             app:navigationIcon="@drawable/ic_back" />
 

--- a/src/android/app/src/main/res/layout/fragment_addons.xml
+++ b/src/android/app/src/main/res/layout/fragment_addons.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -19,6 +20,7 @@
             android:id="@+id/toolbar_addons"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
             app:navigationIcon="@drawable/ic_back" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/src/android/app/src/main/res/layout/fragment_addons.xml
+++ b/src/android/app/src/main/res/layout/fragment_addons.xml
@@ -30,6 +30,8 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:clipToPadding="false"
+        android:defaultFocusHighlightEnabled="false"
+        android:nextFocusDown="@id/button_install"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/src/android/app/src/main/res/layout/fragment_applet_launcher.xml
+++ b/src/android/app/src/main/res/layout/fragment_applet_launcher.xml
@@ -10,12 +10,14 @@
         android:id="@+id/appbar_applets"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_applets"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
             app:navigationIcon="@drawable/ic_back"
             app:title="@string/applets" />
 

--- a/src/android/app/src/main/res/layout/fragment_driver_manager.xml
+++ b/src/android/app/src/main/res/layout/fragment_driver_manager.xml
@@ -15,12 +15,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fitsSystemWindows="true"
+            android:touchscreenBlocksFocus="false"
             app:liftOnScrollTargetViewId="@id/list_drivers">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar_drivers"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                android:touchscreenBlocksFocus="false"
                 app:navigationIcon="@drawable/ic_back"
                 app:title="@string/gpu_driver_manager" />
 

--- a/src/android/app/src/main/res/layout/fragment_early_access.xml
+++ b/src/android/app/src/main/res/layout/fragment_early_access.xml
@@ -32,6 +32,7 @@
         android:paddingBottom="20dp"
         android:scrollbars="vertical"
         android:fadeScrollbars="false"
+        android:defaultFocusHighlightEnabled="false"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout

--- a/src/android/app/src/main/res/layout/fragment_early_access.xml
+++ b/src/android/app/src/main/res/layout/fragment_early_access.xml
@@ -11,12 +11,14 @@
         android:id="@+id/appbar_ea"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_about"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
             app:navigationIcon="@drawable/ic_back"
             app:title="@string/early_access" />
 

--- a/src/android/app/src/main/res/layout/fragment_emulation.xml
+++ b/src/android/app/src/main/res/layout/fragment_emulation.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:keepScreenOn="true"
+    android:defaultFocusHighlightEnabled="false"
     tools:context="org.yuzu.yuzu_emu.fragments.EmulationFragment"
     tools:openDrawer="start">
 
@@ -24,7 +25,8 @@
                 android:layout_height="match_parent"
                 android:layout_gravity="center"
                 android:focusable="false"
-                android:focusableInTouchMode="false" />
+                android:focusableInTouchMode="false"
+                android:defaultFocusHighlightEnabled="false" />
 
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/loading_indicator"
@@ -32,7 +34,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:focusable="false"
+                android:defaultFocusHighlightEnabled="false"
                 android:clickable="false">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
@@ -118,6 +120,7 @@
                 android:layout_gravity="center"
                 android:focusable="true"
                 android:focusableInTouchMode="true"
+                android:defaultFocusHighlightEnabled="false"
                 android:visibility="invisible" />
 
             <Button

--- a/src/android/app/src/main/res/layout/fragment_emulation.xml
+++ b/src/android/app/src/main/res/layout/fragment_emulation.xml
@@ -160,6 +160,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
+        android:focusedByDefault="true"
         app:headerLayout="@layout/header_in_game"
         app:menu="@menu/menu_in_game"
         tools:visibility="gone" />

--- a/src/android/app/src/main/res/layout/fragment_folders.xml
+++ b/src/android/app/src/main/res/layout/fragment_folders.xml
@@ -15,12 +15,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fitsSystemWindows="true"
+            android:touchscreenBlocksFocus="false"
             app:liftOnScrollTargetViewId="@id/list_folders">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar_folders"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                android:touchscreenBlocksFocus="false"
                 app:navigationIcon="@drawable/ic_back"
                 app:title="@string/game_folders" />
 

--- a/src/android/app/src/main/res/layout/fragment_folders.xml
+++ b/src/android/app/src/main/res/layout/fragment_folders.xml
@@ -33,6 +33,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clipToPadding="false"
+            android:defaultFocusHighlightEnabled="false"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/android/app/src/main/res/layout/fragment_game_info.xml
+++ b/src/android/app/src/main/res/layout/fragment_game_info.xml
@@ -11,12 +11,14 @@
         android:id="@+id/appbar_info"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:touchscreenBlocksFocus="false"
         android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_info"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
             app:navigationIcon="@drawable/ic_back" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/src/android/app/src/main/res/layout/fragment_game_info.xml
+++ b/src/android/app/src/main/res/layout/fragment_game_info.xml
@@ -27,6 +27,7 @@
         android:id="@+id/scroll_info"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:defaultFocusHighlightEnabled="false"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout

--- a/src/android/app/src/main/res/layout/fragment_game_properties.xml
+++ b/src/android/app/src/main/res/layout/fragment_game_properties.xml
@@ -12,7 +12,8 @@
         android:layout_height="match_parent"
         android:scrollbars="vertical"
         android:fadeScrollbars="false"
-        android:clipToPadding="false">
+        android:clipToPadding="false"
+        android:defaultFocusHighlightEnabled="false">
 
         <LinearLayout
             android:id="@+id/layout_all"
@@ -86,7 +87,7 @@
                 android:id="@+id/list_properties"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                tools:listitem="@layout/card_simple_outlined" />
+                android:defaultFocusHighlightEnabled="false" />
 
         </LinearLayout>
 

--- a/src/android/app/src/main/res/layout/fragment_games.xml
+++ b/src/android/app/src/main/res/layout/fragment_games.xml
@@ -27,6 +27,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
+            android:defaultFocusHighlightEnabled="false"
             tools:listitem="@layout/card_game" />
 
     </RelativeLayout>

--- a/src/android/app/src/main/res/layout/fragment_home_settings.xml
+++ b/src/android/app/src/main/res/layout/fragment_home_settings.xml
@@ -7,7 +7,8 @@
     android:background="?attr/colorSurface"
     android:scrollbars="vertical"
     android:fadeScrollbars="false"
-    android:clipToPadding="false">
+    android:clipToPadding="false"
+    android:defaultFocusHighlightEnabled="false">
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/linear_layout_settings"

--- a/src/android/app/src/main/res/layout/fragment_installables.xml
+++ b/src/android/app/src/main/res/layout/fragment_installables.xml
@@ -10,12 +10,14 @@
         android:id="@+id/appbar_installables"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_installables"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
             app:title="@string/manage_yuzu_data"
             app:navigationIcon="@drawable/ic_back" />
 

--- a/src/android/app/src/main/res/layout/fragment_licenses.xml
+++ b/src/android/app/src/main/res/layout/fragment_licenses.xml
@@ -10,12 +10,14 @@
         android:id="@+id/appbar_licenses"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_licenses"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:touchscreenBlocksFocus="false"
             app:title="@string/licenses"
             app:navigationIcon="@drawable/ic_back" />
 

--- a/src/android/app/src/main/res/layout/fragment_settings.xml
+++ b/src/android/app/src/main/res/layout/fragment_settings.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fitsSystemWindows="true"
+        android:touchscreenBlocksFocus="false"
         app:elevation="0dp">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
@@ -24,6 +25,7 @@
                 android:id="@+id/toolbar_settings"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                android:touchscreenBlocksFocus="false"
                 app:layout_collapseMode="pin"
                 app:navigationIcon="@drawable/ic_back" />
 

--- a/src/android/app/src/main/res/layout/list_item_addon.xml
+++ b/src/android/app/src/main/res/layout/list_item_addon.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
-    android:focusable="true"
+    android:focusable="false"
     android:paddingHorizontal="20dp"
     android:paddingVertical="16dp">
 

--- a/src/android/app/src/main/res/layout/list_item_settings_header.xml
+++ b/src/android/app/src/main/res/layout/list_item_settings_header.xml
@@ -12,4 +12,5 @@
     android:textAlignment="viewStart"
     android:textColor="?attr/colorPrimary"
     android:textStyle="bold"
+    android:focusable="false"
     tools:text="CPU Settings" />


### PR DESCRIPTION
This does a few things related to the controller's focus meaning the highlight you see over buttons to indicate that you can click it
- Fixes an issue where you couldn't focus toolbar menu items
- Fixes an issue where the in game menu wouldn't be focused when opened
- Fixes an issue where container views would appear focused even though they aren't clickable
- Fixes an issue where the emulation surface would appear focused and gray
- Adds a landscape layout for the game info page