### PR TITLE
android: Reload global settings on closing emulation

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EmulationFragment.kt
@@ -301,6 +301,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
 
                 R.id.menu_exit -> {
                     emulationState.stop()
+                    NativeConfig.reloadGlobalConfig()
                     emulationViewModel.setIsEmulationStopping(true)
                     binding.drawerLayout.close()
                     binding.inGameMenu.requestFocus()


### PR DESCRIPTION
UI like the driver manager expects the global settings to be loaded when in the MainActivity so we reload global config to properly reset state on exit.