### PR TITLE
Persist filters in multiplayer public lobby list

### DIFF
--- a/src/yuzu/multiplayer/lobby.cpp
+++ b/src/yuzu/multiplayer/lobby.cpp
@@ -77,16 +77,23 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
 
     // UI Buttons
     connect(ui->refresh_list, &QPushButton::clicked, this, &Lobby::RefreshLobby);
+    connect(ui->search, &QLineEdit::textChanged, proxy, &LobbyFilterProxyModel::SetFilterSearch);
     connect(ui->games_owned, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterOwned);
     connect(ui->hide_empty, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterEmpty);
     connect(ui->hide_full, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterFull);
-    connect(ui->search, &QLineEdit::textChanged, proxy, &LobbyFilterProxyModel::SetFilterSearch);
     connect(ui->room_list, &QTreeView::doubleClicked, this, &Lobby::OnJoinRoom);
     connect(ui->room_list, &QTreeView::clicked, this, &Lobby::OnExpandRoom);
 
     // Actions
     connect(&room_list_watcher, &QFutureWatcher<AnnounceMultiplayerRoom::RoomList>::finished, this,
             &Lobby::OnRefreshLobby);
+
+    // Load persistent filters after events are connected to make sure they apply
+    ui->search->setText(
+        QString::fromStdString(UISettings::values.multiplayer_filter_text.GetValue()));
+    ui->games_owned->setChecked(UISettings::values.multiplayer_filter_games_owned.GetValue());
+    ui->hide_empty->setChecked(UISettings::values.multiplayer_filter_hide_empty.GetValue());
+    ui->hide_full->setChecked(UISettings::values.multiplayer_filter_hide_full.GetValue());
 }
 
 Lobby::~Lobby() = default;
@@ -204,6 +211,10 @@ void Lobby::OnJoinRoom(const QModelIndex& source) {
 
     // Save settings
     UISettings::values.multiplayer_nickname = ui->nickname->text().toStdString();
+    UISettings::values.multiplayer_filter_text = ui->search->text().toStdString();
+    UISettings::values.multiplayer_filter_games_owned = ui->games_owned->isChecked();
+    UISettings::values.multiplayer_filter_hide_empty = ui->hide_empty->isChecked();
+    UISettings::values.multiplayer_filter_hide_full = ui->hide_full->isChecked();
     UISettings::values.multiplayer_ip =
         proxy->data(connection_index, LobbyItemHost::HostIPRole).value<QString>().toStdString();
     UISettings::values.multiplayer_port =

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -169,6 +169,13 @@ struct Values {
 
     // multiplayer settings
     Setting<std::string> multiplayer_nickname{linkage, {}, "nickname", Category::Multiplayer};
+    Setting<std::string> multiplayer_filter_text{linkage, {}, "filter_text", Category::Multiplayer};
+    Setting<bool> multiplayer_filter_games_owned{linkage, false, "filter_games_owned",
+                                                 Category::Multiplayer};
+    Setting<bool> multiplayer_filter_hide_empty{linkage, false, "filter_games_hide_empty",
+                                                Category::Multiplayer};
+    Setting<bool> multiplayer_filter_hide_full{linkage, false, "filter_games_hide_full",
+                                               Category::Multiplayer};
     Setting<std::string> multiplayer_ip{linkage, {}, "ip", Category::Multiplayer};
     Setting<u16, true> multiplayer_port{linkage,    24872,  0,
                                         UINT16_MAX, "port", Category::Multiplayer};


### PR DESCRIPTION
- Follow-up to https://github.com/yuzu-emu/yuzu/pull/12850.

After connecting to a room, the chosen filter text, "Games I Own", "Hide Empty Rooms" and "Hide Full Rooms" values are persisted to configuration so they are preserved across restarts.

This makes it easier to rejoin a room if you regularly play the same game, or after a crash.
