### PR TITLE
glue/time: Remove global variables

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -343,7 +343,7 @@ void SetColorConsoleBackendEnabled(bool enabled) {
 }
 
 void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
-                       unsigned int line_num, const char* function, const char* format,
+                       unsigned int line_num, const char* function, fmt::string_view format,
                        const fmt::format_args& args) {
     if (!initialization_in_progress_suppress_logging) {
         Impl::Instance().PushEntry(log_class, log_level, filename, line_num, function,

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -24,12 +24,12 @@ constexpr const char* TrimSourcePath(std::string_view source) {
 
 /// Logs a message to the global logger, using fmt
 void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
-                       unsigned int line_num, const char* function, const char* format,
+                       unsigned int line_num, const char* function, fmt::string_view format,
                        const fmt::format_args& args);
 
 template <typename... Args>
 void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                   const char* function, const char* format, const Args&... args) {
+                   const char* function, fmt::format_string<Args...> format, const Args&... args) {
     FmtLogMessageImpl(log_class, log_level, filename, line_num, function, format,
                       fmt::make_format_args(args...));
 }

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -105,12 +105,4 @@ VirtualDir PartitionFilesystem::GetParentDirectory() const {
     return nullptr;
 }
 
-void PartitionFilesystem::PrintDebugInfo() const {
-    LOG_DEBUG(Service_FS, "Magic:                  {:.4}", pfs_header.magic);
-    LOG_DEBUG(Service_FS, "Files:                  {}", pfs_header.num_entries);
-    for (u32 i = 0; i < pfs_header.num_entries; i++) {
-        LOG_DEBUG(Service_FS, " > File {}:              {} (0x{:X} bytes)", i,
-                  pfs_files[i]->GetName(), pfs_files[i]->GetSize());
-    }
-}
 } // namespace FileSys

--- a/src/core/file_sys/partition_filesystem.h
+++ b/src/core/file_sys/partition_filesystem.h
@@ -35,7 +35,6 @@ public:
     std::vector<VirtualDir> GetSubdirectories() const override;
     std::string GetName() const override;
     VirtualDir GetParentDirectory() const override;
-    void PrintDebugInfo() const;
 
 private:
     struct Header {

--- a/src/core/hle/service/glue/time/manager.h
+++ b/src/core/hle/service/glue/time/manager.h
@@ -10,6 +10,7 @@
 #include "core/file_sys/vfs/vfs_types.h"
 #include "core/hle/service/glue/time/file_timestamp_worker.h"
 #include "core/hle/service/glue/time/standard_steady_clock_resource.h"
+#include "core/hle/service/glue/time/time_zone_binary.h"
 #include "core/hle/service/glue/time/worker.h"
 #include "core/hle/service/service.h"
 
@@ -26,7 +27,7 @@ namespace Service::Glue::Time {
 class TimeManager {
 public:
     explicit TimeManager(Core::System& system);
-    ~TimeManager();
+    ~TimeManager() = default;
 
     std::shared_ptr<Service::Set::ISystemSettingsServer> m_set_sys;
 
@@ -34,6 +35,7 @@ public:
     std::shared_ptr<Service::PSC::Time::StaticService> m_time_sm{};
     StandardSteadyClockResource m_steady_clock_resource;
     FileTimestampWorker m_file_timestamp_worker;
+    TimeZoneBinary m_time_zone_binary;
     TimeWorker m_worker;
 
 private:

--- a/src/core/hle/service/glue/time/static.cpp
+++ b/src/core/hle/service/glue/time/static.cpp
@@ -26,8 +26,9 @@ StaticService::StaticService(Core::System& system_,
                              std::shared_ptr<TimeManager> time, const char* name)
     : ServiceFramework{system_, name}, m_system{system_}, m_time_m{time->m_time_m},
       m_setup_info{setup_info}, m_time_sm{time->m_time_sm},
-      m_file_timestamp_worker{time->m_file_timestamp_worker}, m_standard_steady_clock_resource{
-                                                                  time->m_steady_clock_resource} {
+      m_file_timestamp_worker{time->m_file_timestamp_worker},
+      m_standard_steady_clock_resource{time->m_steady_clock_resource},
+      m_time_zone_binary{time->m_time_zone_binary} {
     // clang-format off
         static const FunctionInfo functions[] = {
             {0,   D<&StaticService::GetStandardUserSystemClock>, "GetStandardUserSystemClock"},
@@ -106,7 +107,7 @@ Result StaticService::GetTimeZoneService(OutInterface<TimeZoneService> out_servi
 
     *out_service = std::make_shared<TimeZoneService>(
         m_system, m_file_timestamp_worker, m_setup_info.can_write_timezone_device_location,
-        m_time_zone);
+        m_time_zone_binary, m_time_zone);
     R_SUCCEED();
 }
 

--- a/src/core/hle/service/glue/time/static.h
+++ b/src/core/hle/service/glue/time/static.h
@@ -80,5 +80,6 @@ private:
     std::shared_ptr<Service::PSC::Time::TimeZoneService> m_time_zone;
     FileTimestampWorker& m_file_timestamp_worker;
     StandardSteadyClockResource& m_standard_steady_clock_resource;
+    TimeZoneBinary& m_time_zone_binary;
 };
 } // namespace Service::Glue::Time

--- a/src/core/hle/service/glue/time/time_zone.cpp
+++ b/src/core/hle/service/glue/time/time_zone.cpp
@@ -15,19 +15,16 @@
 #include "core/hle/service/sm/sm.h"
 
 namespace Service::Glue::Time {
-namespace {
-static std::mutex g_list_mutex;
-static Common::IntrusiveListBaseTraits<Service::PSC::Time::OperationEvent>::ListType g_list_nodes{};
-} // namespace
 
 TimeZoneService::TimeZoneService(
     Core::System& system_, FileTimestampWorker& file_timestamp_worker,
-    bool can_write_timezone_device_location,
+    bool can_write_timezone_device_location, TimeZoneBinary& time_zone_binary,
     std::shared_ptr<Service::PSC::Time::TimeZoneService> time_zone_service)
     : ServiceFramework{system_, "ITimeZoneService"}, m_system{system},
       m_can_write_timezone_device_location{can_write_timezone_device_location},
-      m_file_timestamp_worker{file_timestamp_worker},
-      m_wrapped_service{std::move(time_zone_service)}, m_operation_event{m_system} {
+      m_file_timestamp_worker{file_timestamp_worker}, m_wrapped_service{std::move(
+                                                          time_zone_service)},
+      m_operation_event{m_system}, m_time_zone_binary{time_zone_binary} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0,   D<&TimeZoneService::GetDeviceLocationName>, "GetDeviceLocationName"},
@@ -48,7 +45,6 @@ TimeZoneService::TimeZoneService(
     // clang-format on
     RegisterHandlers(functions);
 
-    g_list_nodes.clear();
     m_set_sys =
         m_system.ServiceManager().GetService<Service::Set::ISystemSettingsServer>("set:sys", true);
 }
@@ -69,13 +65,13 @@ Result TimeZoneService::SetDeviceLocationName(
     LOG_DEBUG(Service_Time, "called. location_name={}", location_name);
 
     R_UNLESS(m_can_write_timezone_device_location, Service::PSC::Time::ResultPermissionDenied);
-    R_UNLESS(IsTimeZoneBinaryValid(location_name), Service::PSC::Time::ResultTimeZoneNotFound);
+    R_UNLESS(m_time_zone_binary.IsValid(location_name), Service::PSC::Time::ResultTimeZoneNotFound);
 
     std::scoped_lock l{m_mutex};
 
     std::span<const u8> binary{};
     size_t binary_size{};
-    R_TRY(GetTimeZoneRule(binary, binary_size, location_name))
+    R_TRY(m_time_zone_binary.GetTimeZoneRule(binary, binary_size, location_name))
 
     R_TRY(m_wrapped_service->SetDeviceLocationNameWithTimeZoneRule(location_name, binary));
 
@@ -88,8 +84,8 @@ Result TimeZoneService::SetDeviceLocationName(
     m_set_sys->SetDeviceTimeZoneLocationName(name);
     m_set_sys->SetDeviceTimeZoneLocationUpdatedTime(time_point);
 
-    std::scoped_lock m{g_list_mutex};
-    for (auto& operation_event : g_list_nodes) {
+    std::scoped_lock m{m_list_mutex};
+    for (auto& operation_event : m_list_nodes) {
         operation_event.m_event->Signal();
     }
     R_SUCCEED();
@@ -112,7 +108,8 @@ Result TimeZoneService::LoadLocationNameList(
     };
 
     std::scoped_lock l{m_mutex};
-    R_RETURN(GetTimeZoneLocationList(*out_count, out_names, out_names.size(), index));
+    R_RETURN(
+        m_time_zone_binary.GetTimeZoneLocationList(*out_count, out_names, out_names.size(), index));
 }
 
 Result TimeZoneService::LoadTimeZoneRule(OutRule out_rule,
@@ -122,7 +119,7 @@ Result TimeZoneService::LoadTimeZoneRule(OutRule out_rule,
     std::scoped_lock l{m_mutex};
     std::span<const u8> binary{};
     size_t binary_size{};
-    R_TRY(GetTimeZoneRule(binary, binary_size, name))
+    R_TRY(m_time_zone_binary.GetTimeZoneRule(binary, binary_size, name))
     R_RETURN(m_wrapped_service->ParseTimeZoneBinary(out_rule, binary));
 }
 
@@ -174,7 +171,7 @@ Result TimeZoneService::GetDeviceLocationNameOperationEventReadableHandle(
             m_operation_event.m_ctx.CreateEvent("Psc:TimeZoneService:OperationEvent");
         operation_event_initialized = true;
         std::scoped_lock l{m_mutex};
-        g_list_nodes.push_back(m_operation_event);
+        m_list_nodes.push_back(m_operation_event);
     }
 
     *out_event = &m_operation_event.m_event->GetReadableEvent();

--- a/src/core/hle/service/glue/time/time_zone.h
+++ b/src/core/hle/service/glue/time/time_zone.h
@@ -32,6 +32,7 @@ class TimeZoneService;
 
 namespace Service::Glue::Time {
 class FileTimestampWorker;
+class TimeZoneBinary;
 
 class TimeZoneService final : public ServiceFramework<TimeZoneService> {
     using InRule = InLargeData<Tz::Rule, BufferAttr_HipcMapAlias>;
@@ -40,7 +41,7 @@ class TimeZoneService final : public ServiceFramework<TimeZoneService> {
 public:
     explicit TimeZoneService(
         Core::System& system, FileTimestampWorker& file_timestamp_worker,
-        bool can_write_timezone_device_location,
+        bool can_write_timezone_device_location, TimeZoneBinary& time_zone_binary,
         std::shared_ptr<Service::PSC::Time::TimeZoneService> time_zone_service);
 
     ~TimeZoneService() override;
@@ -85,6 +86,10 @@ private:
     std::mutex m_mutex;
     bool operation_event_initialized{};
     Service::PSC::Time::OperationEvent m_operation_event;
+    TimeZoneBinary& m_time_zone_binary;
+
+    std::mutex m_list_mutex;
+    Common::IntrusiveListBaseTraits<Service::PSC::Time::OperationEvent>::ListType m_list_nodes{};
 };
 
 } // namespace Service::Glue::Time

--- a/src/core/hle/service/glue/time/time_zone_binary.h
+++ b/src/core/hle/service/glue/time/time_zone_binary.h
@@ -6,6 +6,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "core/hle/service/psc/time/common.h"
 
@@ -15,18 +16,34 @@ class System;
 
 namespace Service::Glue::Time {
 
-void ResetTimeZoneBinary();
-Result MountTimeZoneBinary(Core::System& system);
-void GetTimeZoneBinaryListPath(std::string& out_path);
-void GetTimeZoneBinaryVersionPath(std::string& out_path);
-void GetTimeZoneZonePath(std::string& out_path, const Service::PSC::Time::LocationName& name);
-bool IsTimeZoneBinaryValid(const Service::PSC::Time::LocationName& name);
-u32 GetTimeZoneCount();
-Result GetTimeZoneVersion(Service::PSC::Time::RuleVersion& out_rule_version);
-Result GetTimeZoneRule(std::span<const u8>& out_rule, size_t& out_rule_size,
-                       const Service::PSC::Time::LocationName& name);
-Result GetTimeZoneLocationList(u32& out_count,
-                               std::span<Service::PSC::Time::LocationName> out_names,
-                               size_t max_names, u32 index);
+class TimeZoneBinary {
+public:
+    explicit TimeZoneBinary(Core::System& system_)
+        : time_zone_scratch_space(0x2800, 0), system{system_} {}
+
+    Result Mount();
+    bool IsValid(const Service::PSC::Time::LocationName& name);
+    u32 GetTimeZoneCount();
+    Result GetTimeZoneVersion(Service::PSC::Time::RuleVersion& out_rule_version);
+    Result GetTimeZoneRule(std::span<const u8>& out_rule, size_t& out_rule_size,
+                           const Service::PSC::Time::LocationName& name);
+    Result GetTimeZoneLocationList(u32& out_count,
+                                   std::span<Service::PSC::Time::LocationName> out_names,
+                                   size_t max_names, u32 index);
+
+private:
+    void Reset();
+    Result Read(size_t& out_read_size, std::span<u8> out_buffer, size_t out_buffer_size,
+                std::string_view path);
+    void GetListPath(std::string& out_path);
+    void GetVersionPath(std::string& out_path);
+    void GetTimeZonePath(std::string& out_path, const Service::PSC::Time::LocationName& name);
+
+    FileSys::VirtualDir time_zone_binary_romfs{};
+    Result time_zone_binary_mount_result{ResultUnknown};
+    std::vector<u8> time_zone_scratch_space;
+
+    Core::System& system;
+};
 
 } // namespace Service::Glue::Time

--- a/src/core/hle/service/glue/time/worker.h
+++ b/src/core/hle/service/glue/time/worker.h
@@ -34,6 +34,9 @@ public:
     void StartThread();
 
 private:
+    template <typename T>
+    T GetSettingsItemValue(const std::string& category, const std::string& name);
+
     void ThreadFunc(std::stop_token stop_token);
 
     Core::System& m_system;
@@ -59,6 +62,11 @@ private:
     std::shared_ptr<Core::Timing::EventType> m_timer_file_system_timing_event;
     AlarmWorker m_alarm_worker;
     PmStateChangeHandler m_pm_state_change_handler;
+
+    bool m_ig_report_network_clock_context_set{};
+    Service::PSC::Time::SystemClockContext m_report_network_clock_context{};
+    bool m_ig_report_ephemeral_clock_context_set{};
+    Service::PSC::Time::SystemClockContext m_report_ephemeral_clock_context{};
 };
 
 } // namespace Service::Glue::Time

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -71,7 +71,7 @@ const char* GetType(GLenum type) {
 
 void APIENTRY DebugHandler(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
                            const GLchar* message, const void* user_param) {
-    const char format[] = "{} {} {}: {}";
+    constexpr std::string_view format = "{} {} {}: {}";
     const char* const str_source = GetSource(source);
     const char* const str_type = GetType(type);
 


### PR DESCRIPTION
These have no good reason to be there, so I made them class members instead.

Also ports https://github.com/citra-emu/citra/pull/7463 from Citra.