### PR TITLE
nvnflinger: release buffers before presentation sleep

### DIFF
--- a/src/core/hle/service/nvnflinger/hardware_composer.h
+++ b/src/core/hle/service/nvnflinger/hardware_composer.h
@@ -27,7 +27,7 @@ public:
     ~HardwareComposer();
 
     u32 ComposeLocked(f32* out_speed_scale, VI::Display& display,
-                      Nvidia::Devices::nvdisp_disp0& nvdisp, u32 frame_advance);
+                      Nvidia::Devices::nvdisp_disp0& nvdisp);
     void RemoveLayerLocked(VI::Display& display, LayerId layer_id);
 
 private:

--- a/src/core/hle/service/nvnflinger/nvnflinger.cpp
+++ b/src/core/hle/service/nvnflinger/nvnflinger.cpp
@@ -291,8 +291,7 @@ void Nvnflinger::Compose() {
         auto nvdisp = nvdrv->GetDevice<Nvidia::Devices::nvdisp_disp0>(disp_fd);
         ASSERT(nvdisp);
 
-        swap_interval = display.GetComposer().ComposeLocked(&compose_speed_scale, display, *nvdisp,
-                                                            swap_interval);
+        swap_interval = display.GetComposer().ComposeLocked(&compose_speed_scale, display, *nvdisp);
     }
 }
 


### PR DESCRIPTION
Currently the composer sleeps and then releases any acquired buffers after it wakes up again on the next vsync signal. This seems incorrect - it should release them as soon as possible after they are presented to avoid starving the guest present queue.

I believe this should address #12902, but needs testing.