### PR TITLE
android: Message dialog tweaks

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AddonsFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AddonsFragment.kt
@@ -104,7 +104,10 @@ class AddonsFragment : Fragment() {
                                 requireActivity(),
                                 titleId = R.string.addon_notice,
                                 descriptionId = R.string.addon_notice_description,
-                                positiveAction = { addonViewModel.showModInstallPicker(true) }
+                                dismissible = false,
+                                positiveAction = { addonViewModel.showModInstallPicker(true) },
+                                negativeAction = {},
+                                negativeButtonTitleId = R.string.close
                             ).show(parentFragmentManager, MessageDialogFragment.TAG)
                             addonViewModel.showModNoticeDialog(false)
                         }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AddonsFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/AddonsFragment.kt
@@ -119,7 +119,8 @@ class AddonsFragment : Fragment() {
                                 requireActivity(),
                                 titleId = R.string.confirm_uninstall,
                                 descriptionId = R.string.confirm_uninstall_description,
-                                positiveAction = { addonViewModel.onDeleteAddon(it) }
+                                positiveAction = { addonViewModel.onDeleteAddon(it) },
+                                negativeAction = {}
                             ).show(parentFragmentManager, MessageDialogFragment.TAG)
                             addonViewModel.setAddonToDelete(null)
                         }

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/MessageDialogFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/fragments/MessageDialogFragment.kt
@@ -42,9 +42,9 @@ class MessageDialogFragment : DialogFragment() {
         } else if (positiveButtonString.isNotEmpty()) {
             positiveButtonString
         } else if (messageDialogViewModel.positiveAction != null) {
-            getString(R.string.close)
-        } else {
             getString(android.R.string.ok)
+        } else {
+            getString(R.string.close)
         }
 
         val negativeButtonId = requireArguments().getInt(NEGATIVE_BUTTON_TITLE_ID)
@@ -131,7 +131,7 @@ class MessageDialogFragment : DialogFragment() {
          * @param positiveButtonTitleId String resource ID that will be used for the positive button.
          * [positiveButtonTitleString] used if 0.
          * @param positiveButtonTitleString String that will be used for the positive button.
-         * android.R.string.ok used if empty. android.R.string.close will be used if [positiveAction]
+         * android.R.string.close used if empty. android.R.string.ok will be used if [positiveAction]
          * is not null.
          * @param positiveAction Lambda to run when the positive button is clicked.
          * @param showNegativeButton Normally the negative button isn't shown if there is no


### PR DESCRIPTION
- Fixes an issue where "Close" appeared where "OK" should in message dialogs
- Show a cancel option for the delete addons dialog
- Prevent the user from dismissing the mod/cheats notice (Can only be dismissed via "OK" or "Close")