### PR TITLE
android: Thermal throttling indicator

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/BooleanSetting.kt
@@ -25,7 +25,8 @@ enum class BooleanSetting(override val key: String) : AbstractBooleanSetting {
     HAPTIC_FEEDBACK("haptic_feedback"),
     SHOW_PERFORMANCE_OVERLAY("show_performance_overlay"),
     SHOW_INPUT_OVERLAY("show_input_overlay"),
-    TOUCHSCREEN("touchscreen");
+    TOUCHSCREEN("touchscreen"),
+    SHOW_THERMAL_OVERLAY("show_thermal_overlay");
 
     override fun getBoolean(needsGlobal: Boolean): Boolean =
         NativeConfig.getBoolean(key, needsGlobal)

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.MarginLayoutParams
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
@@ -27,6 +26,7 @@ import org.yuzu.yuzu_emu.R
 import org.yuzu.yuzu_emu.databinding.FragmentSettingsBinding
 import org.yuzu.yuzu_emu.features.settings.model.Settings
 import org.yuzu.yuzu_emu.model.SettingsViewModel
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class SettingsFragment : Fragment() {
     private lateinit var presenter: SettingsFragmentPresenter
@@ -125,18 +125,10 @@ class SettingsFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpSettingsList = binding.listSettings.layoutParams as MarginLayoutParams
-            mlpSettingsList.leftMargin = leftInsets
-            mlpSettingsList.rightMargin = rightInsets
-            binding.listSettings.layoutParams = mlpSettingsList
-            binding.listSettings.updatePadding(
-                bottom = barInsets.bottom
-            )
+            binding.listSettings.updateMargins(left = leftInsets, right = rightInsets)
+            binding.listSettings.updatePadding(bottom = barInsets.bottom)
 
-            val mlpAppBar = binding.appbarSettings.layoutParams as MarginLayoutParams
-            mlpAppBar.leftMargin = leftInsets
-            mlpAppBar.rightMargin = rightInsets
-            binding.appbarSettings.layoutParams = mlpAppBar
+            binding.appbarSettings.updateMargins(left = leftInsets, right = rightInsets)
             windowInsets
         }
     }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AboutFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AboutFragment.kt
@@ -13,7 +13,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.MarginLayoutParams
 import android.widget.Toast
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -26,6 +25,7 @@ import org.yuzu.yuzu_emu.BuildConfig
 import org.yuzu.yuzu_emu.R
 import org.yuzu.yuzu_emu.databinding.FragmentAboutBinding
 import org.yuzu.yuzu_emu.model.HomeViewModel
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class AboutFragment : Fragment() {
     private var _binding: FragmentAboutBinding? = null
@@ -114,15 +114,8 @@ class AboutFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpToolbar = binding.toolbarAbout.layoutParams as MarginLayoutParams
-            mlpToolbar.leftMargin = leftInsets
-            mlpToolbar.rightMargin = rightInsets
-            binding.toolbarAbout.layoutParams = mlpToolbar
-
-            val mlpScrollAbout = binding.scrollAbout.layoutParams as MarginLayoutParams
-            mlpScrollAbout.leftMargin = leftInsets
-            mlpScrollAbout.rightMargin = rightInsets
-            binding.scrollAbout.layoutParams = mlpScrollAbout
+            binding.toolbarAbout.updateMargins(left = leftInsets, right = rightInsets)
+            binding.scrollAbout.updateMargins(left = leftInsets, right = rightInsets)
 
             binding.contentAbout.updatePadding(bottom = barInsets.bottom)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AddonsFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AddonsFragment.kt
@@ -31,6 +31,7 @@ import org.yuzu.yuzu_emu.model.AddonViewModel
 import org.yuzu.yuzu_emu.model.HomeViewModel
 import org.yuzu.yuzu_emu.utils.AddonUtil
 import org.yuzu.yuzu_emu.utils.FileUtil.copyFilesTo
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 import java.io.File
 
 class AddonsFragment : Fragment() {
@@ -202,27 +203,19 @@ class AddonsFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpToolbar = binding.toolbarAddons.layoutParams as ViewGroup.MarginLayoutParams
-            mlpToolbar.leftMargin = leftInsets
-            mlpToolbar.rightMargin = rightInsets
-            binding.toolbarAddons.layoutParams = mlpToolbar
-
-            val mlpAddonsList = binding.listAddons.layoutParams as ViewGroup.MarginLayoutParams
-            mlpAddonsList.leftMargin = leftInsets
-            mlpAddonsList.rightMargin = rightInsets
-            binding.listAddons.layoutParams = mlpAddonsList
+            binding.toolbarAddons.updateMargins(left = leftInsets, right = rightInsets)
+            binding.listAddons.updateMargins(left = leftInsets, right = rightInsets)
             binding.listAddons.updatePadding(
                 bottom = barInsets.bottom +
                     resources.getDimensionPixelSize(R.dimen.spacing_bottom_list_fab)
             )
 
             val fabSpacing = resources.getDimensionPixelSize(R.dimen.spacing_fab)
-            val mlpFab =
-                binding.buttonInstall.layoutParams as ViewGroup.MarginLayoutParams
-            mlpFab.leftMargin = leftInsets + fabSpacing
-            mlpFab.rightMargin = rightInsets + fabSpacing
-            mlpFab.bottomMargin = barInsets.bottom + fabSpacing
-            binding.buttonInstall.layoutParams = mlpFab
+            binding.buttonInstall.updateMargins(
+                left = leftInsets + fabSpacing,
+                right = rightInsets + fabSpacing,
+                bottom = barInsets.bottom + fabSpacing
+            )
 
             windowInsets
         }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AppletLauncherFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AppletLauncherFragment.kt
@@ -21,6 +21,7 @@ import org.yuzu.yuzu_emu.databinding.FragmentAppletLauncherBinding
 import org.yuzu.yuzu_emu.model.Applet
 import org.yuzu.yuzu_emu.model.AppletInfo
 import org.yuzu.yuzu_emu.model.HomeViewModel
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class AppletLauncherFragment : Fragment() {
     private var _binding: FragmentAppletLauncherBinding? = null
@@ -95,16 +96,8 @@ class AppletLauncherFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpAppBar = binding.toolbarApplets.layoutParams as ViewGroup.MarginLayoutParams
-            mlpAppBar.leftMargin = leftInsets
-            mlpAppBar.rightMargin = rightInsets
-            binding.toolbarApplets.layoutParams = mlpAppBar
-
-            val mlpListApplets =
-                binding.listApplets.layoutParams as ViewGroup.MarginLayoutParams
-            mlpListApplets.leftMargin = leftInsets
-            mlpListApplets.rightMargin = rightInsets
-            binding.listApplets.layoutParams = mlpListApplets
+            binding.toolbarApplets.updateMargins(left = leftInsets, right = rightInsets)
+            binding.listApplets.updateMargins(left = leftInsets, right = rightInsets)
 
             binding.listApplets.updatePadding(bottom = barInsets.bottom)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/DriverManagerFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/DriverManagerFragment.kt
@@ -34,6 +34,7 @@ import org.yuzu.yuzu_emu.model.HomeViewModel
 import org.yuzu.yuzu_emu.utils.FileUtil
 import org.yuzu.yuzu_emu.utils.GpuDriverHelper
 import org.yuzu.yuzu_emu.utils.NativeConfig
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 import java.io.File
 import java.io.IOException
 
@@ -141,23 +142,15 @@ class DriverManagerFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpAppBar = binding.toolbarDrivers.layoutParams as ViewGroup.MarginLayoutParams
-            mlpAppBar.leftMargin = leftInsets
-            mlpAppBar.rightMargin = rightInsets
-            binding.toolbarDrivers.layoutParams = mlpAppBar
-
-            val mlplistDrivers = binding.listDrivers.layoutParams as ViewGroup.MarginLayoutParams
-            mlplistDrivers.leftMargin = leftInsets
-            mlplistDrivers.rightMargin = rightInsets
-            binding.listDrivers.layoutParams = mlplistDrivers
+            binding.toolbarDrivers.updateMargins(left = leftInsets, right = rightInsets)
+            binding.listDrivers.updateMargins(left = leftInsets, right = rightInsets)
 
             val fabSpacing = resources.getDimensionPixelSize(R.dimen.spacing_fab)
-            val mlpFab =
-                binding.buttonInstall.layoutParams as ViewGroup.MarginLayoutParams
-            mlpFab.leftMargin = leftInsets + fabSpacing
-            mlpFab.rightMargin = rightInsets + fabSpacing
-            mlpFab.bottomMargin = barInsets.bottom + fabSpacing
-            binding.buttonInstall.layoutParams = mlpFab
+            binding.buttonInstall.updateMargins(
+                left = leftInsets + fabSpacing,
+                right = rightInsets + fabSpacing,
+                bottom = barInsets.bottom + fabSpacing
+            )
 
             binding.listDrivers.updatePadding(
                 bottom = barInsets.bottom +

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EarlyAccessFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/EarlyAccessFragment.kt
@@ -19,6 +19,7 @@ import com.google.android.material.transition.MaterialSharedAxis
 import org.yuzu.yuzu_emu.R
 import org.yuzu.yuzu_emu.databinding.FragmentEarlyAccessBinding
 import org.yuzu.yuzu_emu.model.HomeViewModel
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class EarlyAccessFragment : Fragment() {
     private var _binding: FragmentEarlyAccessBinding? = null
@@ -73,10 +74,7 @@ class EarlyAccessFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpAppBar = binding.appbarEa.layoutParams as ViewGroup.MarginLayoutParams
-            mlpAppBar.leftMargin = leftInsets
-            mlpAppBar.rightMargin = rightInsets
-            binding.appbarEa.layoutParams = mlpAppBar
+            binding.appbarEa.updateMargins(left = leftInsets, right = rightInsets)
 
             binding.scrollEa.updatePadding(
                 left = leftInsets,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GameFoldersFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GameFoldersFragment.kt
@@ -26,6 +26,7 @@ import org.yuzu.yuzu_emu.databinding.FragmentFoldersBinding
 import org.yuzu.yuzu_emu.model.GamesViewModel
 import org.yuzu.yuzu_emu.model.HomeViewModel
 import org.yuzu.yuzu_emu.ui.main.MainActivity
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class GameFoldersFragment : Fragment() {
     private var _binding: FragmentFoldersBinding? = null
@@ -100,23 +101,16 @@ class GameFoldersFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpToolbar = binding.toolbarFolders.layoutParams as ViewGroup.MarginLayoutParams
-            mlpToolbar.leftMargin = leftInsets
-            mlpToolbar.rightMargin = rightInsets
-            binding.toolbarFolders.layoutParams = mlpToolbar
+            binding.toolbarFolders.updateMargins(left = leftInsets, right = rightInsets)
 
             val fabSpacing = resources.getDimensionPixelSize(R.dimen.spacing_fab)
-            val mlpFab =
-                binding.buttonAdd.layoutParams as ViewGroup.MarginLayoutParams
-            mlpFab.leftMargin = leftInsets + fabSpacing
-            mlpFab.rightMargin = rightInsets + fabSpacing
-            mlpFab.bottomMargin = barInsets.bottom + fabSpacing
-            binding.buttonAdd.layoutParams = mlpFab
+            binding.buttonAdd.updateMargins(
+                left = leftInsets + fabSpacing,
+                right = rightInsets + fabSpacing,
+                bottom = barInsets.bottom + fabSpacing
+            )
 
-            val mlpListFolders = binding.listFolders.layoutParams as ViewGroup.MarginLayoutParams
-            mlpListFolders.leftMargin = leftInsets
-            mlpListFolders.rightMargin = rightInsets
-            binding.listFolders.layoutParams = mlpListFolders
+            binding.listFolders.updateMargins(left = leftInsets, right = rightInsets)
 
             binding.listFolders.updatePadding(
                 bottom = barInsets.bottom +

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GameInfoFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GameInfoFragment.kt
@@ -27,6 +27,7 @@ import org.yuzu.yuzu_emu.databinding.FragmentGameInfoBinding
 import org.yuzu.yuzu_emu.model.GameVerificationResult
 import org.yuzu.yuzu_emu.model.HomeViewModel
 import org.yuzu.yuzu_emu.utils.GameMetadata
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class GameInfoFragment : Fragment() {
     private var _binding: FragmentGameInfoBinding? = null
@@ -122,11 +123,13 @@ class GameInfoFragment : Fragment() {
                                 titleId = R.string.verify_success,
                                 descriptionId = R.string.operation_completed_successfully
                             )
+
                         GameVerificationResult.Failed ->
                             MessageDialogFragment.newInstance(
                                 titleId = R.string.verify_failure,
                                 descriptionId = R.string.verify_failure_description
                             )
+
                         GameVerificationResult.NotImplemented ->
                             MessageDialogFragment.newInstance(
                                 titleId = R.string.verify_no_result,
@@ -165,15 +168,8 @@ class GameInfoFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpToolbar = binding.toolbarInfo.layoutParams as ViewGroup.MarginLayoutParams
-            mlpToolbar.leftMargin = leftInsets
-            mlpToolbar.rightMargin = rightInsets
-            binding.toolbarInfo.layoutParams = mlpToolbar
-
-            val mlpScrollAbout = binding.scrollInfo.layoutParams as ViewGroup.MarginLayoutParams
-            mlpScrollAbout.leftMargin = leftInsets
-            mlpScrollAbout.rightMargin = rightInsets
-            binding.scrollInfo.layoutParams = mlpScrollAbout
+            binding.toolbarInfo.updateMargins(left = leftInsets, right = rightInsets)
+            binding.scrollInfo.updateMargins(left = leftInsets, right = rightInsets)
 
             binding.contentInfo.updatePadding(bottom = barInsets.bottom)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GamePropertiesFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GamePropertiesFragment.kt
@@ -46,6 +46,7 @@ import org.yuzu.yuzu_emu.utils.FileUtil
 import org.yuzu.yuzu_emu.utils.GameIconUtils
 import org.yuzu.yuzu_emu.utils.GpuDriverHelper
 import org.yuzu.yuzu_emu.utils.MemoryUtil
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 import java.io.BufferedOutputStream
 import java.io.File
 
@@ -320,46 +321,25 @@ class GamePropertiesFragment : Fragment() {
 
             val smallLayout = resources.getBoolean(R.bool.small_layout)
             if (smallLayout) {
-                val mlpListAll =
-                    binding.listAll.layoutParams as ViewGroup.MarginLayoutParams
-                mlpListAll.leftMargin = leftInsets
-                mlpListAll.rightMargin = rightInsets
-                binding.listAll.layoutParams = mlpListAll
+                binding.listAll.updateMargins(left = leftInsets, right = rightInsets)
             } else {
                 if (ViewCompat.getLayoutDirection(binding.root) ==
                     ViewCompat.LAYOUT_DIRECTION_LTR
                 ) {
-                    val mlpListAll =
-                        binding.listAll.layoutParams as ViewGroup.MarginLayoutParams
-                    mlpListAll.rightMargin = rightInsets
-                    binding.listAll.layoutParams = mlpListAll
-
-                    val mlpIconLayout =
-                        binding.iconLayout!!.layoutParams as ViewGroup.MarginLayoutParams
-                    mlpIconLayout.topMargin = barInsets.top
-                    mlpIconLayout.leftMargin = leftInsets
-                    binding.iconLayout!!.layoutParams = mlpIconLayout
+                    binding.listAll.updateMargins(right = rightInsets)
+                    binding.iconLayout!!.updateMargins(top = barInsets.top, left = leftInsets)
                 } else {
-                    val mlpListAll =
-                        binding.listAll.layoutParams as ViewGroup.MarginLayoutParams
-                    mlpListAll.leftMargin = leftInsets
-                    binding.listAll.layoutParams = mlpListAll
-
-                    val mlpIconLayout =
-                        binding.iconLayout!!.layoutParams as ViewGroup.MarginLayoutParams
-                    mlpIconLayout.topMargin = barInsets.top
-                    mlpIconLayout.rightMargin = rightInsets
-                    binding.iconLayout!!.layoutParams = mlpIconLayout
+                    binding.listAll.updateMargins(left = leftInsets)
+                    binding.iconLayout!!.updateMargins(top = barInsets.top, right = rightInsets)
                 }
             }
 
             val fabSpacing = resources.getDimensionPixelSize(R.dimen.spacing_fab)
-            val mlpFab =
-                binding.buttonStart.layoutParams as ViewGroup.MarginLayoutParams
-            mlpFab.leftMargin = leftInsets + fabSpacing
-            mlpFab.rightMargin = rightInsets + fabSpacing
-            mlpFab.bottomMargin = barInsets.bottom + fabSpacing
-            binding.buttonStart.layoutParams = mlpFab
+            binding.buttonStart.updateMargins(
+                left = leftInsets + fabSpacing,
+                right = rightInsets + fabSpacing,
+                bottom = barInsets.bottom + fabSpacing
+            )
 
             binding.layoutAll.updatePadding(
                 top = barInsets.top,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/HomeSettingsFragment.kt
@@ -12,7 +12,6 @@ import android.provider.DocumentsContract
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.MarginLayoutParams
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
@@ -44,6 +43,7 @@ import org.yuzu.yuzu_emu.ui.main.MainActivity
 import org.yuzu.yuzu_emu.utils.FileUtil
 import org.yuzu.yuzu_emu.utils.GpuDriverHelper
 import org.yuzu.yuzu_emu.utils.Log
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class HomeSettingsFragment : Fragment() {
     private var _binding: FragmentHomeSettingsBinding? = null
@@ -408,10 +408,7 @@ class HomeSettingsFragment : Fragment() {
                 bottom = barInsets.bottom
             )
 
-            val mlpScrollSettings = binding.scrollViewSettings.layoutParams as MarginLayoutParams
-            mlpScrollSettings.leftMargin = leftInsets
-            mlpScrollSettings.rightMargin = rightInsets
-            binding.scrollViewSettings.layoutParams = mlpScrollSettings
+            binding.scrollViewSettings.updateMargins(left = leftInsets, right = rightInsets)
 
             binding.linearLayoutSettings.updatePadding(bottom = spacingNavigation)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/InstallableFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/InstallableFragment.kt
@@ -34,6 +34,7 @@ import org.yuzu.yuzu_emu.model.TaskState
 import org.yuzu.yuzu_emu.ui.main.MainActivity
 import org.yuzu.yuzu_emu.utils.DirectoryInitialization
 import org.yuzu.yuzu_emu.utils.FileUtil
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 import java.io.BufferedOutputStream
 import java.io.File
 import java.math.BigInteger
@@ -172,16 +173,8 @@ class InstallableFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpAppBar = binding.toolbarInstallables.layoutParams as ViewGroup.MarginLayoutParams
-            mlpAppBar.leftMargin = leftInsets
-            mlpAppBar.rightMargin = rightInsets
-            binding.toolbarInstallables.layoutParams = mlpAppBar
-
-            val mlpScrollAbout =
-                binding.listInstallables.layoutParams as ViewGroup.MarginLayoutParams
-            mlpScrollAbout.leftMargin = leftInsets
-            mlpScrollAbout.rightMargin = rightInsets
-            binding.listInstallables.layoutParams = mlpScrollAbout
+            binding.toolbarInstallables.updateMargins(left = leftInsets, right = rightInsets)
+            binding.listInstallables.updateMargins(left = leftInsets, right = rightInsets)
 
             binding.listInstallables.updatePadding(bottom = barInsets.bottom)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/LicensesFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/LicensesFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.MarginLayoutParams
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -22,6 +21,7 @@ import org.yuzu.yuzu_emu.adapters.LicenseAdapter
 import org.yuzu.yuzu_emu.databinding.FragmentLicensesBinding
 import org.yuzu.yuzu_emu.model.HomeViewModel
 import org.yuzu.yuzu_emu.model.License
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class LicensesFragment : Fragment() {
     private var _binding: FragmentLicensesBinding? = null
@@ -122,15 +122,8 @@ class LicensesFragment : Fragment() {
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
 
-            val mlpAppBar = binding.appbarLicenses.layoutParams as MarginLayoutParams
-            mlpAppBar.leftMargin = leftInsets
-            mlpAppBar.rightMargin = rightInsets
-            binding.appbarLicenses.layoutParams = mlpAppBar
-
-            val mlpScrollAbout = binding.listLicenses.layoutParams as MarginLayoutParams
-            mlpScrollAbout.leftMargin = leftInsets
-            mlpScrollAbout.rightMargin = rightInsets
-            binding.listLicenses.layoutParams = mlpScrollAbout
+            binding.appbarLicenses.updateMargins(left = leftInsets, right = rightInsets)
+            binding.listLicenses.updateMargins(left = leftInsets, right = rightInsets)
 
             binding.listLicenses.updatePadding(bottom = barInsets.bottom)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/SettingsSearchFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/SettingsSearchFragment.kt
@@ -29,6 +29,7 @@ import org.yuzu.yuzu_emu.features.settings.model.view.SettingsItem
 import org.yuzu.yuzu_emu.features.settings.ui.SettingsAdapter
 import org.yuzu.yuzu_emu.model.SettingsViewModel
 import org.yuzu.yuzu_emu.utils.NativeConfig
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class SettingsSearchFragment : Fragment() {
     private var _binding: FragmentSettingsSearchBinding? = null
@@ -174,15 +175,14 @@ class SettingsSearchFragment : Fragment() {
                 bottom = barInsets.bottom
             )
 
-            val mlpSettingsList = binding.settingsList.layoutParams as ViewGroup.MarginLayoutParams
-            mlpSettingsList.leftMargin = leftInsets + sideMargin
-            mlpSettingsList.rightMargin = rightInsets + sideMargin
-            binding.settingsList.layoutParams = mlpSettingsList
-
-            val mlpDivider = binding.divider.layoutParams as ViewGroup.MarginLayoutParams
-            mlpDivider.leftMargin = leftInsets + sideMargin
-            mlpDivider.rightMargin = rightInsets + sideMargin
-            binding.divider.layoutParams = mlpDivider
+            binding.settingsList.updateMargins(
+                left = leftInsets + sideMargin,
+                right = rightInsets + sideMargin
+            )
+            binding.divider.updateMargins(
+                left = leftInsets + sideMargin,
+                right = rightInsets + sideMargin
+            )
 
             windowInsets
         }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/ui/GamesFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.MarginLayoutParams
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -27,6 +26,7 @@ import org.yuzu.yuzu_emu.databinding.FragmentGamesBinding
 import org.yuzu.yuzu_emu.layout.AutofitGridLayoutManager
 import org.yuzu.yuzu_emu.model.GamesViewModel
 import org.yuzu.yuzu_emu.model.HomeViewModel
+import org.yuzu.yuzu_emu.utils.ViewUtils.updateMargins
 
 class GamesFragment : Fragment() {
     private var _binding: FragmentGamesBinding? = null
@@ -169,15 +169,16 @@ class GamesFragment : Fragment() {
 
             val leftInsets = barInsets.left + cutoutInsets.left
             val rightInsets = barInsets.right + cutoutInsets.right
-            val mlpSwipe = binding.swipeRefresh.layoutParams as MarginLayoutParams
+            val left: Int
+            val right: Int
             if (ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_LTR) {
-                mlpSwipe.leftMargin = leftInsets + spacingNavigationRail
-                mlpSwipe.rightMargin = rightInsets
+                left = leftInsets + spacingNavigationRail
+                right = rightInsets
             } else {
-                mlpSwipe.leftMargin = leftInsets
-                mlpSwipe.rightMargin = rightInsets + spacingNavigationRail
+                left = leftInsets
+                right = rightInsets + spacingNavigationRail
             }
-            binding.swipeRefresh.layoutParams = mlpSwipe
+            binding.swipeRefresh.updateMargins(left = left, right = right)
 
             binding.noticeText.updatePadding(bottom = spacingNavigation)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/ViewUtils.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/ViewUtils.kt
@@ -4,6 +4,7 @@
 package org.yuzu.yuzu_emu.utils
 
 import android.view.View
+import android.view.ViewGroup
 
 object ViewUtils {
     fun showView(view: View, length: Long = 300) {
@@ -31,5 +32,29 @@ object ViewUtils {
         }.withEndAction {
             view.visibility = View.INVISIBLE
         }.start()
+    }
+
+    fun View.updateMargins(
+        left: Int = -1,
+        top: Int = -1,
+        right: Int = -1,
+        bottom: Int = -1
+    ) {
+        val layoutParams = this.layoutParams as ViewGroup.MarginLayoutParams
+        layoutParams.apply {
+            if (left != -1) {
+                leftMargin = left
+            }
+            if (top != -1) {
+                topMargin = top
+            }
+            if (right != -1) {
+                rightMargin = right
+            }
+            if (bottom != -1) {
+                bottomMargin = bottom
+            }
+        }
+        this.layoutParams = layoutParams
     }
 }

--- a/src/android/app/src/main/jni/android_settings.h
+++ b/src/android/app/src/main/jni/android_settings.h
@@ -60,6 +60,8 @@ struct Values {
                                             Settings::Category::Overlay};
     Settings::Setting<bool> show_performance_overlay{linkage, true, "show_performance_overlay",
                                                      Settings::Category::Overlay};
+    Settings::Setting<bool> show_thermal_overlay{linkage, false, "show_thermal_overlay",
+                                                 Settings::Category::Overlay};
     Settings::Setting<bool> show_input_overlay{linkage, true, "show_input_overlay",
                                                Settings::Category::Overlay};
     Settings::Setting<bool> touchscreen{linkage, true, "touchscreen", Settings::Category::Overlay};

--- a/src/android/app/src/main/res/layout/fragment_emulation.xml
+++ b/src/android/app/src/main/res/layout/fragment_emulation.xml
@@ -140,6 +140,7 @@
             android:id="@+id/overlay_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_marginHorizontal="20dp"
             android:fitsSystemWindows="true">
 
             <com.google.android.material.textview.MaterialTextView
@@ -150,7 +151,19 @@
                 android:layout_gravity="left"
                 android:clickable="false"
                 android:focusable="false"
-                android:paddingHorizontal="20dp"
+                android:textColor="@android:color/white"
+                android:shadowColor="@android:color/black"
+                android:shadowRadius="3"
+                tools:ignore="RtlHardcoded" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/show_thermals_text"
+                style="@style/TextAppearance.Material3.BodySmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="right"
+                android:clickable="false"
+                android:focusable="false"
                 android:textColor="@android:color/white"
                 android:shadowColor="@android:color/black"
                 android:shadowRadius="3"

--- a/src/android/app/src/main/res/menu/menu_overlay_options.xml
+++ b/src/android/app/src/main/res/menu/menu_overlay_options.xml
@@ -7,6 +7,11 @@
         android:checkable="true" />
 
     <item
+        android:id="@+id/thermal_indicator"
+        android:title="@string/emulation_thermal_indicator"
+        android:checkable="true" />
+
+    <item
         android:id="@+id/menu_edit_overlay"
         android:title="@string/emulation_touch_overlay_edit" />
 

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -380,6 +380,7 @@
     <string name="emulation_exit">Exit emulation</string>
     <string name="emulation_done">Done</string>
     <string name="emulation_fps_counter">FPS counter</string>
+    <string name="emulation_thermal_indicator">Thermal indicator</string>
     <string name="emulation_toggle_controls">Toggle controls</string>
     <string name="emulation_rel_stick_center">Relative stick center</string>
     <string name="emulation_dpad_slide">D-pad slide</string>


### PR DESCRIPTION
Adds an additional overlay option to show if your device is thermally throttling

Android has a system service that allows you to check if the system is reducing performance to improve throttling so we expose that via an emoji indicator. Each of these emojis will indicate the following thermal statuses. (Learn more about each status [here](https://source.android.com/docs/core/power/thermal-mitigation#codes))

🙂 - No throttling
😥 - Light throttling
🥵 - Moderate throttling
🔥 - Severe throttling
☢️ - Platform has done everything to reduce power
Thanks to @liamwhite for the idea to represent throttling this way

These definitions can vary between each vendor, but they are useful to see why one session is performing better than another.

![image](https://github.com/yuzu-emu/yuzu/assets/14132249/691feeba-6c95-4798-9e6c-aad6e886b050)
(My Galaxy S21 quickly reaching severe throttling after just 5 minutes of gameplay)