### PR TITLE
configure_graphics: Avoid crash when vsync_mode_combobox is empty

### DIFF
--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -224,6 +224,11 @@ void ConfigureGraphics::PopulateVSyncModeSelection(bool use_setting) {
 }
 
 void ConfigureGraphics::UpdateVsyncSetting() const {
+    const Settings::RendererBackend backend{GetCurrentGraphicsBackend()};
+    if (backend == Settings::RendererBackend::Null) {
+        return;
+    }
+
     const auto mode = vsync_mode_combobox_enum_map[vsync_mode_combobox->currentIndex()];
     const auto vsync_mode = PresentModeToSetting(mode);
     Settings::values.vsync_mode.SetValue(vsync_mode);


### PR DESCRIPTION
Steps to reproduce crash:
1. Setup graphics backend to be Null.
2. Open the settings window.
3. Close the settings window.
4. Crash occurs.

Crash occurs because `vsync_mode_combobox->currentIndex() == -1` with the above.