### PR TITLE
cmake: use vulkan-headers config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,7 @@ find_package(ZLIB 1.2 REQUIRED)
 find_package(zstd 1.5 REQUIRED)
 
 if (NOT YUZU_USE_EXTERNAL_VULKAN_HEADERS)
-    find_package(Vulkan 1.3.274 REQUIRED)
+    find_package(VulkanHeaders 1.3.274 REQUIRED)
 endif()
 
 if (NOT YUZU_USE_EXTERNAL_VULKAN_UTILITY_LIBRARIES)


### PR DESCRIPTION
The `FindVulkan.cmake` module provided by CMake is deprecated and will be [removed](https://gitlab.kitware.com/cmake/cmake/-/issues/25617) in the future, so use upstream `VulkanHeadersConfig.cmake` file instead.