### PR TITLE
buffer_cache: use mapped range with large vertex buffer size

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1130,7 +1130,7 @@ void BufferCache<P>::UpdateVertexBuffer(u32 index) {
         channel_state->vertex_buffers[index] = NULL_BINDING;
         return;
     }
-    if (!gpu_memory->IsWithinGPUAddressRange(gpu_addr_end)) {
+    if (!gpu_memory->IsWithinGPUAddressRange(gpu_addr_end) || size >= 64_MiB) {
         size = static_cast<u32>(gpu_memory->MaxContinuousRange(gpu_addr_begin, size));
     }
     const BufferId buffer_id = FindBuffer(*device_addr, size);


### PR DESCRIPTION
The limit register for vertex buffers is purely advisory. Since I'm pretty sure we don't support sparse buffers at all, this will ensure we don't expand to fill all available memory with buffers if the guest driver passes something like 4GB and has something mapped on the high end.

Fixes #12185