### PR TITLE
core: hid: Reintroduce vibration filter

### DIFF
--- a/src/hid_core/frontend/emulated_controller.h
+++ b/src/hid_core/frontend/emulated_controller.h
@@ -583,6 +583,7 @@ private:
     std::size_t nfc_handles{0};
     std::array<VibrationValue, 2> last_vibration_value{DEFAULT_VIBRATION_VALUE,
                                                        DEFAULT_VIBRATION_VALUE};
+    std::array<std::chrono::steady_clock::time_point, 2> last_vibration_timepoint{};
 
     // Temporary values to avoid doing changes while the controller is in configuring mode
     NpadStyleIndex tmp_npad_type{NpadStyleIndex::None};

--- a/src/hid_core/hid_types.h
+++ b/src/hid_core/hid_types.h
@@ -638,7 +638,11 @@ struct VibrationValue {
         if (low_amplitude != b.low_amplitude || high_amplitude != b.high_amplitude) {
             return false;
         }
-        if (low_frequency != b.low_amplitude || high_frequency != b.high_frequency) {
+        // Changes in frequency without amplitude don't have any effect
+        if (low_amplitude == 0 && high_amplitude == 0) {
+            return true;
+        }
+        if (low_frequency != b.low_frequency || high_frequency != b.high_frequency) {
             return false;
         }
         return true;

--- a/src/hid_core/resources/npad/npad.cpp
+++ b/src/hid_core/resources/npad/npad.cpp
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <array>
-#include <chrono>
 #include <cstring>
 
 #include "common/assert.h"


### PR DESCRIPTION
Modern controllers clearly can't handle this. Add the vibration filter back to remove controller lag issues.