### PR TITLE
texture_cache: do not track invalid addresses

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -2098,7 +2098,9 @@ void TextureCache<P>::TrackImage(ImageBase& image, ImageId image_id) {
     ASSERT(False(image.flags & ImageFlagBits::Tracked));
     image.flags |= ImageFlagBits::Tracked;
     if (False(image.flags & ImageFlagBits::Sparse)) {
-        device_memory.UpdatePagesCachedCount(image.cpu_addr, image.guest_size_bytes, 1);
+        if (image.cpu_addr < ~(1ULL << 40)) {
+            device_memory.UpdatePagesCachedCount(image.cpu_addr, image.guest_size_bytes, 1);
+        }
         return;
     }
     if (True(image.flags & ImageFlagBits::Registered)) {
@@ -2124,7 +2126,9 @@ void TextureCache<P>::UntrackImage(ImageBase& image, ImageId image_id) {
     ASSERT(True(image.flags & ImageFlagBits::Tracked));
     image.flags &= ~ImageFlagBits::Tracked;
     if (False(image.flags & ImageFlagBits::Sparse)) {
-        device_memory.UpdatePagesCachedCount(image.cpu_addr, image.guest_size_bytes, -1);
+        if (image.cpu_addr < ~(1ULL << 40)) {
+            device_memory.UpdatePagesCachedCount(image.cpu_addr, image.guest_size_bytes, -1);
+        }
         return;
     }
     ASSERT(True(image.flags & ImageFlagBits::Registered));


### PR DESCRIPTION
The texture cache intentionally generates invalid device addresses for gpu mappings it cannot resolve:
https://github.com/yuzu-emu/yuzu/blob/f9bfdb15559c7ce447151162af61cc69efcbec01/src/video_core/texture_cache/texture_cache.h#L1355-L1357

Tracking these will lead to a crash, so don't do that. "Fixes" #13169