### PR TITLE
service: fs: Skip non user id folders

### DIFF
--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 #include <fmt/format.h>
+#include "common/assert.h"
 #include "common/common_types.h"
 
 namespace Common {
@@ -29,6 +30,8 @@ namespace Common {
 
 template <std::size_t Size, bool le = false>
 [[nodiscard]] constexpr std::array<u8, Size> HexStringToArray(std::string_view str) {
+    ASSERT_MSG(Size * 2 <= str.size(), "Invalid string size");
+
     std::array<u8, Size> out{};
     if constexpr (le) {
         for (std::size_t i = 2 * Size - 2; i <= 2 * Size; i -= 2) {

--- a/src/core/hle/service/filesystem/fsp/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp/fsp_srv.cpp
@@ -115,6 +115,11 @@ private:
             if (type->GetName() == "save") {
                 for (const auto& save_id : type->GetSubdirectories()) {
                     for (const auto& user_id : save_id->GetSubdirectories()) {
+                        // Skip non user id subdirectories
+                        if (user_id->GetName().size() != 0x20) {
+                            continue;
+                        }
+
                         const auto save_id_numeric = stoull_be(save_id->GetName());
                         auto user_id_numeric = Common::HexStringToArray<0x10>(user_id->GetName());
                         std::reverse(user_id_numeric.begin(), user_id_numeric.end());
@@ -160,6 +165,10 @@ private:
             } else if (space == FileSys::SaveDataSpaceId::TemporaryStorage) {
                 // Temporary Storage
                 for (const auto& user_id : type->GetSubdirectories()) {
+                    // Skip non user id subdirectories
+                    if (user_id->GetName().size() != 0x20) {
+                        continue;
+                    }
                     for (const auto& title_id : user_id->GetSubdirectories()) {
                         if (!title_id->GetFiles().empty() ||
                             !title_id->GetSubdirectories().empty()) {


### PR DESCRIPTION
I sometimes create backups in the same folder where saves are. This avoids an out of bounds memory read when some folders aren't the correct size.