### PR TITLE
settings: Allow audio sink, input, and output to be set per game

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -134,12 +134,12 @@ struct Values {
     Linkage linkage{};
 
     // Audio
-    Setting<AudioEngine> sink_id{linkage, AudioEngine::Auto, "output_engine", Category::Audio,
-                                 Specialization::RuntimeList};
-    Setting<std::string> audio_output_device_id{linkage, "auto", "output_device", Category::Audio,
-                                                Specialization::RuntimeList};
-    Setting<std::string> audio_input_device_id{linkage, "auto", "input_device", Category::Audio,
-                                               Specialization::RuntimeList};
+    SwitchableSetting<AudioEngine> sink_id{linkage, AudioEngine::Auto, "output_engine",
+                                           Category::Audio, Specialization::RuntimeList};
+    SwitchableSetting<std::string> audio_output_device_id{
+        linkage, "auto", "output_device", Category::Audio, Specialization::RuntimeList};
+    SwitchableSetting<std::string> audio_input_device_id{
+        linkage, "auto", "input_device", Category::Audio, Specialization::RuntimeList};
     SwitchableSetting<AudioMode, true> sound_index{
         linkage,       AudioMode::Stereo,     AudioMode::Mono,         AudioMode::Surround,
         "sound_index", Category::SystemAudio, Specialization::Default, true,

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -45,7 +45,8 @@ private:
     void UpdateAudioDevices(int sink_index);
 
     void SetOutputSinkFromSinkID();
-    void SetAudioDevicesFromDeviceID();
+    void SetOutputDevicesFromDeviceID();
+    void SetInputDevicesFromDeviceID();
 
     void Setup(const ConfigurationShared::Builder& builder);
 
@@ -55,7 +56,11 @@ private:
 
     std::vector<std::function<void(bool)>> apply_funcs{};
 
+    bool updating_devices = false;
     QComboBox* sink_combo_box;
+    QPushButton* restore_sink_button;
     QComboBox* output_device_combo_box;
+    QPushButton* restore_output_device_button;
     QComboBox* input_device_combo_box;
+    QPushButton* restore_input_device_button;
 };


### PR DESCRIPTION
Since the audio output/input are set based on the audio sink, there's some custom logic around the reset to global button to ensure that you can't reset the audio device to something that only the global sink has access to.

![dropdown](https://github.com/yuzu-emu/yuzu/assets/14132249/4459e5c0-53f6-4503-9ffd-9743e627feeb)
