### PR TITLE
host_shaders: add vendor workaround for adreno drivers

### DIFF
--- a/src/video_core/host_shaders/vulkan_present.vert
+++ b/src/video_core/host_shaders/vulkan_present.vert
@@ -19,15 +19,13 @@ layout (push_constant) uniform PushConstants {
 //   Any member of a push constant block that is declared as an
 //   array must only be accessed with dynamically uniform indices.
 ScreenRectVertex GetVertex(int index) {
-    switch (index) {
-    case 0:
-    default:
+    if (index < 1) {
         return vertices[0];
-    case 1:
+    } else if (index < 2) {
         return vertices[1];
-    case 2:
+    } else if (index < 3) {
         return vertices[2];
-    case 3:
+    } else {
         return vertices[3];
     }
 }


### PR DESCRIPTION
Older Adreno drivers crash when comparing exact values of gl_VertexIndex. How does a bug like this even exist????