### PR TITLE
ci: bump mac to macos-14

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -73,7 +73,7 @@ jobs:
   build-mac:
     name: 'test build (macos)'
     needs: format
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
         with:
@@ -87,7 +87,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          export Qt5_DIR="/usr/local/opt/qt@5/lib/cmake"
+          export Qt5_DIR="$(brew --prefix qt@5)/lib/cmake"
           cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DYUZU_USE_BUNDLED_VCPKG=OFF -DYUZU_TESTS=OFF -DENABLE_WEB_SERVICE=OFF -DENABLE_LIBUSB=OFF
           ninja
   build-msvc:


### PR DESCRIPTION
This changes the build architecture to arm64, which reflects the environment most people will be compiling it with.