### PR TITLE
yuzu: Make controller keys easier to assign

### DIFF
--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -45,15 +45,23 @@ ConfigureHotkeys::ConfigureHotkeys(Core::HID::HIDCore& hid_core, QWidget* parent
 
     controller = hid_core.GetEmulatedController(Core::HID::NpadIdType::Player1);
 
-    connect(timeout_timer.get(), &QTimer::timeout, [this] { SetPollingResult({}, true); });
+    connect(timeout_timer.get(), &QTimer::timeout, [this] {
+        const bool is_button_pressed = pressed_buttons != Core::HID::NpadButton::None ||
+                                       pressed_home_button || pressed_capture_button;
+        SetPollingResult(!is_button_pressed);
+    });
 
     connect(poll_timer.get(), &QTimer::timeout, [this] {
-        const auto buttons = controller->GetNpadButtons();
-        const auto home_pressed = controller->GetHomeButtons().home != 0;
-        const auto capture_pressed = controller->GetCaptureButtons().capture != 0;
-        if (home_pressed || capture_pressed) {
-            SetPollingResult(buttons.raw, false);
-            return;
+        pressed_buttons |= controller->GetNpadButtons().raw;
+        pressed_home_button |= this->controller->GetHomeButtons().home != 0;
+        pressed_capture_button |= this->controller->GetCaptureButtons().capture != 0;
+        if (pressed_buttons != Core::HID::NpadButton::None || pressed_home_button ||
+            pressed_capture_button) {
+            const QString button_name =
+                GetButtonCombinationName(pressed_buttons, pressed_home_button,
+                                         pressed_capture_button) +
+                QStringLiteral("...");
+            model->setData(button_model_index, button_name);
         }
     });
     RetranslateUI();
@@ -154,16 +162,14 @@ void ConfigureHotkeys::ConfigureController(QModelIndex index) {
 
     const auto previous_key = model->data(index);
 
-    input_setter = [this, index, previous_key](const Core::HID::NpadButton button,
-                                               const bool cancel) {
+    input_setter = [this, index, previous_key](const bool cancel) {
         if (cancel) {
             model->setData(index, previous_key);
             return;
         }
-        const auto home_pressed = this->controller->GetHomeButtons().home != 0;
-        const auto capture_pressed = this->controller->GetCaptureButtons().capture != 0;
+
         const QString button_string =
-            GetButtonCombinationName(button, home_pressed, capture_pressed);
+            GetButtonCombinationName(pressed_buttons, pressed_home_button, pressed_capture_button);
 
         const auto [key_sequence_used, used_action] = IsUsedControllerKey(button_string);
 
@@ -177,17 +183,22 @@ void ConfigureHotkeys::ConfigureController(QModelIndex index) {
         }
     };
 
+    button_model_index = index;
+    pressed_buttons = Core::HID::NpadButton::None;
+    pressed_home_button = false;
+    pressed_capture_button = false;
+
     model->setData(index, tr("[waiting]"));
     timeout_timer->start(2500); // Cancel after 2.5 seconds
-    poll_timer->start(200);     // Check for new inputs every 200ms
+    poll_timer->start(100);     // Check for new inputs every 100ms
     // We need to disable configuration to be able to read npad buttons
     controller->DisableConfiguration();
 }
 
-void ConfigureHotkeys::SetPollingResult(Core::HID::NpadButton button, const bool cancel) {
+void ConfigureHotkeys::SetPollingResult(const bool cancel) {
     timeout_timer->stop();
     poll_timer->stop();
-    (*input_setter)(button, cancel);
+    (*input_setter)(cancel);
     // Re-Enable configuration
     controller->EnableConfiguration();
 

--- a/src/yuzu/configuration/configure_hotkeys.h
+++ b/src/yuzu/configuration/configure_hotkeys.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <QStandardItemModel>
 #include <QWidget>
 
 namespace Common {
@@ -54,14 +55,20 @@ private:
     void RestoreControllerHotkey(QModelIndex index);
     void RestoreHotkey(QModelIndex index);
 
+    void SetPollingResult(bool cancel);
+    QString GetButtonCombinationName(Core::HID::NpadButton button, bool home, bool capture) const;
+
     std::unique_ptr<Ui::ConfigureHotkeys> ui;
 
     QStandardItemModel* model;
 
-    void SetPollingResult(Core::HID::NpadButton button, bool cancel);
-    QString GetButtonCombinationName(Core::HID::NpadButton button, bool home, bool capture) const;
+    bool pressed_home_button;
+    bool pressed_capture_button;
+    QModelIndex button_model_index;
+    Core::HID::NpadButton pressed_buttons;
+
     Core::HID::EmulatedController* controller;
     std::unique_ptr<QTimer> timeout_timer;
     std::unique_ptr<QTimer> poll_timer;
-    std::optional<std::function<void(Core::HID::NpadButton, bool)>> input_setter;
+    std::optional<std::function<void(bool)>> input_setter;
 };

--- a/src/yuzu/hotkeys.cpp
+++ b/src/yuzu/hotkeys.cpp
@@ -193,8 +193,7 @@ void ControllerShortcut::ControllerUpdateEvent(Core::HID::ControllerTriggerType 
     if (!Settings::values.controller_navigation) {
         return;
     }
-    if (button_sequence.npad.raw == Core::HID::NpadButton::None &&
-        button_sequence.capture.raw == 0 && button_sequence.home.raw == 0) {
+    if (button_sequence.npad.raw == Core::HID::NpadButton::None) {
         return;
     }
 


### PR DESCRIPTION
One of the most common complains is how difficult is to use custom controller hotkeys. Right now users need to press home/screenshot button + another button at the same time to save the button presses. This makes it almost impossible to do a 3+ key press.

This simplifies the method in these ways:
- One key presses are allowed. It will be user responsibility to avoid issues from accidentally pressing the hotkey while playing.
- You will see a preview of the button presses followed with "..."
- Finally the box will save the output after 2.5 seconds.

![image](https://github.com/yuzu-emu/yuzu/assets/5944268/11de61a9-fd00-4686-856b-892e8137231a)
