### PR TITLE
service: hid: Don't try to vibrate if device isn't initialized

### DIFF
--- a/src/hid_core/resource_manager.cpp
+++ b/src/hid_core/resource_manager.cpp
@@ -373,6 +373,10 @@ Result ResourceManager::SendVibrationValue(u64 aruid,
         device = GetNSVibrationDevice(handle);
     }
     if (device != nullptr) {
+        // Prevent sending vibrations to an inactive vibration handle
+        if (!device->IsActive()) {
+            return ResultSuccess;
+        }
         result = device->SendVibrationValue(value);
     }
     return result;

--- a/src/hid_core/resources/vibration/vibration_base.cpp
+++ b/src/hid_core/resources/vibration/vibration_base.cpp
@@ -23,6 +23,10 @@ Result NpadVibrationBase::Deactivate() {
     return ResultSuccess;
 }
 
+bool NpadVibrationBase::IsActive() const {
+    return ref_counter > 0;
+}
+
 bool NpadVibrationBase::IsVibrationMounted() const {
     return is_mounted;
 }

--- a/src/hid_core/resources/vibration/vibration_base.h
+++ b/src/hid_core/resources/vibration/vibration_base.h
@@ -21,6 +21,7 @@ public:
     virtual Result Activate();
     virtual Result Deactivate();
 
+    bool IsActive() const;
     bool IsVibrationMounted() const;
 
 protected:


### PR DESCRIPTION
Some games enable vibration before npad is initialized. Others like `Taiko no Tatsujin Rhythm Festival` send vibrations before vibration is initialized. I reviewed the code a couple of times but there's no mistake from my RE. The only explanation I found is that vibration is probably already initialized from system side. To fix this issue I simply avoid any vibration while the handle is inactive.

Fixes #12797