### PR TITLE
Fix firmware timezone boot load check.

### DIFF
--- a/src/core/hle/service/glue/time/time_zone_binary.cpp
+++ b/src/core/hle/service/glue/time/time_zone_binary.cpp
@@ -65,6 +65,7 @@ Result MountTimeZoneBinary(Core::System& system) {
         // Validate that the romfs is readable, using invalid firmware keys can cause this to get
         // set but the files to be garbage. In that case, we want to hit the next path and
         // synthesise them instead.
+        g_time_zone_binary_mount_result = ResultSuccess;
         Service::PSC::Time::LocationName name{"Etc/GMT"};
         if (!IsTimeZoneBinaryValid(name)) {
             ResetTimeZoneBinary();


### PR DESCRIPTION
IsTimeZoneBinaryValid checks the mount result, and it's not set until the end of the function we're calling it from, so just set it as success before attempting the check. If the check fails, it'll be reset to Unknown.