### PR TITLE
android: Expose FSR slider and add vertical alignment setting

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
@@ -24,7 +24,8 @@ enum class IntSetting(override val key: String) : AbstractIntSetting {
     THEME_MODE("theme_mode"),
     OVERLAY_SCALE("control_scale"),
     OVERLAY_OPACITY("control_opacity"),
-    LOCK_DRAWER("lock_drawer");
+    LOCK_DRAWER("lock_drawer"),
+    FSR_SHARPENING_SLIDER("fsr_sharpening_slider");
 
     override fun getInt(needsGlobal: Boolean): Int = NativeConfig.getInt(key, needsGlobal)
 

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/IntSetting.kt
@@ -25,6 +25,7 @@ enum class IntSetting(override val key: String) : AbstractIntSetting {
     OVERLAY_SCALE("control_scale"),
     OVERLAY_OPACITY("control_opacity"),
     LOCK_DRAWER("lock_drawer"),
+    VERTICAL_ALIGNMENT("vertical_alignment"),
     FSR_SHARPENING_SLIDER("fsr_sharpening_slider");
 
     override fun getInt(needsGlobal: Boolean): Int = NativeConfig.getInt(key, needsGlobal)

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/Settings.kt
@@ -93,4 +93,15 @@ object Settings {
                 entries.firstOrNull { it.int == int } ?: Unspecified
         }
     }
+
+    enum class EmulationVerticalAlignment(val int: Int) {
+        Top(1),
+        Center(0),
+        Bottom(2);
+
+        companion object {
+            fun from(int: Int): EmulationVerticalAlignment =
+                entries.firstOrNull { it.int == int } ?: Center
+        }
+    }
 }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
@@ -189,6 +189,16 @@ abstract class SettingsItem(
                 )
             )
             put(
+                SliderSetting(
+                    IntSetting.FSR_SHARPENING_SLIDER,
+                    R.string.fsr_sharpness,
+                    R.string.fsr_sharpness_description,
+                    0,
+                    100,
+                    "%"
+                )
+            )
+            put(
                 SingleChoiceSetting(
                     IntSetting.RENDERER_ANTI_ALIASING,
                     R.string.renderer_anti_aliasing,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
@@ -226,6 +226,15 @@ abstract class SettingsItem(
                 )
             )
             put(
+                SingleChoiceSetting(
+                    IntSetting.VERTICAL_ALIGNMENT,
+                    R.string.vertical_alignment,
+                    0,
+                    R.array.verticalAlignmentEntries,
+                    R.array.verticalAlignmentValues
+                )
+            )
+            put(
                 SwitchSetting(
                     BooleanSetting.RENDERER_USE_DISK_SHADER_CACHE,
                     R.string.use_disk_shader_cache,

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -143,6 +143,7 @@ class SettingsFragmentPresenter(
             add(IntSetting.RENDERER_RESOLUTION.key)
             add(IntSetting.RENDERER_VSYNC.key)
             add(IntSetting.RENDERER_SCALING_FILTER.key)
+            add(IntSetting.FSR_SHARPENING_SLIDER.key)
             add(IntSetting.RENDERER_ANTI_ALIASING.key)
             add(IntSetting.MAX_ANISOTROPY.key)
             add(IntSetting.RENDERER_SCREEN_LAYOUT.key)

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -148,6 +148,7 @@ class SettingsFragmentPresenter(
             add(IntSetting.MAX_ANISOTROPY.key)
             add(IntSetting.RENDERER_SCREEN_LAYOUT.key)
             add(IntSetting.RENDERER_ASPECT_RATIO.key)
+            add(IntSetting.VERTICAL_ALIGNMENT.key)
             add(BooleanSetting.PICTURE_IN_PICTURE.key)
             add(BooleanSetting.RENDERER_USE_DISK_SHADER_CACHE.key)
             add(BooleanSetting.RENDERER_FORCE_MAX_CLOCK.key)

--- a/src/android/app/src/main/jni/android_settings.h
+++ b/src/android/app/src/main/jni/android_settings.h
@@ -38,6 +38,13 @@ struct Values {
                                          Settings::Specialization::Default,
                                          true,
                                          true};
+    Settings::Setting<s32> vertical_alignment{linkage,
+                                              0,
+                                              "vertical_alignment",
+                                              Settings::Category::Android,
+                                              Settings::Specialization::Default,
+                                              true,
+                                              true};
 
     Settings::SwitchableSetting<std::string, false> driver_path{linkage, "", "driver_path",
                                                                 Settings::Category::GpuDriver};

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -292,4 +292,15 @@
         <item>5</item>
     </integer-array>
 
+    <string-array name="verticalAlignmentEntries">
+        <item>@string/top</item>
+        <item>@string/center</item>
+        <item>@string/bottom</item>
+    </string-array>
+    <integer-array name="verticalAlignmentValues">
+        <item>1</item>
+        <item>0</item>
+        <item>2</item>
+    </integer-array>
+
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -226,6 +226,8 @@
     <string name="renderer_screen_layout">Orientation</string>
     <string name="renderer_aspect_ratio">Aspect ratio</string>
     <string name="renderer_scaling_filter">Window adapting filter</string>
+    <string name="fsr_sharpness">FSR sharpness</string>
+    <string name="fsr_sharpness_description">Determines how sharpened the image will look while using FSR\'s dynamic contrast</string>
     <string name="renderer_anti_aliasing">Anti-aliasing method</string>
     <string name="renderer_force_max_clock">Force maximum clocks (Adreno only)</string>
     <string name="renderer_force_max_clock_description">Forces the GPU to run at the maximum possible clocks (thermal constraints will still be applied).</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -560,6 +560,12 @@
     <string name="mute">Mute</string>
     <string name="unmute">Unmute</string>
 
+    <!-- Emulation vertical alignment -->
+    <string name="vertical_alignment">Vertical alignment</string>
+    <string name="top">Top</string>
+    <string name="center">Center</string>
+    <string name="bottom">Bottom</string>
+
     <!-- Licenses screen strings -->
     <string name="licenses">Licenses</string>
     <string name="license_fidelityfx_fsr" translatable="false">FidelityFX-FSR</string>


### PR DESCRIPTION
Had a couple requests for settings that I expose/add
- FSR sharpness slider: Changes how sharp the image will look when using FSR
- Vertical alignment: Allows you to move the emulation surface to the top/bottom/center of your display
![image](https://github.com/yuzu-emu/yuzu/assets/14132249/132a4098-bb82-4c25-90dc-f42c4b77d485)
