### PR TITLE
am: account for offset in transfer memory storage

### DIFF
--- a/src/core/hle/service/am/library_applet_storage.cpp
+++ b/src/core/hle/service/am/library_applet_storage.cpp
@@ -70,7 +70,7 @@ public:
     Result Read(s64 offset, void* buffer, size_t size) override {
         R_TRY(ValidateOffset(offset, size, m_size));
 
-        m_memory.ReadBlock(m_trmem->GetSourceAddress(), buffer, size);
+        m_memory.ReadBlock(m_trmem->GetSourceAddress() + offset, buffer, size);
 
         R_SUCCEED();
     }
@@ -79,7 +79,7 @@ public:
         R_UNLESS(m_is_writable, ResultUnknown);
         R_TRY(ValidateOffset(offset, size, m_size));
 
-        m_memory.WriteBlock(m_trmem->GetSourceAddress(), buffer, size);
+        m_memory.WriteBlock(m_trmem->GetSourceAddress() + offset, buffer, size);
 
         R_SUCCEED();
     }


### PR DESCRIPTION
Fixes #13033 and all other cases where the applet keyboard was not displaying the input string correctly
Fixes #13039