### PR TITLE
android: Only do first startup automapping if nothing has been mapped

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/activities/EmulationActivity.kt
@@ -80,8 +80,14 @@ class EmulationActivity : AppCompatActivity(), SensorEventListener {
         super.onCreate(savedInstanceState)
 
         InputHandler.updateControllerData()
-        val playerOne = NativeConfig.getInputSettings(true)[0]
-        if (!playerOne.hasMapping() && InputHandler.androidControllers.isNotEmpty()) {
+        val players = NativeConfig.getInputSettings(true)
+        var hasConfiguredControllers = false
+        players.forEach {
+            if (it.hasMapping()) {
+                hasConfiguredControllers = true
+            }
+        }
+        if (!hasConfiguredControllers && InputHandler.androidControllers.isNotEmpty()) {
             var params: ParamPackage? = null
             for (controller in InputHandler.registeredControllers) {
                 if (controller.get("port", -1) == 0) {


### PR DESCRIPTION
Fixes an issue where player 1 could be mapped silently with the controller on port 0 even if you wanted to use touch controls for P1 and a controller for P2