### PR TITLE
service: hid: Multiple fixes

### DIFF
--- a/src/hid_core/resource_manager.h
+++ b/src/hid_core/resource_manager.h
@@ -147,6 +147,10 @@ private:
     std::shared_ptr<SixAxis> six_axis{nullptr};
     std::shared_ptr<SleepButton> sleep_button{nullptr};
     std::shared_ptr<UniquePad> unique_pad{nullptr};
+    std::shared_ptr<Core::Timing::EventType> npad_update_event;
+    std::shared_ptr<Core::Timing::EventType> default_update_event;
+    std::shared_ptr<Core::Timing::EventType> mouse_keyboard_update_event;
+    std::shared_ptr<Core::Timing::EventType> motion_update_event;
 
     // TODO: Create these resources
     // std::shared_ptr<AudioControl> audio_control{nullptr};
@@ -178,11 +182,6 @@ public:
 
 private:
     void GetSharedMemoryHandle(HLERequestContext& ctx);
-
-    std::shared_ptr<Core::Timing::EventType> npad_update_event{nullptr};
-    std::shared_ptr<Core::Timing::EventType> default_update_event{nullptr};
-    std::shared_ptr<Core::Timing::EventType> mouse_keyboard_update_event{nullptr};
-    std::shared_ptr<Core::Timing::EventType> motion_update_event{nullptr};
 
     u64 aruid{};
     std::shared_ptr<ResourceManager> resource_manager;

--- a/src/hid_core/resources/digitizer/digitizer.cpp
+++ b/src/hid_core/resources/digitizer/digitizer.cpp
@@ -17,10 +17,6 @@ void Digitizer::OnInit() {}
 void Digitizer::OnRelease() {}
 
 void Digitizer::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
-    if (!smart_update) {
-        return;
-    }
-
     std::scoped_lock shared_lock{*shared_mutex};
     const u64 aruid = applet_resource->GetActiveAruid();
     auto* data = applet_resource->GetAruidData(aruid);

--- a/src/hid_core/resources/digitizer/digitizer.h
+++ b/src/hid_core/resources/digitizer/digitizer.h
@@ -20,8 +20,5 @@ public:
 
     // When the controller is requesting an update for the shared memory
     void OnUpdate(const Core::Timing::CoreTiming& core_timing) override;
-
-private:
-    bool smart_update{};
 };
 } // namespace Service::HID

--- a/src/hid_core/resources/npad/npad.h
+++ b/src/hid_core/resources/npad/npad.h
@@ -164,6 +164,7 @@ private:
         NpadInternalState* shared_memory = nullptr;
         Core::HID::EmulatedController* device = nullptr;
 
+        bool is_active{};
         bool is_connected{};
 
         // Dual joycons can have only one side connected

--- a/src/hid_core/resources/unique_pad/unique_pad.cpp
+++ b/src/hid_core/resources/unique_pad/unique_pad.cpp
@@ -17,10 +17,6 @@ void UniquePad::OnInit() {}
 void UniquePad::OnRelease() {}
 
 void UniquePad::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
-    if (!smart_update) {
-        return;
-    }
-
     const u64 aruid = applet_resource->GetActiveAruid();
     auto* data = applet_resource->GetAruidData(aruid);
 

--- a/src/hid_core/resources/unique_pad/unique_pad.h
+++ b/src/hid_core/resources/unique_pad/unique_pad.h
@@ -20,8 +20,5 @@ public:
 
     // When the controller is requesting an update for the shared memory
     void OnUpdate(const Core::Timing::CoreTiming& core_timing) override;
-
-private:
-    bool smart_update{};
 };
 } // namespace Service::HID


### PR DESCRIPTION
Currently we have a weird input issue on multiple applets chained together. While this PR doesn't fix that issue we found a couple of mistakes that might cause issues in some games.

- Fixes polling when multiple aruid are registered.
- Controllers registering as connected before styleset is defined.
- Fixes color corruption.
- Fixes external pad state.
- Fixes unique pad and digitizer missing header.