### PR TITLE
structured_control_flow: Add Samsung Proprietary Driver ID to Reorder Pass

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -382,7 +382,7 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
         .support_float16 = device.IsFloat16Supported(),
         .support_int64 = device.IsShaderInt64Supported(),
         .needs_demote_reorder =
-            driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE,
+            driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE || driver_id == VK_DRIVER_ID_SAMSUNG_PROPRIETARY,
         .support_snorm_render_buffer = true,
         .support_viewport_index_layer = device.IsExtShaderViewportIndexLayerSupported(),
         .min_ssbo_alignment = static_cast<u32>(device.GetStorageBufferAlignment()),

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -381,8 +381,9 @@ PipelineCache::PipelineCache(Tegra::MaxwellDeviceMemoryManager& device_memory_,
         .support_float64 = device.IsFloat64Supported(),
         .support_float16 = device.IsFloat16Supported(),
         .support_int64 = device.IsShaderInt64Supported(),
-        .needs_demote_reorder =
-            driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE || driver_id == VK_DRIVER_ID_SAMSUNG_PROPRIETARY,
+        .needs_demote_reorder = driver_id == VK_DRIVER_ID_AMD_PROPRIETARY ||
+                                driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE ||
+                                driver_id == VK_DRIVER_ID_SAMSUNG_PROPRIETARY,
         .support_snorm_render_buffer = true,
         .support_viewport_index_layer = device.IsExtShaderViewportIndexLayerSupported(),
         .min_ssbo_alignment = static_cast<u32>(device.GetStorageBufferAlignment()),

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -868,6 +868,8 @@ std::string Device::GetDriverName() const {
         return "Qualcomm";
     case VK_DRIVER_ID_ARM_PROPRIETARY:
         return "Mali";
+    case VK_DRIVER_ID_SAMSUNG_PROPRIETARY:
+        return "Xclipse";
     case VK_DRIVER_ID_GOOGLE_SWIFTSHADER:
         return "SwiftShader";
     case VK_DRIVER_ID_BROADCOM_PROPRIETARY:


### PR DESCRIPTION
For RDNA-based Samsung Xclipse GPUs, this fixes wireframes in Pokémon games such as Sword/Shield, Scarlet/Violet and possibly others.

Based on the original #6900 @ameerj made, this just adds the new `VK_DRIVER_ID_SAMSUNG_PROPRIETARY` driver ID to the reorder pass

Thanks to @no.kola on Discord for testing the fix and @liamwhite for the driver ID