### PR TITLE
.tx/config: Use language mappings for android "tx pull"

### DIFF
--- a/dist/languages/.tx/config
+++ b/dist/languages/.tx/config
@@ -11,3 +11,4 @@ type = QT
 file_filter = ../../src/android/app/src/main/res/values-<lang>/strings.xml
 source_file = ../../src/android/app/src/main/res/values/strings.xml
 type = ANDROID
+lang_map = ja_JP:ja, ko_KR:ko, pt_BR:pt-rBR, pt_PT:pt-rPT, ru_RU:ru, vi_VN:vi, zh_CN:zh-rCN, zh_TW:zh-rTW


### PR DESCRIPTION
The language names we are using in the android resources differ from those on Transifex.
We need to manually specify mappings for them, so Transifex is able to place the files in the correct folders.

Now all that's missing for us to Pull translations automatically, is a small change to zhaobot.