### PR TITLE
yuzu: Fully hide linux tab

### DIFF
--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -73,8 +73,11 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::st
     ui->tabWidget->addTab(graphics_advanced_tab.get(), tr("Adv. Graphics"));
     ui->tabWidget->addTab(audio_tab.get(), tr("Audio"));
     ui->tabWidget->addTab(input_tab.get(), tr("Input Profiles"));
+
     // Only show Linux tab on Unix
+    linux_tab->setVisible(false);
 #ifdef __unix__
+    linux_tab->setVisible(true);
     ui->tabWidget->addTab(linux_tab.get(), tr("Linux"));
 #endif
 


### PR DESCRIPTION
Eliminates the element from appearing on windows. On the top left.

![image](https://github.com/yuzu-emu/yuzu/assets/5944268/e8a1a4cd-80ba-4fa7-bc2a-6b93f1b79257)