### PR TITLE
service: set: Enable nfc and others by default and bump version

### DIFF
--- a/src/core/hle/service/set/setting_formats/system_settings.cpp
+++ b/src/core/hle/service/set/setting_formats/system_settings.cpp
@@ -52,6 +52,10 @@ SystemSettings DefaultSystemSettings() {
     settings.battery_percentage_flag = true;
     settings.chinese_traditional_input_method = ChineseTraditionalInputMethod::Unknown0;
     settings.vibration_master_volume = 1.0f;
+    settings.touch_screen_mode = TouchScreenMode::Standard;
+    settings.nfc_enable_flag = true;
+    settings.bluetooth_enable_flag = true;
+    settings.wireless_lan_enable_flag = true;
 
     const auto language_code =
         available_language_codes[static_cast<s32>(::Settings::values.language_index.GetValue())];

--- a/src/core/hle/service/set/system_settings_server.cpp
+++ b/src/core/hle/service/set/system_settings_server.cpp
@@ -26,7 +26,7 @@
 namespace Service::Set {
 
 namespace {
-constexpr u32 SETTINGS_VERSION{3u};
+constexpr u32 SETTINGS_VERSION{4u};
 constexpr auto SETTINGS_MAGIC = Common::MakeMagic('y', 'u', 'z', 'u', '_', 's', 'e', 't');
 struct SettingsHeader {
     u64 magic;


### PR DESCRIPTION
I keep forgetting to enable settings when implementing the services. This fixes amiibo detection regressed by #13140 