### PR TITLE
fix build for gcc 11

### DIFF
--- a/src/core/hle/service/set/setting_formats/system_settings.cpp
+++ b/src/core/hle/service/set/setting_formats/system_settings.cpp
@@ -45,7 +45,7 @@ SystemSettings DefaultSystemSettings() {
         .console_sleep_plan = ConsoleSleepPlan::Sleep1Hour,
     };
 
-    settings.device_time_zone_location_name = {"UTC"};
+    settings.device_time_zone_location_name = Service::PSC::Time::LocationName{"UTC"};
     settings.user_system_clock_automatic_correction_enabled = true;
 
     settings.primary_album_storage = PrimaryAlbumStorage::SdCard;


### PR DESCRIPTION
Build in ubuntu jammy arm64 gcc 11 with cmake cmd `VCPKG_FORCE_SYSTEM_BINARIES=1 cmake .. -GNinja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DYUZU_USE_QT_WEB_ENGINE=ON -DLINUX=1 -DYUZU_USE_BUNDLED_VCPKG=ON`
This commit fixes build error:
```
/build/deb_build/yuzu-0-1696/src/core/hle/service/set/setting_formats/system_settings.cpp:47:53: error: no match for ‘operator=’ (operand types are ‘Service::PSC::Time::LocationName’ and ‘<brace-enclosed initializer list>’)
   47 |     settings.device_time_zone_location_name = {"UTC"};
      |                                                     ^
In file included from /build/deb_build/yuzu-0-1696/src/./core/hle/service/set/settings_types.h:12,
                 from /build/deb_build/yuzu-0-1696/src/./core/hle/service/set/setting_formats/private_settings.h:10,
                 from /build/deb_build/yuzu-0-1696/src/./core/hle/service/set/setting_formats/system_settings.h:13,
                 from /build/deb_build/yuzu-0-1696/src/core/hle/service/set/setting_formats/system_settings.cpp:4:
/build/deb_build/yuzu-0-1696/src/./core/hle/service/psc/time/common.h:70:8: note: candidate: ‘constexpr Service::PSC::Time::LocationName& Service::PSC::Time::LocationName::operator=(const Service::PSC::Time::LocationName&)’
   70 | struct LocationName {
      |        ^~~~~~~~~~~~
```