### PR TITLE
vfs: misc performance improvements

### DIFF
--- a/src/core/file_sys/vfs/vfs_offset.cpp
+++ b/src/core/file_sys/vfs/vfs_offset.cpp
@@ -9,9 +9,8 @@
 namespace FileSys {
 
 OffsetVfsFile::OffsetVfsFile(VirtualFile file_, std::size_t size_, std::size_t offset_,
-                             std::string name_, VirtualDir parent_)
-    : file(file_), offset(offset_), size(size_), name(std::move(name_)),
-      parent(parent_ == nullptr ? file->GetContainingDirectory() : std::move(parent_)) {}
+                             std::string name_)
+    : file(file_), offset(offset_), size(size_), name(std::move(name_)) {}
 
 OffsetVfsFile::~OffsetVfsFile() = default;
 
@@ -37,7 +36,7 @@ bool OffsetVfsFile::Resize(std::size_t new_size) {
 }
 
 VirtualDir OffsetVfsFile::GetContainingDirectory() const {
-    return parent;
+    return nullptr;
 }
 
 bool OffsetVfsFile::IsWritable() const {

--- a/src/core/file_sys/vfs/vfs_offset.h
+++ b/src/core/file_sys/vfs/vfs_offset.h
@@ -16,7 +16,7 @@ namespace FileSys {
 class OffsetVfsFile : public VfsFile {
 public:
     OffsetVfsFile(VirtualFile file, std::size_t size, std::size_t offset = 0,
-                  std::string new_name = "", VirtualDir new_parent = nullptr);
+                  std::string new_name = "");
     ~OffsetVfsFile() override;
 
     std::string GetName() const override;
@@ -44,7 +44,6 @@ private:
     std::size_t offset;
     std::size_t size;
     std::string name;
-    VirtualDir parent;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/vfs/vfs_real.h
+++ b/src/core/file_sys/vfs/vfs_real.h
@@ -62,6 +62,7 @@ private:
 private:
     friend class RealVfsDirectory;
     VirtualFile OpenFileFromEntry(std::string_view path, std::optional<u64> size,
+                                  std::optional<std::string> parent_path,
                                   OpenMode perms = OpenMode::Read);
 
 private:
@@ -91,7 +92,7 @@ public:
 private:
     RealVfsFile(RealVfsFilesystem& base, std::unique_ptr<FileReference> reference,
                 const std::string& path, OpenMode perms = OpenMode::Read,
-                std::optional<u64> size = {});
+                std::optional<u64> size = {}, std::optional<std::string> parent_path = {});
 
     RealVfsFilesystem& base;
     std::unique_ptr<FileReference> reference;

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -36,22 +36,23 @@ std::optional<FileType> IdentifyFileLoader(FileSys::VirtualFile file) {
 } // namespace
 
 FileType IdentifyFile(FileSys::VirtualFile file) {
-    if (const auto romdir_type = IdentifyFileLoader<AppLoader_DeconstructedRomDirectory>(file)) {
-        return *romdir_type;
-    } else if (const auto nso_type = IdentifyFileLoader<AppLoader_NSO>(file)) {
-        return *nso_type;
+    if (const auto nsp_type = IdentifyFileLoader<AppLoader_NSP>(file)) {
+        return *nsp_type;
+    } else if (const auto xci_type = IdentifyFileLoader<AppLoader_XCI>(file)) {
+        return *xci_type;
     } else if (const auto nro_type = IdentifyFileLoader<AppLoader_NRO>(file)) {
         return *nro_type;
     } else if (const auto nca_type = IdentifyFileLoader<AppLoader_NCA>(file)) {
         return *nca_type;
-    } else if (const auto xci_type = IdentifyFileLoader<AppLoader_XCI>(file)) {
-        return *xci_type;
     } else if (const auto nax_type = IdentifyFileLoader<AppLoader_NAX>(file)) {
         return *nax_type;
-    } else if (const auto nsp_type = IdentifyFileLoader<AppLoader_NSP>(file)) {
-        return *nsp_type;
     } else if (const auto kip_type = IdentifyFileLoader<AppLoader_KIP>(file)) {
         return *kip_type;
+    } else if (const auto nso_type = IdentifyFileLoader<AppLoader_NSO>(file)) {
+        return *nso_type;
+    } else if (const auto romdir_type =
+                   IdentifyFileLoader<AppLoader_DeconstructedRomDirectory>(file)) {
+        return *romdir_type;
     } else {
         return FileType::Unknown;
     }


### PR DESCRIPTION
1. Not necessary to record the parent directory for offset files as we never care about the parent.
2. When enumerating a directory to get the file sizes we also happen to know the name of the parent directory and don't have to look it up again.
3. Check the most common file types first in the loader to increase the chances of early termination.