### PR TITLE
vk_rasterizer: flip scissor y on lower left origin mode

### DIFF
--- a/src/video_core/engines/draw_manager.cpp
+++ b/src/video_core/engines/draw_manager.cpp
@@ -216,14 +216,11 @@ void DrawManager::DrawTexture() {
     const bool lower_left{regs.window_origin.mode !=
                           Maxwell3D::Regs::WindowOrigin::Mode::UpperLeft};
     if (lower_left) {
-        draw_texture_state.dst_y0 -= dst_height;
+        draw_texture_state.dst_y0 =
+            static_cast<f32>(regs.surface_clip.height) - draw_texture_state.dst_y0;
     }
-    draw_texture_state.dst_x1 =
-        draw_texture_state.dst_x0 +
-        static_cast<f32>(Settings::values.resolution_info.ScaleUp(static_cast<u32>(dst_width)));
-    draw_texture_state.dst_y1 =
-        draw_texture_state.dst_y0 +
-        static_cast<f32>(Settings::values.resolution_info.ScaleUp(static_cast<u32>(dst_height)));
+    draw_texture_state.dst_x1 = draw_texture_state.dst_x0 + dst_width;
+    draw_texture_state.dst_y1 = draw_texture_state.dst_y0 + dst_height;
     draw_texture_state.src_x0 = static_cast<float>(regs.draw_texture.src_x0) / 4096.f;
     draw_texture_state.src_y0 = static_cast<float>(regs.draw_texture.src_y0) / 4096.f;
     draw_texture_state.src_x1 =

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -125,11 +125,23 @@ VkRect2D GetScissorState(const Maxwell& regs, size_t index, u32 up_scale = 1, u3
         return value < 0 ? std::min<s32>(converted_value - acumm, -1)
                          : std::max<s32>(converted_value + acumm, 1);
     };
+
+    const bool lower_left = regs.window_origin.mode != Maxwell::WindowOrigin::Mode::UpperLeft;
+    const s32 clip_height = regs.surface_clip.height;
+
+    // Flip coordinates if lower left
+    s32 min_y = lower_left ? (clip_height - src.max_y) : src.min_y.Value();
+    s32 max_y = lower_left ? (clip_height - src.min_y) : src.max_y.Value();
+
+    // Bound to render area
+    min_y = std::max(min_y, 0);
+    max_y = std::max(max_y, 0);
+
     if (src.enable) {
-        scissor.offset.x = scale_up(static_cast<s32>(src.min_x));
-        scissor.offset.y = scale_up(static_cast<s32>(src.min_y));
+        scissor.offset.x = scale_up(src.min_x);
+        scissor.offset.y = scale_up(min_y);
         scissor.extent.width = scale_up(src.max_x - src.min_x);
-        scissor.extent.height = scale_up(src.max_y - src.min_y);
+        scissor.extent.height = scale_up(max_y - min_y);
     } else {
         scissor.offset.x = 0;
         scissor.offset.y = 0;

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1962,21 +1962,22 @@ Framebuffer::Framebuffer(TextureCacheRuntime& runtime, std::span<ImageView*, NUM
 }
 
 Framebuffer::Framebuffer(TextureCacheRuntime& runtime, ImageView* color_buffer,
-                         ImageView* depth_buffer, VkExtent2D extent, bool is_rescaled)
+                         ImageView* depth_buffer, VkExtent2D extent, bool is_rescaled_)
     : render_area{extent} {
     std::array<ImageView*, NUM_RT> color_buffers{color_buffer};
-    CreateFramebuffer(runtime, color_buffers, depth_buffer, is_rescaled);
+    CreateFramebuffer(runtime, color_buffers, depth_buffer, is_rescaled_);
 }
 
 Framebuffer::~Framebuffer() = default;
 
 void Framebuffer::CreateFramebuffer(TextureCacheRuntime& runtime,
                                     std::span<ImageView*, NUM_RT> color_buffers,
-                                    ImageView* depth_buffer, bool is_rescaled) {
+                                    ImageView* depth_buffer, bool is_rescaled_) {
     boost::container::small_vector<VkImageView, NUM_RT + 1> attachments;
     RenderPassKey renderpass_key{};
     s32 num_layers = 1;
 
+    is_rescaled = is_rescaled_;
     const auto& resolution = runtime.resolution;
 
     u32 width = std::numeric_limits<u32>::max();

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -361,6 +361,10 @@ public:
         return has_stencil;
     }
 
+    [[nodiscard]] bool IsRescaled() const noexcept {
+        return is_rescaled;
+    }
+
 private:
     vk::Framebuffer framebuffer;
     VkRenderPass renderpass{};
@@ -373,6 +377,7 @@ private:
     std::array<size_t, NUM_RT> rt_map{};
     bool has_depth{};
     bool has_stencil{};
+    bool is_rescaled{};
 };
 
 struct TextureCacheParams {


### PR DESCRIPTION
Fixes cut off rendering in handheld mode on Tomb Raider I-III Remastered. Oversight of #12235