### PR TITLE
service: Implement functions needed by Qlaunch

### DIFF
--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -329,9 +329,8 @@ bool ProfileManager::GetProfileBaseAndData(const ProfileInfo& user, ProfileBase&
 
 /// Returns if the system is allowing user registrations or not
 bool ProfileManager::CanSystemRegisterUser() const {
-    return false; // TODO(ogniK): Games shouldn't have
-                  // access to user registration, when we
-    // emulate qlaunch. Update this to dynamically change.
+    // TODO: Both games and applets can register users. Determine when this condition is not meet.
+    return true;
 }
 
 bool ProfileManager::RemoveUser(UUID uuid) {

--- a/src/core/hle/service/am/applet_manager.cpp
+++ b/src/core/hle/service/am/applet_manager.cpp
@@ -35,6 +35,21 @@ AppletStorageChannel& InitializeFakeCallerApplet(Core::System& system,
     return applet->caller_applet_broker->GetInData();
 }
 
+void PushInShowQlaunch(Core::System& system, AppletStorageChannel& channel) {
+    const CommonArguments arguments{
+        .arguments_version = CommonArgumentVersion::Version3,
+        .size = CommonArgumentSize::Version3,
+        .library_version = 0,
+        .theme_color = ThemeColor::BasicBlack,
+        .play_startup_sound = true,
+        .system_tick = system.CoreTiming().GetClockTicks(),
+    };
+
+    std::vector<u8> argument_data(sizeof(arguments));
+    std::memcpy(argument_data.data(), &arguments, sizeof(arguments));
+    channel.Push(std::make_shared<IStorage>(system, std::move(argument_data)));
+}
+
 void PushInShowAlbum(Core::System& system, AppletStorageChannel& channel) {
     const CommonArguments arguments{
         .arguments_version = CommonArgumentVersion::Version3,
@@ -284,6 +299,9 @@ void AppletManager::CreateAndInsertByFrontendAppletParameters(
 
     // Starting from frontend, some applets require input data.
     switch (applet->applet_id) {
+    case AppletId::QLaunch:
+        PushInShowQlaunch(m_system, InitializeFakeCallerApplet(m_system, applet));
+        break;
     case AppletId::Cabinet:
         PushInShowCabinetData(m_system, InitializeFakeCallerApplet(m_system, applet));
         break;

--- a/src/core/hle/service/am/service/library_applet_self_accessor.cpp
+++ b/src/core/hle/service/am/service/library_applet_self_accessor.cpp
@@ -284,17 +284,17 @@ Result ILibraryAppletSelfAccessor::GetCurrentApplicationId(Out<u64> out_applicat
 }
 
 Result ILibraryAppletSelfAccessor::GetMainAppletAvailableUsers(
-    Out<bool> out_no_users_available, Out<s32> out_users_count,
+    Out<bool> out_can_select_any_user, Out<s32> out_users_count,
     OutArray<Common::UUID, BufferAttr_HipcMapAlias> out_users) {
     const Service::Account::ProfileManager manager{};
 
-    *out_no_users_available = true;
+    *out_can_select_any_user = false;
     *out_users_count = -1;
 
     LOG_INFO(Service_AM, "called");
 
     if (manager.GetUserCount() > 0) {
-        *out_no_users_available = false;
+        *out_can_select_any_user = true;
         *out_users_count = static_cast<s32>(manager.GetUserCount());
 
         const auto users = manager.GetAllUsers();

--- a/src/core/hle/service/am/service/library_applet_self_accessor.h
+++ b/src/core/hle/service/am/service/library_applet_self_accessor.h
@@ -71,7 +71,7 @@ private:
         ErrorCode error_code, InLargeData<ErrorContext, BufferAttr_HipcMapAlias> error_context);
     Result GetMainAppletApplicationDesiredLanguage(Out<u64> out_desired_language);
     Result GetCurrentApplicationId(Out<u64> out_application_id);
-    Result GetMainAppletAvailableUsers(Out<bool> out_no_users_available, Out<s32> out_users_count,
+    Result GetMainAppletAvailableUsers(Out<bool> out_can_select_any_user, Out<s32> out_users_count,
                                        OutArray<Common::UUID, BufferAttr_HipcMapAlias> out_users);
     Result ShouldSetGpuTimeSliceManually(Out<bool> out_should_set_gpu_time_slice_manually);
     Result Cmd160(Out<u64> out_unknown0);

--- a/src/core/hle/service/caps/caps_a.cpp
+++ b/src/core/hle/service/caps/caps_a.cpp
@@ -16,7 +16,7 @@ IAlbumAccessorService::IAlbumAccessorService(Core::System& system_,
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetAlbumFileCount"},
-        {1, nullptr, "GetAlbumFileList"},
+        {1, C<&IAlbumAccessorService::GetAlbumFileList>, "GetAlbumFileList"},
         {2, nullptr, "LoadAlbumFile"},
         {3, C<&IAlbumAccessorService::DeleteAlbumFile>, "DeleteAlbumFile"},
         {4, nullptr, "StorageCopyAlbumFile"},
@@ -61,6 +61,15 @@ IAlbumAccessorService::IAlbumAccessorService(Core::System& system_,
 }
 
 IAlbumAccessorService::~IAlbumAccessorService() = default;
+
+Result IAlbumAccessorService::GetAlbumFileList(
+    Out<u64> out_count, AlbumStorage storage,
+    OutArray<AlbumEntry, BufferAttr_HipcMapAlias> out_entries) {
+    LOG_INFO(Service_Capture, "called, storage={}", storage);
+
+    const Result result = manager->GetAlbumFileList(out_entries, *out_count, storage, 0);
+    R_RETURN(TranslateResult(result));
+}
 
 Result IAlbumAccessorService::DeleteAlbumFile(AlbumFileId file_id) {
     LOG_INFO(Service_Capture, "called, application_id=0x{:0x}, storage={}, type={}",

--- a/src/core/hle/service/caps/caps_a.h
+++ b/src/core/hle/service/caps/caps_a.h
@@ -21,6 +21,9 @@ public:
     ~IAlbumAccessorService() override;
 
 private:
+    Result GetAlbumFileList(Out<u64> out_count, AlbumStorage storage,
+                            OutArray<AlbumEntry, BufferAttr_HipcMapAlias> out_entries);
+
     Result DeleteAlbumFile(AlbumFileId file_id);
 
     Result IsAlbumMounted(Out<bool> out_is_mounted, AlbumStorage storage);

--- a/src/core/hle/service/erpt/erpt.cpp
+++ b/src/core/hle/service/erpt/erpt.cpp
@@ -3,6 +3,8 @@
 
 #include <memory>
 
+#include "common/logging/log.h"
+#include "core/hle/service/cmif_serialization.h"
 #include "core/hle/service/erpt/erpt.h"
 #include "core/hle/service/server_manager.h"
 #include "core/hle/service/service.h"
@@ -15,7 +17,7 @@ public:
     explicit ErrorReportContext(Core::System& system_) : ServiceFramework{system_, "erpt:c"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "SubmitContext"},
+            {0, C<&ErrorReportContext::SubmitContext>, "SubmitContext"},
             {1, nullptr, "CreateReportV0"},
             {2, nullptr, "SetInitialLaunchSettingsCompletionTime"},
             {3, nullptr, "ClearInitialLaunchSettingsCompletionTime"},
@@ -35,6 +37,14 @@ public:
         // clang-format on
 
         RegisterHandlers(functions);
+    }
+
+private:
+    Result SubmitContext(InBuffer<BufferAttr_HipcMapAlias> buffer_a,
+                         InBuffer<BufferAttr_HipcMapAlias> buffer_b) {
+        LOG_WARNING(Service_SET, "(STUBBED) called, buffer_a_size={}, buffer_b_size={}",
+                    buffer_a.size(), buffer_b.size());
+        R_SUCCEED();
     }
 };
 


### PR DESCRIPTION
Implements the launcher for Qlaunch. Fixes the user creation applet. Implements caps_a::GetAlbumFIleList and erpt::SubmitContext.

No user facing changes are done on this PR.