### PR TITLE
core: hid: hid_core doesn't have access to LIBUSB

### DIFF
--- a/src/hid_core/frontend/emulated_controller.cpp
+++ b/src/hid_core/frontend/emulated_controller.cpp
@@ -175,10 +175,9 @@ void EmulatedController::LoadDevices() {
     if (npad_id_type == NpadIdType::Player1 || npad_id_type == NpadIdType::Handheld) {
         camera_params[1] = Common::ParamPackage{"engine:camera,camera:1"};
         nfc_params[0] = Common::ParamPackage{"engine:virtual_amiibo,nfc:1"};
-#ifdef HAVE_LIBUSB
+#ifndef ANDROID
         ring_params[1] = Common::ParamPackage{"engine:joycon,axis_x:100,axis_y:101"};
-#endif
-#ifdef ANDROID
+#else
         android_params = Common::ParamPackage{"engine:android,port:100"};
 #endif
     }


### PR DESCRIPTION
One step forward and two back. LIBUSB is only available on input_common. So the ring param never got compiled on systems that support it. This fixes the ring with joycons.