### PR TITLE
 shader_recompiler: fix non-const offset for arrayed image types 

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -321,17 +321,23 @@ void AddOffsetToCoordinates(EmitContext& ctx, const IR::TextureInstInfo& info, I
     Id result_type{};
     switch (info.type) {
     case TextureType::Buffer:
-    case TextureType::Color1D:
-    case TextureType::ColorArray1D: {
+    case TextureType::Color1D: {
         result_type = ctx.U32[1];
         break;
     }
+    case TextureType::ColorArray1D:
+        offset = ctx.OpCompositeConstruct(ctx.U32[2], offset, ctx.u32_zero_value);
+        [[fallthrough]];
     case TextureType::Color2D:
-    case TextureType::Color2DRect:
-    case TextureType::ColorArray2D: {
+    case TextureType::Color2DRect: {
         result_type = ctx.U32[2];
         break;
     }
+    case TextureType::ColorArray2D:
+        offset = ctx.OpCompositeConstruct(ctx.U32[3], ctx.OpCompositeExtract(ctx.U32[1], coords, 0),
+                                          ctx.OpCompositeExtract(ctx.U32[1], coords, 1),
+                                          ctx.u32_zero_value);
+        [[fallthrough]];
     case TextureType::Color3D: {
         result_type = ctx.U32[3];
         break;

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -537,8 +537,8 @@ Id EmitImageGather(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id 
                    const IR::Value& offset, const IR::Value& offset2);
 Id EmitImageGatherDref(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,
                        const IR::Value& offset, const IR::Value& offset2, Id dref);
-Id EmitImageFetch(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,
-                  const IR::Value& offset, Id lod, Id ms);
+Id EmitImageFetch(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords, Id offset,
+                  Id lod, Id ms);
 Id EmitImageQueryDimensions(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id lod,
                             const IR::Value& skip_mips);
 Id EmitImageQueryLod(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords);


### PR DESCRIPTION
Fixes #13025

Can't use ConstOffset with the scaler because resolution info is dynamic, so...