### PR TITLE
ipc: additional fixes

### DIFF
--- a/src/core/hle/service/cmif_serialization.h
+++ b/src/core/hle/service/cmif_serialization.h
@@ -280,7 +280,7 @@ void ReadInArgument(bool is_domain, CallArguments& args, const u8* raw_data, HLE
 
             u32 value{};
             std::memcpy(&value, raw_data + ArgOffset, ArgSize);
-            std::get<ArgIndex>(args) = ctx.GetDomainHandler<ArgType::Type>(value - 1);
+            std::get<ArgIndex>(args) = ctx.GetDomainHandler<typename ArgType::element_type>(value - 1);
 
             return ReadInArgument<MethodArguments, CallArguments, ArgAlign, ArgEnd, HandleIndex, InBufferIndex, OutBufferIndex, true, ArgIndex + 1>(is_domain, args, raw_data, ctx, temp);
         } else if constexpr (ArgumentTraits<ArgType>::Type == ArgumentType::InCopyHandle) {

--- a/src/core/hle/service/cmif_types.h
+++ b/src/core/hle/service/cmif_types.h
@@ -65,6 +65,14 @@ struct ClientProcessId {
 };
 
 struct ProcessId {
+    explicit ProcessId() : pid() {}
+    explicit ProcessId(u64 p) : pid(p) {}
+    /* implicit */ ProcessId(const ClientProcessId& c) : pid(c.pid) {}
+
+    bool operator==(const ProcessId& rhs) const {
+        return pid == rhs.pid;
+    }
+
     explicit operator bool() const {
         return pid != 0;
     }

--- a/src/core/hle/service/hle_ipc.cpp
+++ b/src/core/hle/service/hle_ipc.cpp
@@ -299,8 +299,12 @@ Result HLERequestContext::WriteToOutgoingCommandBuffer() {
     if (GetManager()->IsDomain()) {
         current_offset = domain_offset - static_cast<u32>(outgoing_domain_objects.size());
         for (auto& object : outgoing_domain_objects) {
-            GetManager()->AppendDomainHandler(std::move(object));
-            cmd_buf[current_offset++] = static_cast<u32_le>(GetManager()->DomainHandlerCount());
+            if (object) {
+                GetManager()->AppendDomainHandler(std::move(object));
+                cmd_buf[current_offset++] = static_cast<u32_le>(GetManager()->DomainHandlerCount());
+            } else {
+                cmd_buf[current_offset++] = 0;
+            }
         }
     }
 


### PR DESCRIPTION
1. Fix compile error when receiving in domains (ArgType::Type doesn't exist, it's a shared_ptr<T>)
2. Make unqualified ProcessId and AppletResourceUserId more convenient to use outside of IPC
3. Correctly handle null domain outputs