### PR TITLE
kernel: add and enable system suspend type

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -242,7 +242,7 @@ struct System::Impl {
     void Run() {
         std::unique_lock<std::mutex> lk(suspend_guard);
 
-        kernel.SuspendApplication(false);
+        kernel.SuspendEmulation(false);
         core_timing.SyncPause(false);
         is_paused.store(false, std::memory_order_relaxed);
     }
@@ -251,7 +251,7 @@ struct System::Impl {
         std::unique_lock<std::mutex> lk(suspend_guard);
 
         core_timing.SyncPause(true);
-        kernel.SuspendApplication(true);
+        kernel.SuspendEmulation(true);
         is_paused.store(true, std::memory_order_relaxed);
     }
 
@@ -261,7 +261,7 @@ struct System::Impl {
 
     std::unique_lock<std::mutex> StallApplication() {
         std::unique_lock<std::mutex> lk(suspend_guard);
-        kernel.SuspendApplication(true);
+        kernel.SuspendEmulation(true);
         core_timing.SyncPause(true);
         return lk;
     }
@@ -269,7 +269,7 @@ struct System::Impl {
     void UnstallApplication() {
         if (!IsPaused()) {
             core_timing.SyncPause(false);
-            kernel.SuspendApplication(false);
+            kernel.SuspendEmulation(false);
         }
     }
 
@@ -459,7 +459,7 @@ struct System::Impl {
         }
 
         Network::CancelPendingSocketOperations();
-        kernel.SuspendApplication(true);
+        kernel.SuspendEmulation(true);
         if (services) {
             services->KillNVNFlinger();
         }

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -66,6 +66,7 @@ enum class SuspendType : u32 {
     Debug = 2,
     Backtrace = 3,
     Init = 4,
+    System = 5,
 
     Count,
 };
@@ -84,8 +85,9 @@ enum class ThreadState : u16 {
     DebugSuspended = (1 << (2 + SuspendShift)),
     BacktraceSuspended = (1 << (3 + SuspendShift)),
     InitSuspended = (1 << (4 + SuspendShift)),
+    SystemSuspended = (1 << (5 + SuspendShift)),
 
-    SuspendFlagMask = ((1 << 5) - 1) << SuspendShift,
+    SuspendFlagMask = ((1 << 6) - 1) << SuspendShift,
 };
 DECLARE_ENUM_FLAG_OPERATORS(ThreadState);
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -258,8 +258,8 @@ public:
     /// Gets the shared memory object for HIDBus services.
     const Kernel::KSharedMemory& GetHidBusSharedMem() const;
 
-    /// Suspend/unsuspend application process.
-    void SuspendApplication(bool suspend);
+    /// Suspend/unsuspend emulated processes.
+    void SuspendEmulation(bool suspend);
 
     /// Exceptional exit application process.
     void ExceptionalExitApplication();


### PR DESCRIPTION
Currently suspension does not put processes other than the main process to sleep. With applets running, it is now possible for this to have noticeable side effects. This fixes the problem by moving away from SetActivity and adding a new suspend type for the system level suspends we want to enforce.