### PR TITLE
Color player counts in the multiplayer public lobby list

### DIFF
--- a/src/yuzu/multiplayer/lobby_p.h
+++ b/src/yuzu/multiplayer/lobby_p.h
@@ -193,12 +193,29 @@ public:
     }
 
     QVariant data(int role) const override {
-        if (role != Qt::DisplayRole) {
+        switch (role) {
+        case Qt::DisplayRole: {
+            auto members = data(MemberListRole).toList();
+            return QStringLiteral("%1 / %2 ")
+                .arg(QString::number(members.size()), data(MaxPlayerRole).toString());
+        }
+        case Qt::ForegroundRole: {
+            auto members = data(MemberListRole).toList();
+            auto max_players = data(MaxPlayerRole).toInt();
+            if (members.size() >= max_players) {
+                return QBrush(QColor(255, 48, 32));
+            } else if (members.size() == (max_players - 1)) {
+                return QBrush(QColor(255, 140, 32));
+            } else if (members.size() == 0) {
+                return QBrush(QColor(128, 128, 128));
+            }
+            // FIXME: How to return a value that tells Qt not to modify the
+            // text color from the default (as if Qt::ForegroundRole wasn't overridden)?
+            return QBrush(nullptr);
+        }
+        default:
             return LobbyItem::data(role);
         }
-        auto members = data(MemberListRole).toList();
-        return QStringLiteral("%1 / %2 ")
-            .arg(QString::number(members.size()), data(MaxPlayerRole).toString());
     }
 
     bool operator<(const QStandardItem& other) const override {


### PR DESCRIPTION
- Full lobbies have their player count displayed in red.
- Lobbies with one slot left have their player count displayed in orange.
- Empty lobbies have their player count grayed out.

This makes the lobby list easier to visually parse.

## Preview

### Light theme

![Screenshot_20240130_010523](https://github.com/yuzu-emu/yuzu/assets/180032/1ef290d1-041c-412c-bb57-9e405a1fc282) | ![Screenshot_20240130_010713](https://github.com/yuzu-emu/yuzu/assets/180032/b648eb2a-1e39-4453-8c87-0d00ef63a893)
-|-

### Dark theme

![Screenshot_20240130_010333](https://github.com/yuzu-emu/yuzu/assets/180032/1f3109f0-f146-4486-a874-3bd8123ecbc8) |
-|