### PR TITLE
dmnt: cheats: Update cheat vm to latest version

### DIFF
--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -27,14 +27,14 @@ public:
     StandardVmCallbacks(System& system_, const CheatProcessMetadata& metadata_);
     ~StandardVmCallbacks() override;
 
-    void MemoryRead(VAddr address, void* data, u64 size) override;
-    void MemoryWrite(VAddr address, const void* data, u64 size) override;
+    void MemoryReadUnsafe(VAddr address, void* data, u64 size) override;
+    void MemoryWriteUnsafe(VAddr address, const void* data, u64 size) override;
     u64 HidKeysDown() override;
     void DebugLog(u8 id, u64 value) override;
     void CommandLog(std::string_view data) override;
 
 private:
-    VAddr SanitizeAddress(VAddr address) const;
+    bool IsAddressInRange(VAddr address) const;
 
     const CheatProcessMetadata& metadata;
     Core::System& system;

--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -37,7 +37,7 @@ private:
     VAddr SanitizeAddress(VAddr address) const;
 
     const CheatProcessMetadata& metadata;
-    System& system;
+    Core::System& system;
 };
 
 // Intermediary class that parses a text file or other disk format for storing cheats into a

--- a/src/core/memory/dmnt_cheat_types.h
+++ b/src/core/memory/dmnt_cheat_types.h
@@ -18,7 +18,7 @@ struct CheatProcessMetadata {
     MemoryRegionExtents main_nso_extents{};
     MemoryRegionExtents heap_extents{};
     MemoryRegionExtents alias_extents{};
-    MemoryRegionExtents address_space_extents{};
+    MemoryRegionExtents aslr_extents{};
     std::array<u8, 0x20> main_nso_build_id{};
 };
 

--- a/src/core/memory/dmnt_cheat_vm.cpp
+++ b/src/core/memory/dmnt_cheat_vm.cpp
@@ -773,7 +773,7 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
             case 2:
             case 4:
             case 8:
-                callbacks->MemoryWrite(dst_address, &dst_value, store_static->bit_width);
+                callbacks->MemoryWriteUnsafe(dst_address, &dst_value, store_static->bit_width);
                 break;
             }
         } else if (auto begin_cond = std::get_if<BeginConditionalOpcode>(&cur_opcode.opcode)) {
@@ -786,7 +786,7 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
             case 2:
             case 4:
             case 8:
-                callbacks->MemoryRead(src_address, &src_value, begin_cond->bit_width);
+                callbacks->MemoryReadUnsafe(src_address, &src_value, begin_cond->bit_width);
                 break;
             }
             // Check against condition.
@@ -857,8 +857,8 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
             case 2:
             case 4:
             case 8:
-                callbacks->MemoryRead(src_address, &registers[ldr_memory->reg_index],
-                                      ldr_memory->bit_width);
+                callbacks->MemoryReadUnsafe(src_address, &registers[ldr_memory->reg_index],
+                                            ldr_memory->bit_width);
                 break;
             }
         } else if (auto str_static = std::get_if<StoreStaticToAddressOpcode>(&cur_opcode.opcode)) {
@@ -874,7 +874,7 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
             case 2:
             case 4:
             case 8:
-                callbacks->MemoryWrite(dst_address, &dst_value, str_static->bit_width);
+                callbacks->MemoryWriteUnsafe(dst_address, &dst_value, str_static->bit_width);
                 break;
             }
             // Increment register if relevant.
@@ -1032,7 +1032,7 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
             case 2:
             case 4:
             case 8:
-                callbacks->MemoryWrite(dst_address, &dst_value, str_register->bit_width);
+                callbacks->MemoryWriteUnsafe(dst_address, &dst_value, str_register->bit_width);
                 break;
             }
 
@@ -1111,7 +1111,8 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
                 case 2:
                 case 4:
                 case 8:
-                    callbacks->MemoryRead(cond_address, &cond_value, begin_reg_cond->bit_width);
+                    callbacks->MemoryReadUnsafe(cond_address, &cond_value,
+                                                begin_reg_cond->bit_width);
                     break;
                 }
             }
@@ -1253,7 +1254,7 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
                 case 2:
                 case 4:
                 case 8:
-                    callbacks->MemoryRead(val_address, &log_value, debug_log->bit_width);
+                    callbacks->MemoryReadUnsafe(val_address, &log_value, debug_log->bit_width);
                     break;
                 }
             }

--- a/src/core/memory/dmnt_cheat_vm.h
+++ b/src/core/memory/dmnt_cheat_vm.h
@@ -42,12 +42,16 @@ enum class CheatVmOpcodeType : u32 {
     DoubleExtendedWidth = 0xF0,
 
     // Double-extended width opcodes.
+    PauseProcess = 0xFF0,
+    ResumeProcess = 0xFF1,
     DebugLog = 0xFFF,
 };
 
 enum class MemoryAccessType : u32 {
     MainNso = 0,
     Heap = 1,
+    Alias = 2,
+    Aslr = 3,
 };
 
 enum class ConditionalComparisonType : u32 {
@@ -131,7 +135,9 @@ struct BeginConditionalOpcode {
     VmInt value{};
 };
 
-struct EndConditionalOpcode {};
+struct EndConditionalOpcode {
+    bool is_else;
+};
 
 struct ControlLoopOpcode {
     bool start_loop{};
@@ -222,6 +228,10 @@ struct ReadWriteStaticRegisterOpcode {
     u32 idx{};
 };
 
+struct PauseProcessOpcode {};
+
+struct ResumeProcessOpcode {};
+
 struct DebugLogOpcode {
     u32 bit_width{};
     u32 log_id{};
@@ -244,8 +254,8 @@ struct CheatVmOpcode {
                  PerformArithmeticStaticOpcode, BeginKeypressConditionalOpcode,
                  PerformArithmeticRegisterOpcode, StoreRegisterToAddressOpcode,
                  BeginRegisterConditionalOpcode, SaveRestoreRegisterOpcode,
-                 SaveRestoreRegisterMaskOpcode, ReadWriteStaticRegisterOpcode, DebugLogOpcode,
-                 UnrecognizedInstruction>
+                 SaveRestoreRegisterMaskOpcode, ReadWriteStaticRegisterOpcode, PauseProcessOpcode,
+                 ResumeProcessOpcode, DebugLogOpcode, UnrecognizedInstruction>
         opcode{};
 };
 
@@ -296,7 +306,7 @@ private:
     std::array<std::size_t, NumRegisters> loop_tops{};
 
     bool DecodeNextOpcode(CheatVmOpcode& out);
-    void SkipConditionalBlock();
+    void SkipConditionalBlock(bool is_if);
     void ResetState();
 
     // For implementing the DebugLog opcode.

--- a/src/core/memory/dmnt_cheat_vm.h
+++ b/src/core/memory/dmnt_cheat_vm.h
@@ -266,8 +266,8 @@ public:
     public:
         virtual ~Callbacks();
 
-        virtual void MemoryRead(VAddr address, void* data, u64 size) = 0;
-        virtual void MemoryWrite(VAddr address, const void* data, u64 size) = 0;
+        virtual void MemoryReadUnsafe(VAddr address, void* data, u64 size) = 0;
+        virtual void MemoryWriteUnsafe(VAddr address, const void* data, u64 size) = 0;
 
         virtual u64 HidKeysDown() = 0;
 


### PR DESCRIPTION
Updates cheat codes to support if-else statements. Along this fixes a few mistakes like: Static registers loosing their value, missing `alias` and `aslr` memory spaces, pause/resume opcodes returning as invalid opcodes.

Note: Pause and Resume aren't implemented yet. I need to research a bit before implementing them.