### PR TITLE
dmnt: cheat: Avoid invalidating cache on 32bit

### DIFF
--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -64,7 +64,8 @@ void StandardVmCallbacks::MemoryWriteUnsafe(VAddr address, const void* data, u64
         return;
     }
 
-    if (system.ApplicationMemory().WriteBlock(address, data, size)) {
+    if (system.ApplicationMemory().WriteBlock(address, data, size) &&
+        system.ApplicationProcess()->Is64Bit()) {
         Core::InvalidateInstructionCacheRange(system.ApplicationProcess(), address, size);
     }
 }


### PR DESCRIPTION
Dynarmic crashes on 32bit games when invalidating memory while using cheats. This fixes the recent crashes with MHU.

This is a temporary workaround while the real issue is fixed.