### PR TITLE
Fix multiplayer player count color in dark themes | Temp fix until #12744: Add green color for counts > 0 and < max_players - 1

### DIFF
--- a/src/yuzu/multiplayer/lobby_p.h
+++ b/src/yuzu/multiplayer/lobby_p.h
@@ -202,25 +202,20 @@ public:
         case Qt::ForegroundRole: {
             auto members = data(MemberListRole).toList();
             auto max_players = data(MaxPlayerRole).toInt();
+            QColor room_full_color(255, 48, 32);
+            QColor room_almost_full_color(255, 140, 32);
+            QColor room_empty_color(128, 128, 128);
 
-            if (QIcon::themeName().contains(QStringLiteral("dark")) ||
-                QIcon::themeName().contains(QStringLiteral("midnight"))) {
-                if (members.size() >= max_players) {
-                    return QBrush(QColor(255, 48, 32));
-                } else if (members.size() == (max_players - 1)) {
-                    return QBrush(QColor(255, 140, 32));
-                } else if (members.size() == 0) {
-                    return QBrush(QColor(128, 128, 128));
-                } else if (members.size() > 0 && members.size() < max_players - 1) {
-                    return QBrush(QColor(204, 204, 204));
-                }
-            } else {
-                if (members.size() >= max_players) {
-                    return QBrush(QColor(255, 48, 32));
-                } else if (members.size() == (max_players - 1)) {
-                    return QBrush(QColor(255, 140, 32));
-                } else if (members.size() == 0) {
-                    return QBrush(QColor(128, 128, 128));
+            if (members.size() >= max_players) {
+                return QBrush(room_full_color);
+            } else if (members.size() == (max_players - 1)) {
+                return QBrush(room_almost_full_color);
+            } else if (members.size() == 0) {
+                return QBrush(room_empty_color);
+            } else if (members.size() > 0 && members.size() < max_players - 1) {
+                if (QIcon::themeName().contains(QStringLiteral("dark")) ||
+                    QIcon::themeName().contains(QStringLiteral("midnight"))) {
+                    return QBrush(QColor(255, 255, 255));
                 }
             }
             // FIXME: How to return a value that tells Qt not to modify the

--- a/src/yuzu/multiplayer/lobby_p.h
+++ b/src/yuzu/multiplayer/lobby_p.h
@@ -202,9 +202,10 @@ public:
         case Qt::ForegroundRole: {
             auto members = data(MemberListRole).toList();
             auto max_players = data(MaxPlayerRole).toInt();
-            QColor room_full_color(255, 48, 32);
-            QColor room_almost_full_color(255, 140, 32);
-            QColor room_empty_color(128, 128, 128);
+            const QColor room_full_color(255, 48, 32);
+            const QColor room_almost_full_color(255, 140, 32);
+            const QColor room_has_players_color(32, 160, 32);
+            const QColor room_empty_color(128, 128, 128);
 
             if (members.size() >= max_players) {
                 return QBrush(room_full_color);
@@ -212,8 +213,8 @@ public:
                 return QBrush(room_almost_full_color);
             } else if (members.size() == 0) {
                 return QBrush(room_empty_color);
-            } else if (members.size() > 0 && members.size() < max_players - 1) {
-                return QBrush(QColor(32, 160, 32));
+            } else if (members.size() > 0 && members.size() < (max_players - 1)) {
+                return QBrush(room_has_players_color);
             }
             // FIXME: How to return a value that tells Qt not to modify the
             // text color from the default (as if Qt::ForegroundRole wasn't overridden)?

--- a/src/yuzu/multiplayer/lobby_p.h
+++ b/src/yuzu/multiplayer/lobby_p.h
@@ -213,10 +213,7 @@ public:
             } else if (members.size() == 0) {
                 return QBrush(room_empty_color);
             } else if (members.size() > 0 && members.size() < max_players - 1) {
-                if (QIcon::themeName().contains(QStringLiteral("dark")) ||
-                    QIcon::themeName().contains(QStringLiteral("midnight"))) {
-                    return QBrush(QColor(255, 255, 255));
-                }
+                return QBrush(QColor(32, 160, 32));
             }
             // FIXME: How to return a value that tells Qt not to modify the
             // text color from the default (as if Qt::ForegroundRole wasn't overridden)?

--- a/src/yuzu/multiplayer/lobby_p.h
+++ b/src/yuzu/multiplayer/lobby_p.h
@@ -202,12 +202,26 @@ public:
         case Qt::ForegroundRole: {
             auto members = data(MemberListRole).toList();
             auto max_players = data(MaxPlayerRole).toInt();
-            if (members.size() >= max_players) {
-                return QBrush(QColor(255, 48, 32));
-            } else if (members.size() == (max_players - 1)) {
-                return QBrush(QColor(255, 140, 32));
-            } else if (members.size() == 0) {
-                return QBrush(QColor(128, 128, 128));
+
+            if (QIcon::themeName().contains(QStringLiteral("dark")) ||
+                QIcon::themeName().contains(QStringLiteral("midnight"))) {
+                if (members.size() >= max_players) {
+                    return QBrush(QColor(255, 48, 32));
+                } else if (members.size() == (max_players - 1)) {
+                    return QBrush(QColor(255, 140, 32));
+                } else if (members.size() == 0) {
+                    return QBrush(QColor(128, 128, 128));
+                } else if (members.size() > 0 && members.size() < max_players - 1) {
+                    return QBrush(QColor(204, 204, 204));
+                }
+            } else {
+                if (members.size() >= max_players) {
+                    return QBrush(QColor(255, 48, 32));
+                } else if (members.size() == (max_players - 1)) {
+                    return QBrush(QColor(255, 140, 32));
+                } else if (members.size() == 0) {
+                    return QBrush(QColor(128, 128, 128));
+                }
             }
             // FIXME: How to return a value that tells Qt not to modify the
             // text color from the default (as if Qt::ForegroundRole wasn't overridden)?


### PR DESCRIPTION
This fixes #12852 to the intended color in dark and midnight themes.

<h2>Preview</h2>

Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/yuzu-emu/yuzu/assets/56404895/98f87aac-deca-4589-9afa-917fabc00458)  | ![image](https://github.com/yuzu-emu/yuzu/assets/56404895/6f733e23-05ee-4f08-9724-7e1efdd63f06)