### PR TITLE
general: fix asan errors

### DIFF
--- a/src/core/file_sys/fssystem/fssystem_aes_xts_storage.cpp
+++ b/src/core/file_sys/fssystem/fssystem_aes_xts_storage.cpp
@@ -31,8 +31,8 @@ AesXtsStorage::AesXtsStorage(VirtualFile base, const void* key1, const void* key
     ASSERT(iv_size == IvSize);
     ASSERT(Common::IsAligned(m_block_size, AesBlockSize));
 
-    std::memcpy(m_key.data() + 0, key1, KeySize);
-    std::memcpy(m_key.data() + 0x10, key2, KeySize);
+    std::memcpy(m_key.data() + 0, key1, KeySize / 2);
+    std::memcpy(m_key.data() + 0x10, key2, KeySize / 2);
     std::memcpy(m_iv.data(), iv, IvSize);
 
     m_cipher.emplace(m_key, Core::Crypto::Mode::XTS);

--- a/src/core/hle/service/server_manager.cpp
+++ b/src/core/hle/service/server_manager.cpp
@@ -93,13 +93,19 @@ ServerManager::~ServerManager() {
     m_threads.clear();
 
     // Clean up ports.
-    for (auto it = m_servers.begin(); it != m_servers.end(); it = m_servers.erase(it)) {
-        delete std::addressof(*it);
+    auto port_it = m_servers.begin();
+    while (port_it != m_servers.end()) {
+        auto* const port = std::addressof(*port_it);
+        port_it = m_servers.erase(port_it);
+        delete port;
     }
 
     // Clean up sessions.
-    for (auto it = m_sessions.begin(); it != m_sessions.end(); it = m_sessions.erase(it)) {
-        delete std::addressof(*it);
+    auto session_it = m_sessions.begin();
+    while (session_it != m_sessions.end()) {
+        auto* const session = std::addressof(*session_it);
+        session_it = m_sessions.erase(session_it);
+        delete session;
     }
 
     // Close wakeup event.


### PR DESCRIPTION
(Harmless) buffer overflow in xts storage and use-after-free in server manager (oops)
Rest is surprisingly clean but requires use of detect_stack_use_after_return=false or it inserts poison bytes into kernel data structures which live on the stack.