### PR TITLE
common/ring_buffer: Include <limits> header

### DIFF
--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstring>
+#include <limits>
 #include <new>
 #include <span>
 #include <type_traits>


### PR DESCRIPTION
Rather unimportant IWYU patch, but I use the RingBuffer class as a small library in another project and the missing <limits> header makes the build fail when trying to instantiate std::numeric_limits<std::size_t> in line 29