### PR TITLE
config: Always delete control settings in ClearControlPlayerValues

### DIFF
--- a/src/frontend_common/config.cpp
+++ b/src/frontend_common/config.cpp
@@ -867,15 +867,9 @@ void Config::Reload() {
 }
 
 void Config::ClearControlPlayerValues() const {
-    // If key is an empty string, all keys in the current group() are removed.
+    // Removes the entire [Controls] section
     const char* section = Settings::TranslateCategory(Settings::Category::Controls);
-    CSimpleIniA::TNamesDepend keys;
-    config->GetAllKeys(section, keys);
-    for (const auto& key : keys) {
-        if (std::string(config->GetValue(section, key.pItem)).empty()) {
-            config->Delete(section, key.pItem);
-        }
-    }
+    config->Delete(section, nullptr, true);
 }
 
 const std::string& Config::GetConfigFilePath() const {


### PR DESCRIPTION
This fixes a bug from #11889 where per-game input config would not be cleared upon selecting "Use global input configuration"

I mistakenly interpreted "If key is an empty string, all keys in the current group() are removed." where I thought that only settings with no value should be removed. This was obviously in reference to how you pass in an empty `QString` to `QSettings::remove` in order to delete an entire section. 🤦