### PR TITLE
android: Swap confirmation buttons for delete save data dialog

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GamePropertiesFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/GamePropertiesFragment.kt
@@ -243,7 +243,9 @@ class GamePropertiesFragment : Fragment() {
                                     requireActivity(),
                                     titleId = R.string.delete_save_data,
                                     descriptionId = R.string.delete_save_data_warning_description,
-                                    positiveAction = {
+                                    positiveButtonTitleId = android.R.string.cancel,
+                                    negativeButtonTitleId = android.R.string.ok,
+                                    negativeAction = {
                                         File(args.game.saveDir).deleteRecursively()
                                         Toast.makeText(
                                             YuzuApplication.appContext,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/MessageDialogViewModel.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/model/MessageDialogViewModel.kt
@@ -7,8 +7,10 @@ import androidx.lifecycle.ViewModel
 
 class MessageDialogViewModel : ViewModel() {
     var positiveAction: (() -> Unit)? = null
+    var negativeAction: (() -> Unit)? = null
 
     fun clear() {
         positiveAction = null
+        negativeAction = null
     }
 }


### PR DESCRIPTION
I've received a couple reports for this so clearly some people are speeding through the UI quickly enough to accidently delete their save data.
I swapped the "OK" and "Cancel" buttons to hopefully alleviate this.
![image](https://github.com/yuzu-emu/yuzu/assets/14132249/5c4220b9-a7d5-4c84-88ed-1b69e31921a0)
