### PR TITLE
android: Move JNI setup and helpers to common

### DIFF
--- a/src/android/app/src/main/jni/CMakeLists.txt
+++ b/src/android/app/src/main/jni/CMakeLists.txt
@@ -2,14 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 add_library(yuzu-android SHARED
-    android_common/android_common.cpp
-    android_common/android_common.h
-    applets/software_keyboard.cpp
-    applets/software_keyboard.h
     emu_window/emu_window.cpp
     emu_window/emu_window.h
-    id_cache.cpp
-    id_cache.h
     native.cpp
     native.h
     native_config.cpp

--- a/src/android/app/src/main/jni/emu_window/emu_window.cpp
+++ b/src/android/app/src/main/jni/emu_window/emu_window.cpp
@@ -3,6 +3,7 @@
 
 #include <android/native_window_jni.h>
 
+#include "common/android/id_cache.h"
 #include "common/logging/log.h"
 #include "input_common/drivers/touch_screen.h"
 #include "input_common/drivers/virtual_amiibo.h"
@@ -60,7 +61,8 @@ void EmuWindow_Android::OnRemoveNfcTag() {
 
 void EmuWindow_Android::OnFrameDisplayed() {
     if (!m_first_frame) {
-        EmulationSession::GetInstance().OnEmulationStarted();
+        Common::Android::RunJNIOnFiber<void>(
+            [&](JNIEnv* env) { EmulationSession::GetInstance().OnEmulationStarted(); });
         m_first_frame = true;
     }
 }

--- a/src/android/app/src/main/jni/game_metadata.cpp
+++ b/src/android/app/src/main/jni/game_metadata.cpp
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/android/android_common.h"
 #include "core/core.h"
 #include "core/file_sys/fs_filesystem.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/loader/loader.h"
 #include "core/loader/nro.h"
-#include "jni.h"
-#include "jni/android_common/android_common.h"
 #include "native.h"
 
 struct RomMetadata {
@@ -79,7 +78,7 @@ extern "C" {
 jboolean Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getIsValid(JNIEnv* env, jobject obj,
                                                                jstring jpath) {
     const auto file = EmulationSession::GetInstance().System().GetFilesystem()->OpenFile(
-        GetJString(env, jpath), FileSys::OpenMode::Read);
+        Common::Android::GetJString(env, jpath), FileSys::OpenMode::Read);
     if (!file) {
         return false;
     }
@@ -104,27 +103,31 @@ jboolean Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getIsValid(JNIEnv* env, jobj
 
 jstring Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getTitle(JNIEnv* env, jobject obj,
                                                             jstring jpath) {
-    return ToJString(env, GetRomMetadata(GetJString(env, jpath)).title);
+    return Common::Android::ToJString(
+        env, GetRomMetadata(Common::Android::GetJString(env, jpath)).title);
 }
 
 jstring Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getProgramId(JNIEnv* env, jobject obj,
                                                                 jstring jpath) {
-    return ToJString(env, std::to_string(GetRomMetadata(GetJString(env, jpath)).programId));
+    return Common::Android::ToJString(
+        env, std::to_string(GetRomMetadata(Common::Android::GetJString(env, jpath)).programId));
 }
 
 jstring Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getDeveloper(JNIEnv* env, jobject obj,
                                                                 jstring jpath) {
-    return ToJString(env, GetRomMetadata(GetJString(env, jpath)).developer);
+    return Common::Android::ToJString(
+        env, GetRomMetadata(Common::Android::GetJString(env, jpath)).developer);
 }
 
 jstring Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getVersion(JNIEnv* env, jobject obj,
                                                               jstring jpath, jboolean jreload) {
-    return ToJString(env, GetRomMetadata(GetJString(env, jpath), jreload).version);
+    return Common::Android::ToJString(
+        env, GetRomMetadata(Common::Android::GetJString(env, jpath), jreload).version);
 }
 
 jbyteArray Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getIcon(JNIEnv* env, jobject obj,
                                                               jstring jpath) {
-    auto icon_data = GetRomMetadata(GetJString(env, jpath)).icon;
+    auto icon_data = GetRomMetadata(Common::Android::GetJString(env, jpath)).icon;
     jbyteArray icon = env->NewByteArray(static_cast<jsize>(icon_data.size()));
     env->SetByteArrayRegion(icon, 0, env->GetArrayLength(icon),
                             reinterpret_cast<jbyte*>(icon_data.data()));
@@ -133,7 +136,8 @@ jbyteArray Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getIcon(JNIEnv* env, jobje
 
 jboolean Java_org_yuzu_yuzu_1emu_utils_GameMetadata_getIsHomebrew(JNIEnv* env, jobject obj,
                                                                   jstring jpath) {
-    return static_cast<jboolean>(GetRomMetadata(GetJString(env, jpath)).isHomebrew);
+    return static_cast<jboolean>(
+        GetRomMetadata(Common::Android::GetJString(env, jpath)).isHomebrew);
 }
 
 void Java_org_yuzu_yuzu_1emu_utils_GameMetadata_resetMetadata(JNIEnv* env, jobject obj) {

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <android/native_window_jni.h>
+#include "common/android/applets/software_keyboard.h"
 #include "common/detached_tasks.h"
 #include "core/core.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/hle/service/acc/profile_manager.h"
 #include "core/perf_stats.h"
 #include "frontend_common/content_manager.h"
-#include "jni/applets/software_keyboard.h"
 #include "jni/emu_window/emu_window.h"
 #include "video_core/rasterizer_interface.h"
 
@@ -54,7 +54,7 @@ public:
     void SetDeviceType([[maybe_unused]] int index, int type);
     void OnGamepadConnectEvent([[maybe_unused]] int index);
     void OnGamepadDisconnectEvent([[maybe_unused]] int index);
-    SoftwareKeyboard::AndroidKeyboard* SoftwareKeyboard();
+    Common::Android::SoftwareKeyboard::AndroidKeyboard* SoftwareKeyboard();
 
     static void OnEmulationStarted();
 
@@ -79,7 +79,7 @@ private:
     Core::SystemResultStatus m_load_result{Core::SystemResultStatus::ErrorNotInitialized};
     std::atomic<bool> m_is_running = false;
     std::atomic<bool> m_is_paused = false;
-    SoftwareKeyboard::AndroidKeyboard* m_software_keyboard{};
+    Common::Android::SoftwareKeyboard::AndroidKeyboard* m_software_keyboard{};
     std::unique_ptr<FileSys::ManualContentProvider> m_manual_provider;
     int m_applet_id{1};
 

--- a/src/android/app/src/main/jni/native_log.cpp
+++ b/src/android/app/src/main/jni/native_log.cpp
@@ -1,31 +1,30 @@
 // SPDX-FileCopyrightText: 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <common/android/android_common.h>
 #include <common/logging/log.h>
 #include <jni.h>
-
-#include "android_common/android_common.h"
 
 extern "C" {
 
 void Java_org_yuzu_yuzu_1emu_utils_Log_debug(JNIEnv* env, jobject obj, jstring jmessage) {
-    LOG_DEBUG(Frontend, "{}", GetJString(env, jmessage));
+    LOG_DEBUG(Frontend, "{}", Common::Android::GetJString(env, jmessage));
 }
 
 void Java_org_yuzu_yuzu_1emu_utils_Log_warning(JNIEnv* env, jobject obj, jstring jmessage) {
-    LOG_WARNING(Frontend, "{}", GetJString(env, jmessage));
+    LOG_WARNING(Frontend, "{}", Common::Android::GetJString(env, jmessage));
 }
 
 void Java_org_yuzu_yuzu_1emu_utils_Log_info(JNIEnv* env, jobject obj, jstring jmessage) {
-    LOG_INFO(Frontend, "{}", GetJString(env, jmessage));
+    LOG_INFO(Frontend, "{}", Common::Android::GetJString(env, jmessage));
 }
 
 void Java_org_yuzu_yuzu_1emu_utils_Log_error(JNIEnv* env, jobject obj, jstring jmessage) {
-    LOG_ERROR(Frontend, "{}", GetJString(env, jmessage));
+    LOG_ERROR(Frontend, "{}", Common::Android::GetJString(env, jmessage));
 }
 
 void Java_org_yuzu_yuzu_1emu_utils_Log_critical(JNIEnv* env, jobject obj, jstring jmessage) {
-    LOG_CRITICAL(Frontend, "{}", GetJString(env, jmessage));
+    LOG_CRITICAL(Frontend, "{}", Common::Android::GetJString(env, jmessage));
 }
 
 } // extern "C"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -179,9 +179,15 @@ endif()
 
 if(ANDROID)
     target_sources(common
-        PRIVATE
+        PUBLIC
             fs/fs_android.cpp
             fs/fs_android.h
+            android/android_common.cpp
+            android/android_common.h
+            android/id_cache.cpp
+            android/id_cache.h
+            android/applets/software_keyboard.cpp
+            android/applets/software_keyboard.h
     )
 endif()
 

--- a/src/common/android/android_common.cpp
+++ b/src/common/android/android_common.cpp
@@ -1,15 +1,17 @@
 // SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "jni/android_common/android_common.h"
+#include "android_common.h"
 
 #include <string>
 #include <string_view>
 
 #include <jni.h>
 
+#include "common/android/id_cache.h"
 #include "common/string_util.h"
-#include "jni/id_cache.h"
+
+namespace Common::Android {
 
 std::string GetJString(JNIEnv* env, jstring jstr) {
     if (!jstr) {
@@ -18,7 +20,8 @@ std::string GetJString(JNIEnv* env, jstring jstr) {
 
     const jchar* jchars = env->GetStringChars(jstr, nullptr);
     const jsize length = env->GetStringLength(jstr);
-    const std::u16string_view string_view(reinterpret_cast<const char16_t*>(jchars), length);
+    const std::u16string_view string_view(reinterpret_cast<const char16_t*>(jchars),
+                                          static_cast<u32>(length));
     const std::string converted_string = Common::UTF16ToUTF8(string_view);
     env->ReleaseStringChars(jstr, jchars);
 
@@ -36,25 +39,27 @@ jstring ToJString(JNIEnv* env, std::u16string_view str) {
 }
 
 double GetJDouble(JNIEnv* env, jobject jdouble) {
-    return env->GetDoubleField(jdouble, IDCache::GetDoubleValueField());
+    return env->GetDoubleField(jdouble, GetDoubleValueField());
 }
 
 jobject ToJDouble(JNIEnv* env, double value) {
-    return env->NewObject(IDCache::GetDoubleClass(), IDCache::GetDoubleConstructor(), value);
+    return env->NewObject(GetDoubleClass(), GetDoubleConstructor(), value);
 }
 
 s32 GetJInteger(JNIEnv* env, jobject jinteger) {
-    return env->GetIntField(jinteger, IDCache::GetIntegerValueField());
+    return env->GetIntField(jinteger, GetIntegerValueField());
 }
 
 jobject ToJInteger(JNIEnv* env, s32 value) {
-    return env->NewObject(IDCache::GetIntegerClass(), IDCache::GetIntegerConstructor(), value);
+    return env->NewObject(GetIntegerClass(), GetIntegerConstructor(), value);
 }
 
 bool GetJBoolean(JNIEnv* env, jobject jboolean) {
-    return env->GetBooleanField(jboolean, IDCache::GetBooleanValueField());
+    return env->GetBooleanField(jboolean, GetBooleanValueField());
 }
 
 jobject ToJBoolean(JNIEnv* env, bool value) {
-    return env->NewObject(IDCache::GetBooleanClass(), IDCache::GetBooleanConstructor(), value);
+    return env->NewObject(GetBooleanClass(), GetBooleanConstructor(), value);
 }
+
+} // namespace Common::Android

--- a/src/common/android/android_common.h
+++ b/src/common/android/android_common.h
@@ -8,6 +8,8 @@
 #include <jni.h>
 #include "common/common_types.h"
 
+namespace Common::Android {
+
 std::string GetJString(JNIEnv* env, jstring jstr);
 jstring ToJString(JNIEnv* env, std::string_view str);
 jstring ToJString(JNIEnv* env, std::u16string_view str);
@@ -20,3 +22,5 @@ jobject ToJInteger(JNIEnv* env, s32 value);
 
 bool GetJBoolean(JNIEnv* env, jobject jboolean);
 jobject ToJBoolean(JNIEnv* env, bool value);
+
+} // namespace Common::Android

--- a/src/common/android/applets/software_keyboard.h
+++ b/src/common/android/applets/software_keyboard.h
@@ -7,7 +7,7 @@
 
 #include "core/frontend/applets/software_keyboard.h"
 
-namespace SoftwareKeyboard {
+namespace Common::Android::SoftwareKeyboard {
 
 class AndroidKeyboard final : public Core::Frontend::SoftwareKeyboardApplet {
 public:
@@ -66,7 +66,7 @@ void InitJNI(JNIEnv* env);
 // Should be called in JNI_Unload
 void CleanupJNI(JNIEnv* env);
 
-} // namespace SoftwareKeyboard
+} // namespace Common::Android::SoftwareKeyboard
 
 // Native function calls
 extern "C" {

--- a/src/common/android/id_cache.cpp
+++ b/src/common/android/id_cache.cpp
@@ -3,10 +3,10 @@
 
 #include <jni.h>
 
+#include "applets/software_keyboard.h"
+#include "common/android/id_cache.h"
 #include "common/assert.h"
 #include "common/fs/fs_android.h"
-#include "jni/applets/software_keyboard.h"
-#include "jni/id_cache.h"
 #include "video_core/rasterizer_interface.h"
 
 static JavaVM* s_java_vm;
@@ -67,7 +67,7 @@ static jfieldID s_boolean_value_field;
 
 static constexpr jint JNI_VERSION = JNI_VERSION_1_6;
 
-namespace IDCache {
+namespace Common::Android {
 
 JNIEnv* GetEnvForThread() {
     thread_local static struct OwnedEnv {
@@ -276,8 +276,6 @@ jfieldID GetBooleanValueField() {
     return s_boolean_value_field;
 }
 
-} // namespace IDCache
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -393,7 +391,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     Common::FS::Android::RegisterCallbacks(env, s_native_library_class);
 
     // Initialize applets
-    SoftwareKeyboard::InitJNI(env);
+    Common::Android::SoftwareKeyboard::InitJNI(env);
 
     return JNI_VERSION;
 }
@@ -426,3 +424,5 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
 #ifdef __cplusplus
 }
 #endif
+
+} // namespace Common::Android

--- a/src/common/fs/fs_android.h
+++ b/src/common/fs/fs_android.h
@@ -7,38 +7,17 @@
 #include <vector>
 #include <jni.h>
 
-#define ANDROID_STORAGE_FUNCTIONS(V)                                                               \
-    V(OpenContentUri, int, (const std::string& filepath, OpenMode openmode), open_content_uri,     \
-      "openContentUri", "(Ljava/lang/String;Ljava/lang/String;)I")
-
-#define ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(V)                                                 \
-    V(GetSize, std::uint64_t, get_size, CallStaticLongMethod, "getSize", "(Ljava/lang/String;)J")  \
-    V(IsDirectory, bool, is_directory, CallStaticBooleanMethod, "isDirectory",                     \
-      "(Ljava/lang/String;)Z")                                                                     \
-    V(Exists, bool, file_exists, CallStaticBooleanMethod, "exists", "(Ljava/lang/String;)Z")
-
-#define ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(V)                                                    \
-    V(GetParentDirectory, get_parent_directory, CallStaticObjectMethod, "getParentDirectory",      \
-      "(Ljava/lang/String;)Ljava/lang/String;")                                                    \
-    V(GetFilename, get_filename, CallStaticObjectMethod, "getFilename",                            \
-      "(Ljava/lang/String;)Ljava/lang/String;")
-
 namespace Common::FS::Android {
 
 static JavaVM* g_jvm = nullptr;
 static jclass native_library = nullptr;
 
-#define FH(FunctionName, JMethodID, Caller, JMethodName, Signature) F(JMethodID)
-#define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature) F(JMethodID)
-#define FS(FunctionName, ReturnValue, Parameters, JMethodID, JMethodName, Signature) F(JMethodID)
-#define F(JMethodID) static jmethodID JMethodID = nullptr;
-ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(FH)
-ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(FR)
-ANDROID_STORAGE_FUNCTIONS(FS)
-#undef F
-#undef FS
-#undef FR
-#undef FH
+static jmethodID s_get_parent_directory;
+static jmethodID s_get_filename;
+static jmethodID s_get_size;
+static jmethodID s_is_directory;
+static jmethodID s_file_exists;
+static jmethodID s_open_content_uri;
 
 enum class OpenMode {
     Read,
@@ -57,24 +36,11 @@ void UnRegisterCallbacks();
 
 bool IsContentUri(const std::string& path);
 
-#define FS(FunctionName, ReturnValue, Parameters, JMethodID, JMethodName, Signature)               \
-    F(FunctionName, Parameters, ReturnValue)
-#define F(FunctionName, Parameters, ReturnValue) ReturnValue FunctionName Parameters;
-ANDROID_STORAGE_FUNCTIONS(FS)
-#undef F
-#undef FS
-
-#define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature)                   \
-    F(FunctionName, ReturnValue)
-#define F(FunctionName, ReturnValue) ReturnValue FunctionName(const std::string& filepath);
-ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(FR)
-#undef F
-#undef FR
-
-#define FH(FunctionName, JMethodID, Caller, JMethodName, Signature) F(FunctionName)
-#define F(FunctionName) std::string FunctionName(const std::string& filepath);
-ANDROID_SINGLE_PATH_HELPER_FUNCTIONS(FH)
-#undef F
-#undef FH
+int OpenContentUri(const std::string& filepath, OpenMode openmode);
+std::uint64_t GetSize(const std::string& filepath);
+bool IsDirectory(const std::string& filepath);
+bool Exists(const std::string& filepath);
+std::string GetParentDirectory(const std::string& filepath);
+std::string GetFilename(const std::string& filepath);
 
 } // namespace Common::FS::Android


### PR DESCRIPTION
Makes it easier to call JNI from other parts of the project.

Additionally provides a fix for #12873 for running the OnEmulationStarted callback where the app would crash when trying to call JNI on a fiber. This provides a workaround by starting a new thread and waiting for the result.