### PR TITLE
Small time fixes

### DIFF
--- a/src/core/hle/service/glue/time/time_zone.cpp
+++ b/src/core/hle/service/glue/time/time_zone.cpp
@@ -197,32 +197,27 @@ Result TimeZoneService::ToCalendarTimeWithMyRule(
 
 Result TimeZoneService::ToPosixTime(Out<u32> out_count,
                                     OutArray<s64, BufferAttr_HipcPointer> out_times,
-                                    Out<u32> out_times_count,
-                                    Service::PSC::Time::CalendarTime& calendar_time, InRule rule) {
+                                    const Service::PSC::Time::CalendarTime& calendar_time,
+                                    InRule rule) {
     SCOPE_EXIT({
         LOG_DEBUG(Service_Time,
-                  "called. calendar_time={} out_count={} out_times[0]={} out_times[1]={} "
-                  "out_times_count={}",
-                  calendar_time, *out_count, out_times[0], out_times[1], *out_times_count);
+                  "called. calendar_time={} out_count={} out_times[0]={} out_times[1]={}",
+                  calendar_time, *out_count, out_times[0], out_times[1]);
     });
 
-    R_RETURN(
-        m_wrapped_service->ToPosixTime(out_count, out_times, out_times_count, calendar_time, rule));
+    R_RETURN(m_wrapped_service->ToPosixTime(out_count, out_times, calendar_time, rule));
 }
 
-Result TimeZoneService::ToPosixTimeWithMyRule(Out<u32> out_count,
-                                              OutArray<s64, BufferAttr_HipcPointer> out_times,
-                                              Out<u32> out_times_count,
-                                              Service::PSC::Time::CalendarTime& calendar_time) {
+Result TimeZoneService::ToPosixTimeWithMyRule(
+    Out<u32> out_count, OutArray<s64, BufferAttr_HipcPointer> out_times,
+    const Service::PSC::Time::CalendarTime& calendar_time) {
     SCOPE_EXIT({
         LOG_DEBUG(Service_Time,
-                  "called. calendar_time={} out_count={} out_times[0]={} out_times[1]={} "
-                  "out_times_count={}",
-                  calendar_time, *out_count, out_times[0], out_times[1], *out_times_count);
+                  "called. calendar_time={} out_count={} out_times[0]={} out_times[1]={}",
+                  calendar_time, *out_count, out_times[0], out_times[1]);
     });
 
-    R_RETURN(m_wrapped_service->ToPosixTimeWithMyRule(out_count, out_times, out_times_count,
-                                                      calendar_time));
+    R_RETURN(m_wrapped_service->ToPosixTimeWithMyRule(out_count, out_times, calendar_time));
 }
 
 } // namespace Service::Glue::Time

--- a/src/core/hle/service/glue/time/time_zone.h
+++ b/src/core/hle/service/glue/time/time_zone.h
@@ -68,12 +68,10 @@ public:
         Out<Service::PSC::Time::CalendarTime> out_calendar_time,
         Out<Service::PSC::Time::CalendarAdditionalInfo> out_additional_info, s64 time);
     Result ToPosixTime(Out<u32> out_count, OutArray<s64, BufferAttr_HipcPointer> out_times,
-                       Out<u32> out_times_count, Service::PSC::Time::CalendarTime& calendar_time,
-                       InRule rule);
+                       const Service::PSC::Time::CalendarTime& calendar_time, InRule rule);
     Result ToPosixTimeWithMyRule(Out<u32> out_count,
                                  OutArray<s64, BufferAttr_HipcPointer> out_times,
-                                 Out<u32> out_times_count,
-                                 Service::PSC::Time::CalendarTime& calendar_time);
+                                 const Service::PSC::Time::CalendarTime& calendar_time);
 
 private:
     Core::System& m_system;

--- a/src/core/hle/service/psc/time/common.h
+++ b/src/core/hle/service/psc/time/common.h
@@ -189,7 +189,7 @@ struct fmt::formatter<Service::PSC::Time::SteadyClockTimePoint> : fmt::formatter
     template <typename FormatContext>
     auto format(const Service::PSC::Time::SteadyClockTimePoint& time_point,
                 FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "time_point={}", time_point.time_point);
+        return fmt::format_to(ctx.out(), "[time_point={}]", time_point.time_point);
     }
 };
 
@@ -197,7 +197,7 @@ template <>
 struct fmt::formatter<Service::PSC::Time::SystemClockContext> : fmt::formatter<fmt::string_view> {
     template <typename FormatContext>
     auto format(const Service::PSC::Time::SystemClockContext& context, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "offset={} steady_time_point={}", context.offset,
+        return fmt::format_to(ctx.out(), "[offset={} steady_time_point={}]", context.offset,
                               context.steady_time_point.time_point);
     }
 };
@@ -206,8 +206,9 @@ template <>
 struct fmt::formatter<Service::PSC::Time::CalendarTime> : fmt::formatter<fmt::string_view> {
     template <typename FormatContext>
     auto format(const Service::PSC::Time::CalendarTime& calendar, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "{}/{}/{} {}:{}:{}", calendar.day, calendar.month,
-                              calendar.year, calendar.hour, calendar.minute, calendar.second);
+        return fmt::format_to(ctx.out(), "[{:02}/{:02}/{:04} {:02}:{:02}:{:02}]", calendar.day,
+                              calendar.month, calendar.year, calendar.hour, calendar.minute,
+                              calendar.second);
     }
 };
 
@@ -217,7 +218,7 @@ struct fmt::formatter<Service::PSC::Time::CalendarAdditionalInfo>
     template <typename FormatContext>
     auto format(const Service::PSC::Time::CalendarAdditionalInfo& additional,
                 FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "weekday={} yearday={} name={} is_dst={} ut_offset={}",
+        return fmt::format_to(ctx.out(), "[weekday={} yearday={} name={} is_dst={} ut_offset={}]",
                               additional.day_of_week, additional.day_of_year,
                               additional.name.data(), additional.is_dst, additional.ut_offset);
     }
@@ -227,8 +228,7 @@ template <>
 struct fmt::formatter<Service::PSC::Time::LocationName> : fmt::formatter<fmt::string_view> {
     template <typename FormatContext>
     auto format(const Service::PSC::Time::LocationName& name, FormatContext& ctx) const {
-        std::string_view n{name.data(), name.size()};
-        return formatter<string_view>::format(n, ctx);
+        return formatter<string_view>::format(name.data(), ctx);
     }
 };
 
@@ -236,8 +236,7 @@ template <>
 struct fmt::formatter<Service::PSC::Time::RuleVersion> : fmt::formatter<fmt::string_view> {
     template <typename FormatContext>
     auto format(const Service::PSC::Time::RuleVersion& version, FormatContext& ctx) const {
-        std::string_view v{version.data(), version.size()};
-        return formatter<string_view>::format(v, ctx);
+        return formatter<string_view>::format(version.data(), ctx);
     }
 };
 
@@ -247,10 +246,11 @@ struct fmt::formatter<Service::PSC::Time::ClockSnapshot> : fmt::formatter<fmt::s
     auto format(const Service::PSC::Time::ClockSnapshot& snapshot, FormatContext& ctx) const {
         return fmt::format_to(
             ctx.out(),
-            "user_context={} network_context={} user_time={} network_time={} user_calendar_time={} "
+            "[user_context={} network_context={} user_time={} network_time={} "
+            "user_calendar_time={} "
             "network_calendar_time={} user_calendar_additional_time={} "
             "network_calendar_additional_time={} steady_clock_time_point={} location={} "
-            "is_automatic_correction_enabled={} type={}",
+            "is_automatic_correction_enabled={} type={}]",
             snapshot.user_context, snapshot.network_context, snapshot.user_time,
             snapshot.network_time, snapshot.user_calendar_time, snapshot.network_calendar_time,
             snapshot.user_calendar_additional_time, snapshot.network_calendar_additional_time,
@@ -266,7 +266,7 @@ struct fmt::formatter<Service::PSC::Time::ContinuousAdjustmentTimePoint>
     auto format(const Service::PSC::Time::ContinuousAdjustmentTimePoint& time_point,
                 FormatContext& ctx) const {
         return fmt::format_to(ctx.out(),
-                              "rtc_offset={} diff_scale={} shift_amount={} lower={} upper={}",
+                              "[rtc_offset={} diff_scale={} shift_amount={} lower={} upper={}]",
                               time_point.rtc_offset, time_point.diff_scale, time_point.shift_amount,
                               time_point.lower, time_point.upper);
     }

--- a/src/core/hle/service/psc/time/service_manager.cpp
+++ b/src/core/hle/service/psc/time/service_manager.cpp
@@ -120,11 +120,8 @@ Result ServiceManager::SetupStandardNetworkSystemClockCore(SystemClockContext& c
               context, context.steady_time_point.clock_source_id.RawString(), accuracy);
 
     // TODO this is a hack! The network clock should be updated independently, from the ntc service
-    // and maybe elsewhere. We do not do that, so fix the clock to the local clock on first boot
-    // to avoid it being stuck at 0.
-    if (context == Service::PSC::Time::SystemClockContext{}) {
-        m_local_system_clock.GetContext(context);
-    }
+    // and maybe elsewhere. We do not do that, so fix the clock to the local clock.
+    m_local_system_clock.GetContext(context);
 
     m_network_system_clock.SetContextWriter(m_network_system_context_writer);
     m_network_system_clock.Initialize(context, accuracy);
@@ -137,13 +134,6 @@ Result ServiceManager::SetupStandardUserSystemClockCore(bool automatic_correctio
                                                         SteadyClockTimePoint& time_point) {
     LOG_DEBUG(Service_Time, "called. automatic_correction={} time_point={} clock_source_id={}",
               automatic_correction, time_point, time_point.clock_source_id.RawString());
-
-    // TODO this is a hack! The user clock should be updated independently, from the ntc service
-    // and maybe elsewhere. We do not do that, so fix the clock to the local clock on first boot
-    // to avoid it being stuck at 0.
-    if (time_point == Service::PSC::Time::SteadyClockTimePoint{}) {
-        m_local_system_clock.GetCurrentTimePoint(time_point);
-    }
 
     m_user_system_clock.SetAutomaticCorrection(automatic_correction);
     m_user_system_clock.SetTimePointAndSignal(time_point);

--- a/src/core/hle/service/psc/time/time_zone.h
+++ b/src/core/hle/service/psc/time/time_zone.h
@@ -38,18 +38,18 @@ public:
                                     CalendarAdditionalInfo& calendar_additional, s64 time);
     Result ParseBinary(LocationName& name, std::span<const u8> binary);
     Result ParseBinaryInto(Tz::Rule& out_rule, std::span<const u8> binary);
-    Result ToPosixTime(u32& out_count, std::span<s64> out_times, u32 out_times_count,
-                       CalendarTime& calendar, const Tz::Rule& rule);
-    Result ToPosixTimeWithMyRule(u32& out_count, std::span<s64> out_times, u32 out_times_count,
-                                 CalendarTime& calendar);
+    Result ToPosixTime(u32& out_count, std::span<s64> out_times, size_t out_times_max_count,
+                       const CalendarTime& calendar, const Tz::Rule& rule);
+    Result ToPosixTimeWithMyRule(u32& out_count, std::span<s64> out_times,
+                                 size_t out_times_max_count, const CalendarTime& calendar);
 
 private:
     Result ParseBinaryImpl(Tz::Rule& out_rule, std::span<const u8> binary);
     Result ToCalendarTimeImpl(CalendarTime& out_calendar_time,
                               CalendarAdditionalInfo& out_additional_info, s64 time,
                               const Tz::Rule& rule);
-    Result ToPosixTimeImpl(u32& out_count, std::span<s64> out_times, u32 out_times_count,
-                           CalendarTime& calendar, const Tz::Rule& rule, s32 is_dst);
+    Result ToPosixTimeImpl(u32& out_count, std::span<s64> out_times, size_t out_times_max_count,
+                           const CalendarTime& calendar, const Tz::Rule& rule, s32 is_dst);
 
     bool m_initialized{};
     std::recursive_mutex m_mutex;

--- a/src/core/hle/service/psc/time/time_zone_service.cpp
+++ b/src/core/hle/service/psc/time/time_zone_service.cpp
@@ -138,32 +138,28 @@ Result TimeZoneService::ToCalendarTimeWithMyRule(Out<CalendarTime> out_calendar_
 
 Result TimeZoneService::ToPosixTime(Out<u32> out_count,
                                     OutArray<s64, BufferAttr_HipcPointer> out_times,
-                                    Out<u32> out_times_count, CalendarTime& calendar_time,
-                                    InRule rule) {
+                                    const CalendarTime& calendar_time, InRule rule) {
     SCOPE_EXIT({
         LOG_DEBUG(Service_Time,
-                  "called. calendar_time={} out_count={} out_times[0]={} out_times[1]={} "
-                  "out_times_count={}",
-                  calendar_time, *out_count, out_times[0], out_times[1], *out_times_count);
+                  "called. calendar_time={} out_count={} out_times[0]={} out_times[1]={} ",
+                  calendar_time, *out_count, out_times[0], out_times[1]);
     });
 
     R_RETURN(
-        m_time_zone.ToPosixTime(*out_count, out_times, *out_times_count, calendar_time, *rule));
+        m_time_zone.ToPosixTime(*out_count, out_times, out_times.size(), calendar_time, *rule));
 }
 
 Result TimeZoneService::ToPosixTimeWithMyRule(Out<u32> out_count,
                                               OutArray<s64, BufferAttr_HipcPointer> out_times,
-                                              Out<u32> out_times_count,
-                                              CalendarTime& calendar_time) {
+                                              const CalendarTime& calendar_time) {
     SCOPE_EXIT({
         LOG_DEBUG(Service_Time,
-                  "called. calendar_time={} out_count={} out_times[0]={} out_times[1]={} "
-                  "out_times_count={}",
-                  calendar_time, *out_count, out_times[0], out_times[1], *out_times_count);
+                  "called. calendar_time={} out_count={} out_times[0]={} out_times[1]={} ",
+                  calendar_time, *out_count, out_times[0], out_times[1]);
     });
 
     R_RETURN(
-        m_time_zone.ToPosixTimeWithMyRule(*out_count, out_times, *out_times_count, calendar_time));
+        m_time_zone.ToPosixTimeWithMyRule(*out_count, out_times, out_times.size(), calendar_time));
 }
 
 } // namespace Service::PSC::Time

--- a/src/core/hle/service/psc/time/time_zone_service.h
+++ b/src/core/hle/service/psc/time/time_zone_service.h
@@ -50,10 +50,10 @@ public:
     Result ToCalendarTimeWithMyRule(Out<CalendarTime> out_calendar_time,
                                     Out<CalendarAdditionalInfo> out_additional_info, s64 time);
     Result ToPosixTime(Out<u32> out_count, OutArray<s64, BufferAttr_HipcPointer> out_times,
-                       Out<u32> out_times_count, CalendarTime& calendar_time, InRule rule);
+                       const CalendarTime& calendar_time, InRule rule);
     Result ToPosixTimeWithMyRule(Out<u32> out_count,
                                  OutArray<s64, BufferAttr_HipcPointer> out_times,
-                                 Out<u32> out_times_count, CalendarTime& calendar_time);
+                                 const CalendarTime& calendar_time);
 
 private:
     Core::System& m_system;

--- a/src/core/hle/service/set/system_settings_server.cpp
+++ b/src/core/hle/service/set/system_settings_server.cpp
@@ -25,7 +25,7 @@
 namespace Service::Set {
 
 namespace {
-constexpr u32 SETTINGS_VERSION{2u};
+constexpr u32 SETTINGS_VERSION{3u};
 constexpr auto SETTINGS_MAGIC = Common::MakeMagic('y', 'u', 'z', 'u', '_', 's', 'e', 't');
 struct SettingsHeader {
     u64 magic;


### PR DESCRIPTION
Remove a few hacks for clock setups, which seem to no longer be needed. 
Fix network clock to local clock on every boot, instead of just once on setup, which fixes Pokemon Quest advancing time as it relies on the network clock updating between loads.
Also fix some logging strings.