### PR TITLE
Use the input process handle to get the correct application's memory

### DIFF
--- a/src/audio_core/adsp/apps/audio_renderer/audio_renderer.cpp
+++ b/src/audio_core/adsp/apps/audio_renderer/audio_renderer.cpp
@@ -89,11 +89,13 @@ u32 AudioRenderer::Receive(Direction dir) {
 }
 
 void AudioRenderer::SetCommandBuffer(s32 session_id, CpuAddr buffer, u64 size, u64 time_limit,
-                                     u64 applet_resource_user_id, bool reset) noexcept {
+                                     u64 applet_resource_user_id, Kernel::KProcess* process,
+                                     bool reset) noexcept {
     command_buffers[session_id].buffer = buffer;
     command_buffers[session_id].size = size;
     command_buffers[session_id].time_limit = time_limit;
     command_buffers[session_id].applet_resource_user_id = applet_resource_user_id;
+    command_buffers[session_id].process = process;
     command_buffers[session_id].reset_buffer = reset;
 }
 
@@ -173,7 +175,8 @@ void AudioRenderer::Main(std::stop_token stop_token) {
                     // If there are no remaining commands (from the previous list),
                     // this is a new command list, initialize it.
                     if (command_buffer.remaining_command_count == 0) {
-                        command_list_processor.Initialize(system, command_buffer.buffer,
+                        command_list_processor.Initialize(system, *command_buffer.process,
+                                                          command_buffer.buffer,
                                                           command_buffer.size, streams[index]);
                     }
 

--- a/src/audio_core/adsp/apps/audio_renderer/audio_renderer.h
+++ b/src/audio_core/adsp/apps/audio_renderer/audio_renderer.h
@@ -19,6 +19,10 @@ namespace Core {
 class System;
 } // namespace Core
 
+namespace Kernel {
+class KProcess;
+}
+
 namespace AudioCore {
 namespace Sink {
 class Sink;
@@ -69,7 +73,8 @@ public:
     u32 Receive(Direction dir);
 
     void SetCommandBuffer(s32 session_id, CpuAddr buffer, u64 size, u64 time_limit,
-                          u64 applet_resource_user_id, bool reset) noexcept;
+                          u64 applet_resource_user_id, Kernel::KProcess* process,
+                          bool reset) noexcept;
     u32 GetRemainCommandCount(s32 session_id) const noexcept;
     void ClearRemainCommandCount(s32 session_id) noexcept;
     u64 GetRenderingStartTick(s32 session_id) const noexcept;

--- a/src/audio_core/adsp/apps/audio_renderer/command_buffer.h
+++ b/src/audio_core/adsp/apps/audio_renderer/command_buffer.h
@@ -6,6 +6,10 @@
 #include "audio_core/common/common.h"
 #include "common/common_types.h"
 
+namespace Kernel {
+class KProcess;
+}
+
 namespace AudioCore::ADSP::AudioRenderer {
 
 struct CommandBuffer {
@@ -14,6 +18,7 @@ struct CommandBuffer {
     u64 size{};
     u64 time_limit{};
     u64 applet_resource_user_id{};
+    Kernel::KProcess* process{};
     bool reset_buffer{};
     // Set by the DSP
     u32 remaining_command_count{};

--- a/src/audio_core/adsp/apps/audio_renderer/command_list_processor.cpp
+++ b/src/audio_core/adsp/apps/audio_renderer/command_list_processor.cpp
@@ -9,14 +9,15 @@
 #include "common/settings.h"
 #include "core/core.h"
 #include "core/core_timing.h"
+#include "core/hle/kernel/k_process.h"
 #include "core/memory.h"
 
 namespace AudioCore::ADSP::AudioRenderer {
 
-void CommandListProcessor::Initialize(Core::System& system_, CpuAddr buffer, u64 size,
-                                      Sink::SinkStream* stream_) {
+void CommandListProcessor::Initialize(Core::System& system_, Kernel::KProcess& process,
+                                      CpuAddr buffer, u64 size, Sink::SinkStream* stream_) {
     system = &system_;
-    memory = &system->ApplicationMemory();
+    memory = &process.GetMemory();
     stream = stream_;
     header = reinterpret_cast<Renderer::CommandListHeader*>(buffer);
     commands = reinterpret_cast<u8*>(buffer + sizeof(Renderer::CommandListHeader));

--- a/src/audio_core/adsp/apps/audio_renderer/command_list_processor.h
+++ b/src/audio_core/adsp/apps/audio_renderer/command_list_processor.h
@@ -16,6 +16,10 @@ class Memory;
 class System;
 } // namespace Core
 
+namespace Kernel {
+class KProcess;
+}
+
 namespace AudioCore {
 namespace Sink {
 class SinkStream;
@@ -40,7 +44,8 @@ public:
      * @param size   - The size of the buffer.
      * @param stream - The stream to be used for sending the samples.
      */
-    void Initialize(Core::System& system, CpuAddr buffer, u64 size, Sink::SinkStream* stream);
+    void Initialize(Core::System& system, Kernel::KProcess& process, CpuAddr buffer, u64 size,
+                    Sink::SinkStream* stream);
 
     /**
      * Set the maximum processing time for this command list.

--- a/src/audio_core/renderer/audio_renderer.cpp
+++ b/src/audio_core/renderer/audio_renderer.cpp
@@ -6,6 +6,7 @@
 #include "audio_core/renderer/audio_renderer.h"
 #include "audio_core/renderer/system_manager.h"
 #include "core/core.h"
+#include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_transfer_memory.h"
 #include "core/hle/service/audio/errors.h"
 
@@ -17,7 +18,8 @@ Renderer::Renderer(Core::System& system_, Manager& manager_, Kernel::KEvent* ren
 Result Renderer::Initialize(const AudioRendererParameterInternal& params,
                             Kernel::KTransferMemory* transfer_memory,
                             const u64 transfer_memory_size, const u32 process_handle,
-                            const u64 applet_resource_user_id, const s32 session_id) {
+                            Kernel::KProcess& process, const u64 applet_resource_user_id,
+                            const s32 session_id) {
     if (params.execution_mode == ExecutionMode::Auto) {
         if (!manager.AddSystem(system)) {
             LOG_ERROR(Service_Audio,
@@ -28,7 +30,7 @@ Result Renderer::Initialize(const AudioRendererParameterInternal& params,
     }
 
     initialized = true;
-    system.Initialize(params, transfer_memory, transfer_memory_size, process_handle,
+    system.Initialize(params, transfer_memory, transfer_memory_size, process_handle, process,
                       applet_resource_user_id, session_id);
 
     return ResultSuccess;

--- a/src/audio_core/renderer/audio_renderer.h
+++ b/src/audio_core/renderer/audio_renderer.h
@@ -14,7 +14,8 @@ class System;
 
 namespace Kernel {
 class KTransferMemory;
-}
+class KProcess;
+} // namespace Kernel
 
 namespace AudioCore {
 struct AudioRendererParameterInternal;
@@ -44,7 +45,8 @@ public:
      */
     Result Initialize(const AudioRendererParameterInternal& params,
                       Kernel::KTransferMemory* transfer_memory, u64 transfer_memory_size,
-                      u32 process_handle, u64 applet_resource_user_id, s32 session_id);
+                      u32 process_handle, Kernel::KProcess& process, u64 applet_resource_user_id,
+                      s32 session_id);
 
     /**
      * Finalize the renderer for shutdown.

--- a/src/audio_core/renderer/system.h
+++ b/src/audio_core/renderer/system.h
@@ -29,6 +29,7 @@ class System;
 
 namespace Kernel {
 class KEvent;
+class KProcess;
 class KTransferMemory;
 } // namespace Kernel
 
@@ -80,7 +81,8 @@ public:
      */
     Result Initialize(const AudioRendererParameterInternal& params,
                       Kernel::KTransferMemory* transfer_memory, u64 transfer_memory_size,
-                      u32 process_handle, u64 applet_resource_user_id, s32 session_id);
+                      u32 process_handle, Kernel::KProcess& process, u64 applet_resource_user_id,
+                      s32 session_id);
 
     /**
      * Finalize the system.
@@ -275,6 +277,8 @@ private:
     Common::Event terminate_event{};
     /// Does what locks do
     std::mutex lock{};
+    /// Process this audio render is operating within, used for memory reads/writes.
+    Kernel::KProcess* process{};
     /// Handle for the process for this system, unused
     u32 process_handle{};
     /// Applet resource id for this system, unused


### PR DESCRIPTION
Allows audren to work over multiple processes.