### PR TITLE
android: Misc controller fixes

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/input/model/PlayerInput.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/input/model/PlayerInput.kt
@@ -64,17 +64,17 @@ data class PlayerInput(
     fun hasMapping(): Boolean {
         var hasMapping = false
         buttons.forEach {
-            if (it != "[empty]") {
+            if (it != "[empty]" && it.isNotEmpty()) {
                 hasMapping = true
             }
         }
         analogs.forEach {
-            if (it != "[empty]") {
+            if (it != "[empty]" && it.isNotEmpty()) {
                 hasMapping = true
             }
         }
         motions.forEach {
-            if (it != "[empty]") {
+            if (it != "[empty]" && it.isNotEmpty()) {
                 hasMapping = true
             }
         }

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -292,6 +292,9 @@ void EmulationSession::ShutdownEmulation() {
     // Unload user input.
     m_system.HIDCore().UnloadInputDevices();
 
+    // Enable all controllers
+    m_system.HIDCore().SetSupportedStyleTag({Core::HID::NpadStyleSet::All});
+
     // Shutdown the main emulated process
     if (m_load_result == Core::SystemResultStatus::Success) {
         m_system.DetachDebugger();


### PR DESCRIPTION
- Re-enable all controller styles on emulation shutdown
- Add additional check for startup auto-mapping when you have no mapped controllers
- Change controller style to a supported one on connection if the configured style isn't allowed for a running game